### PR TITLE
fix: anchor context-guard noisy-run match at command position

### DIFF
--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -25,7 +25,15 @@ if data.get("tool_name") != "Bash":
 
 cmd = data.get("tool_input", {}).get("command", "") or ""
 
-NOISY = r"(\bpytest\b|\bmypy\b|\bruff\b)"
+# Anchored at command position (line start, `;`, `&`, `|`, `(`, or a backtick/
+# $( substitution), optionally behind a `uv run` / `python -m` launcher — a bare
+# word match false-positived on commit messages and PR bodies that merely
+# mention pytest/mypy/ruff in quoted text.
+NOISY = (
+    r"(?:^|[;&|(`\n]\s*|\$\(\s*)"
+    r"(?:uv\s+run\s+(?:-\S+\s+)*|python3?\s+-m\s+)?"
+    r"(?:pytest|mypy|ruff)\b"
+)
 if re.search(NOISY + r"[^|]*\|\s*(tail|head|less|more|cat)\b", cmd):
     sys.stderr.write(
         "Blocked (context discipline): noisy runs never pipe to tail/head — a tail caps one run, runs repeat.\n"


### PR DESCRIPTION
The context-guard hook's noisy-run rule matched `pytest`/`mypy`/`ruff` as bare words anywhere in the command string, so a `gh pr create` body or commit message that merely mentioned them — combined with a trailing pipe to tail — tripped the block. Happened twice during the CI install on PR #49.

The pattern now requires the tool name at a command position (string/line start, or after `;`, `&`, `|`, `(`, backtick, `$(`), optionally behind a `uv run` or `python -m` launcher. Quoted mentions pass; every real invocation form still blocks.

Seam for this PR: hook logic pipe-tested 19/19 — the original 11 cases plus both observed false positives as regressions and six invocation-form cases (bare, `python -m`, `uv run --flag`, after `&&`, after newline, inside `$()`).

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)