### PR TITLE
Log every connection state change; 'Needs from you' ticket convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ parent branch reads MERGED while its commits never reach main.
 Close the ticket with the PR link when the work is complete; name any unrun
 live ACs in the close comment.
 
+Every implementation comment on a ticket (close or status) ends with a
+`## Needs from you` section as its **last** section, listing each item that
+requires the human — decisions to make, live ACs to run, installs — even when
+already discussed above. If nothing is needed, omit the section; its absence
+is the signal that the ticket asks nothing of you.
+
 CI (`.github/workflows/ci.yml`) runs the fake tier, mypy strict, and ruff on
 every PR; `review-gate.yml` blocks merge until the PR body's `Review:` line
 reads clean. Both are required status checks on `main`.

--- a/src/resolve_mcp/resolve/connection.py
+++ b/src/resolve_mcp/resolve/connection.py
@@ -31,6 +31,10 @@ class ResolveConnection:
     def __init__(self, connect: Callable[[], Any | None] | None = None) -> None:
         self._connect = connect or load_resolve
         self._handle: Any | None = None
+        # Distinguishes "attached" from "reconnected" in the log even when the retry
+        # arrives via invalidate() (the envelope's mid-call-death path), where no
+        # stale handle is left to observe.
+        self._ever_attached = False
         self._lock = threading.RLock()
 
     @property
@@ -57,22 +61,24 @@ class ResolveConnection:
     def handle(self) -> Any:
         """Return a live Resolve handle, reconnecting once if the held one has died."""
         with self._lock:
-            reconnecting = False
             if self._handle is not None:
                 if self._probe(self._handle):
                     return self._handle
                 log.info("Resolve handle went stale; reconnecting once")
                 self._handle = None
-                reconnecting = True
 
             handle, failure = self._connect_once()
             if handle is not None and self._probe(handle):
                 self._handle = handle
-                log.info("Resolve %s", "reconnected" if reconnecting else "attached")
+                log.info("Resolve %s", "reconnected" if self._ever_attached else "attached")
+                self._ever_attached = True
                 return handle
 
             self._handle = None
-            raise failure or ResolveUnavailableError(cause=NOT_RUNNING)
+            if failure is None:
+                failure = ResolveUnavailableError(cause=NOT_RUNNING)
+                log.warning("Connecting to Resolve failed: %s", failure.cause)
+            raise failure
 
     def _connect_once(self) -> tuple[Any | None, ResolveMcpError | None]:
         try:
@@ -84,6 +90,7 @@ class ResolveConnection:
             log.exception("Connecting to Resolve raised")
             return None, ResolveUnavailableError(cause=f"{type(exc).__name__}: {exc}")
         if handle is None:
+            log.warning("Connecting to Resolve failed: %s", NOT_RUNNING)
             return None, ResolveUnavailableError(cause=NOT_RUNNING)
         return handle, None
 

--- a/src/resolve_mcp/resolve/connection.py
+++ b/src/resolve_mcp/resolve/connection.py
@@ -41,6 +41,8 @@ class ResolveConnection:
     def invalidate(self) -> None:
         """Drop the handle; the next call reconnects."""
         with self._lock:
+            if self._handle is not None:
+                log.info("Resolve handle invalidated; next call reconnects")
             self._handle = None
 
     def dropped(self) -> bool:
@@ -55,15 +57,18 @@ class ResolveConnection:
     def handle(self) -> Any:
         """Return a live Resolve handle, reconnecting once if the held one has died."""
         with self._lock:
+            reconnecting = False
             if self._handle is not None:
                 if self._probe(self._handle):
                     return self._handle
                 log.info("Resolve handle went stale; reconnecting once")
                 self._handle = None
+                reconnecting = True
 
             handle, failure = self._connect_once()
             if handle is not None and self._probe(handle):
                 self._handle = handle
+                log.info("Resolve %s", "reconnected" if reconnecting else "attached")
                 return handle
 
             self._handle = None

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -99,21 +99,24 @@ def test_every_connection_state_change_logs_a_line(
 ) -> None:
     """Attach, reconnect, handle death, invalidate: each leaves a log line, because a
     live failure on a machine no one is at gets diagnosed from the log or not at all."""
-    dead, alive = studio(), studio()
-    attach(dead, alive)
+    first, second, third = studio(), studio(), studio()
+    attach(first, second, third)
     conn = connection_module.get_connection()
 
     with caplog.at_level("INFO", logger=connection_module.log.name):
         conn.handle()
-        dead.drop()
-        conn.handle()
+        first.drop()
+        conn.handle()  # stale handle noticed inside handle()
         conn.invalidate()
+        conn.handle()  # the envelope's recovery path: invalidate, then retry
 
-    messages = [record.getMessage() for record in caplog.records]
-    assert "Resolve attached" in messages
-    assert "Resolve handle went stale; reconnecting once" in messages
-    assert "Resolve reconnected" in messages
-    assert "Resolve handle invalidated; next call reconnects" in messages
+    assert [record.getMessage() for record in caplog.records] == [
+        "Resolve attached",
+        "Resolve handle went stale; reconnecting once",
+        "Resolve reconnected",
+        "Resolve handle invalidated; next call reconnects",
+        "Resolve reconnected",
+    ]
 
 
 def test_reports_whether_it_currently_holds_a_handle(attach: Attach) -> None:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -94,6 +94,28 @@ def test_a_failed_connect_does_not_poison_the_next_call(attach: Attach) -> None:
     assert connector.attempts == 2
 
 
+def test_every_connection_state_change_logs_a_line(
+    attach: Attach, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Attach, reconnect, handle death, invalidate: each leaves a log line, because a
+    live failure on a machine no one is at gets diagnosed from the log or not at all."""
+    dead, alive = studio(), studio()
+    attach(dead, alive)
+    conn = connection_module.get_connection()
+
+    with caplog.at_level("INFO", logger=connection_module.log.name):
+        conn.handle()
+        dead.drop()
+        conn.handle()
+        conn.invalidate()
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "Resolve attached" in messages
+    assert "Resolve handle went stale; reconnecting once" in messages
+    assert "Resolve reconnected" in messages
+    assert "Resolve handle invalidated; next call reconnects" in messages
+
+
 def test_reports_whether_it_currently_holds_a_handle(attach: Attach) -> None:
     fake = studio()
     attach(fake)


### PR DESCRIPTION
Follow-up to #23's checkup.

- **Lifecycle logging**: successful attach, successful reconnect, and `invalidate()` now log a line, completing the CLAUDE.md rule. The attach/reconnect messages are distinct so a remote log distinguishes first attach from recovery — including the envelope's invalidate-then-retry recovery path. Attach failures (loader exception, loader returning `None`, fresh handle failing its probe) all log a warning before the structured error. Guarded by a caplog test at the fake seam asserting the exact ordered log sequence.
- **CLAUDE.md**: implementation comments on tickets end with a `## Needs from you` section listing every human-required item (decisions, live ACs, installs); omitting it signals nothing is needed.

Seam: fake tier — the new test drives attach → drop → reconnect → invalidate → reconnect against `tests/fakes.py`. 61 passed, mypy strict clean, ruff clean.

Two review findings, both fixed in f31ad49:
1. (Spec) The envelope's mid-call-death recovery (`invalidate()` then retry) logged "Resolve attached", not "reconnected" — the `reconnecting` flag only saw stale handles noticed inside `handle()`. Replaced with an ever-attached bit; any attach after the first now logs "reconnected".
2. (Spec/Standards) Two attach-failure paths raised with no INFO-visible log line: loader returning `None` (Resolve not running) and a fresh handle failing its probe. Both now log a warning before the structured error.
The lifecycle test now asserts the exact ordered log sequence including the invalidate-then-retry path.

Review: clean — the two findings above are resolved in f31ad49; re-run checks green (61 passed, mypy strict, ruff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
