### PR TITLE
Review weight follows what the diff touches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,21 @@ once. The same class lives here between the fakes and the attach.
 ## Session workflow
 
 Work from ticket #N happens on branch `issue-<N>`: push early, open a draft
-PR. After `/code-review` (the two-axis mattpocock skill — Standards and Spec
-as parallel sub-agents), append a `Review:` line to the PR body — `Review:
-clean`, or `Review:` followed by the findings written out. "findings held"
-with nothing above it is a contentless token; the review gate rejects it.
+PR. Review weight follows what the diff touches, not how simple it looks —
+"looks simple" is self-assessed by the same author who made the mistake (a
+three-line log fix here hid a mislabelled recovery path that only the review
+caught):
+
+- **Anything executable** — `src/`, `tests/`, `.claude/hooks/`, workflow
+  YAML — gets `/code-review` (the two-axis mattpocock skill — Standards and
+  Spec as parallel sub-agents). Hooks and workflows count: they are config
+  that executes, and a broken gate fails silently for weeks.
+- **Pure prose** — docs, README, CLAUDE.md — gets one lightweight inline
+  pass, and the line reads `Review: clean — prose only, single-pass`.
+
+Either way, append a `Review:` line to the PR body — `Review: clean`, or
+`Review:` followed by the findings written out. "findings held" with nothing
+above it is a contentless token; the review gate rejects it.
 Everything reaches `main` through a PR — never commit to `main` directly.
 After a stacked PR merges, verify its head is an ancestor of `origin/main`
 (`git merge-base --is-ancestor`) — a PR that merges into a just-consumed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,7 @@ once. The same class lives here between the fakes and the attach.
 ## Session workflow
 
 Work from ticket #N happens on branch `issue-<N>`: push early, open a draft
-PR. Review weight follows what the diff touches, not how simple it looks —
-"looks simple" is self-assessed by the same author who made the mistake (a
+PR. Review weight follows what the diff touches, not how simple it looks (a
 three-line log fix here hid a mislabelled recovery path that only the review
 caught):
 


### PR DESCRIPTION
Codifies the proportional-review rule agreed in session: the `Review:` gate stays on every PR, but review weight is set by what the diff touches, not how simple it looks.

- **Anything executable** (`src/`, `tests/`, `.claude/hooks/`, workflow YAML) → full two-axis `/code-review`. Hooks and workflows count as executable: a broken gate fails silently (see #49, #51).
- **Pure prose** (docs, README, CLAUDE.md) → one lightweight inline pass, marked `Review: clean — prose only, single-pass`.

Evidence baked into the rule text: PR #52 was a "three-line log fix" whose two-axis review caught a mislabelled recovery path — small is not simple; and PR #53's two-axis pass on pin-bump plumbing yielded only judgement calls — that is the overhead case the prose lane removes.

This PR is itself prose-only and takes the single-pass lane it defines. Checked inline: the new marker matches the review-gate's `"Review: clean "*` pattern; no conflict with #52's CLAUDE.md hunk (different paragraphs).

Review: clean — prose only, single-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)