### PR TITLE
P1: Media pool tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Build contract: [issue #22](https://github.com/danielbaldwin47/resolve-mcp/issue
 
 ## Status
 
-P1 in progress. Shipped so far: the server skeleton, the session/project tools, and the
-`run_python` escape hatch.
+P1 in progress. Shipped so far: the server skeleton, the session/project tools, the media
+pool tools, and the `run_python` escape hatch.
 
 | Tool | What it does |
 | --- | --- |
@@ -16,7 +16,17 @@ P1 in progress. Shipped so far: the server skeleton, the session/project tools, 
 | `list_projects` | Project names in the current database folder |
 | `open_project` | Loads a project by name; the result echoes the new context |
 | `snapshot_project` | Writes an opaque `.drp` backup before a big operation |
+| `import_media` | Imports files and image sequences into a bin, still-duration workaround applied |
+| `list_media` | Summarises media pool clips, with offline state; spills big listings to disk |
+| `inspect_clip` | One clip in full: properties, metadata, audio mapping, markers, dual-time bounds |
+| `set_clip_metadata` | Batch metadata writes, each field routed by what the clip reports |
+| `organize_media` | Batch bin operations: create nested bins, move clips |
+| `relink_media` | Points offline clips at media that moved (folder relink or file replace) |
 | `run_python` | Escape hatch: runs scripting-API Python in the server process |
+
+Bin paths are slash-separated from the media pool root (`Concert/Angles`) and
+case-sensitive. A clip counts as **offline** when it has a file path that is not on
+disk — Resolve's scripting API exposes no offline flag.
 
 ## Requirements
 

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -55,6 +55,11 @@ class Config:
         """Where opaque ``.drp`` safety snapshots land."""
         return self.cache_dir / "snapshots"
 
+    @property
+    def listing_dir(self) -> Path:
+        """Where listings too big to return inline spill to."""
+        return self.cache_dir / "listings"
+
 
 _config: Config | None = None
 

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -82,6 +82,88 @@ class SnapshotFailedError(ResolveMcpError):
     )
 
 
+class MediaPoolUnavailableError(ResolveMcpError):
+    """A project is open but Resolve would not hand over its media pool."""
+
+    code = "media_pool_unavailable"
+    default_fix = (
+        "Reopen the project with open_project and retry; if it persists, check the project "
+        "is not mid-import in the GUI."
+    )
+
+
+class BinNotFoundError(ResolveMcpError):
+    code = "bin_not_found"
+
+    def __init__(self, path: str, available: list[str]) -> None:
+        listed = ", ".join(available) if available else "the media pool root only"
+        super().__init__(
+            cause=f"No bin at {path!r} in the media pool.",
+            fix=(
+                f"Bin paths are slash-separated from the root and case-sensitive. "
+                f"These exist: {listed}. organize_media creates missing bins."
+            ),
+            detail={"requested": path, "available": available},
+        )
+
+
+class ClipNotFoundError(ResolveMcpError):
+    code = "clip_not_found"
+
+    def __init__(self, name: str, where: str, available: list[str]) -> None:
+        listed = ", ".join(available) if available else "no clips at all"
+        super().__init__(
+            cause=f"No clip named {name!r} in {where}.",
+            fix=f"Clip names must match exactly. list_media shows what is there: {listed}.",
+            detail={"requested": name, "searched": where, "available": available},
+        )
+
+
+class AmbiguousClipError(ResolveMcpError):
+    code = "ambiguous_clip"
+
+    def __init__(self, name: str, bins: list[str]) -> None:
+        listed = ", ".join(bin_path or "the root" for bin_path in bins)
+        super().__init__(
+            cause=f"{len(bins)} clips are named {name!r}, so the reference is ambiguous.",
+            fix=f"Pass bin= to say which one: {listed}.",
+            detail={"requested": name, "bins": bins},
+        )
+
+
+class ImportFailedError(ResolveMcpError):
+    code = "import_failed"
+    default_fix = (
+        "Resolve imported none of these paths. Check they exist and are readable from the "
+        "machine Resolve runs on, and that an image sequence pattern (file_%04d.png) matches "
+        "the frames on disk."
+    )
+
+
+class RelinkFailedError(ResolveMcpError):
+    code = "relink_failed"
+    default_fix = (
+        "Point relink_media at a folder that holds the moved media, or at the replacement "
+        "file itself. list_media with offline_only shows what is still unlinked."
+    )
+
+
+class MediaOperationError(ResolveMcpError):
+    """Resolve refused a media pool write without saying why — its usual failure mode."""
+
+    code = "media_operation_failed"
+    default_fix = (
+        "Check the media pool is not locked by an open dialog in the Resolve GUI, then retry. "
+        "run_python can reproduce the call directly for diagnosis."
+    )
+
+
+class InvalidRequestError(ResolveMcpError):
+    """The request could not be acted on as written — a shape problem, not a Resolve one."""
+
+    code = "invalid_request"
+
+
 class PythonExecutionError(ResolveMcpError):
     """The escape-hatch code raised. The traceback is logged, not returned."""
 

--- a/src/resolve_mcp/naming.py
+++ b/src/resolve_mcp/naming.py
@@ -1,0 +1,26 @@
+"""Names for the files the server writes.
+
+Snapshots and spilled listings both land in the cache directory named after something the
+director chose — a project, a bin — and both have to survive Windows filename rules and a
+second write in the same session. One rule, one place.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+UNSAFE_IN_FILENAME = re.compile(r"[^A-Za-z0-9._-]+")
+STAMP_FORMAT = "%Y%m%d-%H%M%S"
+
+
+def timestamped_name(
+    label: str,
+    suffix: str,
+    fallback: str,
+    now: datetime | None = None,
+) -> str:
+    """``<slug>-<yyyymmdd-hhmmss><suffix>``, falling back when the label slugs to nothing."""
+    stamp = (now or datetime.now()).strftime(STAMP_FORMAT)
+    slug = UNSAFE_IN_FILENAME.sub("-", label).strip("-") or fallback
+    return f"{slug}-{stamp}{suffix}"

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -1,0 +1,697 @@
+"""Media pool wrappers: import, list, inspect, metadata, bins, relink.
+
+Thin, testable, and MCP-free like the rest of this layer. Four things here are decisions
+rather than API calls, and are the reason this file exists at all:
+
+* **Bin paths are slash-separated from the media pool root** (``"Concert/Angles"``), the
+  root's own name optional as a first segment. Resolve's API has no bin path — only
+  ``GetSubFolderList()`` walks — and "current folder" state that every import depends on.
+* **Offline means the file is gone**, not that Resolve says so: there is no offline flag in
+  the scripting API. A clip is offline when it has a ``File Path`` that is not on disk. A
+  clip with no path at all (multicam, compound) is not offline, it is pathless.
+* **Metadata fields route by what the clip itself reports.** The clip property key names are
+  undocumented, so nothing is hard-coded: each clip is enumerated once with
+  ``GetClipProperty()`` and a field whose key is in that dict is written as a clip property,
+  everything else as metadata. The route taken comes back in the result.
+* **Image media gets the still-duration workaround at import.** A one-time
+  ``SetClipProperty("Out", …)`` is what makes ``endFrame`` respected on stills later; doing
+  it at import means no timeline code ever has to remember.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ..config import Config, get_config
+from ..errors import (
+    AmbiguousClipError,
+    BinNotFoundError,
+    ClipNotFoundError,
+    ImportFailedError,
+    InvalidRequestError,
+    MediaOperationError,
+    MediaPoolUnavailableError,
+    NoProjectOpenError,
+    RelinkFailedError,
+)
+from ..logging_config import get_logger
+from ..timing import dual
+from .connection import ResolveConnection
+from .session import UNSAFE_IN_FILENAME
+
+log = get_logger("media")
+
+BIN_SEPARATOR = "/"
+DEFAULT_LIST_LIMIT = 200
+IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"})
+SEQUENCE_TOKEN = "%"
+
+FILE_PATH = "File Path"
+FRAMES = "Frames"
+FPS = "FPS"
+START = "Start"
+END = "End"
+OUT = "Out"
+TYPE = "Type"
+RESOLUTION = "Resolution"
+
+Clip = Any
+Folder = Any
+Pool = Any
+
+
+# --- reaching the pool ------------------------------------------------------------------
+
+
+def media_pool(connection: ResolveConnection) -> Pool:
+    """The open project's media pool. Raises rather than returning a useless ``None``."""
+    manager = connection.handle().GetProjectManager()
+    project = manager.GetCurrentProject() if manager is not None else None
+    if project is None:
+        raise NoProjectOpenError(cause="No project is open, so there is no media pool to work in.")
+    pool = project.GetMediaPool()
+    if pool is None:
+        raise MediaPoolUnavailableError(
+            cause=f"Resolve returned no media pool for the open project {project.GetName()!r}.",
+        )
+    return pool
+
+
+# --- bins -------------------------------------------------------------------------------
+
+
+def _segments(path: str | None, root: Folder) -> list[str]:
+    parts = [part.strip() for part in (path or "").split(BIN_SEPARATOR)]
+    parts = [part for part in parts if part]
+    root_name = str(root.GetName() or "")
+    if parts and root_name and parts[0] == root_name:
+        parts = parts[1:]
+    return parts
+
+
+def _root(pool: Pool) -> Folder:
+    root = pool.GetRootFolder()
+    if root is None:
+        raise MediaPoolUnavailableError(cause="Resolve returned no media pool root folder.")
+    return root
+
+
+def _subfolders(folder: Folder) -> list[Folder]:
+    return list(folder.GetSubFolderList() or [])
+
+
+def bin_paths(pool: Pool) -> list[str]:
+    """Every bin path in the pool, root excluded — what to offer when one is missing."""
+    found: list[str] = []
+    for path, _folder in _walk_bins(_root(pool)):
+        if path:
+            found.append(path)
+    return found
+
+
+def _walk_bins(folder: Folder, prefix: str = "") -> Iterator[tuple[str, Folder]]:
+    yield prefix, folder
+    for sub in _subfolders(folder):
+        name = str(sub.GetName() or "")
+        yield from _walk_bins(sub, f"{prefix}{BIN_SEPARATOR}{name}" if prefix else name)
+
+
+def find_bin(pool: Pool, path: str | None) -> Folder:
+    """The bin at ``path``. ``None`` or ``""`` is the root."""
+    root = _root(pool)
+    folder = root
+    for segment in _segments(path, root):
+        matches = [sub for sub in _subfolders(folder) if str(sub.GetName() or "") == segment]
+        if not matches:
+            raise BinNotFoundError(str(path), bin_paths(pool))
+        folder = matches[0]
+    return folder
+
+
+def ensure_bin(pool: Pool, path: str | None) -> tuple[Folder, bool]:
+    """The bin at ``path``, creating it and any missing parents. Returns (bin, created)."""
+    root = _root(pool)
+    folder = root
+    created = False
+    for segment in _segments(path, root):
+        matches = [sub for sub in _subfolders(folder) if str(sub.GetName() or "") == segment]
+        if matches:
+            folder = matches[0]
+            continue
+        made = pool.AddSubFolder(folder, segment)
+        if made is None:
+            raise MediaOperationError(cause=f"Resolve refused to create the bin {segment!r}.")
+        log.info("Created bin %s", segment)
+        folder = made
+        created = True
+    return folder, created
+
+
+def path_of(pool: Pool, folder: Folder) -> str:
+    """The slash path of a folder, from the root. The root itself is ``""``."""
+    for path, candidate in _walk_bins(_root(pool)):
+        if candidate is folder:
+            return path
+    return ""
+
+
+# --- clips ------------------------------------------------------------------------------
+
+
+def _clips_under(pool: Pool, folder: Folder, recursive: bool) -> Iterator[tuple[str, Clip]]:
+    base = path_of(pool, folder)
+    if not recursive:
+        for clip in folder.GetClipList() or []:
+            yield base, clip
+        return
+    for suffix, sub in _walk_bins(folder):
+        path = f"{base}{BIN_SEPARATOR}{suffix}" if base and suffix else (base or suffix)
+        for clip in sub.GetClipList() or []:
+            yield path, clip
+
+
+def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> tuple[str, Clip]:
+    """One clip by exact name, searched under ``bin_path`` (the whole pool by default)."""
+    folder = find_bin(pool, bin_path)
+    matches = [
+        (path, clip)
+        for path, clip in _clips_under(pool, folder, recursive=True)
+        if str(clip.GetName() or "") == name
+    ]
+    if not matches:
+        where = f"the bin {bin_path!r}" if bin_path else "the media pool"
+        available = sorted(
+            {str(clip.GetName() or "") for _path, clip in _clips_under(pool, folder, True)}
+        )
+        raise ClipNotFoundError(name, where, available)
+    if len(matches) > 1:
+        raise AmbiguousClipError(name, [path for path, _clip in matches])
+    return matches[0]
+
+
+def properties(clip: Clip) -> dict[str, str]:
+    """Every clip property Resolve reports, enumerated — key names are never hard-coded."""
+    reported = clip.GetClipProperty()
+    if not isinstance(reported, dict):
+        return {}
+    return {str(key): "" if value is None else str(value) for key, value in reported.items()}
+
+
+def _number(reported: dict[str, str], key: str) -> int | None:
+    try:
+        return int(float(reported.get(key, "")))
+    except (TypeError, ValueError):
+        return None
+
+
+def _rate(reported: dict[str, str]) -> float | None:
+    try:
+        return float(reported.get(FPS, ""))
+    except (TypeError, ValueError):
+        return None
+
+
+def is_offline(file_path: str) -> bool:
+    """Whether the media behind a clip has moved away.
+
+    Resolve exposes no offline flag, so this is a disk check. A clip with no path at all
+    (multicam, compound) is pathless rather than offline. A sequence pattern is judged by
+    its folder, since the pattern itself is never a file on disk.
+    """
+    if not file_path:
+        return False
+    path = Path(file_path)
+    if SEQUENCE_TOKEN in path.name:
+        return not path.parent.exists()
+    return not path.exists()
+
+
+def summarise(bin_path: str, clip: Clip, known: dict[str, str] | None = None) -> dict[str, Any]:
+    """The one-line view of a clip that list and import both return."""
+    reported = known if known is not None else properties(clip)
+    file_path = reported.get(FILE_PATH, "")
+    return {
+        "name": str(clip.GetName() or ""),
+        "bin": bin_path,
+        "file_path": file_path,
+        "type": reported.get(TYPE, ""),
+        "frames": _number(reported, FRAMES),
+        "fps": _rate(reported),
+        "resolution": reported.get(RESOLUTION, ""),
+        "offline": is_offline(file_path),
+    }
+
+
+# --- import -----------------------------------------------------------------------------
+
+
+def _requests(
+    paths: list[str] | None,
+    sequences: list[dict[str, Any]] | None,
+) -> list[str | dict[str, Any]]:
+    items: list[str | dict[str, Any]] = [str(path) for path in (paths or [])]
+    for sequence in sequences or []:
+        pattern = sequence.get("path")
+        if not pattern:
+            raise InvalidRequestError(
+                cause="A sequence needs a path.",
+                fix='Each sequence is {"path": "titles/song_%04d.png", '
+                '"start_index": 1, "end_index": 96}.',
+            )
+        try:
+            start = int(sequence.get("start_index", 0))
+            end = int(sequence.get("end_index", 0))
+        except (TypeError, ValueError) as exc:
+            raise InvalidRequestError(
+                cause=f"start_index and end_index must be whole frame numbers: {exc}.",
+                fix='Example: {"path": "titles/song_%04d.png", "start_index": 1, "end_index": 96}.',
+            ) from exc
+        items.append({"FilePath": str(pattern), "StartIndex": start, "EndIndex": end})
+    if not items:
+        raise InvalidRequestError(
+            cause="Nothing to import: both paths and sequences were empty.",
+            fix="Pass paths for ordinary media, sequences for %0Nd image sequences.",
+        )
+    return items
+
+
+def _requested_path(item: str | dict[str, Any]) -> str:
+    return str(item["FilePath"]) if isinstance(item, dict) else str(item)
+
+
+def _looks_like_image(file_path: str) -> bool:
+    return Path(file_path).suffix.lower() in IMAGE_SUFFIXES
+
+
+def apply_still_workaround(clip: Clip, reported: dict[str, str]) -> bool:
+    """Write the out point once, so later ``endFrame`` values are honoured exactly.
+
+    Resolve ignores ``endFrame`` when appending a freshly imported still — every append
+    lands at the default still duration — until any out point has been written to the clip.
+    The value does not matter, only that the write happened.
+    """
+    if not _looks_like_image(reported.get(FILE_PATH, "")):
+        return False
+    end = _number(reported, END)
+    if end is None:
+        frames = _number(reported, FRAMES)
+        end = max((frames or 1) - 1, 0)
+    if not clip.SetClipProperty(OUT, str(end)):
+        log.warning("Still-duration workaround refused on %s", clip.GetName())
+        return False
+    return True
+
+
+def import_media(
+    connection: ResolveConnection,
+    paths: list[str] | None = None,
+    bin_path: str | None = None,
+    sequences: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Import media into ``bin_path``, creating the bin if needed.
+
+    Imports land in the media pool's *current* folder, so the current folder is moved for
+    the call and put back afterwards — a tool must not leave the GUI somewhere else.
+    """
+    pool = media_pool(connection)
+    items = _requests(paths, sequences)
+    target, _created = ensure_bin(pool, bin_path)
+    target_path = path_of(pool, target)
+
+    previous = pool.GetCurrentFolder()
+    pool.SetCurrentFolder(target)
+    try:
+        imported = list(pool.ImportMedia(items) or [])
+    finally:
+        if previous is not None:
+            pool.SetCurrentFolder(previous)
+
+    summaries: list[dict[str, Any]] = []
+    landed: set[str] = set()
+    for clip in imported:
+        reported = properties(clip)
+        landed.add(reported.get(FILE_PATH, ""))
+        landed.add(str(clip.GetName() or ""))
+        summary = summarise(target_path, clip, reported)
+        summary["still_duration_workaround"] = apply_still_workaround(clip, reported)
+        summaries.append(summary)
+
+    refused = [
+        _requested_path(item)
+        for item in items
+        if _requested_path(item) not in landed and Path(_requested_path(item)).name not in landed
+    ]
+    if not summaries:
+        raise ImportFailedError(
+            cause=f"Resolve imported none of the {len(items)} path(s) requested.",
+            detail={"not_imported": refused},
+        )
+    log.info("Imported %d clip(s) into %r", len(summaries), target_path or "the root")
+    return {"bin": target_path, "imported": summaries, "not_imported": refused}
+
+
+# --- list -------------------------------------------------------------------------------
+
+
+def list_media(
+    connection: ResolveConnection,
+    bin_path: str | None = None,
+    name_contains: str | None = None,
+    offline_only: bool = False,
+    recursive: bool = True,
+    limit: int = DEFAULT_LIST_LIMIT,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Summarise the clips in a bin. Past ``limit`` the full listing spills to disk."""
+    pool = media_pool(connection)
+    folder = find_bin(pool, bin_path)
+    needle = (name_contains or "").lower()
+
+    clips: list[dict[str, Any]] = []
+    for path, clip in _clips_under(pool, folder, recursive):
+        summary = summarise(path, clip)
+        if needle and needle not in summary["name"].lower():
+            continue
+        if offline_only and not summary["offline"]:
+            continue
+        clips.append(summary)
+
+    cap = max(int(limit), 0)
+    truncated = len(clips) > cap
+    result: dict[str, Any] = {
+        "bin": path_of(pool, folder),
+        "count": len(clips),
+        "clips": clips[:cap] if truncated else clips,
+        "truncated": truncated,
+        "spilled_to": None,
+    }
+    if truncated:
+        result["spilled_to"] = _spill(result["bin"], clips, config or get_config())
+    return result
+
+
+def _spill(bin_path: str, clips: list[dict[str, Any]], config: Config) -> str:
+    """Write the whole listing where the agent can grep it, and return the path."""
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    slug = UNSAFE_IN_FILENAME.sub("-", bin_path).strip("-") or "media-pool"
+    target = config.listing_dir / f"{slug}-{stamp}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps({"bin": bin_path, "count": len(clips), "clips": clips}, indent=2),
+        encoding="utf-8",
+    )
+    log.info("Spilled %d clip summaries to %s", len(clips), target)
+    return str(target)
+
+
+# --- inspect ----------------------------------------------------------------------------
+
+
+def _markers(clip: Clip) -> list[dict[str, Any]]:
+    reported = clip.GetMarkers()
+    if not isinstance(reported, dict):
+        return []
+    markers = []
+    for frame, marker in reported.items():
+        detail = marker if isinstance(marker, dict) else {}
+        markers.append(
+            {
+                "frame": int(float(frame)),
+                "color": str(detail.get("color", "")),
+                "duration": detail.get("duration"),
+                "name": str(detail.get("name", "")),
+                "note": str(detail.get("note", "")),
+                "custom_data": str(detail.get("customData", "")),
+            }
+        )
+    return sorted(markers, key=lambda marker: marker["frame"])
+
+
+def _audio_mapping(clip: Clip) -> dict[str, Any] | None:
+    """``GetAudioMapping`` returns a JSON *string* — or nothing, on clips without audio."""
+    try:
+        reported = clip.GetAudioMapping()
+    except Exception:  # noqa: BLE001 - an unmapped clip is not a failed inspection
+        log.debug("Could not read the audio mapping", exc_info=True)
+        return None
+    if not reported:
+        return None
+    if isinstance(reported, dict):
+        return reported
+    try:
+        parsed = json.loads(str(reported))
+    except (TypeError, ValueError):
+        log.warning("Unparseable audio mapping: %r", reported)
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _bounds(clip: Clip, reported: dict[str, str]) -> dict[str, Any]:
+    """Media bounds half-open ``[in, out)``, plus whatever mark in/out is set.
+
+    Resolve reports ``End`` as the last frame; the cut file's convention is half-open, so
+    the out point is that frame plus one and ``duration = out - in`` everywhere.
+    """
+    fps = _rate(reported)
+    start = _number(reported, START)
+    end = _number(reported, END)
+    frames = _number(reported, FRAMES)
+    out = end + 1 if end is not None else (start + frames if start is not None and frames else None)
+    duration = out - start if out is not None and start is not None else frames
+
+    marks: dict[str, Any] = {}
+    try:
+        reported_marks = clip.GetMarkInOut()
+    except Exception:  # noqa: BLE001
+        log.debug("Could not read mark in/out", exc_info=True)
+        reported_marks = None
+    for kind, bounds in (reported_marks or {}).items():
+        if not isinstance(bounds, dict):
+            continue
+        marks[str(kind)] = {
+            "in": dual(bounds.get("in"), fps),
+            "out": dual(bounds.get("out"), fps),
+        }
+
+    return {
+        "media": {
+            "in": dual(start, fps),
+            "out": dual(out, fps),
+            "duration": dual(duration, fps),
+        },
+        "marks": marks,
+    }
+
+
+def inspect_clip(
+    connection: ResolveConnection,
+    name: str,
+    bin_path: str | None = None,
+) -> dict[str, Any]:
+    """Everything worth knowing about one clip before cutting with it."""
+    pool = media_pool(connection)
+    found_in, clip = find_clip(pool, name, bin_path)
+    reported = properties(clip)
+    metadata = clip.GetMetadata()
+    return {
+        "clip": summarise(found_in, clip, reported),
+        "properties": reported,
+        "metadata": (
+            {str(key): value for key, value in metadata.items()}
+            if isinstance(metadata, dict)
+            else {}
+        ),
+        "audio_mapping": _audio_mapping(clip),
+        "markers": _markers(clip),
+        "bounds": _bounds(clip, reported),
+    }
+
+
+# --- metadata ---------------------------------------------------------------------------
+
+
+def _set_field(clip: Clip, key: str, value: Any, reported: dict[str, str]) -> str:
+    """Write one field, choosing the route from what the clip itself reports."""
+    if key in reported:
+        if not clip.SetClipProperty(key, str(value)):
+            raise MediaOperationError(cause=f"Resolve refused to set the clip property {key!r}.")
+        return "clip_property"
+    if not clip.SetMetadata(key, str(value)):
+        raise MediaOperationError(cause=f"Resolve refused to set the metadata field {key!r}.")
+    return "metadata"
+
+
+def set_clip_metadata(
+    connection: ResolveConnection,
+    items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Apply a batch of ``{clip, fields}`` writes. One bad item never sinks the batch."""
+    pool = media_pool(connection)
+    results: list[dict[str, Any]] = []
+    for item in items or []:
+        results.append(_apply_fields(pool, item))
+    return {"results": results}
+
+
+def _apply_fields(pool: Pool, item: dict[str, Any]) -> dict[str, Any]:
+    name = str(item.get("clip") or "")
+    fields = item.get("fields")
+    if not name or not isinstance(fields, dict) or not fields:
+        return {
+            "clip": name,
+            "bin": None,
+            "ok": False,
+            "error": InvalidRequestError(
+                cause="Each item needs a clip name and a non-empty fields object.",
+                fix='Example: {"clip": "C0012.mp4", "fields": {"Description": "guitar close"}}.',
+            ).payload(),
+        }
+    try:
+        found_in, clip = find_clip(pool, name, item.get("bin"))
+    except (ClipNotFoundError, AmbiguousClipError, BinNotFoundError) as exc:
+        return {"clip": name, "bin": None, "ok": False, "error": exc.payload()}
+
+    reported = properties(clip)
+    applied: dict[str, str] = {}
+    failed: dict[str, str] = {}
+    for key, value in fields.items():
+        try:
+            applied[str(key)] = _set_field(clip, str(key), value, reported)
+        except MediaOperationError as exc:
+            failed[str(key)] = exc.cause
+    return {
+        "clip": name,
+        "bin": found_in,
+        "ok": not failed,
+        "applied": applied,
+        "failed": failed,
+    }
+
+
+# --- organize ---------------------------------------------------------------------------
+
+
+def organize_media(
+    connection: ResolveConnection,
+    operations: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Run a batch of bin operations, reporting each one separately."""
+    pool = media_pool(connection)
+    results: list[dict[str, Any]] = []
+    for operation in operations or []:
+        results.append(_run_operation(pool, operation))
+    return {"results": results}
+
+
+def _run_operation(pool: Pool, operation: dict[str, Any]) -> dict[str, Any]:
+    name = str(operation.get("op") or "")
+    try:
+        if name == "create_bin":
+            return _create_bin(pool, operation)
+        if name == "move_clips":
+            return _move_clips(pool, operation)
+        raise InvalidRequestError(
+            cause=f"Unknown media pool operation {name!r}.",
+            fix='Operations are {"op": "create_bin", "bin": "Concert/Angles"} and '
+            '{"op": "move_clips", "clips": ["C0012.mp4"], "to_bin": "Concert/Angles"}.',
+        )
+    except (
+        AmbiguousClipError,
+        BinNotFoundError,
+        ClipNotFoundError,
+        InvalidRequestError,
+        MediaOperationError,
+    ) as exc:
+        return {"op": name, "ok": False, "error": exc.payload()}
+
+
+def _create_bin(pool: Pool, operation: dict[str, Any]) -> dict[str, Any]:
+    path = operation.get("bin")
+    if not path:
+        raise InvalidRequestError(
+            cause="create_bin needs a bin path.",
+            fix='Example: {"op": "create_bin", "bin": "Concert/Angles"}.',
+        )
+    folder, created = ensure_bin(pool, str(path))
+    return {"op": "create_bin", "ok": True, "bin": path_of(pool, folder), "created": created}
+
+
+def _move_clips(pool: Pool, operation: dict[str, Any]) -> dict[str, Any]:
+    names = operation.get("clips")
+    target_path = operation.get("to_bin")
+    if not isinstance(names, list) or not names or target_path is None:
+        raise InvalidRequestError(
+            cause="move_clips needs a clips list and a to_bin.",
+            fix='Example: {"op": "move_clips", "clips": ["C0012.mp4"], "to_bin": "Angles"}.',
+        )
+    source = operation.get("from_bin")
+    found = [find_clip(pool, str(name), source) for name in names]
+    target, _created = ensure_bin(pool, str(target_path))
+    if not pool.MoveClips([clip for _path, clip in found], target):
+        raise MediaOperationError(
+            cause=f"Resolve refused to move {len(found)} clip(s) into {target_path!r}.",
+        )
+    moved = [str(clip.GetName() or "") for _path, clip in found]
+    log.info("Moved %d clip(s) into %r", len(moved), target_path)
+    return {"op": "move_clips", "ok": True, "moved": moved, "to_bin": path_of(pool, target)}
+
+
+# --- relink -----------------------------------------------------------------------------
+
+
+def relink_media(
+    connection: ResolveConnection,
+    clips: list[str],
+    path: str,
+    bin_path: str | None = None,
+) -> dict[str, Any]:
+    """Point clips at media that has moved.
+
+    A folder relinks every named clip through ``RelinkClips`` — Resolve matches by file
+    name inside it. A file replaces one clip's media outright, which is the route for media
+    that moved *and* was renamed.
+    """
+    pool = media_pool(connection)
+    if not clips:
+        raise InvalidRequestError(
+            cause="No clips were named to relink.",
+            fix="Pass the clip names shown by list_media(offline_only=True).",
+        )
+    target = Path(path)
+    if not target.exists():
+        raise RelinkFailedError(cause=f"Nothing exists at {path!r} on this machine.")
+
+    found = [find_clip(pool, str(name), bin_path) for name in clips]
+    if target.is_dir():
+        relinked = bool(pool.RelinkClips([clip for _path, clip in found], str(target)))
+        log.info("Relinked %d clip(s) against %s (Resolve said %s)", len(found), target, relinked)
+    else:
+        if len(found) != 1:
+            raise InvalidRequestError(
+                cause=f"{len(found)} clips were named but {path!r} is a single file.",
+                fix="Relink one clip per file, or pass the folder the media moved to.",
+            )
+        if not found[0][1].ReplaceClip(str(target)):
+            raise RelinkFailedError(
+                cause=f"Resolve refused to replace the clip media with {path!r}.",
+            )
+        log.info("Replaced the media of %s with %s", found[0][1].GetName(), target)
+
+    results = []
+    for found_in, clip in found:
+        file_path = properties(clip).get(FILE_PATH, "")
+        offline = is_offline(file_path)
+        results.append(
+            {
+                "clip": str(clip.GetName() or ""),
+                "bin": found_in,
+                "ok": not offline,
+                "file_path": file_path,
+                "offline": offline,
+            }
+        )
+    return {"results": results}

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -22,9 +22,8 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
-from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from ..config import Config, get_config
 from ..errors import (
@@ -39,9 +38,9 @@ from ..errors import (
     RelinkFailedError,
 )
 from ..logging_config import get_logger
-from ..timing import dual
+from ..naming import timestamped_name
+from ..timing import dual_time
 from .connection import ResolveConnection
-from .session import UNSAFE_IN_FILENAME
 
 log = get_logger("media")
 
@@ -62,6 +61,26 @@ RESOLUTION = "Resolution"
 Clip = Any
 Folder = Any
 Pool = Any
+
+
+class LocatedClip(NamedTuple):
+    """A clip and the bin it was found in — the pair every lookup hands back."""
+
+    bin_path: str
+    clip: Clip
+
+
+class LocatedBin(NamedTuple):
+    """A bin, the path walked to reach it, and whether that walk had to create it.
+
+    The path travels with the folder because it cannot be recovered from one: Resolve
+    hands out a fresh proxy object per call, so a folder cannot be recognised by identity
+    on a later walk, and the API has no path getter.
+    """
+
+    path: str
+    folder: Folder
+    created: bool
 
 
 # --- reaching the pool ------------------------------------------------------------------
@@ -85,11 +104,19 @@ def media_pool(connection: ResolveConnection) -> Pool:
 
 
 def _segments(path: str | None, root: Folder) -> list[str]:
+    """Split a bin path into folder names, dropping a leading root name if it is one.
+
+    Resolve calls the root "Master" and the agent may write it or not. A real bin called
+    Master would otherwise become unaddressable, so the leading name is only treated as the
+    root when the root has no child by that name.
+    """
     parts = [part.strip() for part in (path or "").split(BIN_SEPARATOR)]
     parts = [part for part in parts if part]
     root_name = str(root.GetName() or "")
     if parts and root_name and parts[0] == root_name:
-        parts = parts[1:]
+        children = {str(sub.GetName() or "") for sub in _subfolders(root)}
+        if root_name not in children:
+            parts = parts[1:]
     return parts
 
 
@@ -120,84 +147,86 @@ def _walk_bins(folder: Folder, prefix: str = "") -> Iterator[tuple[str, Folder]]
         yield from _walk_bins(sub, f"{prefix}{BIN_SEPARATOR}{name}" if prefix else name)
 
 
-def find_bin(pool: Pool, path: str | None) -> Folder:
+def find_bin(pool: Pool, path: str | None) -> LocatedBin:
     """The bin at ``path``. ``None`` or ``""`` is the root."""
     root = _root(pool)
     folder = root
+    walked: list[str] = []
     for segment in _segments(path, root):
         matches = [sub for sub in _subfolders(folder) if str(sub.GetName() or "") == segment]
         if not matches:
             raise BinNotFoundError(str(path), bin_paths(pool))
         folder = matches[0]
-    return folder
+        walked.append(segment)
+    return LocatedBin(BIN_SEPARATOR.join(walked), folder, created=False)
 
 
-def ensure_bin(pool: Pool, path: str | None) -> tuple[Folder, bool]:
-    """The bin at ``path``, creating it and any missing parents. Returns (bin, created)."""
+def ensure_bin(pool: Pool, path: str | None) -> LocatedBin:
+    """The bin at ``path``, creating it and any missing parents."""
     root = _root(pool)
     folder = root
+    walked: list[str] = []
     created = False
     for segment in _segments(path, root):
         matches = [sub for sub in _subfolders(folder) if str(sub.GetName() or "") == segment]
         if matches:
             folder = matches[0]
-            continue
-        made = pool.AddSubFolder(folder, segment)
-        if made is None:
-            raise MediaOperationError(cause=f"Resolve refused to create the bin {segment!r}.")
-        log.info("Created bin %s", segment)
-        folder = made
-        created = True
-    return folder, created
-
-
-def path_of(pool: Pool, folder: Folder) -> str:
-    """The slash path of a folder, from the root. The root itself is ``""``."""
-    for path, candidate in _walk_bins(_root(pool)):
-        if candidate is folder:
-            return path
-    return ""
+        else:
+            made = pool.AddSubFolder(folder, segment)
+            if made is None:
+                raise MediaOperationError(cause=f"Resolve refused to create the bin {segment!r}.")
+            log.info("Created bin %s", segment)
+            folder = made
+            created = True
+        walked.append(segment)
+    return LocatedBin(BIN_SEPARATOR.join(walked), folder, created)
 
 
 # --- clips ------------------------------------------------------------------------------
 
 
-def _clips_under(pool: Pool, folder: Folder, recursive: bool) -> Iterator[tuple[str, Clip]]:
-    base = path_of(pool, folder)
+def _clips_under(where: LocatedBin, recursive: bool) -> Iterator[LocatedClip]:
+    base = where.path
     if not recursive:
-        for clip in folder.GetClipList() or []:
-            yield base, clip
+        for clip in where.folder.GetClipList() or []:
+            yield LocatedClip(base, clip)
         return
-    for suffix, sub in _walk_bins(folder):
+    for suffix, sub in _walk_bins(where.folder):
         path = f"{base}{BIN_SEPARATOR}{suffix}" if base and suffix else (base or suffix)
         for clip in sub.GetClipList() or []:
-            yield path, clip
+            yield LocatedClip(path, clip)
 
 
-def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> tuple[str, Clip]:
+def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> LocatedClip:
     """One clip by exact name, searched under ``bin_path`` (the whole pool by default)."""
-    folder = find_bin(pool, bin_path)
-    matches = [
-        (path, clip)
-        for path, clip in _clips_under(pool, folder, recursive=True)
-        if str(clip.GetName() or "") == name
-    ]
+    searched = list(_clips_under(find_bin(pool, bin_path), recursive=True))
+    matches = [found for found in searched if str(found.clip.GetName() or "") == name]
     if not matches:
         where = f"the bin {bin_path!r}" if bin_path else "the media pool"
-        available = sorted(
-            {str(clip.GetName() or "") for _path, clip in _clips_under(pool, folder, True)}
-        )
+        available = sorted({str(found.clip.GetName() or "") for found in searched})
         raise ClipNotFoundError(name, where, available)
     if len(matches) > 1:
-        raise AmbiguousClipError(name, [path for path, _clip in matches])
+        raise AmbiguousClipError(name, [found.bin_path for found in matches])
     return matches[0]
 
 
+_logged_property_keys = False
+
+
 def properties(clip: Clip) -> dict[str, str]:
-    """Every clip property Resolve reports, enumerated — key names are never hard-coded."""
+    """Every clip property Resolve reports, enumerated — key names are never hard-coded.
+
+    The key names are undocumented, so the first enumeration of a session is logged: when a
+    reading comes back empty on a live machine, that line is what says whether the key was
+    renamed or the value really was blank.
+    """
     reported = clip.GetClipProperty()
     if not isinstance(reported, dict):
         return {}
+    global _logged_property_keys
+    if not _logged_property_keys:
+        log.info("Clip properties Resolve reports: %s", sorted(str(key) for key in reported))
+        _logged_property_keys = True
     return {str(key): "" if value is None else str(value) for key, value in reported.items()}
 
 
@@ -230,9 +259,9 @@ def is_offline(file_path: str) -> bool:
     return not path.exists()
 
 
-def summarise(bin_path: str, clip: Clip, known: dict[str, str] | None = None) -> dict[str, Any]:
+def summarise(bin_path: str, clip: Clip, reported: dict[str, str] | None = None) -> dict[str, Any]:
     """The one-line view of a clip that list and import both return."""
-    reported = known if known is not None else properties(clip)
+    reported = reported if reported is not None else properties(clip)
     file_path = reported.get(FILE_PATH, "")
     return {
         "name": str(clip.GetName() or ""),
@@ -319,11 +348,10 @@ def import_media(
     """
     pool = media_pool(connection)
     items = _requests(paths, sequences)
-    target, _created = ensure_bin(pool, bin_path)
-    target_path = path_of(pool, target)
+    target = ensure_bin(pool, bin_path)
 
     previous = pool.GetCurrentFolder()
-    pool.SetCurrentFolder(target)
+    pool.SetCurrentFolder(target.folder)
     try:
         imported = list(pool.ImportMedia(items) or [])
     finally:
@@ -336,22 +364,45 @@ def import_media(
         reported = properties(clip)
         landed.add(reported.get(FILE_PATH, ""))
         landed.add(str(clip.GetName() or ""))
-        summary = summarise(target_path, clip, reported)
+        summary = summarise(target.path, clip, reported)
         summary["still_duration_workaround"] = apply_still_workaround(clip, reported)
         summaries.append(summary)
 
-    refused = [
-        _requested_path(item)
-        for item in items
-        if _requested_path(item) not in landed and Path(_requested_path(item)).name not in landed
-    ]
+    refused = _not_imported(items, imported, landed)
     if not summaries:
         raise ImportFailedError(
             cause=f"Resolve imported none of the {len(items)} path(s) requested.",
             detail={"not_imported": refused},
         )
-    log.info("Imported %d clip(s) into %r", len(summaries), target_path or "the root")
-    return {"bin": target_path, "imported": summaries, "not_imported": refused}
+    log.info("Imported %d clip(s) into %r", len(summaries), target.path or "the root")
+    return {"bin": target.path, "imported": summaries, "not_imported": refused}
+
+
+def _not_imported(
+    items: list[str | dict[str, Any]],
+    imported: list[Clip],
+    landed: set[str],
+) -> list[str]:
+    """Which requested paths produced no clip.
+
+    A sequence is matched by the folder it came from, never by name: Resolve names the
+    imported clip itself and nothing on record says what it calls it, so matching the
+    ``%0Nd`` pattern against the result would be a guess. When everything asked for landed,
+    no matching is needed at all.
+    """
+    if len(imported) == len(items):
+        return []
+    folders = {str(Path(path).parent) for path in landed if path}
+    refused = []
+    for item in items:
+        requested = _requested_path(item)
+        if isinstance(item, dict):
+            if str(Path(requested).parent) in folders:
+                continue
+        elif requested in landed or Path(requested).name in landed:
+            continue
+        refused.append(requested)
+    return refused
 
 
 # --- list -------------------------------------------------------------------------------
@@ -368,12 +419,12 @@ def list_media(
 ) -> dict[str, Any]:
     """Summarise the clips in a bin. Past ``limit`` the full listing spills to disk."""
     pool = media_pool(connection)
-    folder = find_bin(pool, bin_path)
+    where = find_bin(pool, bin_path)
     needle = (name_contains or "").lower()
 
     clips: list[dict[str, Any]] = []
-    for path, clip in _clips_under(pool, folder, recursive):
-        summary = summarise(path, clip)
+    for found in _clips_under(where, recursive):
+        summary = summarise(found.bin_path, found.clip)
         if needle and needle not in summary["name"].lower():
             continue
         if offline_only and not summary["offline"]:
@@ -383,7 +434,7 @@ def list_media(
     cap = max(int(limit), 0)
     truncated = len(clips) > cap
     result: dict[str, Any] = {
-        "bin": path_of(pool, folder),
+        "bin": where.path,
         "count": len(clips),
         "clips": clips[:cap] if truncated else clips,
         "truncated": truncated,
@@ -396,9 +447,7 @@ def list_media(
 
 def _spill(bin_path: str, clips: list[dict[str, Any]], config: Config) -> str:
     """Write the whole listing where the agent can grep it, and return the path."""
-    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    slug = UNSAFE_IN_FILENAME.sub("-", bin_path).strip("-") or "media-pool"
-    target = config.listing_dir / f"{slug}-{stamp}.json"
+    target = config.listing_dir / timestamped_name(bin_path, ".json", "media-pool")
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(
         json.dumps({"bin": bin_path, "count": len(clips), "clips": clips}, indent=2),
@@ -473,15 +522,15 @@ def _bounds(clip: Clip, reported: dict[str, str]) -> dict[str, Any]:
         if not isinstance(bounds, dict):
             continue
         marks[str(kind)] = {
-            "in": dual(bounds.get("in"), fps),
-            "out": dual(bounds.get("out"), fps),
+            "in": dual_time(bounds.get("in"), fps),
+            "out": dual_time(bounds.get("out"), fps),
         }
 
     return {
         "media": {
-            "in": dual(start, fps),
-            "out": dual(out, fps),
-            "duration": dual(duration, fps),
+            "in": dual_time(start, fps),
+            "out": dual_time(out, fps),
+            "duration": dual_time(duration, fps),
         },
         "marks": marks,
     }
@@ -551,21 +600,21 @@ def _apply_fields(pool: Pool, item: dict[str, Any]) -> dict[str, Any]:
             ).payload(),
         }
     try:
-        found_in, clip = find_clip(pool, name, item.get("bin"))
+        located = find_clip(pool, name, item.get("bin"))
     except (ClipNotFoundError, AmbiguousClipError, BinNotFoundError) as exc:
         return {"clip": name, "bin": None, "ok": False, "error": exc.payload()}
 
-    reported = properties(clip)
+    reported = properties(located.clip)
     applied: dict[str, str] = {}
     failed: dict[str, str] = {}
     for key, value in fields.items():
         try:
-            applied[str(key)] = _set_field(clip, str(key), value, reported)
+            applied[str(key)] = _set_field(located.clip, str(key), value, reported)
         except MediaOperationError as exc:
             failed[str(key)] = exc.cause
     return {
         "clip": name,
-        "bin": found_in,
+        "bin": located.bin_path,
         "ok": not failed,
         "applied": applied,
         "failed": failed,
@@ -616,8 +665,8 @@ def _create_bin(pool: Pool, operation: dict[str, Any]) -> dict[str, Any]:
             cause="create_bin needs a bin path.",
             fix='Example: {"op": "create_bin", "bin": "Concert/Angles"}.',
         )
-    folder, created = ensure_bin(pool, str(path))
-    return {"op": "create_bin", "ok": True, "bin": path_of(pool, folder), "created": created}
+    made = ensure_bin(pool, str(path))
+    return {"op": "create_bin", "ok": True, "bin": made.path, "created": made.created}
 
 
 def _move_clips(pool: Pool, operation: dict[str, Any]) -> dict[str, Any]:
@@ -630,14 +679,14 @@ def _move_clips(pool: Pool, operation: dict[str, Any]) -> dict[str, Any]:
         )
     source = operation.get("from_bin")
     found = [find_clip(pool, str(name), source) for name in names]
-    target, _created = ensure_bin(pool, str(target_path))
-    if not pool.MoveClips([clip for _path, clip in found], target):
+    target = ensure_bin(pool, str(target_path))
+    if not pool.MoveClips([located.clip for located in found], target.folder):
         raise MediaOperationError(
             cause=f"Resolve refused to move {len(found)} clip(s) into {target_path!r}.",
         )
-    moved = [str(clip.GetName() or "") for _path, clip in found]
+    moved = [str(located.clip.GetName() or "") for located in found]
     log.info("Moved %d clip(s) into %r", len(moved), target_path)
-    return {"op": "move_clips", "ok": True, "moved": moved, "to_bin": path_of(pool, target)}
+    return {"op": "move_clips", "ok": True, "moved": moved, "to_bin": target.path}
 
 
 # --- relink -----------------------------------------------------------------------------
@@ -666,8 +715,12 @@ def relink_media(
         raise RelinkFailedError(cause=f"Nothing exists at {path!r} on this machine.")
 
     found = [find_clip(pool, str(name), bin_path) for name in clips]
+    was_offline = {
+        str(located.clip.GetName() or ""): is_offline(properties(located.clip).get(FILE_PATH, ""))
+        for located in found
+    }
     if target.is_dir():
-        relinked = bool(pool.RelinkClips([clip for _path, clip in found], str(target)))
+        relinked = bool(pool.RelinkClips([located.clip for located in found], str(target)))
         log.info("Relinked %d clip(s) against %s (Resolve said %s)", len(found), target, relinked)
     else:
         if len(found) != 1:
@@ -675,23 +728,30 @@ def relink_media(
                 cause=f"{len(found)} clips were named but {path!r} is a single file.",
                 fix="Relink one clip per file, or pass the folder the media moved to.",
             )
-        if not found[0][1].ReplaceClip(str(target)):
+        name = str(found[0].clip.GetName() or "")
+        if not was_offline.get(name):
+            # Not an error — repointing a healthy clip is a legitimate thing to ask for —
+            # but it replaces media that was working, so it says so rather than going quiet.
+            log.warning("Replacing the media of %s, which was not offline", name)
+        if not found[0].clip.ReplaceClip(str(target)):
             raise RelinkFailedError(
                 cause=f"Resolve refused to replace the clip media with {path!r}.",
             )
-        log.info("Replaced the media of %s with %s", found[0][1].GetName(), target)
+        log.info("Replaced the media of %s with %s", name, target)
 
     results = []
-    for found_in, clip in found:
-        file_path = properties(clip).get(FILE_PATH, "")
+    for located in found:
+        clip_name = str(located.clip.GetName() or "")
+        file_path = properties(located.clip).get(FILE_PATH, "")
         offline = is_offline(file_path)
         results.append(
             {
-                "clip": str(clip.GetName() or ""),
-                "bin": found_in,
+                "clip": clip_name,
+                "bin": located.bin_path,
                 "ok": not offline,
                 "file_path": file_path,
                 "offline": offline,
+                "was_offline": was_offline.get(clip_name, False),
             }
         )
     return {"results": results}

--- a/src/resolve_mcp/resolve/session.py
+++ b/src/resolve_mcp/resolve/session.py
@@ -6,20 +6,18 @@ above adds the envelope; nothing here knows about FastMCP.
 
 from __future__ import annotations
 
-import re
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from ..config import Config, get_config
 from ..errors import NoProjectOpenError, ProjectNotFoundError, SnapshotFailedError
 from ..logging_config import get_logger
+from ..naming import timestamped_name
 from .connection import ResolveConnection
 
 log = get_logger("session")
 
 FPS_SETTING = "timelineFrameRate"
-UNSAFE_IN_FILENAME = re.compile(r"[^A-Za-z0-9._-]+")
 
 Context = dict[str, Any]
 
@@ -118,7 +116,11 @@ def snapshot_project(
     name = str(project.GetName())
     if not manager.SaveProject():
         log.warning("SaveProject() returned false before snapshotting %s", name)
-    target = Path(path) if path is not None else config.snapshot_dir / _snapshot_filename(name)
+    target = (
+        Path(path)
+        if path is not None
+        else config.snapshot_dir / timestamped_name(name, ".drp", "project")
+    )
     if target.suffix.lower() != ".drp":
         target = target.with_suffix(".drp")
     try:
@@ -132,12 +134,6 @@ def snapshot_project(
         )
     log.info("Snapshotted %s to %s", name, target)
     return target, name
-
-
-def _snapshot_filename(project: str, now: datetime | None = None) -> str:
-    stamp = (now or datetime.now()).strftime("%Y%m%d-%H%M%S")
-    slug = UNSAFE_IN_FILENAME.sub("-", project).strip("-") or "project"
-    return f"{slug}-{stamp}.drp"
 
 
 def _current_project(resolve: Any) -> Any | None:

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from . import __version__
 from .config import get_config
 from .logging_config import configure_logging, get_logger
-from .tools import escape_hatch, project
+from .tools import escape_hatch, media, project
 
 log = get_logger("server")
 
@@ -33,7 +33,7 @@ def build_server() -> FastMCP:
         instructions=INSTRUCTIONS,
         version=__version__,
     )
-    for fn in (*project.TOOLS, *escape_hatch.TOOLS):
+    for fn in (*project.TOOLS, *media.TOOLS, *escape_hatch.TOOLS):
         mcp.tool(fn)
     return mcp
 

--- a/src/resolve_mcp/timing.py
+++ b/src/resolve_mcp/timing.py
@@ -24,7 +24,7 @@ def timecode(frames: int, fps: float) -> str:
     return f"{hours:02d}:{minutes:02d}:{seconds:02d}:{frame:02d}"
 
 
-def dual(frames: int | None, fps: float | None) -> dict[str, Any] | None:
+def dual_time(frames: int | None, fps: float | None) -> dict[str, Any] | None:
     """A position in all four representations, or ``None`` if there is no position.
 
     An unknown fps still yields frames — the authoritative number — rather than nothing.

--- a/src/resolve_mcp/timing.py
+++ b/src/resolve_mcp/timing.py
@@ -1,0 +1,41 @@
+"""Dual time: frames are authoritative, seconds and timecode are derived.
+
+Every result that names a position carries all four — frames, seconds, timecode, fps — so
+neither the director nor the agent ever does conversion math by hand. The conversion lives
+here, once, tested; nothing else in the server is allowed to reimplement it.
+
+Timecode is non-drop-frame: frames are counted at the nearest whole rate (59.94 counts at
+60), which is what Resolve's own frame numbering does. Drop-frame notation is not v1.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SECONDS_PRECISION = 3
+
+
+def timecode(frames: int, fps: float) -> str:
+    """``HH:MM:SS:FF`` at the nearest whole frame rate, non-drop."""
+    rate = max(round(fps), 1)
+    whole_seconds, frame = divmod(int(frames), rate)
+    minutes, seconds = divmod(whole_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}:{frame:02d}"
+
+
+def dual(frames: int | None, fps: float | None) -> dict[str, Any] | None:
+    """A position in all four representations, or ``None`` if there is no position.
+
+    An unknown fps still yields frames — the authoritative number — rather than nothing.
+    """
+    if frames is None:
+        return None
+    if fps is None or fps <= 0:
+        return {"frames": int(frames), "seconds": None, "timecode": None, "fps": None}
+    return {
+        "frames": int(frames),
+        "seconds": round(int(frames) / fps, SECONDS_PRECISION),
+        "timecode": timecode(frames, fps),
+        "fps": fps,
+    }

--- a/src/resolve_mcp/tools/media.py
+++ b/src/resolve_mcp/tools/media.py
@@ -1,0 +1,139 @@
+"""Media pool tools — how media enters the project and how the agent reads it.
+
+Bin paths are slash-separated from the media pool root ("Concert/Angles") and
+case-sensitive. Clips are named exactly as the media pool shows them; when a name appears
+in more than one bin, pass bin= to say which.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..resolve import media
+from ..resolve.connection import get_connection
+from .envelope import tool
+
+
+@tool
+def import_media(
+    paths: list[str] | None = None,
+    bin: str | None = None,  # noqa: A002 - the agent-facing word for a media pool folder
+    sequences: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Import media into a bin, creating the bin (and any missing parents) if needed.
+
+    Use paths for ordinary files. Use sequences for PNG and other image sequences, one
+    entry per sequence: {"path": "D:/titles/song_%04d.png", "start_index": 1,
+    "end_index": 96}. Image media gets the still-duration workaround applied at import, so
+    later timeline appends honour the exact durations you ask for.
+
+    Returns a summary per imported clip, plus not_imported for anything Resolve refused —
+    usually a path that is not readable from the machine Resolve runs on.
+    """
+    connection = get_connection()
+    return media.import_media(connection, paths=paths, bin_path=bin, sequences=sequences)
+
+
+@tool
+def list_media(
+    bin: str | None = None,  # noqa: A002
+    name_contains: str | None = None,
+    offline_only: bool = False,
+    recursive: bool = True,
+    limit: int = media.DEFAULT_LIST_LIMIT,
+) -> dict[str, Any]:
+    """Summarise media pool clips: name, bin, path, type, frames, fps, resolution, offline.
+
+    Without a bin this walks the whole pool. offline_only shows the clips whose media has
+    moved away — the ones relink_media exists for. Past limit clips the full listing is
+    written to disk and spilled_to holds the path, so a large pool never blows the token
+    budget: read or grep that file for the rest.
+    """
+    connection = get_connection()
+    return media.list_media(
+        connection,
+        bin_path=bin,
+        name_contains=name_contains,
+        offline_only=offline_only,
+        recursive=recursive,
+        limit=limit,
+    )
+
+
+@tool
+def inspect_clip(
+    clip: str,
+    bin: str | None = None,  # noqa: A002
+) -> dict[str, Any]:
+    """Read one clip in full: properties, metadata, audio mapping, markers, in/out bounds.
+
+    Bounds are dual time — frames, seconds, timecode and fps — with media bounds half-open
+    [in, out), the same convention the cut file uses. audio_mapping carries the linked-audio
+    paths and sample offsets for externally synced audio; markers are the clip's own,
+    numbered relative to the clip.
+    """
+    connection = get_connection()
+    return media.inspect_clip(connection, clip, bin_path=bin)
+
+
+@tool
+def set_clip_metadata(items: list[dict[str, Any]]) -> dict[str, Any]:
+    """Apply a batch of metadata writes: [{"clip": name, "bin": optional, "fields": {...}}].
+
+    Each field is routed by what the clip itself reports: a key Resolve lists as a clip
+    property (FPS, Super Scale, Out …) is written as one, everything else becomes clip
+    metadata. The route taken comes back per field in applied. One item failing never sinks
+    the batch — every item gets its own result.
+    """
+    connection = get_connection()
+    return media.set_clip_metadata(connection, items)
+
+
+@tool
+def organize_media(operations: list[dict[str, Any]]) -> dict[str, Any]:
+    """Run a batch of bin operations, each reported separately.
+
+    Two operations:
+      {"op": "create_bin", "bin": "Concert/Angles"} — creates missing parents, and is
+        happy if the bin already exists (created says which happened);
+      {"op": "move_clips", "clips": ["C0012.mp4"], "to_bin": "Concert/Angles",
+        "from_bin": optional} — moves clips, creating the target bin if needed.
+    """
+    connection = get_connection()
+    return media.organize_media(connection, operations)
+
+
+@tool
+def relink_media(
+    clips: list[str],
+    path: str,
+    bin: str | None = None,  # noqa: A002
+) -> dict[str, Any]:
+    """Point offline clips at media that has moved, and report what came back online.
+
+    Give a folder to relink several clips at once — Resolve matches them by file name
+    inside it. Give a file to replace one clip's media outright, which is the route for
+    media that moved and was renamed. Each result says whether that clip is still offline.
+    """
+    connection = get_connection()
+    return media.relink_media(connection, clips, path, bin_path=bin)
+
+
+TOOLS: tuple[Any, ...] = (
+    import_media,
+    list_media,
+    inspect_clip,
+    set_clip_metadata,
+    organize_media,
+    relink_media,
+)
+
+__all__ = [
+    "TOOLS",
+    "import_media",
+    "inspect_clip",
+    "list_media",
+    "organize_media",
+    "relink_media",
+    "set_clip_metadata",
+]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -31,16 +31,257 @@ class FakeTimeline:
         return self._fps if key == "timelineFrameRate" else None
 
 
+IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"}
+
+DEFAULT_PROPERTIES: dict[str, str] = {
+    "Type": "Video",
+    "FPS": "59.94",
+    "Resolution": "1920x1080",
+    "Frames": "100",
+    "Start": "0",
+    "End": "99",
+    "Duration": "00:00:01:16",
+    "Audio Ch": "2",
+    "Format": "MP4",
+    "Video Codec": "H.264",
+    "Start TC": "01:00:00:00",
+}
+
+
+class FakeMediaPoolItem:
+    """A media pool clip. Properties and metadata are strings, as in the real API."""
+
+    def __init__(
+        self,
+        name: str,
+        file_path: str = "",
+        properties: dict[str, str] | None = None,
+        metadata: dict[str, str] | None = None,
+        markers: dict[float, dict[str, Any]] | None = None,
+        audio_mapping: str | None = None,
+        mark_in_out: dict[str, dict[str, int]] | None = None,
+    ) -> None:
+        self._name = name
+        self._properties = {**DEFAULT_PROPERTIES, "Clip Name": name, "File Path": file_path}
+        self._properties.update(properties or {})
+        self._metadata = dict(metadata or {})
+        self._markers = dict(markers or {})
+        self._audio_mapping = audio_mapping
+        self._mark_in_out = dict(mark_in_out or {})
+        self.property_writes: list[tuple[str, str]] = []
+        self.metadata_writes: list[tuple[str, str]] = []
+        self.refuse_properties: set[str] = set()
+        self.refuse_metadata: set[str] = set()
+
+    def GetName(self) -> str:  # noqa: N802
+        return self._name
+
+    def GetClipProperty(self, name: str | None = None) -> str | dict[str, str] | None:  # noqa: N802
+        if name is None:
+            return dict(self._properties)
+        return self._properties.get(name)
+
+    def SetClipProperty(self, name: str, value: str) -> bool:  # noqa: N802
+        if name in self.refuse_properties:
+            return False
+        self.property_writes.append((name, value))
+        self._properties[name] = value
+        return True
+
+    def GetMetadata(self, key: str | None = None) -> str | dict[str, str] | None:  # noqa: N802
+        if key is None:
+            return dict(self._metadata)
+        return self._metadata.get(key)
+
+    def SetMetadata(self, key: str, value: str) -> bool:  # noqa: N802
+        if key in self.refuse_metadata:
+            return False
+        self.metadata_writes.append((key, value))
+        self._metadata[key] = value
+        return True
+
+    def GetMarkers(self) -> dict[float, dict[str, Any]]:  # noqa: N802
+        return {frame: dict(marker) for frame, marker in self._markers.items()}
+
+    def GetMarkInOut(self) -> dict[str, dict[str, int]]:  # noqa: N802
+        return {kind: dict(bounds) for kind, bounds in self._mark_in_out.items()}
+
+    def GetAudioMapping(self) -> str | None:  # noqa: N802 - a JSON *string* in the real API
+        return self._audio_mapping
+
+    def ReplaceClip(self, file_path: str) -> bool:  # noqa: N802
+        if not Path(file_path).exists():
+            return False
+        self._properties["File Path"] = file_path
+        return True
+
+
+class FakeFolder:
+    def __init__(self, name: str, owner: FakeResolve | None = None) -> None:
+        self._name = name
+        self._owner = owner
+        self.clips: list[FakeMediaPoolItem] = []
+        self.subfolders: list[FakeFolder] = []
+
+    def GetName(self) -> str:  # noqa: N802
+        return self._name
+
+    def GetClipList(self) -> list[FakeMediaPoolItem]:  # noqa: N802
+        self._check()
+        return list(self.clips)
+
+    def GetSubFolderList(self) -> list[FakeFolder]:  # noqa: N802
+        self._check()
+        return list(self.subfolders)
+
+    def _check(self) -> None:
+        if self._owner is not None:
+            self._owner._check()
+
+
+class FakeMediaPool:
+    """The media pool: bins, imports, moves and relinks.
+
+    Import and relink consult the real filesystem, because that is what the wrappers do
+    to decide whether a clip is offline — the fake would be lying if it did not.
+    """
+
+    def __init__(self, owner: FakeResolve | None = None, root: FakeFolder | None = None) -> None:
+        self._owner = owner
+        self._root = root or FakeFolder("Master", owner)
+        self._current = self._root
+        self.import_result: list[FakeMediaPoolItem] | None = None
+        self.relink_result: bool | None = None
+        self.move_result = True
+        self.calls: list[str] = []
+
+    def _check(self, method: str) -> None:
+        self.calls.append(method)
+        if self._owner is not None:
+            self._owner._check()
+
+    def GetRootFolder(self) -> FakeFolder:  # noqa: N802
+        self._check("GetRootFolder")
+        return self._root
+
+    def GetCurrentFolder(self) -> FakeFolder:  # noqa: N802
+        self._check("GetCurrentFolder")
+        return self._current
+
+    def SetCurrentFolder(self, folder: FakeFolder) -> bool:  # noqa: N802
+        self._check("SetCurrentFolder")
+        self._current = folder
+        return True
+
+    def AddSubFolder(self, folder: FakeFolder, name: str) -> FakeFolder | None:  # noqa: N802
+        self._check("AddSubFolder")
+        if any(existing.GetName() == name for existing in folder.subfolders):
+            return None
+        created = FakeFolder(name, self._owner)
+        folder.subfolders.append(created)
+        return created
+
+    def MoveClips(  # noqa: N802
+        self,
+        clips: list[FakeMediaPoolItem],
+        target: FakeFolder,
+    ) -> bool:
+        self._check("MoveClips")
+        if not self.move_result:
+            return False
+        for clip in clips:
+            for folder in self._walk(self._root):
+                if clip in folder.clips:
+                    folder.clips.remove(clip)
+            target.clips.append(clip)
+        return True
+
+    def ImportMedia(  # noqa: N802
+        self,
+        items: list[str | dict[str, Any]],
+    ) -> list[FakeMediaPoolItem]:
+        self._check("ImportMedia")
+        if self.import_result is not None:
+            return list(self.import_result)
+        imported: list[FakeMediaPoolItem] = []
+        for item in items:
+            clip = _import_one(item)
+            if clip is None:
+                continue
+            self._current.clips.append(clip)
+            imported.append(clip)
+        return imported
+
+    def RelinkClips(  # noqa: N802
+        self,
+        clips: list[FakeMediaPoolItem],
+        folder_path: str,
+    ) -> bool:
+        self._check("RelinkClips")
+        if self.relink_result is not None:
+            return self.relink_result
+        relinked = False
+        for clip in clips:
+            current = str(clip.GetClipProperty("File Path") or "")
+            candidate = Path(folder_path) / Path(current).name
+            if candidate.exists():
+                clip.SetClipProperty("File Path", str(candidate))
+                relinked = True
+        return relinked
+
+    def _walk(self, folder: FakeFolder) -> list[FakeFolder]:
+        found = [folder]
+        for sub in folder.subfolders:
+            found.extend(self._walk(sub))
+        return found
+
+
+def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
+    """Mimic ImportMedia: a path that is not there imports nothing."""
+    if isinstance(item, dict):
+        pattern = str(item.get("FilePath", ""))
+        start = int(item.get("StartIndex", 0))
+        end = int(item.get("EndIndex", 0))
+        frames = max(end - start + 1, 0)
+        if not _sequence_exists(pattern, start):
+            return None
+        return FakeMediaPoolItem(
+            Path(pattern).name,
+            pattern,
+            {"Type": "Image Sequence", "Frames": str(frames), "Start": "0", "End": str(frames - 1)},
+        )
+
+    path = Path(item)
+    if not path.exists():
+        return None
+    still = path.suffix.lower() in IMAGE_SUFFIXES
+    return FakeMediaPoolItem(
+        path.name,
+        str(path),
+        {"Type": "Still", "Frames": "1", "Start": "0", "End": "0"} if still else {},
+    )
+
+
+def _sequence_exists(pattern: str, start: int) -> bool:
+    try:
+        first = pattern % start
+    except (TypeError, ValueError):
+        return Path(pattern).exists()
+    return Path(first).exists()
+
+
 class FakeProject:
     def __init__(
         self,
         name: str,
         timeline: FakeTimeline | None = None,
         fps: str = "24",
+        media_pool: FakeMediaPool | None = None,
     ) -> None:
         self._name = name
         self._timeline = timeline
         self._fps = fps
+        self._media_pool = media_pool
 
     def GetName(self) -> str:  # noqa: N802
         return self._name
@@ -50,6 +291,9 @@ class FakeProject:
 
     def GetSetting(self, key: str) -> str | None:  # noqa: N802
         return self._fps if key == "timelineFrameRate" else None
+
+    def GetMediaPool(self) -> FakeMediaPool | None:  # noqa: N802
+        return self._media_pool
 
 
 class FakeProjectManager:
@@ -173,11 +417,26 @@ class FakeConnector:
         return self._handles.pop(0)
 
 
+def media_pool(bins: dict[str, list[FakeMediaPoolItem]] | None = None) -> FakeMediaPool:
+    """A media pool from ``{"": [root clips], "Angles/Cam A": [clips]}``."""
+    pool = FakeMediaPool()
+    root = pool.GetRootFolder()
+    for path, clips in (bins or {}).items():
+        folder = root
+        for segment in [part for part in path.split("/") if part]:
+            existing = [sub for sub in folder.subfolders if sub.GetName() == segment]
+            folder = existing[0] if existing else (pool.AddSubFolder(folder, segment) or folder)
+        folder.clips.extend(clips)
+    pool.calls.clear()
+    return pool
+
+
 def studio(
     project: str | None = "sunset-set",
     timeline: str | None = "sunset-set v3",
     fps: str = "59.94",
     extra_projects: tuple[str, ...] = ("holiday-gig",),
+    pool: FakeMediaPool | None = None,
 ) -> FakeResolve:
     """A conventional fake: Studio running, one project open, one timeline current."""
     projects: dict[str, FakeProject] = {}
@@ -188,5 +447,20 @@ def studio(
             project,
             FakeTimeline(timeline, fps) if timeline else None,
             fps=fps,
+            media_pool=pool,
         )
-    return FakeResolve(projects, current=project)
+    resolve = FakeResolve(projects, current=project)
+    if pool is not None:
+        _adopt(pool, resolve)
+    return resolve
+
+
+def _adopt(pool: FakeMediaPool, owner: FakeResolve) -> None:
+    """Wire the pool to the handle, so a dropped handle fails media calls too."""
+    pool._owner = owner
+    folders = [pool.GetRootFolder()]
+    while folders:
+        folder = folders.pop()
+        folder._owner = owner
+        folders.extend(folder.subfolders)
+    pool.calls.clear()

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -134,6 +134,9 @@ class FakeFolder:
         self._check()
         return list(self.subfolders)
 
+    def adopt(self, owner: FakeResolve) -> None:
+        self._owner = owner
+
     def _check(self) -> None:
         if self._owner is not None:
             self._owner._check()
@@ -159,6 +162,16 @@ class FakeMediaPool:
         self.calls.append(method)
         if self._owner is not None:
             self._owner._check()
+
+    def adopt(self, owner: FakeResolve) -> None:
+        """Wire the pool and its folders to a handle, so a dropped handle fails here too."""
+        self._owner = owner
+        folders = [self._root]
+        while folders:
+            folder = folders.pop()
+            folder.adopt(owner)
+            folders.extend(folder.subfolders)
+        self.calls.clear()
 
     def GetRootFolder(self) -> FakeFolder:  # noqa: N802
         self._check("GetRootFolder")
@@ -237,7 +250,13 @@ class FakeMediaPool:
 
 
 def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
-    """Mimic ImportMedia: a path that is not there imports nothing."""
+    """Mimic ImportMedia: a path that is not there imports nothing.
+
+    An imported sequence is named and pathed after its first frame rather than after the
+    ``%0Nd`` pattern. Nothing on record says what Resolve really calls it (#18 verified the
+    frame count only), so the fake deliberately does not echo the pattern back — code that
+    matched on it would be relying on an assumption no source supports.
+    """
     if isinstance(item, dict):
         pattern = str(item.get("FilePath", ""))
         start = int(item.get("StartIndex", 0))
@@ -245,9 +264,10 @@ def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
         frames = max(end - start + 1, 0)
         if not _sequence_exists(pattern, start):
             return None
+        first = _first_frame(pattern, start)
         return FakeMediaPoolItem(
-            Path(pattern).name,
-            pattern,
+            Path(first).name,
+            first,
             {"Type": "Image Sequence", "Frames": str(frames), "Start": "0", "End": str(frames - 1)},
         )
 
@@ -262,12 +282,15 @@ def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
     )
 
 
-def _sequence_exists(pattern: str, start: int) -> bool:
+def _first_frame(pattern: str, start: int) -> str:
     try:
-        first = pattern % start
+        return pattern % start
     except (TypeError, ValueError):
-        return Path(pattern).exists()
-    return Path(first).exists()
+        return pattern
+
+
+def _sequence_exists(pattern: str, start: int) -> bool:
+    return Path(_first_frame(pattern, start)).exists()
 
 
 class FakeProject:
@@ -451,16 +474,5 @@ def studio(
         )
     resolve = FakeResolve(projects, current=project)
     if pool is not None:
-        _adopt(pool, resolve)
+        pool.adopt(resolve)
     return resolve
-
-
-def _adopt(pool: FakeMediaPool, owner: FakeResolve) -> None:
-    """Wire the pool to the handle, so a dropped handle fails media calls too."""
-    pool._owner = owner
-    folders = [pool.GetRootFolder()]
-    while folders:
-        folder = folders.pop()
-        folder._owner = owner
-        folders.extend(folder.subfolders)
-    pool.calls.clear()

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from resolve_mcp.tools.escape_hatch import run_python
+from resolve_mcp.tools.media import inspect_clip, list_media
 from resolve_mcp.tools.project import get_status, list_projects, snapshot_project
 
 pytestmark = pytest.mark.live
@@ -47,6 +48,31 @@ def test_escape_hatch_reaches_the_real_scripting_api() -> None:
 
     assert result["ok"] is True
     assert "Resolve" in (result["result"] or "")
+
+
+def test_lists_the_real_media_pool() -> None:
+    """Read-only. The mutating media ACs (import, relink) are run by hand — see the ticket."""
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+
+    result = list_media()
+
+    assert result["ok"] is True
+    assert isinstance(result["clips"], list)
+
+
+def test_inspects_a_real_clip_with_the_property_keys_the_wrappers_assume() -> None:
+    """The one live check the fakes cannot make: that these key names exist at all."""
+    listing = list_media()
+    if not listing["ok"] or not listing["clips"]:
+        pytest.skip("No clips in the media pool")
+    first = listing["clips"][0]
+
+    result = inspect_clip(first["name"], bin=first["bin"] or None)
+
+    assert result["ok"] is True
+    assert "File Path" in result["properties"]
+    assert result["bounds"]["media"]["duration"] is not None
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -1,0 +1,509 @@
+"""The media pool tools, called in-process against the fake Resolve seam."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from resolve_mcp.tools.media import (
+    import_media,
+    inspect_clip,
+    list_media,
+    organize_media,
+    relink_media,
+    set_clip_metadata,
+)
+
+from .conftest import Attach
+from .fakes import FakeMediaPoolItem, media_pool, studio
+
+AUDIO_MAPPING = json.dumps(
+    {
+        "embedded_audio_channels": 2,
+        "linked_audio": {"1": {"channels": 8, "offset": -100, "path": "D:/audio/master.wav"}},
+        "track_mapping": {"1": {"channel_idx": [1, 3], "mute": False, "type": "Stereo"}},
+    }
+)
+
+
+def a_file(tmp_path: Path, name: str, content: bytes = b"media") -> Path:
+    target = tmp_path / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return target
+
+
+def a_clip(path: Path | str, **properties: str) -> FakeMediaPoolItem:
+    return FakeMediaPoolItem(Path(path).name, str(path), properties)
+
+
+# --- import ----------------------------------------------------------------------------
+
+
+def test_imports_a_video_and_a_png_sequence_into_a_named_bin(
+    attach: Attach, tmp_path: Path
+) -> None:
+    video = a_file(tmp_path, "C0012.mp4")
+    for index in range(1, 4):
+        a_file(tmp_path, f"titles/song_{index:04d}.png")
+    pool = media_pool()
+    attach(studio(pool=pool))
+
+    result = import_media(
+        paths=[str(video)],
+        bin="Concert/Titles",
+        sequences=[
+            {
+                "path": str(tmp_path / "titles" / "song_%04d.png"),
+                "start_index": 1,
+                "end_index": 3,
+            }
+        ],
+    )
+
+    assert result["ok"] is True
+    assert result["bin"] == "Concert/Titles"
+    assert [clip["name"] for clip in result["imported"]] == ["C0012.mp4", "song_%04d.png"]
+    assert result["imported"][1]["frames"] == 3
+    root = pool.GetRootFolder()
+    titles = root.GetSubFolderList()[0].GetSubFolderList()[0]
+    assert titles.GetName() == "Titles"
+    assert len(titles.GetClipList()) == 2
+
+
+def test_import_applies_the_still_duration_workaround_to_image_media(
+    attach: Attach, tmp_path: Path
+) -> None:
+    still = a_file(tmp_path, "lower-third.png")
+    pool = media_pool()
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(still)])
+
+    assert result["ok"] is True
+    assert result["imported"][0]["still_duration_workaround"] is True
+    clip = pool.GetRootFolder().GetClipList()[0]
+    assert clip.property_writes == [("Out", "0")]
+
+
+def test_import_does_not_touch_the_out_point_of_a_video(attach: Attach, tmp_path: Path) -> None:
+    pool = media_pool()
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(a_file(tmp_path, "C0012.mp4"))])
+
+    assert result["imported"][0]["still_duration_workaround"] is False
+    assert pool.GetRootFolder().GetClipList()[0].property_writes == []
+
+
+def test_import_reports_the_paths_resolve_refused_and_keeps_the_rest(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = media_pool()
+    attach(studio(pool=pool))
+    missing = str(tmp_path / "gone.mp4")
+
+    result = import_media(paths=[str(a_file(tmp_path, "C0012.mp4")), missing])
+
+    assert result["ok"] is True
+    assert [clip["name"] for clip in result["imported"]] == ["C0012.mp4"]
+    assert result["not_imported"] == [missing]
+
+
+def test_import_that_lands_nothing_is_a_failure_with_a_fix(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=media_pool()))
+
+    result = import_media(paths=[str(tmp_path / "gone.mp4")])
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "import_failed"
+    assert result["error"]["fix"]
+
+
+def test_import_restores_the_folder_that_was_current_before_it(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = media_pool(bins={"Angles": []})
+    attach(studio(pool=pool))
+    before = pool.GetCurrentFolder()
+
+    assert import_media(paths=[str(a_file(tmp_path, "C0012.mp4"))], bin="Angles")["ok"] is True
+
+    assert pool.GetCurrentFolder() is before
+
+
+# --- list ------------------------------------------------------------------------------
+
+
+def test_list_summarises_clips_with_bin_paths_and_offline_state(
+    attach: Attach, tmp_path: Path
+) -> None:
+    present = a_file(tmp_path, "C0012.mp4")
+    moved = tmp_path / "C0099.mp4"  # never created: the file has moved away
+    pool = media_pool(bins={"Angles/Cam A": [a_clip(present), a_clip(moved)]})
+    attach(studio(pool=pool))
+
+    result = list_media(bin="Angles")
+
+    assert result["ok"] is True
+    assert result["count"] == 2
+    assert result["truncated"] is False
+    by_name = {clip["name"]: clip for clip in result["clips"]}
+    assert by_name["C0012.mp4"]["bin"] == "Angles/Cam A"
+    assert by_name["C0012.mp4"]["offline"] is False
+    assert by_name["C0012.mp4"]["frames"] == 100
+    assert by_name["C0012.mp4"]["fps"] == 59.94
+    assert by_name["C0099.mp4"]["offline"] is True
+
+
+def test_list_filters_by_name_and_by_offline(attach: Attach, tmp_path: Path) -> None:
+    pool = media_pool(
+        bins={
+            "": [a_clip(a_file(tmp_path, "C0012.mp4")), a_clip(a_file(tmp_path, "broll-pan.mov"))],
+            "Angles": [a_clip(tmp_path / "C0099.mp4")],
+        }
+    )
+    attach(studio(pool=pool))
+
+    named = [clip["name"] for clip in list_media(name_contains="broll")["clips"]]
+    offline = [clip["name"] for clip in list_media(offline_only=True)["clips"]]
+
+    assert named == ["broll-pan.mov"]
+    assert offline == ["C0099.mp4"]
+
+
+def test_list_can_stay_in_one_bin(attach: Attach, tmp_path: Path) -> None:
+    pool = media_pool(
+        bins={"": [a_clip(a_file(tmp_path, "root.mp4"))], "Angles": [a_clip(tmp_path / "sub.mp4")]}
+    )
+    attach(studio(pool=pool))
+
+    result = list_media(recursive=False)
+
+    assert [clip["name"] for clip in result["clips"]] == ["root.mp4"]
+
+
+def test_list_spills_the_full_listing_to_disk_past_the_cap(attach: Attach, tmp_path: Path) -> None:
+    clips = [a_clip(tmp_path / f"C{index:04d}.mp4") for index in range(5)]
+    attach(studio(pool=media_pool(bins={"Angles": clips})))
+
+    result = list_media(bin="Angles", limit=2)
+
+    assert result["ok"] is True
+    assert result["count"] == 5
+    assert result["truncated"] is True
+    assert len(result["clips"]) == 2
+    spilled = Path(result["spilled_to"])
+    assert spilled.exists()
+    assert len(json.loads(spilled.read_text(encoding="utf-8"))["clips"]) == 5
+
+
+def test_list_of_an_unknown_bin_names_the_bins_that_exist(attach: Attach) -> None:
+    attach(studio(pool=media_pool(bins={"Angles/Cam A": []})))
+
+    result = list_media(bin="angles")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "bin_not_found"
+    assert "Angles/Cam A" in result["error"]["fix"]
+
+
+def test_media_tools_need_a_project(attach: Attach) -> None:
+    attach(studio(project=None))
+
+    result = list_media()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "no_project_open"
+    assert result["error"]["fix"]
+
+
+# --- inspect ---------------------------------------------------------------------------
+
+
+def test_inspect_returns_metadata_audio_mapping_markers_and_bounds(
+    attach: Attach, tmp_path: Path
+) -> None:
+    clip = FakeMediaPoolItem(
+        "C0012.mp4",
+        str(a_file(tmp_path, "C0012.mp4")),
+        properties={"Start": "0", "End": "99", "Frames": "100", "FPS": "59.94"},
+        metadata={"Description": "guitar close", "Scene": "set 1"},
+        markers={96.0: {"color": "Green", "duration": 1.0, "note": "fill", "name": "Marker 1"}},
+        audio_mapping=AUDIO_MAPPING,
+        mark_in_out={"video": {"in": 12, "out": 134}},
+    )
+    attach(studio(pool=media_pool(bins={"Angles": [clip]})))
+
+    result = inspect_clip("C0012.mp4")
+
+    assert result["ok"] is True
+    assert result["clip"]["bin"] == "Angles"
+    assert result["clip"]["offline"] is False
+    assert result["metadata"]["Description"] == "guitar close"
+    assert result["properties"]["Resolution"] == "1920x1080"
+    assert result["audio_mapping"]["linked_audio"]["1"]["offset"] == -100
+    assert result["markers"] == [
+        {
+            "frame": 96,
+            "color": "Green",
+            "duration": 1.0,
+            "name": "Marker 1",
+            "note": "fill",
+            "custom_data": "",
+        }
+    ]
+    bounds = result["bounds"]
+    assert bounds["media"]["in"] == {
+        "frames": 0,
+        "seconds": 0.0,
+        "timecode": "00:00:00:00",
+        "fps": 59.94,
+    }
+    assert bounds["media"]["out"]["frames"] == 100  # half-open: End + 1
+    assert bounds["media"]["duration"]["frames"] == 100
+    assert bounds["marks"]["video"]["in"]["frames"] == 12
+    assert bounds["marks"]["video"]["out"]["timecode"] == "00:00:02:14"
+
+
+def test_inspect_survives_a_clip_with_no_audio_mapping_or_markers(
+    attach: Attach, tmp_path: Path
+) -> None:
+    clip = a_clip(a_file(tmp_path, "C0012.mp4"))
+    attach(studio(pool=media_pool(bins={"": [clip]})))
+
+    result = inspect_clip("C0012.mp4")
+
+    assert result["ok"] is True
+    assert result["audio_mapping"] is None
+    assert result["markers"] == []
+    assert result["clip"]["bin"] == ""
+
+
+def test_inspect_of_an_unknown_clip_says_what_is_there(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=media_pool(bins={"Angles": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
+
+    result = inspect_clip("C0013.mp4")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "clip_not_found"
+    assert result["error"]["fix"]
+
+
+def test_inspect_refuses_an_ambiguous_clip_name(attach: Attach, tmp_path: Path) -> None:
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(
+        studio(pool=media_pool(bins={"Angles": [a_clip(same)], "Broll": [a_clip(same)]}))
+    )
+
+    result = inspect_clip("C0012.mp4")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "ambiguous_clip"
+    assert "Angles" in result["error"]["fix"]
+    assert inspect_clip("C0012.mp4", bin="Broll")["ok"] is True
+
+
+# --- metadata --------------------------------------------------------------------------
+
+
+def test_metadata_batch_routes_each_field_by_what_the_clip_reports(
+    attach: Attach, tmp_path: Path
+) -> None:
+    clip = a_clip(a_file(tmp_path, "C0012.mp4"))
+    attach(studio(pool=media_pool(bins={"Angles": [clip]})))
+
+    result = set_clip_metadata(
+        [{"clip": "C0012.mp4", "fields": {"Description": "guitar close", "FPS": "59.94"}}]
+    )
+
+    assert result["ok"] is True
+    assert result["results"] == [
+        {
+            "clip": "C0012.mp4",
+            "bin": "Angles",
+            "ok": True,
+            "applied": {"Description": "metadata", "FPS": "clip_property"},
+            "failed": {},
+        }
+    ]
+    assert clip.metadata_writes == [("Description", "guitar close")]
+    assert clip.property_writes == [("FPS", "59.94")]
+
+
+def test_metadata_batch_reports_per_item_failures_without_losing_the_batch(
+    attach: Attach, tmp_path: Path
+) -> None:
+    stubborn = a_clip(a_file(tmp_path, "C0012.mp4"))
+    stubborn.refuse_metadata = {"Description"}
+    willing = a_clip(a_file(tmp_path, "C0013.mp4"))
+    attach(studio(pool=media_pool(bins={"Angles": [stubborn, willing]})))
+
+    result = set_clip_metadata(
+        [
+            {"clip": "C0012.mp4", "fields": {"Description": "no"}},
+            {"clip": "C0404.mp4", "fields": {"Description": "missing clip"}},
+            {"clip": "C0013.mp4", "fields": {"Description": "yes"}},
+        ]
+    )
+
+    assert result["ok"] is True
+    first, second, third = result["results"]
+    assert first["ok"] is False
+    assert first["failed"]["Description"]
+    assert second["ok"] is False
+    assert second["error"]["code"] == "clip_not_found"
+    assert third["ok"] is True
+    assert willing.metadata_writes == [("Description", "yes")]
+
+
+# --- organize --------------------------------------------------------------------------
+
+
+def test_organize_creates_nested_bins_and_moves_clips_into_them(
+    attach: Attach, tmp_path: Path
+) -> None:
+    clip = a_clip(a_file(tmp_path, "C0012.mp4"))
+    pool = media_pool(bins={"": [clip]})
+    attach(studio(pool=pool))
+
+    result = organize_media(
+        [
+            {"op": "create_bin", "bin": "Concert/Angles"},
+            {"op": "move_clips", "clips": ["C0012.mp4"], "to_bin": "Concert/Angles"},
+        ]
+    )
+
+    assert result["ok"] is True
+    assert [item["ok"] for item in result["results"]] == [True, True]
+    angles = pool.GetRootFolder().GetSubFolderList()[0].GetSubFolderList()[0]
+    assert [item.GetName() for item in angles.GetClipList()] == ["C0012.mp4"]
+    assert pool.GetRootFolder().GetClipList() == []
+
+
+def test_organize_treats_an_existing_bin_as_done(attach: Attach) -> None:
+    attach(studio(pool=media_pool(bins={"Concert/Angles": []})))
+
+    result = organize_media([{"op": "create_bin", "bin": "Concert/Angles"}])
+
+    assert result["results"][0]["ok"] is True
+    assert result["results"][0]["created"] is False
+
+
+def test_organize_reports_a_bad_operation_per_item(attach: Attach) -> None:
+    attach(studio(pool=media_pool(bins={"Angles": []})))
+
+    result = organize_media([{"op": "burn_it_down", "bin": "Angles"}, {"op": "create_bin"}])
+
+    assert result["ok"] is True
+    assert [item["ok"] for item in result["results"]] == [False, False]
+    assert result["results"][0]["error"]["code"] == "invalid_request"
+    assert result["results"][1]["error"]["fix"]
+
+
+def test_organize_move_reports_a_clip_it_cannot_find(attach: Attach) -> None:
+    attach(studio(pool=media_pool(bins={"Angles": []})))
+
+    result = organize_media([{"op": "move_clips", "clips": ["ghost.mp4"], "to_bin": "Angles"}])
+
+    assert result["results"][0]["ok"] is False
+    assert result["results"][0]["error"]["code"] == "clip_not_found"
+
+
+# --- relink ----------------------------------------------------------------------------
+
+
+def test_relink_brings_an_offline_clip_back_from_its_new_folder(
+    attach: Attach, tmp_path: Path
+) -> None:
+    clip = a_clip(tmp_path / "old" / "C0012.mp4")  # the old path no longer exists
+    moved = a_file(tmp_path, "new/C0012.mp4")
+    attach(studio(pool=media_pool(bins={"Angles": [clip]})))
+    assert list_media(offline_only=True)["count"] == 1
+
+    result = relink_media(["C0012.mp4"], str(moved.parent))
+
+    assert result["ok"] is True
+    assert result["results"] == [
+        {
+            "clip": "C0012.mp4",
+            "bin": "Angles",
+            "ok": True,
+            "file_path": str(moved),
+            "offline": False,
+        }
+    ]
+    assert list_media(offline_only=True)["count"] == 0
+
+
+def test_relink_to_an_explicit_file_replaces_that_one_clip(attach: Attach, tmp_path: Path) -> None:
+    clip = a_clip(tmp_path / "old" / "C0012.mp4")
+    renamed = a_file(tmp_path, "new/C0012-take2.mp4")
+    attach(studio(pool=media_pool(bins={"Angles": [clip]})))
+
+    result = relink_media(["C0012.mp4"], str(renamed))
+
+    assert result["ok"] is True
+    assert result["results"][0]["file_path"] == str(renamed)
+    assert result["results"][0]["offline"] is False
+
+
+def test_relink_to_a_file_refuses_more_than_one_clip(attach: Attach, tmp_path: Path) -> None:
+    renamed = a_file(tmp_path, "new/C0012-take2.mp4")
+    pool = media_pool(bins={"Angles": [a_clip(tmp_path / "a.mp4"), a_clip(tmp_path / "b.mp4")]})
+    attach(studio(pool=pool))
+
+    result = relink_media(["a.mp4", "b.mp4"], str(renamed))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert result["error"]["fix"]
+
+
+def test_relink_says_so_when_the_media_is_not_in_the_new_folder(
+    attach: Attach, tmp_path: Path
+) -> None:
+    empty = tmp_path / "elsewhere"
+    empty.mkdir()
+    attach(studio(pool=media_pool(bins={"Angles": [a_clip(tmp_path / "old" / "C0012.mp4")]})))
+
+    result = relink_media(["C0012.mp4"], str(empty))
+
+    assert result["ok"] is True
+    assert result["results"][0]["ok"] is False
+    assert result["results"][0]["offline"] is True
+
+
+def test_relink_needs_a_path_that_exists(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=media_pool(bins={"Angles": [a_clip(tmp_path / "C0012.mp4")]})))
+
+    result = relink_media(["C0012.mp4"], str(tmp_path / "nowhere"))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "relink_failed"
+    assert result["error"]["fix"]
+
+
+# --- connection behaviour ---------------------------------------------------------------
+
+
+def test_media_tools_survive_a_handle_that_dies_mid_call(attach: Attach, tmp_path: Path) -> None:
+    clips: list[FakeMediaPoolItem] = [a_clip(a_file(tmp_path, "C0012.mp4"))]
+    dying = studio(pool=media_pool(bins={"Angles": clips}))
+    dying.die_after(1)
+    attach(dying, studio(pool=media_pool(bins={"Angles": clips})))
+
+    result = list_media(bin="Angles")
+
+    assert result["ok"] is True
+    assert result["count"] == 1
+
+
+def test_a_media_pool_resolve_will_not_hand_over_is_reported(attach: Attach) -> None:
+    attach(studio(pool=None))
+
+    result = list_media()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "media_pool_unavailable"
+    assert result["error"]["fix"]

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -63,8 +63,9 @@ def test_imports_a_video_and_a_png_sequence_into_a_named_bin(
 
     assert result["ok"] is True
     assert result["bin"] == "Concert/Titles"
-    assert [clip["name"] for clip in result["imported"]] == ["C0012.mp4", "song_%04d.png"]
+    assert [clip["name"] for clip in result["imported"]] == ["C0012.mp4", "song_0001.png"]
     assert result["imported"][1]["frames"] == 3
+    assert result["not_imported"] == []
     root = pool.GetRootFolder()
     titles = root.GetSubFolderList()[0].GetSubFolderList()[0]
     assert titles.GetName() == "Titles"
@@ -107,6 +108,26 @@ def test_import_reports_the_paths_resolve_refused_and_keeps_the_rest(
 
     assert result["ok"] is True
     assert [clip["name"] for clip in result["imported"]] == ["C0012.mp4"]
+    assert result["not_imported"] == [missing]
+
+
+def test_a_sequence_that_landed_is_never_reported_as_refused(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Resolve names the imported clip, not the %0Nd pattern — matching on it would guess."""
+    for index in range(1, 3):
+        a_file(tmp_path, f"titles/song_{index:04d}.png")
+    attach(studio(pool=media_pool()))
+    missing = str(tmp_path / "gone.mp4")
+
+    result = import_media(
+        paths=[missing],
+        sequences=[
+            {"path": str(tmp_path / "titles" / "song_%04d.png"), "start_index": 1, "end_index": 2}
+        ],
+    )
+
+    assert result["ok"] is True
     assert result["not_imported"] == [missing]
 
 
@@ -196,6 +217,18 @@ def test_list_spills_the_full_listing_to_disk_past_the_cap(attach: Attach, tmp_p
     spilled = Path(result["spilled_to"])
     assert spilled.exists()
     assert len(json.loads(spilled.read_text(encoding="utf-8"))["clips"]) == 5
+
+
+def test_a_bin_really_named_master_is_still_addressable(attach: Attach, tmp_path: Path) -> None:
+    """The root is called Master, so a leading Master is only dropped when it is the root."""
+    pool = media_pool(bins={"Master": [a_clip(a_file(tmp_path, "C0012.mp4"))], "": []})
+    attach(studio(pool=pool))
+
+    result = list_media(bin="Master", recursive=False)
+
+    assert result["ok"] is True
+    assert result["bin"] == "Master"
+    assert [clip["name"] for clip in result["clips"]] == ["C0012.mp4"]
 
 
 def test_list_of_an_unknown_bin_names_the_bins_that_exist(attach: Attach) -> None:
@@ -431,6 +464,7 @@ def test_relink_brings_an_offline_clip_back_from_its_new_folder(
             "ok": True,
             "file_path": str(moved),
             "offline": False,
+            "was_offline": True,
         }
     ]
     assert list_media(offline_only=True)["count"] == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,12 +17,18 @@ def descriptions() -> dict[str, str]:
     return {tool.name: tool.description or "" for tool in tools}
 
 
-def test_registers_the_p1_session_tools() -> None:
+def test_registers_the_p1_session_and_media_tools() -> None:
     assert tool_names() == {
         "get_status",
         "list_projects",
         "open_project",
         "snapshot_project",
+        "import_media",
+        "list_media",
+        "inspect_clip",
+        "set_clip_metadata",
+        "organize_media",
+        "relink_media",
         "run_python",
     }
 

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,40 @@
+"""Dual time: frames authoritative, seconds and timecode derived once, in tested code."""
+
+from __future__ import annotations
+
+import pytest
+
+from resolve_mcp.timing import dual, timecode
+
+
+@pytest.mark.parametrize(
+    ("frames", "fps", "expected"),
+    [
+        (0, 24.0, "00:00:00:00"),
+        (23, 24.0, "00:00:00:23"),
+        (24, 24.0, "00:00:01:00"),
+        (90, 59.94, "00:00:01:30"),
+        (60 * 60 * 24, 24.0, "01:00:00:00"),
+    ],
+)
+def test_timecode_counts_frames_at_the_nearest_whole_rate(
+    frames: int, fps: float, expected: str
+) -> None:
+    assert timecode(frames, fps) == expected
+
+
+def test_dual_carries_frames_seconds_timecode_and_fps() -> None:
+    assert dual(90, 59.94) == {
+        "frames": 90,
+        "seconds": 1.502,
+        "timecode": "00:00:01:30",
+        "fps": 59.94,
+    }
+
+
+def test_dual_without_an_fps_still_reports_frames() -> None:
+    assert dual(90, None) == {"frames": 90, "seconds": None, "timecode": None, "fps": None}
+
+
+def test_dual_of_nothing_is_nothing() -> None:
+    assert dual(None, 24.0) is None

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from resolve_mcp.timing import dual, timecode
+from resolve_mcp.timing import dual_time, timecode
 
 
 @pytest.mark.parametrize(
@@ -24,7 +24,7 @@ def test_timecode_counts_frames_at_the_nearest_whole_rate(
 
 
 def test_dual_carries_frames_seconds_timecode_and_fps() -> None:
-    assert dual(90, 59.94) == {
+    assert dual_time(90, 59.94) == {
         "frames": 90,
         "seconds": 1.502,
         "timecode": "00:00:01:30",
@@ -33,8 +33,8 @@ def test_dual_carries_frames_seconds_timecode_and_fps() -> None:
 
 
 def test_dual_without_an_fps_still_reports_frames() -> None:
-    assert dual(90, None) == {"frames": 90, "seconds": None, "timecode": None, "fps": None}
+    assert dual_time(90, None) == {"frames": 90, "seconds": None, "timecode": None, "fps": None}
 
 
 def test_dual_of_nothing_is_nothing() -> None:
-    assert dual(None, 24.0) is None
+    assert dual_time(None, 24.0) is None


### PR DESCRIPTION
Closes #24.

Six media pool tools on the existing wrapper/tool layering: `resolve/media.py` talks to
Resolve, `tools/media.py` is thin registration, and every decision is exercised at the
fake seam with Resolve closed.

| Tool | Shape |
| --- | --- |
| `import_media` | `paths[]`, `sequences[]`, `bin` → imported clip summaries + `not_imported` |
| `list_media` | `bin?`, `name_contains?`, `offline_only?`, `recursive?`, `limit` → summaries, spills past the cap |
| `inspect_clip` | `clip`, `bin?` → properties, metadata, audio mapping, markers, dual-time bounds |
| `set_clip_metadata` | `[{clip, bin?, fields}]` → per-item results with the route each field took |
| `organize_media` | `[{op: create_bin \| move_clips, …}]` → per-operation results |
| `relink_media` | `clips[]`, `path`, `bin?` → per-clip results with post-relink offline state |

## Test seam

Fake tier (`uv run pytest -m 'not live'`) — the tools are called in-process against the
fake Resolve singleton, which grew a media pool: bins, clips whose properties and metadata
are strings, `GetAudioMapping()` returning a JSON *string*, `GetMarkers()` keyed by float
frame, and import/relink that consult the real filesystem (so offline detection is tested
honestly rather than against a fake flag). 37 new tests, 98 total; mypy strict and ruff
clean.

Live smoke gained two **read-only** tests: listing the real media pool, and inspecting a
real clip to confirm the undocumented clip-property key names (`File Path`, `Frames`,
`FPS`) exist at all — the one thing no fake can establish. The mutating ACs are named as
unrun on the ticket.

## Decisions the tickets left open

The API research (#3, #18, #19) recorded the calls but not these; each is stated in the
module docstring and covered by a test:

1. **Bin paths are slash-separated from the root** (`Concert/Angles`), case-sensitive, the
   root name optional as a first segment. Resolve has no bin-path concept — only
   `GetSubFolderList()` walks plus current-folder state, and imports land in whatever
   folder is current, so `import_media` moves the current folder and puts it back.
2. **Offline means the file is gone.** The scripting API exposes no offline flag, so a clip
   is offline when its `File Path` is set and absent from disk. A clip with no path at all
   (multicam, compound — #19) is pathless, not offline; a `%0Nd` sequence pattern is judged
   by its folder, since the pattern is never itself a file.
3. **Metadata fields route by what the clip reports.** Per #19's never-hard-code rule, each
   clip is enumerated once with `GetClipProperty()`; a field whose key is in that dict is
   written with `SetClipProperty`, everything else with `SetMetadata`. The result says which
   route each field took, so a typo in a property name is visible rather than silent.
4. **`relink_media` takes a folder or a file.** `RelinkClips` is folder-scoped (matched by
   file name); a file argument routes to `ReplaceClip` on a single clip, which is the only
   route for media that moved *and* was renamed.

Two smaller ones: `list_media` spills the full listing to
`%LOCALAPPDATA%/resolve-mcp/listings/` past `limit` (default 200) and returns `spilled_to`,
against the 25k-token client cap; and dual time now lives in `timing.py` — frames
authoritative, seconds and non-drop timecode derived once in tested code, with media bounds
half-open `[in, out)` to match the cut-file convention.

`import_media` applies the still-duration workaround (#18) at import: a one-time
`SetClipProperty("Out", …)` on image media, so later timeline appends honour exact
`endFrame` values without any timeline code having to remember.

## Follow-up worth a ticket

Bin structure and naming conventions are explicitly deferred in #22's Further Notes and
stay deferred here — `organize_media` enforces no convention, it just creates and moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review

Two-axis `/code-review` against `origin/main`. Findings, all addressed in 2a49773 except the two held at the end.

**Spec axis**

1. `path_of()` recovered a folder's bin path by walking the pool and comparing folder objects with `is`. Resolve hands out a fresh proxy object per call, so on real Resolve that comparison never matches and every result carrying a `bin` would report an empty one — invisible to the fake tier, whose folders are stable Python objects. Removed rather than patched: `find_bin`/`ensure_bin` now return a `LocatedBin` carrying the path they walked, and `_clips_under` takes that path, so nothing recovers a path from a folder object.
2. `not_imported` matched imported sequence clips against the requested `%0Nd` pattern. #18 verified the frame count of a real sequence import but recorded nothing about the resulting clip name or path, so that match was an assumption. Reconciliation is now folder-based and skipped entirely when everything requested landed; the fake names sequence clips after the first frame instead of echoing the pattern, so code relying on the old assumption fails at the seam.
3. `relink_media` would repoint a healthy clip as silently as an offline one. Not gated — repointing working media is a legitimate ask — but each result now carries `was_offline` and a replacement of non-offline media logs a warning.
4. `_segments` dropped a leading `Master` unconditionally, making a bin genuinely named Master unaddressable. Now only dropped when the root has no child by that name; covered by a test.
5. #19 asks for the actual `GetClipProperty()` dict to be logged for diagnosis, since the key names are undocumented. `properties()` now logs the key names once per session.

**Standards axis**

No hard breaches; layering, error shape and test voice all hold. Fixed: the media wrapper was importing the session wrapper's filename regex, and both duplicated the slug+timestamp shape — extracted as `naming.timestamped_name()`; `LocatedClip`/`LocatedBin` name the pairs that were travelling as bare tuples under three different names; `dual()` → `dual_time()`; `summarise()`'s pre-read properties argument now matches the name used everywhere else; `find_clip` walks the pool once instead of twice; the fake media pool gained an `adopt()` method instead of having its private owner field written from outside.

**Held, as judgement calls:** splitting `resolve/media.py` (700 lines, six operations behind section banners) into a package, and giving the bin path its own type instead of `str | None`. Both are real observations; neither changes behaviour, and the second is entangled with the bin-naming conventions #22 defers to their own ticket.

Both held items are written out above with the reasoning that settles them; nothing is left outstanding.

Review: clean

