### PR TITLE
docs: record what the live run showed about clip property routing

### DIFF
--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -12,7 +12,9 @@ rather than API calls, and are the reason this file exists at all:
 * **Metadata fields route by what the clip itself reports.** The clip property key names are
   undocumented, so nothing is hard-coded: each clip is enumerated once with
   ``GetClipProperty()`` and a field whose key is in that dict is written as a clip property,
-  everything else as metadata. The route taken comes back in the result.
+  everything else as metadata. The route taken comes back in the result. Live, that dict
+  holds the whole namespace and the property route reaches metadata too, so the metadata
+  branch rarely fires — see ``_set_field``.
 * **Image media gets the still-duration workaround at import.** A one-time
   ``SetClipProperty("Out", …)`` is what makes ``endFrame`` respected on stills later; doing
   it at import means no timeline code ever has to remember.
@@ -564,7 +566,15 @@ def inspect_clip(
 
 
 def _set_field(clip: Clip, key: str, value: Any, reported: dict[str, str]) -> str:
-    """Write one field, choosing the route from what the clip itself reports."""
+    """Write one field, choosing the route from what the clip itself reports.
+
+    The property branch takes nearly everything. A real clip enumerates around 250 keys —
+    the whole namespace, production metadata (``Scene``, ``Take``, ``Director``, ``Keyword``)
+    included — and a property write to one of those names reads back through
+    ``GetMetadata()``, so the two accessors are one store rather than two (verified live,
+    Resolve 21.0.3.7). The metadata branch is the fallback for a clip that reports less,
+    not the route metadata-named fields take.
+    """
     if key in reported:
         if not clip.SetClipProperty(key, str(value)):
             raise MediaOperationError(cause=f"Resolve refused to set the clip property {key!r}.")

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -12,9 +12,8 @@ rather than API calls, and are the reason this file exists at all:
 * **Metadata fields route by what the clip itself reports.** The clip property key names are
   undocumented, so nothing is hard-coded: each clip is enumerated once with
   ``GetClipProperty()`` and a field whose key is in that dict is written as a clip property,
-  everything else as metadata. The route taken comes back in the result. Live, that dict
-  holds the whole namespace and the property route reaches metadata too, so the metadata
-  branch rarely fires — see ``_set_field``.
+  everything else as metadata. The route taken comes back in the result; on real media that
+  dict is large enough that the property branch takes nearly everything — see ``_set_field``.
 * **Image media gets the still-duration workaround at import.** A one-time
   ``SetClipProperty("Out", …)`` is what makes ``endFrame`` respected on stills later; doing
   it at import means no timeline code ever has to remember.
@@ -568,12 +567,13 @@ def inspect_clip(
 def _set_field(clip: Clip, key: str, value: Any, reported: dict[str, str]) -> str:
     """Write one field, choosing the route from what the clip itself reports.
 
-    The property branch takes nearly everything. A real clip enumerates around 250 keys —
-    the whole namespace, production metadata (``Scene``, ``Take``, ``Director``, ``Keyword``)
-    included — and a property write to one of those names reads back through
-    ``GetMetadata()``, so the two accessors are one store rather than two (verified live,
-    Resolve 21.0.3.7). The metadata branch is the fallback for a clip that reports less,
-    not the route metadata-named fields take.
+    The property branch takes nearly everything. The one clip probed live so far (Resolve
+    Studio 21.0.3.7) enumerated around 250 keys — the whole namespace, production metadata
+    (``Scene``, ``Take``, ``Director``, ``Keyword``) included — while ``GetMetadata()`` on
+    the same clip returned ``{}``. Writing ``Scene`` through ``SetClipProperty`` then read
+    back through ``GetMetadata()``, so for that field the two accessors reach the same
+    value; whether that holds across the other keys was not tested. The metadata branch is
+    kept for a clip that reports less, which no probe has yet found.
     """
     if key in reported:
         if not clip.SetClipProperty(key, str(value)):


### PR DESCRIPTION
Comments only — no behaviour change, no test change.

The live pass on #24 turned up two facts about Resolve that the code cannot show on its own, and that the next agent reading `_set_field` would otherwise re-derive from scratch:

- `GetClipProperty()` on a real clip returns around 250 keys — the whole clip namespace, production metadata names (`Scene`, `Take`, `Director`, `Keyword`) included — while `GetMetadata()` on the same clip returned `{}`.
- Writing `Scene` through `SetClipProperty` read back through `GetMetadata()`.

Together those mean the `if key in reported` branch in `_set_field` takes nearly everything and the `SetMetadata` branch almost never fires. A reader who assumes both branches carry real traffic will misjudge that function — which is what this note prevents.

The live results themselves live on #24 (two comments, with environment and the probe transcript); this records only the part that belongs next to the code.

## Test seam

None — the fake tier cannot verify a claim about real Resolve, and this diff changes no behaviour for it to verify. The seam that established these facts was the live tier plus two read-only probes, recorded on #24. Fake tier still 100 passed, mypy strict and ruff clean.

## Review

Two-axis `/code-review` against `main`, both axes as parallel sub-agents.

### Standards

- **Overstated claim (judgement call).** "the two accessors are one store rather than two (verified live)" — an architectural inference about Resolve's internals presented as an observation; a mirroring layer would produce the same external behaviour. *Fixed:* now says the two accessors reach the same value for that field, and says the rest was not tested.
- **Duplicated Code, prose form (judgement call).** The module docstring bullet said "see `_set_field`" and then restated the substance anyway. *Fixed:* the bullet now points and stops.
- Checked and clear: no documented-standard violation; `docs/agents/domain.md` does not require a `CONTEXT.md` or ADR entry for this. The axis noted the live result must also be on the ticket — it is, in two comments on #24.

### Spec

- **Single-sample generalisation (the main finding).** "verified live" attached to a claim covering the whole ~250-key namespace, when exactly one key (`Scene`) on one clip was round-tripped. *Fixed:* the probe's scope is now stated — one clip, one field.
- **Inference stated as settled behaviour.** "The metadata branch is the fallback for a clip that reports less" — no clip that reports less was ever probed. *Fixed:* now "kept for a clip that reports less, which no probe has yet found".
- **Established fact left out.** `GetMetadata()` returning `{}` is the observation that grounds "the property branch takes nearly everything", and the first draft asserted the conclusion without it. *Fixed:* recorded.
- Siting was judged correct — the detail sits next to the routing logic it explains, with the module docstring cross-referencing it.

Every finding from both axes was fixed in 75b865e; none were held. Re-ran the fake tier, mypy and ruff after the fixes.

Review: clean
