### PR TITLE
P1: Timeline read (list + inspect, dual time)

### DIFF
--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -74,6 +74,28 @@ class ProjectNotFoundError(ResolveMcpError):
         )
 
 
+class NoTimelineOpenError(ResolveMcpError):
+    """A project is open but nothing is on the timeline — or it holds no timelines at all."""
+
+    code = "no_timeline_open"
+    default_fix = (
+        "Open a timeline in Resolve, or name one explicitly — list_timelines shows what "
+        "the project has."
+    )
+
+
+class TimelineNotFoundError(ResolveMcpError):
+    code = "timeline_not_found"
+
+    def __init__(self, name: str, available: list[str]) -> None:
+        listed = ", ".join(available) if available else "the project has no timelines"
+        super().__init__(
+            cause=f"No timeline named {name!r} in the open project.",
+            fix=f"Timeline names must match exactly, version suffix included: {listed}.",
+            detail={"requested": name, "available": available},
+        )
+
+
 class SnapshotFailedError(ResolveMcpError):
     code = "snapshot_failed"
     default_fix = (

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -38,7 +38,7 @@ from ..errors import (
     RelinkFailedError,
 )
 from ..logging_config import get_logger
-from ..naming import timestamped_name
+from ..spill import spill
 from ..timing import dual_time
 from .connection import ResolveConnection
 
@@ -441,20 +441,13 @@ def list_media(
         "spilled_to": None,
     }
     if truncated:
-        result["spilled_to"] = _spill(result["bin"], clips, config or get_config())
+        result["spilled_to"] = spill(
+            result["bin"],
+            {"bin": result["bin"], "count": len(clips), "clips": clips},
+            config or get_config(),
+            fallback="media-pool",
+        )
     return result
-
-
-def _spill(bin_path: str, clips: list[dict[str, Any]], config: Config) -> str:
-    """Write the whole listing where the agent can grep it, and return the path."""
-    target = config.listing_dir / timestamped_name(bin_path, ".json", "media-pool")
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(
-        json.dumps({"bin": bin_path, "count": len(clips), "clips": clips}, indent=2),
-        encoding="utf-8",
-    )
-    log.info("Spilled %d clip summaries to %s", len(clips), target)
-    return str(target)
 
 
 # --- inspect ----------------------------------------------------------------------------

--- a/src/resolve_mcp/resolve/session.py
+++ b/src/resolve_mcp/resolve/session.py
@@ -55,7 +55,7 @@ def context(connection: ResolveConnection) -> Context:
 
     reading["project"] = _read(project.GetName) if project is not None else None
     reading["timeline"] = _read(timeline.GetName) if timeline is not None else None
-    reading["fps"] = _fps(project, timeline)
+    reading["fps"] = frame_rate(project, timeline)
     return reading
 
 
@@ -141,8 +141,12 @@ def _current_project(resolve: Any) -> Any | None:
     return manager.GetCurrentProject() if manager is not None else None
 
 
-def _fps(project: Any, timeline: Any) -> float | None:
-    """Frames per second, timeline setting first — it is what a cut is measured in."""
+def frame_rate(project: Any, timeline: Any) -> float | None:
+    """Frames per second, timeline setting first — it is what a cut is measured in.
+
+    Either side may be ``None``: a timeline read on its own still knows its own rate, and a
+    project with nothing open still knows the rate its timelines are created at.
+    """
     for source in (timeline, project):
         if source is None:
             continue

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -1,0 +1,450 @@
+"""Timeline read wrappers: list with versions and durations, inspect at a chosen detail.
+
+Thin, testable, and MCP-free like the rest of this layer. Four things here are decisions
+rather than API calls, and are the reason this file exists at all:
+
+* **Versions come from the name.** ``<base> v<N>`` is the project's own convention for cut
+  versions (the cut file materialises ``<name> v<N>``), and Resolve has no version concept
+  of its own — so the number is parsed off the name, and a timeline that does not follow
+  the convention has no version rather than a guessed one.
+* **Out points are half-open ``[in, out)``, computed from start + duration.** The scripting
+  docs do not settle whether ``GetEnd()`` is the last frame or one past it, and a one-frame
+  error in a cut point is invisible until it is expensive — so ``GetEnd()`` is never
+  trusted; ``GetDuration()`` is, and the out point follows from it.
+* **The sync offset is the mapping, not a measurement.** For a hand-synced stacked
+  reference, ``timeline_frame = source_frame + sync_offset`` per angle, so the offset is
+  the record start minus the source start. The server computes it and stops there: what it
+  means for a project is the agent's call (spec #22 keeps the server out of sync math).
+* **Detail level and range are the pagination.** A concert timeline holds thousands of
+  items, far past any one reply. ``summary`` and ``tracks`` answer most questions without
+  listing a single clip; past ``limit`` clips the full reading spills to disk, and the
+  range narrows the next read.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from ..config import Config, get_config
+from ..errors import (
+    InvalidRequestError,
+    NoProjectOpenError,
+    NoTimelineOpenError,
+    TimelineNotFoundError,
+)
+from ..logging_config import get_logger
+from ..naming import timestamped_name
+from ..timing import dual_time, to_frames
+from .connection import ResolveConnection
+from .session import frame_rate
+
+log = get_logger("timeline")
+
+DEFAULT_LIST_LIMIT = 100
+DEFAULT_ITEM_LIMIT = 200
+DETAIL_LEVELS = ("summary", "tracks", "clips")
+TRACK_TYPES = ("video", "audio", "subtitle")
+
+VERSION = re.compile(r"^(?P<base>.*?)[\s_-]*v(?P<number>\d+)$", re.IGNORECASE)
+
+Project = Any
+Timeline = Any
+TimelineItem = Any
+
+
+# --- reaching a timeline ------------------------------------------------------------------
+
+
+def _project(connection: ResolveConnection) -> Project:
+    manager = connection.handle().GetProjectManager()
+    project = manager.GetCurrentProject() if manager is not None else None
+    if project is None:
+        raise NoProjectOpenError(cause="No project is open, so there are no timelines to read.")
+    return project
+
+
+def _timelines(project: Project) -> list[Timeline]:
+    """Every timeline the project holds, in Resolve's own order.
+
+    ``GetTimelineByIndex`` is one-based and hands back ``None`` for an index it cannot
+    resolve; a timeline that will not answer is skipped rather than sinking the listing,
+    because the other timelines are still what the agent asked for.
+    """
+    try:
+        count = int(project.GetTimelineCount() or 0)
+    except (TypeError, ValueError):
+        log.warning("Resolve gave an unreadable timeline count", exc_info=True)
+        return []
+    found = []
+    for index in range(1, count + 1):
+        timeline = project.GetTimelineByIndex(index)
+        if timeline is None:
+            log.warning("Resolve returned no timeline at index %d of %d", index, count)
+            continue
+        found.append(timeline)
+    return found
+
+
+def _name(timeline: Timeline) -> str:
+    return str(timeline.GetName() or "")
+
+
+def find_timeline(project: Project, name: str | None) -> Timeline:
+    """The named timeline, or the open one when no name is given."""
+    if name is None:
+        current = project.GetCurrentTimeline()
+        if current is None:
+            raise NoTimelineOpenError(
+                cause="No timeline is open in the project, and none was named.",
+            )
+        return current
+    held = _timelines(project)
+    for timeline in held:
+        if _name(timeline) == name:
+            return timeline
+    raise TimelineNotFoundError(name, [_name(timeline) for timeline in held])
+
+
+def version_of(name: str) -> tuple[str, int | None]:
+    """Split ``"sunset-set v3"`` into its base name and version number."""
+    match = VERSION.match(name)
+    if match is None:
+        return name, None
+    return match.group("base"), int(match.group("number"))
+
+
+# --- shape ---------------------------------------------------------------------------------
+
+
+def _bounds(timeline: Timeline, fps: float | None) -> dict[str, Any]:
+    start = _frames(timeline.GetStartFrame)
+    end = _frames(timeline.GetEndFrame)
+    duration = end - start if start is not None and end is not None else None
+    return {
+        "start": dual_time(start, fps),
+        "end": dual_time(end, fps),
+        "duration": dual_time(duration, fps),
+    }
+
+
+def _frames(getter: Any) -> int | None:
+    try:
+        value = getter()
+    except Exception:  # noqa: BLE001 - one unreadable number is not a lost timeline
+        log.debug("Could not read %s", getattr(getter, "__name__", getter), exc_info=True)
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _track_counts(timeline: Timeline) -> dict[str, int]:
+    counts = {}
+    for track_type in TRACK_TYPES:
+        try:
+            counts[track_type] = int(timeline.GetTrackCount(track_type) or 0)
+        except Exception:  # noqa: BLE001 - a track type this build does not know is zero
+            log.debug("Could not count %s tracks", track_type, exc_info=True)
+            counts[track_type] = 0
+    return counts
+
+
+def summarise(timeline: Timeline, project: Project, current: str | None) -> dict[str, Any]:
+    """The one-line view of a timeline that list and inspect both open with."""
+    name = _name(timeline)
+    base, version = version_of(name)
+    fps = frame_rate(project, timeline)
+    return {
+        "name": name,
+        "base_name": base,
+        "version": version,
+        "current": name == current,
+        "fps": fps,
+        **_bounds(timeline, fps),
+        "tracks": _track_counts(timeline),
+    }
+
+
+# --- list ------------------------------------------------------------------------------------
+
+
+def list_timelines(
+    connection: ResolveConnection,
+    limit: int = DEFAULT_LIST_LIMIT,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Every timeline in the project with its version, duration and track stack."""
+    project = _project(connection)
+    current = project.GetCurrentTimeline()
+    current_name = _name(current) if current is not None else None
+
+    timelines = [summarise(timeline, project, current_name) for timeline in _timelines(project)]
+
+    cap = max(int(limit), 0)
+    truncated = len(timelines) > cap
+    result: dict[str, Any] = {
+        "count": len(timelines),
+        "current": current_name,
+        "timelines": timelines[:cap] if truncated else timelines,
+        "latest_versions": _latest_versions(timelines),
+        "truncated": truncated,
+        "spilled_to": None,
+    }
+    if truncated:
+        full = {**result, "timelines": timelines, "truncated": False, "spilled_to": None}
+        result["spilled_to"] = _spill("timelines", full, config or get_config())
+    return result
+
+
+def _latest_versions(timelines: list[dict[str, Any]]) -> dict[str, str]:
+    """The newest numbered timeline per base name — the answer to "where did I get to"."""
+    latest: dict[str, dict[str, Any]] = {}
+    for entry in timelines:
+        if entry["version"] is None:
+            continue
+        best = latest.get(entry["base_name"])
+        if best is None or entry["version"] > best["version"]:
+            latest[entry["base_name"]] = entry
+    return {base: entry["name"] for base, entry in latest.items()}
+
+
+def _spill(label: str, payload: dict[str, Any], config: Config) -> str:
+    """Write the whole reading where the agent can grep it, and return the path."""
+    target = config.listing_dir / timestamped_name(label, ".json", "timeline")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    log.info("Spilled the full %s reading to %s", label, target)
+    return str(target)
+
+
+# --- inspect ----------------------------------------------------------------------------------
+
+
+def inspect_timeline(
+    connection: ResolveConnection,
+    name: str | None = None,
+    detail: str = "tracks",
+    start: Any = None,
+    end: Any = None,
+    limit: int = DEFAULT_ITEM_LIMIT,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Read one timeline at a chosen detail level, over a chosen range."""
+    if detail not in DETAIL_LEVELS:
+        raise InvalidRequestError(
+            cause=f"{detail!r} is not a detail level.",
+            fix=(
+                "Use summary (how long, how many tracks), tracks (the stack, named) or "
+                "clips (every shot in the range)."
+            ),
+            detail={"requested": detail, "available": list(DETAIL_LEVELS)},
+        )
+
+    project = _project(connection)
+    timeline = find_timeline(project, name)
+    current = project.GetCurrentTimeline()
+    heading = summarise(timeline, project, _name(current) if current is not None else None)
+    fps = heading["fps"]
+
+    window = _window(timeline, start, end, fps)
+    tracks = [
+        _read_track(timeline, track_type, index, window, fps, detail == "clips")
+        for track_type in TRACK_TYPES
+        for index in range(1, heading["tracks"][track_type] + 1)
+    ]
+    item_count = sum(track["item_count"] for track in tracks)
+
+    result: dict[str, Any] = {
+        "timeline": {**heading, "markers": _marker_count(timeline)},
+        "detail": detail,
+        "range": {"in": dual_time(window[0], fps), "out": dual_time(window[1], fps)},
+        "tracks": None if detail == "summary" else [_without_items(track) for track in tracks],
+        "item_count": item_count,
+        "truncated": False,
+        "spilled_to": None,
+    }
+    if detail != "clips":
+        return result
+
+    cap = max(int(limit), 0)
+    result["tracks"] = _capped(tracks, cap)
+    if item_count > cap:
+        result["truncated"] = True
+        full = {**result, "tracks": tracks, "truncated": False, "spilled_to": None}
+        result["spilled_to"] = _spill(heading["name"], full, config or get_config())
+    return result
+
+
+def _window(timeline: Timeline, start: Any, end: Any, fps: float | None) -> tuple[int, int]:
+    """The range to read, half-open ``[in, out)``, defaulting to the whole timeline."""
+    asked_start = to_frames(start, fps, field="start")
+    asked_end = to_frames(end, fps, field="end")
+    first = asked_start if asked_start is not None else (_frames(timeline.GetStartFrame) or 0)
+    last = asked_end if asked_end is not None else _frames(timeline.GetEndFrame)
+    if last is None:
+        last = first
+    if last < first:
+        raise InvalidRequestError(
+            cause=f"The range ends at {last} but starts at {first}.",
+            fix="Ranges are half-open [start, end) and run forwards; swap the two.",
+            detail={"start": first, "end": last},
+        )
+    return first, last
+
+
+def _read_track(
+    timeline: Timeline,
+    track_type: str,
+    index: int,
+    window: tuple[int, int],
+    fps: float | None,
+    with_items: bool,
+) -> dict[str, Any]:
+    items = [
+        read_item(item, track_type, index, fps)
+        for item in _items_in_track(timeline, track_type, index)
+    ]
+    in_range = [item for item in items if _touches(item, window)]
+    return {
+        "type": track_type,
+        "index": index,
+        "name": _track_name(timeline, track_type, index),
+        "enabled": _flag(timeline.GetIsTrackEnabled, track_type, index, default=True),
+        "locked": _flag(timeline.GetIsTrackLocked, track_type, index, default=False),
+        "item_count": len(in_range),
+        "items": in_range if with_items else [],
+    }
+
+
+def _without_items(track: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in track.items() if key != "items"}
+
+
+def _capped(tracks: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
+    """Keep the first ``cap`` items across the whole stack, tracks in order."""
+    left = cap
+    capped = []
+    for track in tracks:
+        kept = track["items"][:left]
+        left -= len(kept)
+        capped.append({**track, "items": kept})
+    return capped
+
+
+def _touches(item: dict[str, Any], window: tuple[int, int]) -> bool:
+    """Whether a shot overlaps the range at all — an edge that only meets it does not."""
+    first, last = window
+    record = item["record"]
+    starts = (record["in"] or {}).get("frames")
+    ends = (record["out"] or {}).get("frames")
+    if starts is None or ends is None:
+        return True
+    return bool(starts < last and ends > first)
+
+
+def _items_in_track(timeline: Timeline, track_type: str, index: int) -> list[TimelineItem]:
+    try:
+        return list(timeline.GetItemListInTrack(track_type, index) or [])
+    except Exception:  # noqa: BLE001 - an unreadable track is empty, not a failed inspection
+        log.warning("Could not read %s track %d", track_type, index, exc_info=True)
+        return []
+
+
+def _track_name(timeline: Timeline, track_type: str, index: int) -> str:
+    try:
+        return str(timeline.GetTrackName(track_type, index) or "")
+    except Exception:  # noqa: BLE001
+        log.debug("Could not read the name of %s track %d", track_type, index, exc_info=True)
+        return ""
+
+
+def _flag(getter: Any, track_type: str, index: int, default: bool) -> bool:
+    try:
+        return bool(getter(track_type, index))
+    except Exception:  # noqa: BLE001 - an older build without the getter reports the default
+        log.debug("Could not read a track flag on %s %d", track_type, index, exc_info=True)
+        return default
+
+
+def _marker_count(timeline: Timeline) -> int:
+    try:
+        markers = timeline.GetMarkers()
+    except Exception:  # noqa: BLE001
+        log.debug("Could not read the timeline markers", exc_info=True)
+        return 0
+    return len(markers) if isinstance(markers, dict) else 0
+
+
+def read_item(
+    item: TimelineItem,
+    track_type: str,
+    index: int,
+    fps: float | None,
+) -> dict[str, Any]:
+    """One shot: where it sits, where it came from, and the offset between the two."""
+    record_in = _frames(item.GetStart)
+    duration = _frames(item.GetDuration)
+    record_out = record_in + duration if record_in is not None and duration is not None else None
+    source_in = _source_start(item)
+    source_out = source_in + duration if source_in is not None and duration is not None else None
+    offset = record_in - source_in if record_in is not None and source_in is not None else None
+    return {
+        "name": str(item.GetName() or ""),
+        "track": {"type": track_type, "index": index},
+        "record": {
+            "in": dual_time(record_in, fps),
+            "out": dual_time(record_out, fps),
+            "duration": dual_time(duration, fps),
+        },
+        "source": {"in": dual_time(source_in, fps), "out": dual_time(source_out, fps)},
+        "sync_offset": dual_time(offset, fps),
+        "clip": _clip_name(item),
+        "enabled": _read(item, "GetClipEnabled", True),
+        "takes": _read(item, "GetTakeCount", 0),
+    }
+
+
+def _source_start(item: TimelineItem) -> int | None:
+    """Where the shot starts in its own media.
+
+    ``GetSourceStartFrame`` is the direct answer and only exists on newer builds;
+    ``GetLeftOffset`` carries the same number counted from the media's first frame, which
+    is what an offset against a common clock needs either way.
+    """
+    for getter in ("GetSourceStartFrame", "GetLeftOffset"):
+        found = getattr(item, getter, None)
+        if found is None:
+            continue
+        frames = _frames(found)
+        if frames is not None:
+            return frames
+    return None
+
+
+def _clip_name(item: TimelineItem) -> str | None:
+    try:
+        clip = item.GetMediaPoolItem()
+    except Exception:  # noqa: BLE001 - a generator or title has no media pool item
+        log.debug("Could not reach the media pool item behind a shot", exc_info=True)
+        return None
+    if clip is None:
+        return None
+    try:
+        return str(clip.GetName() or "")
+    except Exception:  # noqa: BLE001
+        log.debug("Could not read the name of the clip behind a shot", exc_info=True)
+        return None
+
+
+def _read(item: TimelineItem, getter: str, default: Any) -> Any:
+    found = getattr(item, getter, None)
+    if found is None:
+        return default
+    try:
+        return found()
+    except Exception:  # noqa: BLE001 - a build without this getter reports the default
+        log.debug("Could not read %s", getter, exc_info=True)
+        return default

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -168,29 +168,22 @@ def _frames(value: Any) -> int | None:
 
 
 def _optional(getter: Any, default: Any, *args: Any) -> Any:
-    """Read something this Resolve build may not offer; the default is not a failure.
+    """Read a getter this Resolve build may not have at all; a missing one is not a failure.
 
-    Getters come and go between versions and a few refuse on particular clip kinds, so a
-    reading that cannot be taken falls back rather than sinking the whole inspection.
+    Absence is the only thing forgiven here. A getter that is present and *raises* is left
+    to raise, because that is what a handle dying mid-read looks like — and a field-level
+    fallback would turn a lost connection into a reading full of plausible defaults that
+    the agent has no reason to distrust. One reconnect, or a stated failure, is the only
+    honest pair of outcomes.
     """
-    if getter is None:
-        return default
-    try:
-        return getter(*args)
-    except Exception:  # noqa: BLE001 - one unreadable field is not a lost timeline
-        log.debug("Could not read %s%s", getattr(getter, "__name__", getter), args, exc_info=True)
-        return default
+    return default if getter is None else getter(*args)
 
 
 def _track_counts(timeline: Timeline) -> dict[str, int]:
-    counts = {}
-    for track_type in TRACK_TYPES:
-        try:
-            counts[track_type] = int(_optional(timeline.GetTrackCount, 0, track_type) or 0)
-        except (TypeError, ValueError):
-            log.debug("Unreadable %s track count", track_type, exc_info=True)
-            counts[track_type] = 0
-    return counts
+    """How many tracks of each kind — the stack that identifies a sync reference."""
+    return {
+        track_type: _frames(timeline.GetTrackCount(track_type)) or 0 for track_type in TRACK_TYPES
+    }
 
 
 def summarise(timeline: Timeline, project: Project, current: str | None) -> dict[str, Any]:
@@ -236,7 +229,7 @@ def list_timelines(
     }
     if truncated:
         full = {**result, "timelines": timelines, "truncated": False, "spilled_to": None}
-        result["spilled_to"] = spill("timelines", full, config or get_config(), "timeline")
+        result["spilled_to"] = spill("timelines", full, config or get_config(), fallback="timeline")
     return result
 
 
@@ -281,12 +274,12 @@ def inspect_timeline(
     heading = summarise(timeline, project, _name(current) if current is not None else None)
     fps = heading["fps"]
 
-    window = _window(timeline, start, end, fps)
+    window = _window(heading, start, end, fps)
     with_items = detail == "clips"
     tracks = [
         _read_track(timeline, track_type, index, window, fps, with_items)
-        for track_type in TRACK_TYPES
-        for index in range(1, heading["tracks"][track_type] + 1)
+        for track_type, count in heading["tracks"].items()
+        for index in range(1, count + 1)
     ]
     item_count = sum(track["item_count"] for track in tracks)
 
@@ -307,16 +300,24 @@ def inspect_timeline(
     if item_count > cap:
         result["truncated"] = True
         full = {**result, "tracks": tracks, "truncated": False, "spilled_to": None}
-        result["spilled_to"] = spill(heading["name"], full, config or get_config(), "timeline")
+        result["spilled_to"] = spill(
+            heading["name"], full, config or get_config(), fallback="timeline"
+        )
     return result
 
 
-def _window(timeline: Timeline, start: Any, end: Any, fps: float | None) -> tuple[int, int]:
-    """The range to read, half-open ``[in, out)``, defaulting to the whole timeline."""
+def _window(heading: dict[str, Any], start: Any, end: Any, fps: float | None) -> tuple[int, int]:
+    """The range to read, half-open ``[in, out)``, defaulting to the whole timeline.
+
+    The default comes from the heading rather than from Resolve again: two reads of the
+    same bounds are two chances to disagree, and the range would then not be the range the
+    reply says it is.
+    """
     asked_start = to_frames(start, fps, field="start")
     asked_end = to_frames(end, fps, field="end")
-    first = asked_start if asked_start is not None else (_frames(timeline.GetStartFrame()) or 0)
-    last = asked_end if asked_end is not None else _frames(timeline.GetEndFrame())
+    bounds = {edge: (heading[edge] or {}).get("frames") for edge in ("start", "end")}
+    first = asked_start if asked_start is not None else (bounds["start"] or 0)
+    last = asked_end if asked_end is not None else bounds["end"]
     if last is None:
         last = first
     if last < first:
@@ -369,14 +370,25 @@ def _without_items(track: dict[str, Any]) -> dict[str, Any]:
 
 
 def _capped(tracks: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
-    """Keep the first ``cap`` items across the whole stack, tracks in order."""
+    """Share ``cap`` shots across the stack, a round at a time.
+
+    Filling track by track would spend the whole budget on a busy V1 and hand back a
+    stacked reference with every angle below it empty — which is the one layout this tool
+    exists to make readable. Taking a round from each track keeps the stack visible, and
+    each track still reads in its own order.
+    """
+    kept: list[list[dict[str, Any]]] = [[] for _ in tracks]
     left = cap
-    capped = []
-    for track in tracks:
-        kept = track["items"][:left]
-        left -= len(kept)
-        capped.append({**track, "items": kept})
-    return capped
+    depth = 0
+    while left > 0 and any(len(track["items"]) > depth for track in tracks):
+        for position, track in enumerate(tracks):
+            if left == 0:
+                break
+            if len(track["items"]) > depth:
+                kept[position].append(track["items"][depth])
+                left -= 1
+        depth += 1
+    return [{**track, "items": kept[position]} for position, track in enumerate(tracks)]
 
 
 def _touches(placement: Placement, window: tuple[int, int]) -> bool:
@@ -417,7 +429,7 @@ def read_item(
     record_in, duration = placement.start, placement.duration
     record_out = placement.end
     source_in = _source_start(item)
-    source_out = source_in + duration if source_in is not None and duration is not None else None
+    source_out = _source_end(item, source_in, duration)
     offset = record_in - source_in if record_in is not None and source_in is not None else None
     return {
         "name": str(item.GetName() or ""),
@@ -438,15 +450,31 @@ def read_item(
 def _source_start(item: TimelineItem) -> int | None:
     """Where the shot starts in its own media.
 
-    ``GetSourceStartFrame`` is the direct answer and only exists on newer builds;
-    ``GetLeftOffset`` carries the same number counted from the media's first frame, which
-    is what an offset against a common clock needs either way.
+    ``GetSourceStartFrame`` is the direct answer and exists only on newer builds. Failing
+    that, ``GetLeftOffset`` is how far into the media pool item the shot begins — the same
+    number whenever the media itself starts at frame zero, which camera files do, and the
+    closest answer available on a build without the newer getter.
     """
     for getter in ("GetSourceStartFrame", "GetLeftOffset"):
         frames = _frames(_optional(getattr(item, getter, None), None))
         if frames is not None:
             return frames
     return None
+
+
+def _source_end(item: TimelineItem, source_in: int | None, duration: int | None) -> int | None:
+    """One past the shot's last source frame.
+
+    Read rather than derived where Resolve offers it: a retimed shot covers more or fewer
+    source frames than it occupies on the timeline, so ``source_in + duration`` is only
+    right at 1:1 speed. ``GetSourceEndFrame`` reports the last frame, hence the plus one.
+    """
+    reported = _frames(_optional(getattr(item, "GetSourceEndFrame", None), None))
+    if reported is not None:
+        return reported + 1
+    if source_in is None or duration is None:
+        return None
+    return source_in + duration
 
 
 def _clip_name(item: TimelineItem) -> str | None:

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -8,9 +8,12 @@ rather than API calls, and are the reason this file exists at all:
   of its own — so the number is parsed off the name, and a timeline that does not follow
   the convention has no version rather than a guessed one.
 * **Out points are half-open ``[in, out)``, computed from start + duration.** The scripting
-  docs do not settle whether ``GetEnd()`` is the last frame or one past it, and a one-frame
-  error in a cut point is invisible until it is expensive — so ``GetEnd()`` is never
-  trusted; ``GetDuration()`` is, and the out point follows from it.
+  docs do not settle whether a timeline item's ``GetEnd()`` is the last frame or one past
+  it, and a one-frame error in a cut point is invisible until it is expensive — so
+  ``GetEnd()`` is never read; ``GetDuration()`` is, and the out point follows from it. A
+  timeline itself has no duration getter, so its own end has to be taken from
+  ``GetEndFrame()`` as exclusive; that is the one place the reading rests on the
+  convention rather than side-stepping it, and it is what the live smoke tier checks.
 * **The sync offset is the mapping, not a measurement.** For a hand-synced stacked
   reference, ``timeline_frame = source_frame + sync_offset`` per angle, so the offset is
   the record start minus the source start. The server computes it and stops there: what it
@@ -23,9 +26,8 @@ rather than API calls, and are the reason this file exists at all:
 
 from __future__ import annotations
 
-import json
 import re
-from typing import Any
+from typing import Any, NamedTuple
 
 from ..config import Config, get_config
 from ..errors import (
@@ -35,7 +37,7 @@ from ..errors import (
     TimelineNotFoundError,
 )
 from ..logging_config import get_logger
-from ..naming import timestamped_name
+from ..spill import spill
 from ..timing import dual_time, to_frames
 from .connection import ResolveConnection
 from .session import frame_rate
@@ -43,7 +45,11 @@ from .session import frame_rate
 log = get_logger("timeline")
 
 DEFAULT_LIST_LIMIT = 100
-DEFAULT_ITEM_LIMIT = 200
+# A shot with its record, source and offset positions in dual time runs to roughly 700
+# characters of JSON, so a hundred of them sits inside the client's 25k-token reply cap
+# with the heading and track stack alongside. Raising this spends the agent's whole reply
+# on one read; narrowing the range is the cheaper move.
+DEFAULT_ITEM_LIMIT = 100
 DETAIL_LEVELS = ("summary", "tracks", "clips")
 TRACK_TYPES = ("video", "audio", "subtitle")
 
@@ -52,6 +58,25 @@ VERSION = re.compile(r"^(?P<base>.*?)[\s_-]*v(?P<number>\d+)$", re.IGNORECASE)
 Project = Any
 Timeline = Any
 TimelineItem = Any
+
+
+class Placement(NamedTuple):
+    """Where a shot sits on the timeline, read once and passed along.
+
+    Range filtering and the shot's own reading both need these two numbers, and every read
+    of them is a round trip into Resolve — so they travel together rather than being asked
+    for twice.
+    """
+
+    start: int | None
+    duration: int | None
+
+    @property
+    def end(self) -> int | None:
+        """One past the last frame, the half-open convention the cut file uses."""
+        if self.start is None or self.duration is None:
+            return None
+        return self.start + self.duration
 
 
 # --- reaching a timeline ------------------------------------------------------------------
@@ -119,8 +144,8 @@ def version_of(name: str) -> tuple[str, int | None]:
 
 
 def _bounds(timeline: Timeline, fps: float | None) -> dict[str, Any]:
-    start = _frames(timeline.GetStartFrame)
-    end = _frames(timeline.GetEndFrame)
+    start = _frames(timeline.GetStartFrame())
+    end = _frames(timeline.GetEndFrame())
     duration = end - start if start is not None and end is not None else None
     return {
         "start": dual_time(start, fps),
@@ -129,25 +154,41 @@ def _bounds(timeline: Timeline, fps: float | None) -> dict[str, Any]:
     }
 
 
-def _frames(getter: Any) -> int | None:
-    try:
-        value = getter()
-    except Exception:  # noqa: BLE001 - one unreadable number is not a lost timeline
-        log.debug("Could not read %s", getattr(getter, "__name__", getter), exc_info=True)
-        return None
+def _frames(value: Any) -> int | None:
+    """A frame number as Resolve reports it — sometimes a string, sometimes nothing.
+
+    Only the parsing is forgiving. A getter that *raises* is left to raise: that is what a
+    handle dying mid-read looks like, and swallowing it here would turn a lost connection
+    into a half-empty reading the agent has no reason to distrust.
+    """
     try:
         return int(float(value))
     except (TypeError, ValueError):
         return None
 
 
+def _optional(getter: Any, default: Any, *args: Any) -> Any:
+    """Read something this Resolve build may not offer; the default is not a failure.
+
+    Getters come and go between versions and a few refuse on particular clip kinds, so a
+    reading that cannot be taken falls back rather than sinking the whole inspection.
+    """
+    if getter is None:
+        return default
+    try:
+        return getter(*args)
+    except Exception:  # noqa: BLE001 - one unreadable field is not a lost timeline
+        log.debug("Could not read %s%s", getattr(getter, "__name__", getter), args, exc_info=True)
+        return default
+
+
 def _track_counts(timeline: Timeline) -> dict[str, int]:
     counts = {}
     for track_type in TRACK_TYPES:
         try:
-            counts[track_type] = int(timeline.GetTrackCount(track_type) or 0)
-        except Exception:  # noqa: BLE001 - a track type this build does not know is zero
-            log.debug("Could not count %s tracks", track_type, exc_info=True)
+            counts[track_type] = int(_optional(timeline.GetTrackCount, 0, track_type) or 0)
+        except (TypeError, ValueError):
+            log.debug("Unreadable %s track count", track_type, exc_info=True)
             counts[track_type] = 0
     return counts
 
@@ -195,7 +236,7 @@ def list_timelines(
     }
     if truncated:
         full = {**result, "timelines": timelines, "truncated": False, "spilled_to": None}
-        result["spilled_to"] = _spill("timelines", full, config or get_config())
+        result["spilled_to"] = spill("timelines", full, config or get_config(), "timeline")
     return result
 
 
@@ -209,15 +250,6 @@ def _latest_versions(timelines: list[dict[str, Any]]) -> dict[str, str]:
         if best is None or entry["version"] > best["version"]:
             latest[entry["base_name"]] = entry
     return {base: entry["name"] for base, entry in latest.items()}
-
-
-def _spill(label: str, payload: dict[str, Any], config: Config) -> str:
-    """Write the whole reading where the agent can grep it, and return the path."""
-    target = config.listing_dir / timestamped_name(label, ".json", "timeline")
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    log.info("Spilled the full %s reading to %s", label, target)
-    return str(target)
 
 
 # --- inspect ----------------------------------------------------------------------------------
@@ -250,8 +282,9 @@ def inspect_timeline(
     fps = heading["fps"]
 
     window = _window(timeline, start, end, fps)
+    with_items = detail == "clips"
     tracks = [
-        _read_track(timeline, track_type, index, window, fps, detail == "clips")
+        _read_track(timeline, track_type, index, window, fps, with_items)
         for track_type in TRACK_TYPES
         for index in range(1, heading["tracks"][track_type] + 1)
     ]
@@ -266,7 +299,7 @@ def inspect_timeline(
         "truncated": False,
         "spilled_to": None,
     }
-    if detail != "clips":
+    if not with_items:
         return result
 
     cap = max(int(limit), 0)
@@ -274,7 +307,7 @@ def inspect_timeline(
     if item_count > cap:
         result["truncated"] = True
         full = {**result, "tracks": tracks, "truncated": False, "spilled_to": None}
-        result["spilled_to"] = _spill(heading["name"], full, config or get_config())
+        result["spilled_to"] = spill(heading["name"], full, config or get_config(), "timeline")
     return result
 
 
@@ -282,8 +315,8 @@ def _window(timeline: Timeline, start: Any, end: Any, fps: float | None) -> tupl
     """The range to read, half-open ``[in, out)``, defaulting to the whole timeline."""
     asked_start = to_frames(start, fps, field="start")
     asked_end = to_frames(end, fps, field="end")
-    first = asked_start if asked_start is not None else (_frames(timeline.GetStartFrame) or 0)
-    last = asked_end if asked_end is not None else _frames(timeline.GetEndFrame)
+    first = asked_start if asked_start is not None else (_frames(timeline.GetStartFrame()) or 0)
+    last = asked_end if asked_end is not None else _frames(timeline.GetEndFrame())
     if last is None:
         last = first
     if last < first:
@@ -303,19 +336,31 @@ def _read_track(
     fps: float | None,
     with_items: bool,
 ) -> dict[str, Any]:
-    items = [
-        read_item(item, track_type, index, fps)
-        for item in _items_in_track(timeline, track_type, index)
+    """One track, and the shots on it that touch the range.
+
+    The range is applied to raw frame numbers before anything is shaped: a concert track
+    holds thousands of shots, and building the dual-time reading of each one only to throw
+    it away is the difference between a quick read and a slow one.
+    """
+    in_range = [
+        (item, placement)
+        for item, placement in (
+            (item, _placement(item)) for item in _items_in_track(timeline, track_type, index)
+        )
+        if _touches(placement, window)
     ]
-    in_range = [item for item in items if _touches(item, window)]
     return {
         "type": track_type,
         "index": index,
-        "name": _track_name(timeline, track_type, index),
-        "enabled": _flag(timeline.GetIsTrackEnabled, track_type, index, default=True),
-        "locked": _flag(timeline.GetIsTrackLocked, track_type, index, default=False),
+        "name": str(_optional(timeline.GetTrackName, "", track_type, index) or ""),
+        "enabled": bool(_optional(timeline.GetIsTrackEnabled, True, track_type, index)),
+        "locked": bool(_optional(timeline.GetIsTrackLocked, False, track_type, index)),
         "item_count": len(in_range),
-        "items": in_range if with_items else [],
+        "items": (
+            [read_item(item, track_type, index, fps, placement) for item, placement in in_range]
+            if with_items
+            else []
+        ),
     }
 
 
@@ -334,48 +379,31 @@ def _capped(tracks: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
     return capped
 
 
-def _touches(item: dict[str, Any], window: tuple[int, int]) -> bool:
-    """Whether a shot overlaps the range at all — an edge that only meets it does not."""
+def _touches(placement: Placement, window: tuple[int, int]) -> bool:
+    """Whether a shot overlaps the range at all — an edge that only meets it does not.
+
+    A shot whose position cannot be read is kept: dropping it would quietly shorten the
+    reading of a cut, which is worse than one entry the agent has to look at twice.
+    """
     first, last = window
-    record = item["record"]
-    starts = (record["in"] or {}).get("frames")
-    ends = (record["out"] or {}).get("frames")
-    if starts is None or ends is None:
+    if placement.start is None or placement.end is None:
         return True
-    return bool(starts < last and ends > first)
+    return bool(placement.start < last and placement.end > first)
 
 
 def _items_in_track(timeline: Timeline, track_type: str, index: int) -> list[TimelineItem]:
-    try:
-        return list(timeline.GetItemListInTrack(track_type, index) or [])
-    except Exception:  # noqa: BLE001 - an unreadable track is empty, not a failed inspection
-        log.warning("Could not read %s track %d", track_type, index, exc_info=True)
-        return []
-
-
-def _track_name(timeline: Timeline, track_type: str, index: int) -> str:
-    try:
-        return str(timeline.GetTrackName(track_type, index) or "")
-    except Exception:  # noqa: BLE001
-        log.debug("Could not read the name of %s track %d", track_type, index, exc_info=True)
-        return ""
-
-
-def _flag(getter: Any, track_type: str, index: int, default: bool) -> bool:
-    try:
-        return bool(getter(track_type, index))
-    except Exception:  # noqa: BLE001 - an older build without the getter reports the default
-        log.debug("Could not read a track flag on %s %d", track_type, index, exc_info=True)
-        return default
+    """The shots on one track. An empty track answers ``None`` rather than an empty list."""
+    return list(timeline.GetItemListInTrack(track_type, index) or [])
 
 
 def _marker_count(timeline: Timeline) -> int:
-    try:
-        markers = timeline.GetMarkers()
-    except Exception:  # noqa: BLE001
-        log.debug("Could not read the timeline markers", exc_info=True)
-        return 0
+    markers = _optional(timeline.GetMarkers, None)
     return len(markers) if isinstance(markers, dict) else 0
+
+
+def _placement(item: TimelineItem) -> Placement:
+    """Where a shot sits, in the two numbers everything else is derived from."""
+    return Placement(_frames(item.GetStart()), _frames(item.GetDuration()))
 
 
 def read_item(
@@ -383,11 +411,11 @@ def read_item(
     track_type: str,
     index: int,
     fps: float | None,
+    placement: Placement,
 ) -> dict[str, Any]:
     """One shot: where it sits, where it came from, and the offset between the two."""
-    record_in = _frames(item.GetStart)
-    duration = _frames(item.GetDuration)
-    record_out = record_in + duration if record_in is not None and duration is not None else None
+    record_in, duration = placement.start, placement.duration
+    record_out = placement.end
     source_in = _source_start(item)
     source_out = source_in + duration if source_in is not None and duration is not None else None
     offset = record_in - source_in if record_in is not None and source_in is not None else None
@@ -402,8 +430,8 @@ def read_item(
         "source": {"in": dual_time(source_in, fps), "out": dual_time(source_out, fps)},
         "sync_offset": dual_time(offset, fps),
         "clip": _clip_name(item),
-        "enabled": _read(item, "GetClipEnabled", True),
-        "takes": _read(item, "GetTakeCount", 0),
+        "enabled": bool(_optional(getattr(item, "GetClipEnabled", None), True)),
+        "takes": int(_optional(getattr(item, "GetTakeCount", None), 0) or 0),
     }
 
 
@@ -415,36 +443,16 @@ def _source_start(item: TimelineItem) -> int | None:
     is what an offset against a common clock needs either way.
     """
     for getter in ("GetSourceStartFrame", "GetLeftOffset"):
-        found = getattr(item, getter, None)
-        if found is None:
-            continue
-        frames = _frames(found)
+        frames = _frames(_optional(getattr(item, getter, None), None))
         if frames is not None:
             return frames
     return None
 
 
 def _clip_name(item: TimelineItem) -> str | None:
-    try:
-        clip = item.GetMediaPoolItem()
-    except Exception:  # noqa: BLE001 - a generator or title has no media pool item
-        log.debug("Could not reach the media pool item behind a shot", exc_info=True)
-        return None
+    """The media pool clip a shot came from — a generator or title has none."""
+    clip = _optional(item.GetMediaPoolItem, None)
     if clip is None:
         return None
-    try:
-        return str(clip.GetName() or "")
-    except Exception:  # noqa: BLE001
-        log.debug("Could not read the name of the clip behind a shot", exc_info=True)
-        return None
-
-
-def _read(item: TimelineItem, getter: str, default: Any) -> Any:
-    found = getattr(item, getter, None)
-    if found is None:
-        return default
-    try:
-        return found()
-    except Exception:  # noqa: BLE001 - a build without this getter reports the default
-        log.debug("Could not read %s", getter, exc_info=True)
-        return default
+    name = _optional(clip.GetName, None)
+    return None if name is None else str(name)

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -167,26 +167,52 @@ def _frames(value: Any) -> int | None:
         return None
 
 
-def _optional(getter: Any, default: Any, *args: Any) -> Any:
-    """Read a getter this Resolve build may not have at all; a missing one is not a failure.
+class Reader:
+    """Reads fields that may not answer, degrading only while Resolve is still there.
 
-    Absence is the only thing forgiven here. A getter that is present and *raises* is left
-    to raise, because that is what a handle dying mid-read looks like — and a field-level
-    fallback would turn a lost connection into a reading full of plausible defaults that
-    the agent has no reason to distrust. One reconnect, or a stated failure, is the only
-    honest pair of outcomes.
+    Two failures look identical at the call site and must not be treated alike. A getter
+    that refuses on one clip kind — a Fusion title has no source frames, an old build has
+    no getter at all — should cost that one field and nothing more. A getter that fails
+    because Resolve went away must not be smoothed into a plausible default: the agent
+    would have a whole timeline of them and no reason to distrust a single one.
+
+    The exception cannot tell them apart, so this asks the connection instead. A dead
+    handle re-raises, which is what the tool layer's single reconnect exists for. The
+    asking costs the same cheap version probe the connection already makes before every
+    call, and only on the path where a read has already failed.
     """
-    return default if getter is None else getter(*args)
+
+    def __init__(self, connection: ResolveConnection) -> None:
+        self._connection = connection
+
+    def optional(self, target: Any, method: str, default: Any, *args: Any) -> Any:
+        getter = getattr(target, method, None)
+        if getter is None:
+            return default
+        try:
+            return getter(*args)
+        except Exception:
+            if self._connection.dropped():
+                log.info("Resolve went away while reading %s", method)
+                raise
+            log.debug("Resolve would not answer %s%s", method, args, exc_info=True)
+            return default
 
 
-def _track_counts(timeline: Timeline) -> dict[str, int]:
+def _track_counts(reader: Reader, timeline: Timeline) -> dict[str, int]:
     """How many tracks of each kind — the stack that identifies a sync reference."""
     return {
-        track_type: _frames(timeline.GetTrackCount(track_type)) or 0 for track_type in TRACK_TYPES
+        track_type: _frames(reader.optional(timeline, "GetTrackCount", 0, track_type)) or 0
+        for track_type in TRACK_TYPES
     }
 
 
-def summarise(timeline: Timeline, project: Project, current: str | None) -> dict[str, Any]:
+def summarise(
+    reader: Reader,
+    timeline: Timeline,
+    project: Project,
+    current: str | None,
+) -> dict[str, Any]:
     """The one-line view of a timeline that list and inspect both open with."""
     name = _name(timeline)
     base, version = version_of(name)
@@ -198,7 +224,7 @@ def summarise(timeline: Timeline, project: Project, current: str | None) -> dict
         "current": name == current,
         "fps": fps,
         **_bounds(timeline, fps),
-        "tracks": _track_counts(timeline),
+        "tracks": _track_counts(reader, timeline),
     }
 
 
@@ -212,10 +238,13 @@ def list_timelines(
 ) -> dict[str, Any]:
     """Every timeline in the project with its version, duration and track stack."""
     project = _project(connection)
+    reader = Reader(connection)
     current = project.GetCurrentTimeline()
     current_name = _name(current) if current is not None else None
 
-    timelines = [summarise(timeline, project, current_name) for timeline in _timelines(project)]
+    timelines = [
+        summarise(reader, timeline, project, current_name) for timeline in _timelines(project)
+    ]
 
     cap = max(int(limit), 0)
     truncated = len(timelines) > cap
@@ -269,22 +298,23 @@ def inspect_timeline(
         )
 
     project = _project(connection)
+    reader = Reader(connection)
     timeline = find_timeline(project, name)
     current = project.GetCurrentTimeline()
-    heading = summarise(timeline, project, _name(current) if current is not None else None)
+    heading = summarise(reader, timeline, project, _name(current) if current is not None else None)
     fps = heading["fps"]
 
     window = _window(heading, start, end, fps)
     with_items = detail == "clips"
     tracks = [
-        _read_track(timeline, track_type, index, window, fps, with_items)
+        _read_track(reader, timeline, track_type, index, window, fps, with_items)
         for track_type, count in heading["tracks"].items()
         for index in range(1, count + 1)
     ]
     item_count = sum(track["item_count"] for track in tracks)
 
     result: dict[str, Any] = {
-        "timeline": {**heading, "markers": _marker_count(timeline)},
+        "timeline": {**heading, "markers": _marker_count(reader, timeline)},
         "detail": detail,
         "range": {"in": dual_time(window[0], fps), "out": dual_time(window[1], fps)},
         "tracks": None if detail == "summary" else [_without_items(track) for track in tracks],
@@ -330,6 +360,7 @@ def _window(heading: dict[str, Any], start: Any, end: Any, fps: float | None) ->
 
 
 def _read_track(
+    reader: Reader,
     timeline: Timeline,
     track_type: str,
     index: int,
@@ -353,12 +384,15 @@ def _read_track(
     return {
         "type": track_type,
         "index": index,
-        "name": str(_optional(timeline.GetTrackName, "", track_type, index) or ""),
-        "enabled": bool(_optional(timeline.GetIsTrackEnabled, True, track_type, index)),
-        "locked": bool(_optional(timeline.GetIsTrackLocked, False, track_type, index)),
+        "name": str(reader.optional(timeline, "GetTrackName", "", track_type, index) or ""),
+        "enabled": bool(reader.optional(timeline, "GetIsTrackEnabled", True, track_type, index)),
+        "locked": bool(reader.optional(timeline, "GetIsTrackLocked", False, track_type, index)),
         "item_count": len(in_range),
         "items": (
-            [read_item(item, track_type, index, fps, placement) for item, placement in in_range]
+            [
+                read_item(reader, item, track_type, index, fps, placement)
+                for item, placement in in_range
+            ]
             if with_items
             else []
         ),
@@ -408,8 +442,8 @@ def _items_in_track(timeline: Timeline, track_type: str, index: int) -> list[Tim
     return list(timeline.GetItemListInTrack(track_type, index) or [])
 
 
-def _marker_count(timeline: Timeline) -> int:
-    markers = _optional(timeline.GetMarkers, None)
+def _marker_count(reader: Reader, timeline: Timeline) -> int:
+    markers = reader.optional(timeline, "GetMarkers", None)
     return len(markers) if isinstance(markers, dict) else 0
 
 
@@ -419,6 +453,7 @@ def _placement(item: TimelineItem) -> Placement:
 
 
 def read_item(
+    reader: Reader,
     item: TimelineItem,
     track_type: str,
     index: int,
@@ -428,8 +463,7 @@ def read_item(
     """One shot: where it sits, where it came from, and the offset between the two."""
     record_in, duration = placement.start, placement.duration
     record_out = placement.end
-    source_in = _source_start(item)
-    source_out = _source_end(item, source_in, duration)
+    source_in, source_out = _source_bounds(reader, item, duration)
     offset = record_in - source_in if record_in is not None and source_in is not None else None
     return {
         "name": str(item.GetName() or ""),
@@ -441,46 +475,46 @@ def read_item(
         },
         "source": {"in": dual_time(source_in, fps), "out": dual_time(source_out, fps)},
         "sync_offset": dual_time(offset, fps),
-        "clip": _clip_name(item),
-        "enabled": bool(_optional(getattr(item, "GetClipEnabled", None), True)),
-        "takes": int(_optional(getattr(item, "GetTakeCount", None), 0) or 0),
+        "clip": _clip_name(reader, item),
+        "enabled": bool(reader.optional(item, "GetClipEnabled", True)),
+        "takes": int(reader.optional(item, "GetTakeCount", 0) or 0),
     }
 
 
-def _source_start(item: TimelineItem) -> int | None:
-    """Where the shot starts in its own media.
+def _source_bounds(
+    reader: Reader,
+    item: TimelineItem,
+    duration: int | None,
+) -> tuple[int | None, int | None]:
+    """Where the shot starts and ends in its own media, both on the same clock.
 
-    ``GetSourceStartFrame`` is the direct answer and exists only on newer builds. Failing
-    that, ``GetLeftOffset`` is how far into the media pool item the shot begins — the same
-    number whenever the media itself starts at frame zero, which camera files do, and the
-    closest answer available on a build without the newer getter.
+    ``GetSourceStartFrame``/``GetSourceEndFrame`` are the direct answer and exist only on
+    newer builds; the end is the last frame, hence the plus one. Reading it rather than
+    deriving it matters on a retime, where a shot covers more or fewer source frames than
+    it occupies on the timeline.
+
+    Failing those, ``GetLeftOffset`` is how far into the media pool item the shot begins —
+    the same number whenever the media itself starts at frame zero, which camera files do.
+    The two routes are never mixed: an in point counted from the media start against an
+    out point in absolute source frames would be a span that means nothing.
     """
-    for getter in ("GetSourceStartFrame", "GetLeftOffset"):
-        frames = _frames(_optional(getattr(item, getter, None), None))
-        if frames is not None:
-            return frames
-    return None
+    start = _frames(reader.optional(item, "GetSourceStartFrame", None))
+    if start is not None:
+        last = _frames(reader.optional(item, "GetSourceEndFrame", None))
+        if last is not None:
+            return start, last + 1
+        return start, (start + duration if duration is not None else None)
+
+    offset = _frames(reader.optional(item, "GetLeftOffset", None))
+    if offset is None:
+        return None, None
+    return offset, (offset + duration if duration is not None else None)
 
 
-def _source_end(item: TimelineItem, source_in: int | None, duration: int | None) -> int | None:
-    """One past the shot's last source frame.
-
-    Read rather than derived where Resolve offers it: a retimed shot covers more or fewer
-    source frames than it occupies on the timeline, so ``source_in + duration`` is only
-    right at 1:1 speed. ``GetSourceEndFrame`` reports the last frame, hence the plus one.
-    """
-    reported = _frames(_optional(getattr(item, "GetSourceEndFrame", None), None))
-    if reported is not None:
-        return reported + 1
-    if source_in is None or duration is None:
-        return None
-    return source_in + duration
-
-
-def _clip_name(item: TimelineItem) -> str | None:
+def _clip_name(reader: Reader, item: TimelineItem) -> str | None:
     """The media pool clip a shot came from — a generator or title has none."""
-    clip = _optional(item.GetMediaPoolItem, None)
+    clip = reader.optional(item, "GetMediaPoolItem", None)
     if clip is None:
         return None
-    name = _optional(clip.GetName, None)
+    name = reader.optional(clip, "GetName", None)
     return None if name is None else str(name)

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from . import __version__
 from .config import get_config
 from .logging_config import configure_logging, get_logger
-from .tools import escape_hatch, media, project
+from .tools import escape_hatch, media, project, timeline
 
 log = get_logger("server")
 
@@ -23,6 +23,10 @@ Call get_status first to see what Resolve has open — every result echoes the c
 project, timeline and fps, so watch that context for switches. Take a snapshot_project
 backup before any big or risky operation. Failures come back as ok:false with a cause and
 a fix; act on the fix rather than retrying blindly.
+
+Time is frames-first: every position comes back as frames, seconds, timecode and fps
+together, ranges are half-open [in, out), and a time you give in seconds must say how to
+snap it to a frame ({"seconds": 2.52, "snap": "floor"}).
 """
 
 
@@ -33,7 +37,7 @@ def build_server() -> FastMCP:
         instructions=INSTRUCTIONS,
         version=__version__,
     )
-    for fn in (*project.TOOLS, *media.TOOLS, *escape_hatch.TOOLS):
+    for fn in (*project.TOOLS, *media.TOOLS, *timeline.TOOLS, *escape_hatch.TOOLS):
         mcp.tool(fn)
     return mcp
 

--- a/src/resolve_mcp/spill.py
+++ b/src/resolve_mcp/spill.py
@@ -1,0 +1,26 @@
+"""Returns too big for a reply, written where the agent can grep them instead.
+
+The client caps a tool result at roughly 25k tokens, and a concert media pool or timeline
+is far past that. Rather than truncate silently, a listing over its cap comes back capped
+*and* says where the whole thing landed — the locked hybrid inline/disk return shape.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .config import Config
+from .logging_config import get_logger
+from .naming import timestamped_name
+
+log = get_logger("spill")
+
+
+def spill(label: str, payload: dict[str, Any], config: Config, fallback: str) -> str:
+    """Write the whole reading to the listing directory and return the path."""
+    target = config.listing_dir / timestamped_name(label, ".json", fallback)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    log.info("Spilled the full %s reading to %s", fallback, target)
+    return str(target)

--- a/src/resolve_mcp/timing.py
+++ b/src/resolve_mcp/timing.py
@@ -25,8 +25,14 @@ SNAPS = ("floor", "ceil")
 
 
 def timecode(frames: int, fps: float) -> str:
-    """``HH:MM:SS:FF`` at the nearest whole frame rate, non-drop."""
+    """``HH:MM:SS:FF`` at the nearest whole frame rate, non-drop.
+
+    A negative count is signed rather than wrapped: not every number here is a position on
+    a timeline — a sync offset is a distance, and it routinely points backwards.
+    """
     rate = max(round(fps), 1)
+    if frames < 0:
+        return f"-{timecode(-int(frames), fps)}"
     whole_seconds, frame = divmod(int(frames), rate)
     minutes, seconds = divmod(whole_seconds, 60)
     hours, minutes = divmod(minutes, 60)

--- a/src/resolve_mcp/timing.py
+++ b/src/resolve_mcp/timing.py
@@ -6,13 +6,22 @@ here, once, tested; nothing else in the server is allowed to reimplement it.
 
 Timecode is non-drop-frame: frames are counted at the nearest whole rate (59.94 counts at
 60), which is what Resolve's own frame numbering does. Drop-frame notation is not v1.
+
+Reading a time *in* is the mirror of that rule: ``to_frames`` takes frames as given and
+turns seconds into frames only when the caller says which way to snap. Seconds rarely land
+on a frame boundary, and a server that picked floor or ceil on the caller's behalf would
+move a cut point by a frame without anyone deciding to — so it refuses instead.
 """
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
+from .errors import InvalidRequestError
+
 SECONDS_PRECISION = 3
+SNAPS = ("floor", "ceil")
 
 
 def timecode(frames: int, fps: float) -> str:
@@ -39,3 +48,76 @@ def dual_time(frames: int | None, fps: float | None) -> dict[str, Any] | None:
         "timecode": timecode(frames, fps),
         "fps": fps,
     }
+
+
+def to_frames(value: Any, fps: float | None, field: str = "time") -> int | None:
+    """A caller-supplied time as frames, or ``None`` if nothing was asked for.
+
+    Accepts a whole number of frames (bare, or ``{"frames": 96}``) and seconds carrying an
+    explicit snap: ``{"seconds": 2.52, "snap": "floor"}``. Bare seconds are refused — see
+    the module docstring for why the server will not choose the rounding.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise _unreadable(field, value)
+    if isinstance(value, int | float):
+        return _whole_frames(value, field)
+    if not isinstance(value, dict):
+        raise _unreadable(field, value)
+
+    frames = value.get("frames")
+    has_seconds = "seconds" in value
+    if frames is not None and has_seconds:
+        raise _unreadable(field, value)
+    if frames is None and not has_seconds:
+        raise _unreadable(field, value)
+    if frames is not None:
+        return _whole_frames(frames, field)
+
+    snap = value.get("snap")
+    if snap not in SNAPS:
+        raise InvalidRequestError(
+            cause=f"{field} was given in seconds without saying how to snap it to a frame.",
+            fix=f'Add "snap": "floor" or "ceil" — {field} in seconds is a range, not a frame.',
+            detail={"field": field, "value": value},
+        )
+    if fps is None or fps <= 0:
+        raise InvalidRequestError(
+            cause=f"{field} was given in seconds but the fps here is unknown.",
+            fix=f"Pass {field} in frames instead — frames need no rate to be exact.",
+            detail={"field": field, "value": value},
+        )
+    try:
+        exact = float(value["seconds"]) * fps
+    except (TypeError, ValueError) as exc:
+        raise _unreadable(field, value) from exc
+    return int(math.floor(exact) if snap == "floor" else math.ceil(exact))
+
+
+def _whole_frames(value: Any, field: str) -> int:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise _unreadable(field, value) from exc
+    if number != int(number):
+        raise InvalidRequestError(
+            cause=f"{field} is {number}, which is not a whole frame.",
+            fix=(
+                f"Frames are whole numbers. For a time between frames pass "
+                f'{field}={{"seconds": …, "snap": "floor"}} and say which way to snap.'
+            ),
+            detail={"field": field, "value": value},
+        )
+    return int(number)
+
+
+def _unreadable(field: str, value: Any) -> InvalidRequestError:
+    return InvalidRequestError(
+        cause=f"{field}={value!r} is not a time this server can read.",
+        fix=(
+            f'Give {field} as frames (96 or {{"frames": 96}}) or as seconds with a snap '
+            f'({{"seconds": 2.52, "snap": "floor"}}) — one of the two, never both.'
+        ),
+        detail={"field": field, "value": repr(value)},
+    )

--- a/src/resolve_mcp/tools/timeline.py
+++ b/src/resolve_mcp/tools/timeline.py
@@ -1,0 +1,70 @@
+"""Timeline read tools — finding the sync reference and reading what is on a cut.
+
+Times are dual everywhere: frames are authoritative and every value comes back as frames,
+seconds, timecode and fps together. A time given in seconds must say how to snap it
+({"seconds": 2.52, "snap": "floor"} or "ceil"), because seconds rarely land on a frame and
+this server will not choose the rounding on your behalf. Ranges are half-open [start, end),
+the same convention the cut file uses.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..resolve import timeline as timelines
+from ..resolve.connection import get_connection
+from .envelope import tool
+
+
+@tool
+def list_timelines(limit: int = timelines.DEFAULT_LIST_LIMIT) -> dict[str, Any]:
+    """List the project's timelines with version, duration, fps and track stack.
+
+    version is the number parsed off a "<name> v<N>" name, and latest_versions names the
+    newest one per base name — the cut to carry on from. The sync reference is the timeline
+    carrying an angle per video track, so the track counts are what identifies it. Past
+    limit entries the full listing spills to disk and spilled_to holds the path.
+    """
+    connection = get_connection()
+    return timelines.list_timelines(connection, limit=limit)
+
+
+@tool
+def inspect_timeline(
+    timeline: str | None = None,
+    detail: str = "tracks",
+    start: Any = None,
+    end: Any = None,
+    limit: int = timelines.DEFAULT_ITEM_LIMIT,
+) -> dict[str, Any]:
+    """Read one timeline (the open one by default) at a chosen detail level and range.
+
+    detail is summary (how long, how many tracks, how many shots), tracks (the stack, with
+    names, lock and enable state) or clips (every shot in the range). start and end take
+    frames (96) or seconds with an explicit snap ({"seconds": 2.52, "snap": "floor"}), and
+    default to the whole timeline; a shot is in range when it overlaps it.
+
+    Each shot carries its record position, its source position, and sync_offset — the
+    difference between the two, so that timeline_frame = source_frame + sync_offset. On the
+    director's stacked reference that offset is the per-angle sync, one angle per track.
+
+    Past limit shots the reply is capped and the full reading spills to disk (spilled_to);
+    narrow the range or read that file rather than raising the cap.
+    """
+    connection = get_connection()
+    return timelines.inspect_timeline(
+        connection,
+        name=timeline,
+        detail=detail,
+        start=start,
+        end=end,
+        limit=limit,
+    )
+
+
+TOOLS: tuple[Any, ...] = (
+    list_timelines,
+    inspect_timeline,
+)
+
+__all__ = ["TOOLS", "inspect_timeline", "list_timelines"]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -26,6 +26,10 @@ class FakeTimelineItem:
     ``GetEnd`` is deliberately configurable: the scripting docs do not say whether it is
     the last frame or one past it, so a fake that only ever agreed with
     ``GetStart() + GetDuration()`` would hide a wrapper that trusted the wrong one.
+
+    ``supports_source_frames=False`` models a Resolve older than 18.5, where the source
+    getters are *absent* rather than failing — so ``getattr`` misses them, which is the
+    branch the wrapper actually takes.
     """
 
     def __init__(
@@ -51,6 +55,16 @@ class FakeTimelineItem:
         self._supports_source_frames = supports_source_frames
         self._end_is_inclusive = end_is_inclusive
         self._owner = owner
+
+    SOURCE_GETTERS = ("GetSourceStartFrame", "GetSourceEndFrame")
+
+    def __getattribute__(self, name: str) -> Any:
+        """Hide the source getters entirely on a build that predates them."""
+        if name in FakeTimelineItem.SOURCE_GETTERS and not object.__getattribute__(
+            self, "_supports_source_frames"
+        ):
+            raise AttributeError(name)
+        return object.__getattribute__(self, name)
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
@@ -82,16 +96,10 @@ class FakeTimelineItem:
 
     def GetSourceStartFrame(self) -> int:  # noqa: N802
         self._check()
-        if not self._supports_source_frames:
-            raise AttributeError("GetSourceStartFrame")
-        if self._source_start is None:
-            return 0
-        return self._source_start
+        return self._source_start or 0
 
     def GetSourceEndFrame(self) -> int:  # noqa: N802
         self._check()
-        if not self._supports_source_frames:
-            raise AttributeError("GetSourceEndFrame")
         return (self._source_start or 0) + self._duration - 1
 
     def GetMediaPoolItem(self) -> FakeMediaPoolItem | None:  # noqa: N802
@@ -144,11 +152,13 @@ class FakeTimeline:
         video: TrackSpec | None = None,
         audio: TrackSpec | None = None,
         markers: dict[float, dict[str, Any]] | None = None,
+        end_frame: int | None = None,
         owner: FakeResolve | None = None,
     ) -> None:
         self._name = name
         self._fps = fps
         self._start_frame = start_frame
+        self._end_frame = end_frame
         self._tracks: dict[str, list[FakeTrack]] = {
             "video": _as_tracks(video, "Video"),
             "audio": _as_tracks(audio, "Audio"),
@@ -185,7 +195,15 @@ class FakeTimeline:
         return self._start_frame
 
     def GetEndFrame(self) -> int:  # noqa: N802
+        """Where the timeline ends.
+
+        ``end_frame`` is settable and independent of the items, so a test can say what
+        Resolve reports rather than have the fake derive a number the wrapper is bound to
+        agree with — the timeline's own duration is the one reading taken on trust.
+        """
         self._check()
+        if self._end_frame is not None:
+            return self._end_frame
         ends = [
             item.GetStart() + item.GetDuration()
             for tracks in self._tracks.values()
@@ -496,8 +514,9 @@ class FakeProject:
         timeline: FakeTimeline | None = None,
         fps: str = "24",
         media_pool: FakeMediaPool | None = None,
-        timelines: list[FakeTimeline] | None = None,
+        timelines: list[FakeTimeline | None] | None = None,
     ) -> None:
+        """``timelines`` may hold a ``None``: Resolve sometimes answers an index with one."""
         self._name = name
         self._timeline = timeline
         self._fps = fps
@@ -693,7 +712,7 @@ def studio(
     fps: str = "59.94",
     extra_projects: tuple[str, ...] = ("holiday-gig",),
     pool: FakeMediaPool | None = None,
-    timelines: list[FakeTimeline] | None = None,
+    timelines: list[FakeTimeline | None] | None = None,
 ) -> FakeResolve:
     """A conventional fake: Studio running, one project open, one timeline current.
 
@@ -722,7 +741,7 @@ def studio(
     resolve = FakeResolve(projects, current=project)
     if pool is not None:
         pool.adopt(resolve)
-    owned = list(timelines or [])
+    owned = [one for one in (timelines or []) if one is not None]
     if current is not None and current not in owned:
         owned.append(current)
     for one in owned:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -38,6 +38,8 @@ class FakeTimelineItem:
         start: int,
         duration: int,
         source_start: int | None = None,
+        left_offset: int | None = None,
+        source_end: int | None = None,
         media_item: FakeMediaPoolItem | None = None,
         enabled: bool = True,
         takes: int = 0,
@@ -49,6 +51,8 @@ class FakeTimelineItem:
         self._start = start
         self._duration = duration
         self._source_start = source_start
+        self._left_offset = left_offset
+        self._source_end = source_end
         self._media_item = media_item
         self._enabled = enabled
         self._takes = takes
@@ -91,15 +95,20 @@ class FakeTimelineItem:
         return end - 1 if self._end_is_inclusive else end
 
     def GetLeftOffset(self) -> int:  # noqa: N802
+        """How far into the media the shot begins. Set it apart from the source start to
+        say which getter a reading came from."""
         self._check()
-        return self._source_start or 0
+        return (self._left_offset if self._left_offset is not None else self._source_start) or 0
 
     def GetSourceStartFrame(self) -> int:  # noqa: N802
         self._check()
         return self._source_start or 0
 
     def GetSourceEndFrame(self) -> int:  # noqa: N802
+        """The last source frame — inclusive, and not derivable from duration on a retime."""
         self._check()
+        if self._source_end is not None:
+            return self._source_end
         return (self._source_start or 0) + self._duration - 1
 
     def GetMediaPoolItem(self) -> FakeMediaPoolItem | None:  # noqa: N802

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -44,6 +44,7 @@ class FakeTimelineItem:
         enabled: bool = True,
         takes: int = 0,
         supports_source_frames: bool = True,
+        refuses: frozenset[str] | set[str] | None = None,
         end_is_inclusive: bool = False,
         owner: FakeResolve | None = None,
     ) -> None:
@@ -57,6 +58,7 @@ class FakeTimelineItem:
         self._enabled = enabled
         self._takes = takes
         self._supports_source_frames = supports_source_frames
+        self._refuses = set(refuses or ())
         self._end_is_inclusive = end_is_inclusive
         self._owner = owner
 
@@ -73,7 +75,9 @@ class FakeTimelineItem:
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
 
-    def _check(self) -> None:
+    def _check(self, method: str = "") -> None:
+        if method and method in self._refuses:
+            raise RuntimeError(f"{method} is not supported for this clip type")
         if self._owner is not None:
             self._owner._check()
 
@@ -101,7 +105,7 @@ class FakeTimelineItem:
         return (self._left_offset if self._left_offset is not None else self._source_start) or 0
 
     def GetSourceStartFrame(self) -> int:  # noqa: N802
-        self._check()
+        self._check("GetSourceStartFrame")
         return self._source_start or 0
 
     def GetSourceEndFrame(self) -> int:  # noqa: N802
@@ -112,15 +116,15 @@ class FakeTimelineItem:
         return (self._source_start or 0) + self._duration - 1
 
     def GetMediaPoolItem(self) -> FakeMediaPoolItem | None:  # noqa: N802
-        self._check()
+        self._check("GetMediaPoolItem")
         return self._media_item
 
     def GetClipEnabled(self) -> bool:  # noqa: N802
-        self._check()
+        self._check("GetClipEnabled")
         return self._enabled
 
     def GetTakeCount(self) -> int:  # noqa: N802
-        self._check()
+        self._check("GetTakeCount")
         return self._takes
 
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -11,6 +11,7 @@ come back as strings.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -19,16 +20,211 @@ class DroppedHandleError(RuntimeError):
     """What a stale Resolve handle raises when the app has gone away."""
 
 
-class FakeTimeline:
-    def __init__(self, name: str, fps: str = "59.94") -> None:
+class FakeTimelineItem:
+    """A clip on a track.
+
+    ``GetEnd`` is deliberately configurable: the scripting docs do not say whether it is
+    the last frame or one past it, so a fake that only ever agreed with
+    ``GetStart() + GetDuration()`` would hide a wrapper that trusted the wrong one.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        start: int,
+        duration: int,
+        source_start: int | None = None,
+        media_item: FakeMediaPoolItem | None = None,
+        enabled: bool = True,
+        takes: int = 0,
+        supports_source_frames: bool = True,
+        end_is_inclusive: bool = False,
+        owner: FakeResolve | None = None,
+    ) -> None:
         self._name = name
-        self._fps = fps
+        self._start = start
+        self._duration = duration
+        self._source_start = source_start
+        self._media_item = media_item
+        self._enabled = enabled
+        self._takes = takes
+        self._supports_source_frames = supports_source_frames
+        self._end_is_inclusive = end_is_inclusive
+        self._owner = owner
+
+    def adopt(self, owner: FakeResolve) -> None:
+        self._owner = owner
+
+    def _check(self) -> None:
+        if self._owner is not None:
+            self._owner._check()
 
     def GetName(self) -> str:  # noqa: N802 - mirrors the Resolve API
+        self._check()
+        return self._name
+
+    def GetStart(self) -> int:  # noqa: N802
+        self._check()
+        return self._start
+
+    def GetDuration(self) -> int:  # noqa: N802
+        self._check()
+        return self._duration
+
+    def GetEnd(self) -> int:  # noqa: N802
+        self._check()
+        end = self._start + self._duration
+        return end - 1 if self._end_is_inclusive else end
+
+    def GetLeftOffset(self) -> int:  # noqa: N802
+        self._check()
+        return self._source_start or 0
+
+    def GetSourceStartFrame(self) -> int:  # noqa: N802
+        self._check()
+        if not self._supports_source_frames:
+            raise AttributeError("GetSourceStartFrame")
+        if self._source_start is None:
+            return 0
+        return self._source_start
+
+    def GetSourceEndFrame(self) -> int:  # noqa: N802
+        self._check()
+        if not self._supports_source_frames:
+            raise AttributeError("GetSourceEndFrame")
+        return (self._source_start or 0) + self._duration - 1
+
+    def GetMediaPoolItem(self) -> FakeMediaPoolItem | None:  # noqa: N802
+        self._check()
+        return self._media_item
+
+    def GetClipEnabled(self) -> bool:  # noqa: N802
+        self._check()
+        return self._enabled
+
+    def GetTakeCount(self) -> int:  # noqa: N802
+        self._check()
+        return self._takes
+
+
+class FakeTrack:
+    """One track's worth of state: the API reaches it only through the timeline."""
+
+    def __init__(
+        self,
+        name: str,
+        items: list[FakeTimelineItem] | None = None,
+        enabled: bool = True,
+        locked: bool = False,
+    ) -> None:
+        self.name = name
+        self.items = list(items or [])
+        self.enabled = enabled
+        self.locked = locked
+
+
+TrackSpec = Sequence["FakeTrack | list[FakeTimelineItem]"]
+
+
+def _as_tracks(spec: TrackSpec | None, label: str) -> list[FakeTrack]:
+    tracks: list[FakeTrack] = []
+    for index, entry in enumerate(spec or [], start=1):
+        tracks.append(
+            entry if isinstance(entry, FakeTrack) else FakeTrack(f"{label} {index}", entry)
+        )
+    return tracks
+
+
+class FakeTimeline:
+    def __init__(
+        self,
+        name: str,
+        fps: str = "59.94",
+        start_frame: int = 0,
+        video: TrackSpec | None = None,
+        audio: TrackSpec | None = None,
+        markers: dict[float, dict[str, Any]] | None = None,
+        owner: FakeResolve | None = None,
+    ) -> None:
+        self._name = name
+        self._fps = fps
+        self._start_frame = start_frame
+        self._tracks: dict[str, list[FakeTrack]] = {
+            "video": _as_tracks(video, "Video"),
+            "audio": _as_tracks(audio, "Audio"),
+            "subtitle": [],
+        }
+        self._markers = markers or {}
+        self._owner = owner
+
+    def adopt(self, owner: FakeResolve) -> None:
+        self._owner = owner
+        for tracks in self._tracks.values():
+            for track in tracks:
+                for item in track.items:
+                    item.adopt(owner)
+
+    def _check(self) -> None:
+        if self._owner is not None:
+            self._owner._check()
+
+    def _track(self, track_type: str, index: int) -> FakeTrack | None:
+        tracks = self._tracks.get(track_type, [])
+        return tracks[index - 1] if 1 <= index <= len(tracks) else None
+
+    def GetName(self) -> str:  # noqa: N802 - mirrors the Resolve API
+        self._check()
         return self._name
 
     def GetSetting(self, key: str) -> str | None:  # noqa: N802
+        self._check()
         return self._fps if key == "timelineFrameRate" else None
+
+    def GetStartFrame(self) -> int:  # noqa: N802
+        self._check()
+        return self._start_frame
+
+    def GetEndFrame(self) -> int:  # noqa: N802
+        self._check()
+        ends = [
+            item.GetStart() + item.GetDuration()
+            for tracks in self._tracks.values()
+            for track in tracks
+            for item in track.items
+        ]
+        return max(ends, default=self._start_frame)
+
+    def GetTrackCount(self, track_type: str) -> int:  # noqa: N802
+        self._check()
+        return len(self._tracks.get(track_type, []))
+
+    def GetTrackName(self, track_type: str, index: int) -> str | None:  # noqa: N802
+        self._check()
+        track = self._track(track_type, index)
+        return track.name if track else None
+
+    def GetItemListInTrack(  # noqa: N802
+        self,
+        track_type: str,
+        index: int,
+    ) -> list[FakeTimelineItem] | None:
+        self._check()
+        track = self._track(track_type, index)
+        return list(track.items) if track else None
+
+    def GetIsTrackEnabled(self, track_type: str, index: int) -> bool:  # noqa: N802
+        self._check()
+        track = self._track(track_type, index)
+        return bool(track and track.enabled)
+
+    def GetIsTrackLocked(self, track_type: str, index: int) -> bool:  # noqa: N802
+        self._check()
+        track = self._track(track_type, index)
+        return bool(track and track.locked)
+
+    def GetMarkers(self) -> dict[float, dict[str, Any]]:  # noqa: N802
+        self._check()
+        return dict(self._markers)
 
 
 IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"}
@@ -300,17 +496,31 @@ class FakeProject:
         timeline: FakeTimeline | None = None,
         fps: str = "24",
         media_pool: FakeMediaPool | None = None,
+        timelines: list[FakeTimeline] | None = None,
     ) -> None:
         self._name = name
         self._timeline = timeline
         self._fps = fps
         self._media_pool = media_pool
+        if timelines is not None:
+            self._timelines = list(timelines)
+        else:
+            self._timelines = [timeline] if timeline is not None else []
 
     def GetName(self) -> str:  # noqa: N802
         return self._name
 
     def GetCurrentTimeline(self) -> FakeTimeline | None:  # noqa: N802
         return self._timeline
+
+    def GetTimelineCount(self) -> int:  # noqa: N802
+        return len(self._timelines)
+
+    def GetTimelineByIndex(self, index: int) -> FakeTimeline | None:  # noqa: N802
+        """One-based, as in the real API; out of range returns ``None`` rather than raising."""
+        if 1 <= index <= len(self._timelines):
+            return self._timelines[index - 1]
+        return None
 
     def GetSetting(self, key: str) -> str | None:  # noqa: N802
         return self._fps if key == "timelineFrameRate" else None
@@ -454,25 +664,67 @@ def media_pool(bins: dict[str, list[FakeMediaPoolItem]] | None = None) -> FakeMe
     return pool
 
 
+def sync_reference(
+    name: str = "sunset-set sync",
+    fps: str = "59.94",
+    angles: dict[str, tuple[int, int, int]] | None = None,
+    start_frame: int = 0,
+) -> FakeTimeline:
+    """The director's stacked layout: one angle per video track, each landing on its own frame.
+
+    ``angles`` maps a track name to ``(record_start, source_start, duration)``. That is the
+    shape a hand-synced reference has, and the per-angle sync offset is the difference
+    between the two starts.
+    """
+    angles = angles or {"Cam A": (0, 1000, 500), "Cam B": (120, 3000, 400)}
+    video = [
+        FakeTrack(
+            track,
+            [FakeTimelineItem(f"{track}.mp4", record, duration, source_start=source)],
+        )
+        for track, (record, source, duration) in angles.items()
+    ]
+    return FakeTimeline(name, fps, start_frame=start_frame, video=video)
+
+
 def studio(
     project: str | None = "sunset-set",
-    timeline: str | None = "sunset-set v3",
+    timeline: str | FakeTimeline | None = "sunset-set v3",
     fps: str = "59.94",
     extra_projects: tuple[str, ...] = ("holiday-gig",),
     pool: FakeMediaPool | None = None,
+    timelines: list[FakeTimeline] | None = None,
 ) -> FakeResolve:
-    """A conventional fake: Studio running, one project open, one timeline current."""
+    """A conventional fake: Studio running, one project open, one timeline current.
+
+    ``timeline`` is the current one, by name or as a built ``FakeTimeline``; ``timelines``
+    is everything the project holds, defaulting to the current one alone. Passing
+    ``timelines`` makes the first of them current, unless ``timeline`` says otherwise —
+    ``None`` for a project whose timelines are all closed.
+    """
+    if isinstance(timeline, FakeTimeline) or timeline is None:
+        current = timeline
+    elif timelines is not None:
+        current = timelines[0] if timelines else None
+    else:
+        current = FakeTimeline(timeline, fps)
     projects: dict[str, FakeProject] = {}
     for name in extra_projects:
         projects[name] = FakeProject(name, fps=fps)
     if project is not None:
         projects[project] = FakeProject(
             project,
-            FakeTimeline(timeline, fps) if timeline else None,
+            current,
             fps=fps,
             media_pool=pool,
+            timelines=timelines,
         )
     resolve = FakeResolve(projects, current=project)
     if pool is not None:
         pool.adopt(resolve)
+    owned = list(timelines or [])
+    if current is not None and current not in owned:
+        owned.append(current)
+    for one in owned:
+        one.adopt(resolve)
     return resolve

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -100,18 +100,26 @@ def test_the_frame_math_holds_on_a_real_timeline() -> None:
     if get_status()["context"]["timeline"] is None:
         pytest.skip("No timeline open in Resolve")
 
-    result = inspect_timeline(detail="clips")
+    whole = inspect_timeline(detail="summary")
+    assert whole["ok"] is True
+    ends_at = whole["timeline"]["end"]["frames"]
 
-    assert result["ok"] is True
-    ends_at = result["timeline"]["end"]["frames"]
-    outs = [
-        item["record"]["out"]["frames"] for track in result["tracks"] for item in track["items"]
-    ]
-    if outs and not result["truncated"]:
-        # The timeline's own duration is the one number taken from GetEndFrame on trust
-        # (a timeline has no duration getter). A Resolve that reported the last frame
-        # rather than one past it would show up here as an off-by-one, and nowhere else.
+    # The timeline's own duration is the one number taken from GetEndFrame on trust (a
+    # timeline has no duration getter). A Resolve that reported the last frame rather than
+    # one past it shows up here as an off-by-one and nowhere else — so read the tail
+    # rather than the whole cut, which on a real concert timeline would truncate and skip
+    # this check exactly where it matters.
+    tail = inspect_timeline(
+        detail="clips", start=max(ends_at - 600, whole["timeline"]["start"]["frames"])
+    )
+    assert tail["ok"] is True
+    assert tail["truncated"] is False, "the tail was still too long to check the end frame"
+    outs = [item["record"]["out"]["frames"] for track in tail["tracks"] for item in track["items"]]
+    if outs:
         assert ends_at == max(outs)
+
+    result = inspect_timeline(detail="clips")
+    assert result["ok"] is True
     for track in result["tracks"]:
         for item in track["items"]:
             record = item["record"]

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -104,6 +104,14 @@ def test_the_frame_math_holds_on_a_real_timeline() -> None:
 
     assert result["ok"] is True
     ends_at = result["timeline"]["end"]["frames"]
+    outs = [
+        item["record"]["out"]["frames"] for track in result["tracks"] for item in track["items"]
+    ]
+    if outs and not result["truncated"]:
+        # The timeline's own duration is the one number taken from GetEndFrame on trust
+        # (a timeline has no duration getter). A Resolve that reported the last frame
+        # rather than one past it would show up here as an off-by-one, and nowhere else.
+        assert ends_at == max(outs)
     for track in result["tracks"]:
         for item in track["items"]:
             record = item["record"]

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -18,6 +18,7 @@ import pytest
 from resolve_mcp.tools.escape_hatch import run_python
 from resolve_mcp.tools.media import inspect_clip, list_media
 from resolve_mcp.tools.project import get_status, list_projects, snapshot_project
+from resolve_mcp.tools.timeline import inspect_timeline, list_timelines
 
 pytestmark = pytest.mark.live
 
@@ -73,6 +74,46 @@ def test_inspects_a_real_clip_with_the_property_keys_the_wrappers_assume() -> No
     assert result["ok"] is True
     assert "File Path" in result["properties"]
     assert result["bounds"]["media"]["duration"] is not None
+
+
+def test_lists_the_real_timelines() -> None:
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+
+    result = list_timelines()
+
+    assert result["ok"] is True
+    assert isinstance(result["timelines"], list)
+    for entry in result["timelines"]:
+        assert entry["fps"]
+        assert entry["duration"] is not None
+
+
+def test_the_frame_math_holds_on_a_real_timeline() -> None:
+    """The fakes prove the arithmetic; only Resolve proves the numbers fed into it.
+
+    Every reported out point is derived from ``GetDuration`` rather than ``GetEnd`` — see
+    the wrapper docstring — so this is where that derivation meets real timeline items:
+    durations must close, shots must land inside the timeline, and the sync offset must be
+    the difference the agent will plan against.
+    """
+    if get_status()["context"]["timeline"] is None:
+        pytest.skip("No timeline open in Resolve")
+
+    result = inspect_timeline(detail="clips")
+
+    assert result["ok"] is True
+    ends_at = result["timeline"]["end"]["frames"]
+    for track in result["tracks"]:
+        for item in track["items"]:
+            record = item["record"]
+            assert record["out"]["frames"] - record["in"]["frames"] == record["duration"]["frames"]
+            assert record["out"]["frames"] <= ends_at
+            if item["source"]["in"] is not None:
+                assert (
+                    item["sync_offset"]["frames"]
+                    == record["in"]["frames"] - item["source"]["in"]["frames"]
+                )
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,7 +17,7 @@ def descriptions() -> dict[str, str]:
     return {tool.name: tool.description or "" for tool in tools}
 
 
-def test_registers_the_p1_session_and_media_tools() -> None:
+def test_registers_the_p1_session_media_and_timeline_tools() -> None:
     assert tool_names() == {
         "get_status",
         "list_projects",
@@ -29,6 +29,8 @@ def test_registers_the_p1_session_and_media_tools() -> None:
         "set_clip_metadata",
         "organize_media",
         "relink_media",
+        "list_timelines",
+        "inspect_timeline",
         "run_python",
     }
 

--- a/tests/test_timeline_tools.py
+++ b/tests/test_timeline_tools.py
@@ -14,7 +14,6 @@ from resolve_mcp.tools.timeline import inspect_timeline, list_timelines
 from .conftest import Attach
 from .fakes import (
     FakeMediaPoolItem,
-    FakeResolve,
     FakeTimeline,
     FakeTimelineItem,
     FakeTrack,
@@ -92,9 +91,7 @@ def test_list_names_the_newest_version_of_each_cut(attach: Attach) -> None:
     assert result["latest_versions"] == {"sunset-set": "sunset-set v12", "encore": "encore_v2"}
 
 
-def test_list_spills_past_the_cap_rather_than_flooding_the_reply(
-    attach: Attach, tmp_path: Path
-) -> None:
+def test_list_spills_past_the_cap_rather_than_flooding_the_reply(attach: Attach) -> None:
     attach(studio(timelines=[a_cut(f"sunset-set v{index}") for index in range(1, 6)]))
 
     result = list_timelines(limit=2)
@@ -130,7 +127,8 @@ def test_timeline_tools_need_a_project(attach: Attach) -> None:
 
 
 def test_inspect_defaults_to_the_open_timeline(attach: Attach) -> None:
-    attach(studio(timelines=[sync_reference(), a_cut()], timeline=a_cut()))
+    cut = a_cut()
+    attach(studio(timelines=[sync_reference(), cut], timeline=cut))
 
     result = inspect_timeline()
 
@@ -242,10 +240,11 @@ def test_each_angle_carries_the_offset_that_maps_its_source_onto_the_timeline(
 
     result = inspect_timeline(detail="clips")
 
-    offsets = {
-        track["name"]: track["items"][0]["sync_offset"]["frames"] for track in result["tracks"]
-    }
-    assert offsets == {"Cam A": -1000, "Cam B": -2880}
+    offsets = {track["name"]: track["items"][0]["sync_offset"] for track in result["tracks"]}
+    assert offsets["Cam A"]["frames"] == -1000
+    assert offsets["Cam B"]["frames"] == -2880
+    assert offsets["Cam A"]["timecode"] == "-00:00:16:40"
+    assert offsets["Cam A"]["seconds"] == -16.683
 
 
 def test_an_angle_on_a_resolve_without_source_frames_still_reports_its_offset(
@@ -353,9 +352,7 @@ def test_a_backwards_range_is_rejected(attach: Attach) -> None:
 # --- pagination --------------------------------------------------------------------------
 
 
-def test_a_long_timeline_caps_the_shots_it_returns_and_spills_the_rest(
-    attach: Attach, tmp_path: Path
-) -> None:
+def test_a_long_timeline_caps_the_shots_it_returns_and_spills_the_rest(attach: Attach) -> None:
     shots = [FakeTimelineItem(f"C{index:04d}.mp4", index * 10, 10) for index in range(20)]
     attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", shots)])))
 
@@ -382,6 +379,43 @@ def test_the_cap_counts_shots_across_every_track(attach: Attach) -> None:
     assert returned == 2
     assert result["item_count"] == 4
     assert result["truncated"] is True
+
+
+def test_the_default_cap_keeps_a_reply_inside_the_client_token_budget(attach: Attach) -> None:
+    """The 25k-token cap is the reason the cap exists, so the default has to fit under it.
+
+    Four characters to a token is the rough conversion; a shot carries six dual-time
+    readings, which is what makes a default anyone picked by feel land wrong.
+    """
+    shots = [
+        FakeTimelineItem(f"C{index:04d}.mp4", index * 10, 10, source_start=index)
+        for index in range(500)
+    ]
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", shots)])))
+
+    result = inspect_timeline(detail="clips")
+
+    assert result["truncated"] is True
+    assert len(json.dumps(result)) < 4 * 25_000
+
+
+def test_the_timeline_duration_is_the_end_resolve_reports(attach: Attach) -> None:
+    """A timeline has no duration getter, so this one reading rests on GetEndFrame."""
+    attach(
+        studio(
+            timeline=FakeTimeline(
+                "cut v1",
+                start_frame=100,
+                end_frame=400,
+                video=[FakeTrack("Video 1", [FakeTimelineItem("C0012.mp4", 100, 60)])],
+            )
+        )
+    )
+
+    result = inspect_timeline(detail="summary")
+
+    assert result["timeline"]["end"]["frames"] == 400
+    assert result["timeline"]["duration"]["frames"] == 300
 
 
 def test_a_summary_never_spills(attach: Attach) -> None:
@@ -424,6 +458,31 @@ def test_resolve_quitting_mid_call_is_a_connection_failure_not_a_bug(attach: Att
     assert result["error"]["code"] == "resolve_unavailable"
 
 
+@pytest.mark.parametrize("survives", range(1, 16))
+def test_a_death_part_way_through_a_read_never_returns_half_a_timeline(
+    attach: Attach, survives: int
+) -> None:
+    """Wherever the handle dies, the answer is a complete reading or a stated failure.
+
+    The field-level readers fall back rather than raise, which is right for a getter an
+    older Resolve does not have and wrong for a handle that has gone away — this pins the
+    difference at every point in the walk, so no fallback can quietly stand in for a
+    dropped connection.
+    """
+    dying = studio(timeline=a_cut())
+    dying.die_after(survives)
+    attach(dying, studio(timeline=a_cut()))
+
+    result = inspect_timeline(detail="clips")
+
+    assert result["ok"] is True
+    shots = result["tracks"][0]["items"]
+    assert [shot["name"] for shot in shots] == ["C0012.mp4", "C0031.mp4", "C0012.mp4"]
+    assert all(shot["record"]["duration"]["frames"] for shot in shots)
+    assert all(shot["sync_offset"] is not None for shot in shots)
+    assert result["timeline"]["duration"]["frames"] == 200
+
+
 def test_a_bug_in_the_wrapper_is_reported_once_as_a_bug(
     attach: Attach, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -447,11 +506,7 @@ def test_a_timeline_that_cannot_be_read_is_skipped_rather_than_sinking_the_list(
     attach: Attach,
 ) -> None:
     """Resolve hands out timeline proxies that occasionally answer nothing at all."""
-    resolve: FakeResolve = studio(timelines=[a_cut("sunset-set v1"), a_cut("sunset-set v2")])
-    project = resolve.projects["sunset-set"]
-    project._timelines.insert(1, None)  # type: ignore[arg-type]
-
-    attach(resolve)
+    attach(studio(timelines=[a_cut("sunset-set v1"), None, a_cut("sunset-set v2")]))
 
     result = list_timelines()
 

--- a/tests/test_timeline_tools.py
+++ b/tests/test_timeline_tools.py
@@ -247,16 +247,41 @@ def test_each_angle_carries_the_offset_that_maps_its_source_onto_the_timeline(
     assert offsets["Cam A"]["seconds"] == -16.683
 
 
+def test_the_source_start_is_read_before_the_left_offset_that_stands_in_for_it(
+    attach: Attach,
+) -> None:
+    item = FakeTimelineItem("A.mp4", 120, 400, source_start=3000, left_offset=7)
+    attach(studio(timeline=FakeTimeline("sync", video=[FakeTrack("Cam A", [item])])))
+
+    result = inspect_timeline(detail="clips")
+
+    assert result["tracks"][0]["items"][0]["source"]["in"]["frames"] == 3000
+
+
 def test_an_angle_on_a_resolve_without_source_frames_still_reports_its_offset(
     attach: Attach,
 ) -> None:
-    """Pre-18.5 has no GetSourceStartFrame; the left offset carries the same information."""
-    item = FakeTimelineItem("A.mp4", 120, 400, source_start=3000, supports_source_frames=False)
+    """Pre-18.5 has no GetSourceStartFrame; the left offset is the closest thing it has."""
+    item = FakeTimelineItem(
+        "A.mp4", 120, 400, source_start=3000, left_offset=3000, supports_source_frames=False
+    )
     attach(studio(timeline=FakeTimeline("sync", video=[FakeTrack("Cam A", [item])])))
 
     result = inspect_timeline(detail="clips")
 
     assert result["tracks"][0]["items"][0]["sync_offset"]["frames"] == -2880
+
+
+def test_a_retimed_shot_reports_the_source_frames_it_really_covers(attach: Attach) -> None:
+    """Half speed: 400 timeline frames over 200 source frames, so duration will not do."""
+    item = FakeTimelineItem("A.mp4", 0, 400, source_start=1000, source_end=1199)
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", [item])])))
+
+    result = inspect_timeline(detail="clips")
+
+    source = result["tracks"][0]["items"][0]["source"]
+    assert source["in"]["frames"] == 1000
+    assert source["out"]["frames"] == 1200
 
 
 def test_a_shot_reports_the_media_pool_clip_it_came_from(attach: Attach) -> None:
@@ -366,6 +391,23 @@ def test_a_long_timeline_caps_the_shots_it_returns_and_spills_the_rest(attach: A
     assert len(json.loads(spilled.read_text(encoding="utf-8"))["tracks"][0]["items"]) == 20
 
 
+def test_a_busy_video_track_cannot_starve_the_angles_stacked_under_it(attach: Attach) -> None:
+    """The stacked reference is the layout this tool exists to make readable."""
+    busy = FakeTrack(
+        "Cam A", [FakeTimelineItem(f"A{index}.mp4", index * 10, 10) for index in range(10)]
+    )
+    quiet = FakeTrack(
+        "Cam B", [FakeTimelineItem(f"B{index}.mp4", index * 10, 10) for index in range(2)]
+    )
+    attach(studio(timeline=FakeTimeline("sync", video=[busy, quiet])))
+
+    result = inspect_timeline(detail="clips", limit=4)
+
+    kept = {track["name"]: [item["name"] for item in track["items"]] for track in result["tracks"]}
+    assert kept == {"Cam A": ["A0.mp4", "A1.mp4"], "Cam B": ["B0.mp4", "B1.mp4"]}
+    assert result["truncated"] is True
+
+
 def test_the_cap_counts_shots_across_every_track(attach: Attach) -> None:
     tracks = [
         FakeTrack(f"Cam {letter}", [FakeTimelineItem(f"{letter}.mp4", index * 10, 10)])
@@ -384,8 +426,10 @@ def test_the_cap_counts_shots_across_every_track(attach: Attach) -> None:
 def test_the_default_cap_keeps_a_reply_inside_the_client_token_budget(attach: Attach) -> None:
     """The 25k-token cap is the reason the cap exists, so the default has to fit under it.
 
-    Four characters to a token is the rough conversion; a shot carries six dual-time
-    readings, which is what makes a default anyone picked by feel land wrong.
+    Dense JSON — repeated keys, runs of digits, six dual-time blocks a shot — runs nearer
+    3.3 characters to the token than the 4 that prose does, so the budget is counted at the
+    tighter rate. It is the shot shape, not the number of shots, that makes a limit picked
+    by feel land wrong; this fails if either grows.
     """
     shots = [
         FakeTimelineItem(f"C{index:04d}.mp4", index * 10, 10, source_start=index)
@@ -396,7 +440,7 @@ def test_the_default_cap_keeps_a_reply_inside_the_client_token_budget(attach: At
     result = inspect_timeline(detail="clips")
 
     assert result["truncated"] is True
-    assert len(json.dumps(result)) < 4 * 25_000
+    assert len(json.dumps(result)) < 3.3 * 25_000
 
 
 def test_the_timeline_duration_is_the_end_resolve_reports(attach: Attach) -> None:
@@ -458,29 +502,68 @@ def test_resolve_quitting_mid_call_is_a_connection_failure_not_a_bug(attach: Att
     assert result["error"]["code"] == "resolve_unavailable"
 
 
-@pytest.mark.parametrize("survives", range(1, 16))
+def a_telling_cut() -> FakeTimeline:
+    """A cut whose every readable field differs from the value a fallback would invent.
+
+    Track names, marker counts, clip names, take counts and the enabled flag all have a
+    default somewhere in the reading path; a timeline built out of those defaults could be
+    fabricated without any test noticing. This one cannot.
+    """
+    return FakeTimeline(
+        "sunset-set v3",
+        start_frame=100,
+        markers={120.0: {"note": "fill"}, 240.0: {"note": "solo"}},
+        video=[
+            FakeTrack(
+                "Cam A",
+                [
+                    FakeTimelineItem(
+                        "C0012.mp4",
+                        100,
+                        60,
+                        source_start=1000,
+                        media_item=FakeMediaPoolItem("C0012.mp4", "D:/angles/C0012.mp4"),
+                        enabled=False,
+                        takes=2,
+                    )
+                ],
+                locked=True,
+            )
+        ],
+        audio=[FakeTrack("Master", [FakeTimelineItem("master_mix.wav", 100, 200)])],
+    )
+
+
+@pytest.mark.parametrize("survives", range(1, 41))
 def test_a_death_part_way_through_a_read_never_returns_half_a_timeline(
     attach: Attach, survives: int
 ) -> None:
     """Wherever the handle dies, the answer is a complete reading or a stated failure.
 
-    The field-level readers fall back rather than raise, which is right for a getter an
-    older Resolve does not have and wrong for a handle that has gone away — this pins the
-    difference at every point in the walk, so no fallback can quietly stand in for a
-    dropped connection.
+    Falling back is right for a getter an older Resolve does not have and wrong for a
+    handle that has gone away: the second would hand the agent a timeline of plausible
+    defaults with nothing to distrust. This walks the death forward through every call the
+    read makes, and every field it checks would read as a fallback if one had been taken.
     """
-    dying = studio(timeline=a_cut())
+    dying = studio(timeline=a_telling_cut())
     dying.die_after(survives)
-    attach(dying, studio(timeline=a_cut()))
+    attach(dying, studio(timeline=a_telling_cut()))
 
     result = inspect_timeline(detail="clips")
 
     assert result["ok"] is True
-    shots = result["tracks"][0]["items"]
-    assert [shot["name"] for shot in shots] == ["C0012.mp4", "C0031.mp4", "C0012.mp4"]
-    assert all(shot["record"]["duration"]["frames"] for shot in shots)
-    assert all(shot["sync_offset"] is not None for shot in shots)
     assert result["timeline"]["duration"]["frames"] == 200
+    assert result["timeline"]["markers"] == 2
+    assert result["timeline"]["tracks"] == {"video": 1, "audio": 1, "subtitle": 0}
+    video = result["tracks"][0]
+    assert video["name"] == "Cam A"
+    assert video["locked"] is True
+    shot = video["items"][0]
+    assert shot["name"] == "C0012.mp4"
+    assert shot["clip"] == "C0012.mp4"
+    assert shot["takes"] == 2
+    assert shot["enabled"] is False
+    assert shot["sync_offset"]["frames"] == -900
 
 
 def test_a_bug_in_the_wrapper_is_reported_once_as_a_bug(

--- a/tests/test_timeline_tools.py
+++ b/tests/test_timeline_tools.py
@@ -272,6 +272,50 @@ def test_an_angle_on_a_resolve_without_source_frames_still_reports_its_offset(
     assert result["tracks"][0]["items"][0]["sync_offset"]["frames"] == -2880
 
 
+def test_one_title_that_refuses_a_getter_costs_a_field_not_the_inspection(
+    attach: Attach,
+) -> None:
+    """A Text+ generator answers some getters and refuses others; the cut still reads."""
+    title = FakeTimelineItem(
+        "Title 01",
+        0,
+        60,
+        refuses={"GetSourceStartFrame", "GetMediaPoolItem", "GetTakeCount"},
+    )
+    shot = FakeTimelineItem("C0012.mp4", 60, 40, source_start=1000)
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", [title, shot])])))
+
+    result = inspect_timeline(detail="clips")
+
+    assert result["ok"] is True
+    titled, filmed = result["tracks"][0]["items"]
+    assert titled["name"] == "Title 01"
+    assert titled["clip"] is None
+    assert titled["takes"] == 0
+    assert titled["record"]["duration"]["frames"] == 60
+    assert filmed["source"]["in"]["frames"] == 1000
+
+
+def test_a_source_span_is_never_half_one_clock_and_half_another(attach: Attach) -> None:
+    """An in point counted from the media start against an absolute out point is a lie."""
+    item = FakeTimelineItem(
+        "A.mp4",
+        0,
+        100,
+        source_start=5,
+        left_offset=5,
+        source_end=86_499,
+        supports_source_frames=False,
+    )
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", [item])])))
+
+    result = inspect_timeline(detail="clips")
+
+    source = result["tracks"][0]["items"][0]["source"]
+    assert source["in"]["frames"] == 5
+    assert source["out"]["frames"] == 105
+
+
 def test_a_retimed_shot_reports_the_source_frames_it_really_covers(attach: Attach) -> None:
     """Half speed: 400 timeline frames over 200 source frames, so duration will not do."""
     item = FakeTimelineItem("A.mp4", 0, 400, source_start=1000, source_end=1199)

--- a/tests/test_timeline_tools.py
+++ b/tests/test_timeline_tools.py
@@ -1,0 +1,462 @@
+"""The timeline read tools, called in-process against the fake Resolve seam."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.resolve import timeline as wrapper
+from resolve_mcp.tools.timeline import inspect_timeline, list_timelines
+
+from .conftest import Attach
+from .fakes import (
+    FakeMediaPoolItem,
+    FakeResolve,
+    FakeTimeline,
+    FakeTimelineItem,
+    FakeTrack,
+    studio,
+    sync_reference,
+)
+
+
+def a_cut(name: str = "sunset-set v3", fps: str = "59.94") -> FakeTimeline:
+    """A built cut: one video track of shots over one continuous audio track."""
+    return FakeTimeline(
+        name,
+        fps,
+        start_frame=100,
+        video=[
+            FakeTrack(
+                "Video 1",
+                [
+                    FakeTimelineItem("C0012.mp4", 100, 60, source_start=1000),
+                    FakeTimelineItem("C0031.mp4", 160, 90, source_start=4200),
+                    FakeTimelineItem("C0012.mp4", 250, 50, source_start=1400),
+                ],
+            )
+        ],
+        audio=[FakeTrack("Master", [FakeTimelineItem("master_mix.wav", 100, 200)])],
+    )
+
+
+# --- list --------------------------------------------------------------------------------
+
+
+def test_list_reports_versions_durations_and_which_one_is_open(attach: Attach) -> None:
+    cut = a_cut()
+    reference = sync_reference("sunset-set sync")
+    attach(studio(timelines=[reference, cut], timeline=cut))
+
+    result = list_timelines()
+
+    assert result["ok"] is True
+    assert result["count"] == 2
+    assert result["current"] == "sunset-set v3"
+    listed = {entry["name"]: entry for entry in result["timelines"]}
+    assert listed["sunset-set v3"]["version"] == 3
+    assert listed["sunset-set v3"]["base_name"] == "sunset-set"
+    assert listed["sunset-set v3"]["current"] is True
+    assert listed["sunset-set v3"]["duration"]["frames"] == 200
+    assert listed["sunset-set sync"]["version"] is None
+    assert listed["sunset-set sync"]["current"] is False
+
+
+def test_list_shows_the_track_stack_that_marks_the_sync_reference(attach: Attach) -> None:
+    """The reference is the timeline with an angle per video track — visible from the list."""
+    attach(studio(timelines=[sync_reference(angles={f"Cam {n}": (0, 0, 10) for n in "ABCD"})]))
+
+    result = list_timelines()
+
+    assert result["timelines"][0]["tracks"] == {"video": 4, "audio": 0, "subtitle": 0}
+
+
+def test_list_names_the_newest_version_of_each_cut(attach: Attach) -> None:
+    attach(
+        studio(
+            timelines=[
+                a_cut("sunset-set v1"),
+                a_cut("sunset-set v12"),
+                a_cut("sunset-set v3"),
+                a_cut("encore_v2"),
+                sync_reference("sunset-set sync"),
+            ]
+        )
+    )
+
+    result = list_timelines()
+
+    assert result["latest_versions"] == {"sunset-set": "sunset-set v12", "encore": "encore_v2"}
+
+
+def test_list_spills_past_the_cap_rather_than_flooding_the_reply(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timelines=[a_cut(f"sunset-set v{index}") for index in range(1, 6)]))
+
+    result = list_timelines(limit=2)
+
+    assert result["count"] == 5
+    assert result["truncated"] is True
+    assert len(result["timelines"]) == 2
+    spilled = Path(result["spilled_to"])
+    assert len(json.loads(spilled.read_text(encoding="utf-8"))["timelines"]) == 5
+
+
+def test_list_of_a_project_with_no_timelines_is_empty_not_an_error(attach: Attach) -> None:
+    attach(studio(timeline=None, timelines=[]))
+
+    result = list_timelines()
+
+    assert result["ok"] is True
+    assert result["count"] == 0
+    assert result["current"] is None
+
+
+def test_timeline_tools_need_a_project(attach: Attach) -> None:
+    attach(studio(project=None))
+
+    result = list_timelines()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "no_project_open"
+    assert result["error"]["fix"]
+
+
+# --- inspect -----------------------------------------------------------------------------
+
+
+def test_inspect_defaults_to_the_open_timeline(attach: Attach) -> None:
+    attach(studio(timelines=[sync_reference(), a_cut()], timeline=a_cut()))
+
+    result = inspect_timeline()
+
+    assert result["ok"] is True
+    assert result["timeline"]["name"] == "sunset-set v3"
+    assert result["timeline"]["current"] is True
+
+
+def test_inspect_names_the_timelines_that_exist_when_the_name_is_wrong(attach: Attach) -> None:
+    attach(studio(timelines=[a_cut("sunset-set v3")]))
+
+    result = inspect_timeline(timeline="sunset-set V3")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_not_found"
+    assert "sunset-set v3" in result["error"]["fix"]
+
+
+def test_inspect_with_nothing_open_says_so(attach: Attach) -> None:
+    attach(studio(timeline=None, timelines=[a_cut()]))
+
+    result = inspect_timeline()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "no_timeline_open"
+    assert result["error"]["fix"]
+
+
+def test_summary_answers_how_long_and_how_many_tracks_without_listing_them(
+    attach: Attach,
+) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = inspect_timeline(detail="summary")
+
+    assert result["timeline"]["tracks"] == {"video": 1, "audio": 1, "subtitle": 0}
+    assert result["timeline"]["duration"]["frames"] == 200
+    assert result["tracks"] is None
+    assert result["item_count"] == 4
+
+
+def test_track_detail_describes_the_stack_without_the_clips(attach: Attach) -> None:
+    attach(
+        studio(
+            timeline=FakeTimeline(
+                "sunset-set sync",
+                video=[FakeTrack("Cam A", [FakeTimelineItem("A.mp4", 0, 10)], locked=True)],
+            )
+        )
+    )
+
+    result = inspect_timeline(detail="tracks")
+
+    assert result["tracks"] == [
+        {
+            "type": "video",
+            "index": 1,
+            "name": "Cam A",
+            "enabled": True,
+            "locked": True,
+            "item_count": 1,
+        }
+    ]
+
+
+def test_clip_detail_lists_the_shots_in_dual_time(attach: Attach) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = inspect_timeline(detail="clips")
+
+    first = result["tracks"][0]["items"][0]
+    assert first["name"] == "C0012.mp4"
+    assert first["record"]["in"] == {
+        "frames": 100,
+        "seconds": 1.668,
+        "timecode": "00:00:01:40",
+        "fps": 59.94,
+    }
+    assert first["record"]["out"]["frames"] == 160
+    assert first["record"]["duration"]["frames"] == 60
+    assert first["source"]["in"]["frames"] == 1000
+    assert first["source"]["out"]["frames"] == 1060
+
+
+def test_an_unknown_detail_level_names_the_ones_that_exist(attach: Attach) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = inspect_timeline(detail="everything")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert "clips" in result["error"]["fix"]
+
+
+# --- the stacked sync reference ----------------------------------------------------------
+
+
+def test_each_angle_carries_the_offset_that_maps_its_source_onto_the_timeline(
+    attach: Attach,
+) -> None:
+    """timeline_frame = source_frame + sync_offset, which is what a common clock needs."""
+    attach(
+        studio(
+            timeline=sync_reference(
+                angles={"Cam A": (0, 1000, 500), "Cam B": (120, 3000, 400)},
+            )
+        )
+    )
+
+    result = inspect_timeline(detail="clips")
+
+    offsets = {
+        track["name"]: track["items"][0]["sync_offset"]["frames"] for track in result["tracks"]
+    }
+    assert offsets == {"Cam A": -1000, "Cam B": -2880}
+
+
+def test_an_angle_on_a_resolve_without_source_frames_still_reports_its_offset(
+    attach: Attach,
+) -> None:
+    """Pre-18.5 has no GetSourceStartFrame; the left offset carries the same information."""
+    item = FakeTimelineItem("A.mp4", 120, 400, source_start=3000, supports_source_frames=False)
+    attach(studio(timeline=FakeTimeline("sync", video=[FakeTrack("Cam A", [item])])))
+
+    result = inspect_timeline(detail="clips")
+
+    assert result["tracks"][0]["items"][0]["sync_offset"]["frames"] == -2880
+
+
+def test_a_shot_reports_the_media_pool_clip_it_came_from(attach: Attach) -> None:
+    clip = FakeMediaPoolItem("C0012.mp4", "D:/angles/C0012.mp4")
+    item = FakeTimelineItem("C0012.mp4", 0, 10, media_item=clip, takes=3)
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", [item])])))
+
+    result = inspect_timeline(detail="clips")
+
+    reported = result["tracks"][0]["items"][0]
+    assert reported["clip"] == "C0012.mp4"
+    assert reported["takes"] == 3
+    assert reported["enabled"] is True
+
+
+def test_the_out_point_is_one_past_the_last_frame_whatever_get_end_says(attach: Attach) -> None:
+    """Half-open [in, out) is the cut file's convention; GetEnd is not trusted to agree."""
+    item = FakeTimelineItem("C0012.mp4", 100, 60, end_is_inclusive=True)
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", [item])])))
+
+    result = inspect_timeline(detail="clips")
+
+    record = result["tracks"][0]["items"][0]["record"]
+    assert record["out"]["frames"] == 160
+    assert record["duration"]["frames"] == 60
+
+
+# --- range -------------------------------------------------------------------------------
+
+
+def test_a_range_in_frames_keeps_only_the_shots_that_touch_it(attach: Attach) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = inspect_timeline(detail="clips", start=155, end=200)
+
+    names = [item["name"] for item in result["tracks"][0]["items"]]
+    assert names == ["C0012.mp4", "C0031.mp4"]
+    assert result["range"]["in"]["frames"] == 155
+    assert result["range"]["out"]["frames"] == 200
+
+
+def test_a_shot_that_ends_exactly_where_the_range_starts_is_outside_it(attach: Attach) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = inspect_timeline(detail="clips", start=160, end=250)
+
+    assert [item["name"] for item in result["tracks"][0]["items"]] == ["C0031.mp4"]
+
+
+def test_a_range_in_seconds_snaps_the_way_the_caller_says(attach: Attach) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = inspect_timeline(
+        detail="clips",
+        start={"seconds": 2.6, "snap": "floor"},
+        end={"seconds": 3.4, "snap": "ceil"},
+    )
+
+    assert result["range"]["in"]["frames"] == 155
+    assert result["range"]["out"]["frames"] == 204
+
+
+def test_a_range_in_bare_seconds_is_rejected_rather_than_guessed(attach: Attach) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = inspect_timeline(start={"seconds": 2.6})
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert "snap" in result["error"]["fix"]
+    assert result["error"]["detail"]["field"] == "start"
+
+
+def test_a_range_defaults_to_the_whole_timeline(attach: Attach) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = inspect_timeline(detail="clips")
+
+    assert result["range"]["in"]["frames"] == 100
+    assert result["range"]["out"]["frames"] == 300
+    assert result["item_count"] == 4
+
+
+def test_a_backwards_range_is_rejected(attach: Attach) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = inspect_timeline(start=200, end=150)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+
+
+# --- pagination --------------------------------------------------------------------------
+
+
+def test_a_long_timeline_caps_the_shots_it_returns_and_spills_the_rest(
+    attach: Attach, tmp_path: Path
+) -> None:
+    shots = [FakeTimelineItem(f"C{index:04d}.mp4", index * 10, 10) for index in range(20)]
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", shots)])))
+
+    result = inspect_timeline(detail="clips", limit=5)
+
+    assert result["item_count"] == 20
+    assert result["truncated"] is True
+    assert len(result["tracks"][0]["items"]) == 5
+    spilled = Path(result["spilled_to"])
+    assert spilled.exists()
+    assert len(json.loads(spilled.read_text(encoding="utf-8"))["tracks"][0]["items"]) == 20
+
+
+def test_the_cap_counts_shots_across_every_track(attach: Attach) -> None:
+    tracks = [
+        FakeTrack(f"Cam {letter}", [FakeTimelineItem(f"{letter}.mp4", index * 10, 10)])
+        for index, letter in enumerate("ABCD")
+    ]
+    attach(studio(timeline=FakeTimeline("sync", video=tracks)))
+
+    result = inspect_timeline(detail="clips", limit=2)
+
+    returned = sum(len(track["items"]) for track in result["tracks"])
+    assert returned == 2
+    assert result["item_count"] == 4
+    assert result["truncated"] is True
+
+
+def test_a_summary_never_spills(attach: Attach) -> None:
+    shots = [FakeTimelineItem(f"C{index:04d}.mp4", index * 10, 10) for index in range(20)]
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", shots)])))
+
+    result = inspect_timeline(detail="summary", limit=5)
+
+    assert result["truncated"] is False
+    assert result["spilled_to"] is None
+
+
+# --- the connection, under the tools -----------------------------------------------------
+
+
+def test_a_dropped_handle_reconnects_once_and_still_answers(attach: Attach) -> None:
+    dead = studio(timeline=a_cut())
+    connector = attach(dead, studio(timeline=a_cut()))
+    assert list_timelines()["ok"] is True
+
+    dead.drop()
+
+    result = list_timelines()
+
+    assert result["ok"] is True
+    assert result["timelines"][0]["name"] == "sunset-set v3"
+    assert connector.attempts == 2
+
+
+def test_resolve_quitting_mid_call_is_a_connection_failure_not_a_bug(attach: Attach) -> None:
+    dying = studio(timeline=a_cut())
+    dying.die_after(1)
+    second = studio(timeline=a_cut())
+    second.drop()
+    attach(dying, second)
+
+    result = inspect_timeline()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "resolve_unavailable"
+
+
+def test_a_bug_in_the_wrapper_is_reported_once_as_a_bug(
+    attach: Attach, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    attach(studio(timeline=a_cut()))
+    calls: list[str] = []
+
+    def explode(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append("called")
+        raise ValueError("boom")
+
+    monkeypatch.setattr(wrapper, "list_timelines", explode)
+
+    result = list_timelines()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "internal_error"
+    assert calls == ["called"]
+
+
+def test_a_timeline_that_cannot_be_read_is_skipped_rather_than_sinking_the_list(
+    attach: Attach,
+) -> None:
+    """Resolve hands out timeline proxies that occasionally answer nothing at all."""
+    resolve: FakeResolve = studio(timelines=[a_cut("sunset-set v1"), a_cut("sunset-set v2")])
+    project = resolve.projects["sunset-set"]
+    project._timelines.insert(1, None)  # type: ignore[arg-type]
+
+    attach(resolve)
+
+    result = list_timelines()
+
+    assert result["ok"] is True
+    assert [entry["name"] for entry in result["timelines"]] == [
+        "sunset-set v1",
+        "sunset-set v2",
+    ]

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from resolve_mcp.timing import dual_time, timecode
+from resolve_mcp.errors import InvalidRequestError
+from resolve_mcp.timing import dual_time, timecode, to_frames
 
 
 @pytest.mark.parametrize(
@@ -38,3 +39,73 @@ def test_dual_without_an_fps_still_reports_frames() -> None:
 
 def test_dual_of_nothing_is_nothing() -> None:
     assert dual_time(None, 24.0) is None
+
+
+# --- reading a time in ------------------------------------------------------------------
+
+
+def test_nothing_asked_for_is_nothing_read() -> None:
+    assert to_frames(None, 24.0) is None
+
+
+@pytest.mark.parametrize("value", [96, 96.0, {"frames": 96}, {"frames": "96"}])
+def test_a_bare_number_is_frames(value: object) -> None:
+    assert to_frames(value, 24.0) == 96
+
+
+@pytest.mark.parametrize(
+    ("snap", "expected"),
+    [("floor", 60), ("ceil", 61)],
+)
+def test_seconds_snap_the_way_the_caller_says(snap: str, expected: int) -> None:
+    assert to_frames({"seconds": 2.52, "snap": snap}, 24.0) == expected
+
+
+def test_seconds_that_land_on_a_frame_snap_to_it_either_way() -> None:
+    assert to_frames({"seconds": 2.5, "snap": "floor"}, 24.0) == 60
+    assert to_frames({"seconds": 2.5, "snap": "ceil"}, 24.0) == 60
+
+
+def test_bare_seconds_are_rejected_rather_than_guessed() -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        to_frames({"seconds": 2.52}, 24.0)
+
+    assert "snap" in raised.value.fix
+    assert raised.value.code == "invalid_request"
+
+
+def test_a_fractional_frame_count_is_rejected_rather_than_rounded() -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        to_frames(96.4, 24.0)
+
+    assert "seconds" in raised.value.fix
+
+
+def test_seconds_need_an_fps_to_become_frames() -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        to_frames({"seconds": 2.5, "snap": "floor"}, None)
+
+    assert "fps" in raised.value.cause
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"seconds": 2.5, "snap": "nearest"},
+        {"frames": 96, "seconds": 2.5, "snap": "floor"},
+        {},
+        {"timecode": "01:00:00:00"},
+        "01:00:00:00",
+        True,
+    ],
+)
+def test_a_time_that_cannot_be_read_without_guessing_is_rejected(value: object) -> None:
+    with pytest.raises(InvalidRequestError):
+        to_frames(value, 24.0)
+
+
+def test_the_rejection_names_the_field_it_came_from() -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        to_frames({"seconds": 2.52}, 24.0, field="end")
+
+    assert "end" in raised.value.cause

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -24,6 +24,17 @@ def test_timecode_counts_frames_at_the_nearest_whole_rate(
     assert timecode(frames, fps) == expected
 
 
+def test_a_backwards_distance_is_signed_not_wrapped() -> None:
+    """A sync offset points backwards as often as forwards, and is not a position."""
+    assert timecode(-1000, 59.94) == "-00:00:16:40"
+    assert dual_time(-1000, 59.94) == {
+        "frames": -1000,
+        "seconds": -16.683,
+        "timecode": "-00:00:16:40",
+        "fps": 59.94,
+    }
+
+
 def test_dual_carries_frames_seconds_timecode_and_fps() -> None:
     assert dual_time(90, 59.94) == {
         "frames": 90,


### PR DESCRIPTION
Closes #25.

## What this adds

Two tools, in the existing three-layer shape (`resolve/timeline.py` wrapper → `tools/timeline.py` → `server.py`):

- **`list_timelines`** — every timeline with its parsed version, duration, fps and track stack, plus `latest_versions` (newest numbered timeline per base name). The stacked sync reference is identifiable from the list: it is the timeline carrying an angle per video track.
- **`inspect_timeline`** — one timeline at `summary` / `tracks` / `clips` detail over a half-open range. Each shot carries record position, source position and `sync_offset`, so `timeline_frame = source_frame + sync_offset` per angle.

`timing.to_frames()` is the new pure-tier rule for reading a time *in*. `session._fps` became `session.frame_rate` (the timeline layer needs the same reading), and `media._spill` / `timeline._spill` became one shared `spill()`.

## Decisions

- **`GetEnd()` is never read.** The docs do not settle whether a timeline item's end is the last frame or one past it, so out points are `GetStart() + GetDuration()`. A timeline has no duration getter, so its own end does rest on `GetEndFrame()` being exclusive — that one assumption is what the live check exists for.
- **Seconds without a snap are refused.** `to_frames` converts seconds only with an explicit `floor`/`ceil`; a silently moved cut point is invisible until it is expensive.
- **Detail level and range are the pagination.** `summary` and `tracks` answer most questions without listing a clip; past `limit` the reading spills to disk — the locked hybrid inline/disk shape. The default limit of 100 was measured, not guessed: ~64.6k characters, ~16k tokens at 4 chars/token and ~20k at the 3.3 that dense JSON actually runs.
- **A refusing clip and a departed Resolve are told apart by asking the connection.** Same exception, opposite handling: one costs a field, the other reconnects.

## Test seam

**Fake tier** (`tests/test_timeline_tools.py`, `tests/test_timing.py`) — every AC is a decision and verifies there. `tests/fakes.py` grew `FakeTimelineItem`, `FakeTrack`, a tracked `FakeTimeline`, `FakeProject.GetTimelineCount/GetTimelineByIndex`, and a `sync_reference()` builder. 196 tests pass, mypy strict and ruff clean.

**Live smoke** (`tests/test_live_smoke.py`, 2 tests, **unrun**) — the one thing fakes cannot prove: that Resolve's own numbers agree with the derivation, and that `GetEndFrame` is exclusive. Named in the ticket close comment.

## Review

Two-axis review (Standards + Spec, parallel sub-agents), three rounds. Findings, all fixed in `9bd2e6e`, `d9fc0a0`, `3a0c592`:

**Round 1 — Spec:** negative `sync_offset` produced garbage timecode (`timecode(-1000, 60)` → `"-1:59:43:20"`); `DEFAULT_ITEM_LIMIT` of 200 put the default reply at ~35k tokens, past the 25k cap AC4 names. **Standards:** the fake derived `GetEndFrame` from its own items so the wrapper could only ever agree; the "pre-18.5" test raised from a method that existed and so never took the missing-attribute branch; a test poked `project._timelines`; `_spill` duplicated `media._spill`; `_touches` dug into dual-time dicts `read_item` had just built, shaping every shot on a track before discarding most; eight try/except getter wrappers, one colliding with `session._read`.

**Round 2 — Standards:** the dropped-handle boundary was **not** held. A `die_after` sweep found `ok:true` with fabricated values at n=22–28 — no markers, an enabled shot, no clip name, zero tracks — because the field-level fallback swallowed the death. The guard test missed it twice: it stopped at n=15, and the fake's values happened to equal the fallbacks, so it would have passed regardless. **Spec:** the token guard counted 4 chars/token and so could not fail until the cap was already breached; the live end-frame check was gated on the read not truncating, so it skipped silently on exactly the timelines it exists for; `_capped` filled track by track, so a busy V1 could starve every angle stacked under it; `source_out = source_in + duration` is only right at 1:1 speed.

**Round 3 — verification:** the boundary now holds across 600 sweep cases. But round 2 had over-corrected: one Text+ title refusing a getter failed the whole inspection, and a mixed-clock source span could be reported as fact. Both fixed; `Reader` asks the connection which failure it is.

Accepted and not changed: `markers` count and per-item `takes` sit outside the four ACs (one scalar each, read-only, and both answer "is there more here"); `latest_versions` is not capped by `limit` (one short string per distinct base name); `session.frame_rate` can report the project rate when a timeline dies mid-read, which is the context echo's documented best-effort behaviour and pre-dates this branch.

Review: clean — three rounds, two axes; all findings fixed in 9bd2e6e, d9fc0a0 and 3a0c592

🤖 Generated with [Claude Code](https://claude.com/claude-code)
