### PR TITLE
P1: Cut-file schema serving + validate_cut

### DIFF
--- a/src/resolve_mcp/cut/__init__.py
+++ b/src/resolve_mcp/cut/__init__.py
@@ -1,0 +1,1 @@
+"""Cut-file schema v1: the contract Claude authors against and the server enforces."""

--- a/src/resolve_mcp/cut/document.py
+++ b/src/resolve_mcp/cut/document.py
@@ -1,0 +1,63 @@
+"""Reading a cut file off disk — the one place JSON becomes a document.
+
+The server never writes cut files: authorship stays with Claude and the director. It
+reads one, hashes exactly the bytes it read, and reports what it found. The hash is what
+ties a built timeline back to the cut state that produced it, so it is taken here, on the
+same bytes that were parsed, and never recomputed from the parsed object.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from ..errors import InvalidRequestError
+from .validate import Finding, parse_failure_finding
+
+HASH_DIGEST_BYTES = 16
+"""BLAKE2b digest length: 32 hex characters, short enough to read in a build report."""
+
+
+class LoadedCut(NamedTuple):
+    """A cut file as read: always a path and a hash, a document only if it parsed."""
+
+    path: Path
+    content_hash: str
+    doc: Any  # the parsed document, or None when parse_error says why there is none
+    parse_error: Finding | None
+
+
+def content_hash(data: bytes) -> str:
+    """The BLAKE2b hash a build report echoes for provenance."""
+    return hashlib.blake2b(data, digest_size=HASH_DIGEST_BYTES).hexdigest()
+
+
+def read_cut_file(cut_file: str) -> LoadedCut:
+    """Read and parse ``cut_file``.
+
+    A file that is missing or unreadable raises: the call itself was wrong, and there is
+    nothing to report findings about. A file that is there but is not JSON comes back as
+    an E1 finding, because that *is* a validation result — rule E1 is "JSON parses".
+    """
+    path = Path(cut_file).expanduser()
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise InvalidRequestError(
+            cause=f"Could not read the cut file {str(path)!r}: {exc.strerror or exc}.",
+            fix="Check the path. Cut files are authored by you, on disk; the server "
+            "never writes them.",
+            detail={"cut_file": str(path)},
+        ) from exc
+
+    digest = content_hash(data)
+    try:
+        doc = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return LoadedCut(path, digest, None, parse_failure_finding(str(exc)))
+    return LoadedCut(path, digest, doc, None)
+
+
+__all__ = ["HASH_DIGEST_BYTES", "LoadedCut", "content_hash", "read_cut_file"]

--- a/src/resolve_mcp/cut/schema.py
+++ b/src/resolve_mcp/cut/schema.py
@@ -62,56 +62,64 @@ ANNOTATED_EXAMPLE: Final = """\
 _PLACEMENT: Final = """\
 ## 1. Placement model: sequential V1, positioned overlays
 
-V1 segments are butt-joined in array order; record positions are computed at
-build. Gaps and flash-frame positions are unrepresentable rather than checked,
-and duration edits never require downstream position fixes. Only overlays carry
-position — anchored, not absolute (§4)."""
+V1 segments are butt-joined in array order; record positions computed at build.
+Gaps/flash-frame positions unrepresentable rather than checked; sidesteps the
+unclamped-recordFrame footgun; duration edits never require downstream position
+fixes. Only overlays carry position — anchored, not absolute (§4)."""
 
 _TAKES: Final = """\
 ## 3. Takes
 
-- Selector = [main, alternates in order]; the selected take is main. The main
-  slot *is* the current selection, always.
-- Every alternate's duration must equal main's — in-place `swap_take` cannot
-  ripple a sequential timeline. An unequal-length take choice is a main-segment
-  edit plus a rebuild.
-- Swap sync: after `swap_take`, you edit the cut file — alternate promoted to
-  main, main demoted. The server never writes your cut file."""
+- Selector = [main, alternates in order]; selected take = main. The main slot
+  *is* the current selection, always.
+- Every alternate's duration must equal main's — in-place `swap_take` can't
+  ripple a sequential timeline; an unequal-length take choice is a main-segment
+  edit + rebuild. Also dodges untested Resolve behavior on mismatched selector
+  lengths.
+- Swap sync: after `swap_take`, Claude edits the file — alternate promoted to
+  main, main demoted. The server never writes the cut file."""
 
 _OVERLAYS: Final = """\
 ## 4. Overlays
 
 Anchored to `{segment, offset}`, never absolute timeline frames — they ride with
 the content they cover through tightening passes; build computes absolute
-position = the anchor segment's computed start + offset. An overlay may run past
-its anchor's end (seam coverage) but must land inside the total V1 span. Video
-only: audio always omitted, no alternates, V2."""
+position = segment's computed start + offset. May run past the anchor's end
+(seam coverage), must land inside the total V1 span. Video only, audio always
+omitted, no alternates, V2."""
 
 _TITLES: Final = """\
 ## 5. Titles: not in the cut file
 
-`apply_titles` and `titles.json` own the Titles track. `build_timeline` never
-touches it; after a rebuild, re-run `apply_titles` on the new version. The cut
-file plus titles.json together fully describe a deliverable."""
+`apply_titles` + `titles.json` own the Titles track. `build_timeline` never
+touches it; after a rebuild, re-run `apply_titles` on the new version. Cut JSON
++ titles.json together fully describe a deliverable."""
 
 _VERSIONING: Final = """\
-## 6. Versioning and naming
+## 6. Versioning/naming
 
-- Timelines materialize as `<name> v<N>`; build scans `^<name> v(\\d+)$` and
-  takes max + 1. One version per review round.
-- The cut file is one evolving `<name>.cut.json` beside songs.json, titles.json
-  and sidecars — no per-version copies; history is versioned timelines + git.
-- The build report echoes the cut file's BLAKE2b hash and the resulting version
-  name, so every timeline is traceable to the exact cut state that built it and
-  `swap_take` drift is detectable."""
+- Timelines materialize as `<name> v<N>`; build scans `^<name> v(\\d+)$`, takes
+  max+1. One version per review round.
+- Cut file: one evolving `<name>.cut.json` beside `songs.json`/`titles.json`/
+  sidecars — no per-version copies; history = versioned timelines + git.
+- Build report echoes the cut-file BLAKE2b hash + resulting version name: every
+  timeline traceable to the exact cut state that built it; `swap_take` drift
+  detectable."""
 
 _TIME: Final = """\
 ## Time
 
-Frames are authoritative; ranges are half-open `[in, out)`, so duration =
-out − in and adjacent takes share a boundary frame without overlap ambiguity.
-Seconds are accepted at the tool boundary with explicit snapping — floor for
-in-points, ceil for out-points."""
+Frames authoritative, half-open `[in, out)` — duration = out − in; adjacent
+takes share a boundary frame without overlap ambiguity. Snapping (floor in,
+ceil out) at the tool boundary."""
+
+_RULES: Final = """\
+## 7. Validation
+
+11 hard errors (E1-E11) block a build; 2 warnings (W1-W2) never do. The list is
+identical in the `validate_cut` dry run and `build_timeline`'s pre-flight, and a
+failing file aborts before Resolve is touched. Every finding is
+`{rule, id, message, fix_hint}` — see the `rules` field of this result."""
 
 SCHEMA_DOC: Final = "\n\n".join(
     [
@@ -123,6 +131,7 @@ SCHEMA_DOC: Final = "\n\n".join(
         _OVERLAYS,
         _TITLES,
         _VERSIONING,
+        _RULES,
     ]
 )
 """The full schema document: prose contract with the annotated example embedded."""

--- a/src/resolve_mcp/cut/schema.py
+++ b/src/resolve_mcp/cut/schema.py
@@ -1,0 +1,128 @@
+"""The settled cut-file schema v1, served verbatim by ``get_cut_schema``.
+
+The text below is the contract from the schema resolution (issue #20). It is
+data, not documentation: Claude authors cut files against exactly this, so the
+example stays annotated and is served character-for-character as written here.
+Editing it changes the contract — do it in a ticket, not in passing.
+"""
+
+from typing import Final
+
+SCHEMA_VERSION: Final = 1
+"""The only cut-file ``schema`` value this server accepts."""
+
+ANNOTATED_EXAMPLE: Final = """\
+{
+  "schema": 1,                       // supported-version check
+  "timeline": {
+    "name": "sunset-set",            // version base name (§6)
+    "fps": 59.94,                    // declared; sources validated against it
+    "bin": "Cuts"                    // optional; default media pool root
+  },
+
+  // Source aliases: segments reference by alias. Identity = clip name
+  // + optional bin, resolved to exactly one media-pool clip at validate.
+  "sources": {
+    "gtr_close":  { "clip": "C0012.mp4", "bin": "Angles", "sync_offset": 1432 },
+    "master_mix": { "clip": "sunset-master.wav" }
+  },
+  // sync_offset: frames, from the sync-reference timeline. Informational —
+  // Claude plans with it; server never computes or validates with it.
+
+  // Optional continuous master-audio clip (concert substrate).
+  // Rough cut omits this block; A-roll segment audio goes to A1.
+  "audio": { "source": "master_mix", "in": 0, "out": 323000 },
+
+  "segments": [
+    {
+      "id": "s014",                  // required, unique, author-chosen
+      "source": "gtr_close",
+      "in": 14032, "out": 14210,     // source-clip frames, half-open [in, out)
+      "audio": false,                // optional; default false when master
+                                     // audio block present, true when absent
+      "alternates": [                // optional; same duration as main
+        { "source": "keys_wide", "in": 8100, "out": 8278 }
+      ],
+      "note": "drum fill response"   // free text; server ignores; feeds cut report
+    }
+  ],
+
+  "overlays": [
+    {
+      "id": "b03",                   // ids share one namespace with segments
+      "source": "broll_pan",
+      "in": 1200, "out": 1440,
+      "over": { "segment": "s014", "offset": 24 },  // anchor + frames into it
+      "note": "cover retake seam"
+    }
+  ]
+}"""
+"""The annotated schema example, verbatim. Comments are ``//`` — strip before parsing."""
+
+_PLACEMENT: Final = """\
+## 1. Placement model: sequential V1, positioned overlays
+
+V1 segments are butt-joined in array order; record positions are computed at
+build. Gaps and flash-frame positions are unrepresentable rather than checked,
+and duration edits never require downstream position fixes. Only overlays carry
+position — anchored, not absolute (§4)."""
+
+_TAKES: Final = """\
+## 3. Takes
+
+- Selector = [main, alternates in order]; the selected take is main. The main
+  slot *is* the current selection, always.
+- Every alternate's duration must equal main's — in-place `swap_take` cannot
+  ripple a sequential timeline. An unequal-length take choice is a main-segment
+  edit plus a rebuild.
+- Swap sync: after `swap_take`, you edit the cut file — alternate promoted to
+  main, main demoted. The server never writes your cut file."""
+
+_OVERLAYS: Final = """\
+## 4. Overlays
+
+Anchored to `{segment, offset}`, never absolute timeline frames — they ride with
+the content they cover through tightening passes; build computes absolute
+position = the anchor segment's computed start + offset. An overlay may run past
+its anchor's end (seam coverage) but must land inside the total V1 span. Video
+only: audio always omitted, no alternates, V2."""
+
+_TITLES: Final = """\
+## 5. Titles: not in the cut file
+
+`apply_titles` and `titles.json` own the Titles track. `build_timeline` never
+touches it; after a rebuild, re-run `apply_titles` on the new version. The cut
+file plus titles.json together fully describe a deliverable."""
+
+_VERSIONING: Final = """\
+## 6. Versioning and naming
+
+- Timelines materialize as `<name> v<N>`; build scans `^<name> v(\\d+)$` and
+  takes max + 1. One version per review round.
+- The cut file is one evolving `<name>.cut.json` beside songs.json, titles.json
+  and sidecars — no per-version copies; history is versioned timelines + git.
+- The build report echoes the cut file's BLAKE2b hash and the resulting version
+  name, so every timeline is traceable to the exact cut state that built it and
+  `swap_take` drift is detectable."""
+
+_TIME: Final = """\
+## Time
+
+Frames are authoritative; ranges are half-open `[in, out)`, so duration =
+out − in and adjacent takes share a boundary frame without overlap ambiguity.
+Seconds are accepted at the tool boundary with explicit snapping — floor for
+in-points, ceil for out-points."""
+
+SCHEMA_DOC: Final = "\n\n".join(
+    [
+        "# Cut-file schema v1",
+        _PLACEMENT,
+        "## 2. Schema\n\n```jsonc\n" + ANNOTATED_EXAMPLE + "\n```",
+        _TIME,
+        _TAKES,
+        _OVERLAYS,
+        _TITLES,
+        _VERSIONING,
+    ]
+)
+"""The full schema document: prose contract with the annotated example embedded."""

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -71,6 +71,11 @@ _FIX_HINTS: Final[dict[str, str]] = {
 }
 
 
+def severity_of(rule: str) -> str:
+    """``error`` blocks the build; ``warning`` is reported and never blocks."""
+    return "warning" if rule.startswith("W") else "error"
+
+
 @dataclass(frozen=True)
 class Finding:
     """One rule firing on one thing, in the shape the agent reads."""
@@ -83,7 +88,7 @@ class Finding:
     @property
     def severity(self) -> str:
         """``error`` blocks the build; ``warning`` is reported and never blocks."""
-        return "warning" if self.rule.startswith("W") else "error"
+        return severity_of(self.rule)
 
     def as_dict(self) -> dict[str, str | None]:
         return {
@@ -522,19 +527,27 @@ def _overlay_errors(doc: dict[str, Any]) -> list[Finding]:
 
 
 def _overlap_errors(spans: list[tuple[str, int, int]]) -> list[Finding]:
-    """E10: overlays share one V2 track, and Resolve will not overwrite on overlap."""
+    """E10: overlays share one V2 track, and Resolve will not overwrite on overlap.
+
+    Swept against the span reaching furthest right rather than the previous one: a short
+    overlay sitting wholly inside a long one is not adjacent to it once sorted, and
+    comparing neighbours alone would wave it through.
+    """
     findings: list[Finding] = []
     ordered = sorted(spans, key=lambda span: (span[1], span[2], span[0]))
-    for earlier, later in zip(ordered, ordered[1:], strict=False):
-        if ranges_overlap(earlier[1], earlier[2], later[1], later[2]):
+    furthest: tuple[str, int, int] | None = None
+    for span in ordered:
+        if furthest is not None and ranges_overlap(furthest[1], furthest[2], span[1], span[2]):
             findings.append(
                 _finding(
                     "E10",
-                    later[0],
-                    f"Overlays {earlier[0]!r} ({earlier[1]}-{earlier[2]}) and {later[0]!r} "
-                    f"({later[1]}-{later[2]}) cover the same frames.",
+                    span[0],
+                    f"Overlays {furthest[0]!r} ({furthest[1]}-{furthest[2]}) and {span[0]!r} "
+                    f"({span[1]}-{span[2]}) cover the same frames.",
                 )
             )
+        if furthest is None or span[2] > furthest[2]:
+            furthest = span
     return findings
 
 
@@ -653,6 +666,18 @@ def _bounds_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[
     return findings
 
 
+def _outside_media(item: dict[str, Any], clip: ClipFacts) -> bool:
+    """Whether a half-open range asks for frames the clip's media does not have."""
+    return bool(item["in"] < clip.start or item["out"] > clip.end_exclusive)
+
+
+def _overrun_message(item: dict[str, Any], clip: ClipFacts, subject: str) -> str:
+    return (
+        f"{subject} asks for frames {item['in']}-{item['out']} of {clip.name!r}, whose "
+        f"media runs {clip.start}-{clip.end_exclusive}."
+    )
+
+
 def _bounds_error(
     item: dict[str, Any],
     resolved: dict[str, ClipFacts],
@@ -666,16 +691,9 @@ def _bounds_error(
         # A still has one frame of media and any duration on a timeline — the
         # end-frame workaround is what makes that exact. Bounds do not apply.
         return []
-    if item["in"] >= clip.start and item["out"] <= clip.end_exclusive:
+    if not _outside_media(item, clip):
         return []
-    return [
-        _finding(
-            "E5",
-            id,
-            f"{subject} asks for frames {item['in']}-{item['out']} of {clip.name!r}, whose "
-            f"media runs {clip.start}-{clip.end_exclusive}.",
-        )
-    ]
+    return [_finding("E5", id, _overrun_message(item, clip, subject))]
 
 
 def _rate_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[Finding]:
@@ -721,15 +739,8 @@ def _audio_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[F
         findings.append(
             _finding("E7", None, f"The audio source {alias!r} ({clip.name}) has no audio.")
         )
-    if audio["in"] < clip.start or audio["out"] > clip.end_exclusive:
-        findings.append(
-            _finding(
-                "E7",
-                None,
-                f"The audio block asks for frames {audio['in']}-{audio['out']} of "
-                f"{clip.name!r}, whose media runs {clip.start}-{clip.end_exclusive}.",
-            )
-        )
+    if _outside_media(audio, clip):
+        findings.append(_finding("E7", None, _overrun_message(audio, clip, "The audio block")))
     return findings
 
 
@@ -740,6 +751,7 @@ __all__ = [
     "Finding",
     "locked_track_finding",
     "parse_failure_finding",
+    "severity_of",
     "total_frames",
     "validate_project",
     "validate_structure",

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -1,0 +1,746 @@
+"""The cut-file validation rules: 11 hard errors, 2 warnings, one implementation.
+
+The list is identical in the ``validate_cut`` dry run and in ``build_timeline``'s
+pre-flight, so it lives here once and both call it. A failing file must abort before
+Resolve is touched — a half-built timeline is the outcome this file exists to prevent.
+
+Two passes, because they need different things:
+
+* :func:`validate_structure` reads the document alone — no project, no connection. It
+  answers everything about shape, ids, ranges, takes and overlay anchoring (E1-E4 for
+  undeclared aliases, E7 for an undeclared audio alias, E8-E10, W1-W2).
+* :func:`validate_project` takes clip facts already gathered from the media pool and
+  answers everything about the media behind the aliases (E4-E7). It is a pure function
+  over those facts, so every rule in this file is unit-testable without Resolve.
+
+E11 is the build-time rule — a locked target track fails *silently* in the Resolve API,
+so the build checks it and reports it in the same shape as everything else.
+
+Every finding is ``{rule, id, message, fix_hint}``: the rule so the agent can look it up,
+the id so it knows which segment to edit, and a fix hint so it does not have to guess.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from typing import Any, Final, TypeGuard
+
+from ..logging_config import get_logger
+from ..timing import duration_frames, ranges_overlap
+from .schema import SCHEMA_VERSION
+
+log = get_logger("cut")
+
+DEFAULT_MIN_SEGMENT_FRAMES: Final = 12
+"""W1's flash-frame guard. A warning, never a block — the creative call stays Claude's."""
+
+FPS_TOLERANCE: Final = 0.01
+"""Reported rates carry float noise; real rate differences (23.976 vs 24) are far wider."""
+
+RULE_DESCRIPTIONS: Final[dict[str, str]] = {
+    "E1": "JSON parses; schema-valid; schema version supported",
+    "E2": "ids unique across segments and overlays (one namespace)",
+    "E3": "in < out everywhere",
+    "E4": "every alias resolves to exactly one media-pool clip",
+    "E5": "in/out inside clip media bounds",
+    "E6": "source fps matches timeline fps (stills exempt)",
+    "E7": "audio block resolves, has audio, bounds valid",
+    "E8": "alternate duration equals main duration",
+    "E9": "overlay anchor exists; offset inside anchor; span inside the total V1",
+    "E10": "overlays do not overlap each other",
+    "E11": "build-time: target tracks unlocked; connection and creation failures",
+    "W1": "segment shorter than min_segment_frames (flash-frame guard)",
+    "W2": "V1 total does not match the master-audio span",
+}
+
+_FIX_HINTS: Final[dict[str, str]] = {
+    "E1": "Call get_cut_schema and match the annotated example exactly.",
+    "E2": "Give every segment and overlay its own id — they share one namespace.",
+    "E3": "Ranges are half-open [in, out); make out strictly greater than in.",
+    "E4": "Fix the alias in sources, or import the clip and re-run validate_cut.",
+    "E5": "Call inspect_clip for the clip's media bounds and pull the range inside them.",
+    "E6": "Conform the source first, or set timeline.fps to the rate the sources are at.",
+    "E7": "Point audio.source at a clip that has audio and keep its range inside the media.",
+    "E8": "Alternates must match the main take frame for frame — swap_take cannot ripple.",
+    "E9": "Anchor the overlay to a segment that exists, at an offset inside it.",
+    "E10": "Move one overlay or shorten it — only one overlay may cover a frame.",
+    "E11": "Unlock the track in Resolve's timeline header and build again.",
+    "W1": "Lengthen the segment, or keep it if the flash is deliberate.",
+    "W2": "Expected when the cut opens cold or runs past the mix; otherwise check the ends.",
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One rule firing on one thing, in the shape the agent reads."""
+
+    rule: str
+    id: str | None
+    message: str
+    fix_hint: str
+
+    @property
+    def severity(self) -> str:
+        """``error`` blocks the build; ``warning`` is reported and never blocks."""
+        return "warning" if self.rule.startswith("W") else "error"
+
+    def as_dict(self) -> dict[str, str | None]:
+        return {
+            "rule": self.rule,
+            "id": self.id,
+            "message": self.message,
+            "fix_hint": self.fix_hint,
+        }
+
+
+@dataclass(frozen=True)
+class ClipFacts:
+    """What the rules need to know about one media-pool clip.
+
+    Gathered once from Resolve and then handed to pure functions, so the rules never
+    hold a Resolve handle. Bounds are half-open — ``end_exclusive`` is Resolve's last
+    frame plus one — matching the cut file's own convention.
+    """
+
+    name: str
+    bin_path: str | None
+    start: int
+    end_exclusive: int
+    fps: float | None
+    has_audio: bool = False
+    is_still: bool = False
+
+
+def _finding(rule: str, id: str | None, message: str, fix_hint: str | None = None) -> Finding:
+    return Finding(rule=rule, id=id, message=message, fix_hint=fix_hint or _FIX_HINTS[rule])
+
+
+def _order(findings: list[Finding]) -> list[Finding]:
+    """Errors before warnings, rule number ascending, document order within a rule."""
+
+    def key(numbered: tuple[int, Finding]) -> tuple[int, int, int]:
+        position, finding = numbered
+        return (0 if finding.severity == "error" else 1, int(finding.rule[1:]), position)
+
+    return [finding for _, finding in sorted(enumerate(findings), key=key)]
+
+
+def parse_failure_finding(detail: str) -> Finding:
+    """E1: the file is on disk but is not JSON, so no other rule can be answered."""
+    return _finding("E1", None, f"The cut file is not valid JSON: {detail}.")
+
+
+def locked_track_finding(track: str) -> Finding:
+    """E11: Resolve accepts an append onto a locked track and silently drops it."""
+    return _finding(
+        "E11",
+        track,
+        f"Track {track} is locked; Resolve would report the append as successful and "
+        f"place nothing.",
+    )
+
+
+# --- shape (E1) -------------------------------------------------------------------------
+
+
+def _is_int(value: Any) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_number(value: Any) -> TypeGuard[int | float]:
+    return _is_int(value) or isinstance(value, float)
+
+
+def _shape_errors(doc: Any) -> Iterator[Finding]:
+    """Everything that makes the document unreadable, reported as E1."""
+    if not isinstance(doc, dict):
+        yield _finding("E1", None, f"The cut file must be a JSON object, got {_kind(doc)}.")
+        return
+
+    yield from _schema_version_errors(doc)
+    yield from _timeline_errors(doc)
+    yield from _sources_errors(doc)
+    yield from _audio_shape_errors(doc)
+    yield from _segments_errors(doc)
+    yield from _overlays_errors(doc)
+
+
+def _kind(value: Any) -> str:
+    return type(value).__name__
+
+
+def _schema_version_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    version = doc.get("schema")
+    if version is None:
+        yield _finding("E1", None, "The cut file has no 'schema' version field.")
+    elif not _is_int(version):
+        yield _finding("E1", None, f"'schema' must be an integer, got {_kind(version)}.")
+    elif version != SCHEMA_VERSION:
+        yield _finding(
+            "E1",
+            None,
+            f"Cut-file schema {version} is not supported; this server serves "
+            f"schema {SCHEMA_VERSION}.",
+        )
+
+
+def _timeline_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    timeline = doc.get("timeline")
+    if not isinstance(timeline, dict):
+        yield _finding("E1", None, "'timeline' must be an object with 'name' and 'fps'.")
+        return
+    if not isinstance(timeline.get("name"), str) or not timeline["name"].strip():
+        yield _finding("E1", None, "'timeline.name' must be a non-empty string.")
+    fps = timeline.get("fps")
+    if not _is_number(fps) or fps <= 0:
+        yield _finding("E1", None, f"'timeline.fps' must be a positive number, got {fps!r}.")
+    if "bin" in timeline and not isinstance(timeline["bin"], str):
+        yield _finding("E1", None, "'timeline.bin' must be a string when present.")
+
+
+def _sources_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    sources = doc.get("sources")
+    if not isinstance(sources, dict) or not sources:
+        yield _finding("E1", None, "'sources' must be a non-empty object of alias -> clip.")
+        return
+    for alias, source in sources.items():
+        where = f"sources.{alias}"
+        if not isinstance(source, dict):
+            yield _finding("E1", alias, f"'{where}' must be an object with a 'clip' name.")
+            continue
+        if not isinstance(source.get("clip"), str) or not source["clip"]:
+            yield _finding("E1", alias, f"'{where}.clip' must be a non-empty clip name.")
+        if "bin" in source and not isinstance(source["bin"], str):
+            yield _finding("E1", alias, f"'{where}.bin' must be a string when present.")
+        if "sync_offset" in source and not _is_int(source["sync_offset"]):
+            yield _finding("E1", alias, f"'{where}.sync_offset' must be an integer frame count.")
+
+
+def _audio_shape_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    if "audio" not in doc:
+        return
+    audio = doc["audio"]
+    if not isinstance(audio, dict):
+        yield _finding("E1", None, "'audio' must be an object with 'source', 'in' and 'out'.")
+        return
+    if not isinstance(audio.get("source"), str):
+        yield _finding("E1", None, "'audio.source' must be a source alias.")
+    yield from _range_shape_errors(audio, "audio", None)
+
+
+def _range_shape_errors(item: dict[str, Any], where: str, id: str | None) -> Iterator[Finding]:
+    for edge in ("in", "out"):
+        if not _is_int(item.get(edge)):
+            yield _finding(
+                "E1",
+                id,
+                f"'{where}.{edge}' must be an integer frame number, got {item.get(edge)!r}.",
+            )
+
+
+def _segments_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    segments = doc.get("segments")
+    if not isinstance(segments, list) or not segments:
+        yield _finding("E1", None, "'segments' must be a non-empty array; a cut needs content.")
+        return
+    for index, segment in enumerate(segments):
+        where = f"segments[{index}]"
+        if not isinstance(segment, dict):
+            yield _finding("E1", None, f"'{where}' must be an object.")
+            continue
+        id = segment.get("id") if isinstance(segment.get("id"), str) else None
+        if not id:
+            yield _finding("E1", None, f"'{where}.id' must be a non-empty string.")
+        if not isinstance(segment.get("source"), str):
+            yield _finding("E1", id, f"'{where}.source' must be a source alias.")
+        yield from _range_shape_errors(segment, where, id)
+        if "audio" in segment and not isinstance(segment["audio"], bool):
+            yield _finding("E1", id, f"'{where}.audio' must be true or false.")
+        if "note" in segment and not isinstance(segment["note"], str):
+            yield _finding("E1", id, f"'{where}.note' must be a string.")
+        yield from _alternates_errors(segment, where, id)
+
+
+def _alternates_errors(segment: dict[str, Any], where: str, id: str | None) -> Iterator[Finding]:
+    if "alternates" not in segment:
+        return
+    alternates = segment["alternates"]
+    if not isinstance(alternates, list):
+        yield _finding("E1", id, f"'{where}.alternates' must be an array.")
+        return
+    for index, alternate in enumerate(alternates):
+        at = f"{where}.alternates[{index}]"
+        if not isinstance(alternate, dict):
+            yield _finding("E1", id, f"'{at}' must be an object.")
+            continue
+        if not isinstance(alternate.get("source"), str):
+            yield _finding("E1", id, f"'{at}.source' must be a source alias.")
+        yield from _range_shape_errors(alternate, at, id)
+
+
+def _overlays_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    if "overlays" not in doc:
+        return
+    overlays = doc["overlays"]
+    if not isinstance(overlays, list):
+        yield _finding("E1", None, "'overlays' must be an array.")
+        return
+    for index, overlay in enumerate(overlays):
+        where = f"overlays[{index}]"
+        if not isinstance(overlay, dict):
+            yield _finding("E1", None, f"'{where}' must be an object.")
+            continue
+        id = overlay.get("id") if isinstance(overlay.get("id"), str) else None
+        if not id:
+            yield _finding("E1", None, f"'{where}.id' must be a non-empty string.")
+        if not isinstance(overlay.get("source"), str):
+            yield _finding("E1", id, f"'{where}.source' must be a source alias.")
+        yield from _range_shape_errors(overlay, where, id)
+        yield from _anchor_shape_errors(overlay, where, id)
+
+
+def _anchor_shape_errors(overlay: dict[str, Any], where: str, id: str | None) -> Iterator[Finding]:
+    over = overlay.get("over")
+    if not isinstance(over, dict):
+        yield _finding(
+            "E1",
+            id,
+            f"'{where}.over' must be an anchor object: "
+            '{"segment": "<segment id>", "offset": <frames>}.',
+        )
+        return
+    if not isinstance(over.get("segment"), str):
+        yield _finding("E1", id, f"'{where}.over.segment' must be a segment id.")
+    if not _is_int(over.get("offset")):
+        yield _finding("E1", id, f"'{where}.over.offset' must be an integer frame count.")
+
+
+# --- the structural pass ----------------------------------------------------------------
+
+
+def validate_structure(
+    doc: Any,
+    *,
+    min_segment_frames: int = DEFAULT_MIN_SEGMENT_FRAMES,
+) -> list[Finding]:
+    """Every rule answerable from the document alone. Never mutates it.
+
+    A document that fails E1 is returned with E1 findings only: the later rules read
+    fields whose types they can no longer trust, so running them would report noise.
+    """
+    shape = list(_shape_errors(doc))
+    if shape:
+        return _order(shape)
+
+    findings: list[Finding] = []
+    findings += _id_errors(doc)
+    findings += _range_errors(doc)
+    findings += _declared_alias_errors(doc)
+    findings += _alternate_duration_errors(doc)
+    findings += _overlay_errors(doc)
+    findings += _segment_length_warnings(doc, min_segment_frames)
+    findings += _audio_span_warnings(doc)
+    return _order(findings)
+
+
+def _segments(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    segments: list[dict[str, Any]] = doc["segments"]
+    return segments
+
+
+def _overlays(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    overlays: list[dict[str, Any]] = doc.get("overlays") or []
+    return overlays
+
+
+def _id_errors(doc: dict[str, Any]) -> list[Finding]:
+    """E2: segments and overlays share one id namespace."""
+    seen: set[str] = set()
+    findings: list[Finding] = []
+    for item in (*_segments(doc), *_overlays(doc)):
+        id = str(item["id"])
+        if id in seen:
+            findings.append(_finding("E2", id, f"The id {id!r} is used more than once."))
+        seen.add(id)
+    return findings
+
+
+def _range_errors(doc: dict[str, Any]) -> list[Finding]:
+    """E3: half-open ranges need in < out, or they name no frames at all."""
+    findings: list[Finding] = []
+    for segment in _segments(doc):
+        findings += _range_error(segment, str(segment["id"]), "Segment")
+        for index, alternate in enumerate(segment.get("alternates") or []):
+            findings += _range_error(
+                alternate, str(segment["id"]), f"Alternate {index} of segment"
+            )
+    for overlay in _overlays(doc):
+        findings += _range_error(overlay, str(overlay["id"]), "Overlay")
+    audio = doc.get("audio")
+    if isinstance(audio, dict):
+        findings += _range_error(audio, None, "The audio block")
+    return findings
+
+
+def _range_error(item: dict[str, Any], id: str | None, subject: str) -> list[Finding]:
+    if item["in"] < item["out"]:
+        return []
+    named = f"{subject} {id!r}" if id else subject
+    return [
+        _finding(
+            "E3",
+            id,
+            f"{named} has in={item['in']} and out={item['out']}; a half-open range "
+            f"names no frames unless in < out.",
+        )
+    ]
+
+
+def _declared_alias_errors(doc: dict[str, Any]) -> list[Finding]:
+    """E4/E7: an alias that is not in the sources table resolves to nothing at all."""
+    declared = set(doc["sources"])
+    findings: list[Finding] = []
+    for alias, id in _alias_uses(doc):
+        if alias not in declared:
+            findings.append(
+                _finding(
+                    "E4",
+                    id,
+                    f"The alias {alias!r} is not declared in 'sources'; declared aliases "
+                    f"are: {_listed(sorted(declared))}.",
+                )
+            )
+    audio = doc.get("audio")
+    if isinstance(audio, dict) and audio["source"] not in declared:
+        findings.append(
+            _finding(
+                "E7",
+                None,
+                f"The audio alias {audio['source']!r} is not declared in 'sources'.",
+            )
+        )
+    return findings
+
+
+def _alias_uses(doc: dict[str, Any]) -> Iterator[tuple[str, str]]:
+    """Every (alias, owning id) the cut references, audio block excluded."""
+    for segment in _segments(doc):
+        yield str(segment["source"]), str(segment["id"])
+        for alternate in segment.get("alternates") or []:
+            yield str(alternate["source"]), str(segment["id"])
+    for overlay in _overlays(doc):
+        yield str(overlay["source"]), str(overlay["id"])
+
+
+def _listed(names: Sequence[str]) -> str:
+    return ", ".join(names) if names else "none"
+
+
+def _alternate_duration_errors(doc: dict[str, Any]) -> list[Finding]:
+    """E8: a take selector cannot change length, so an alternate cannot either."""
+    findings: list[Finding] = []
+    for segment in _segments(doc):
+        main = duration_frames(segment["in"], segment["out"])
+        for index, alternate in enumerate(segment.get("alternates") or []):
+            alternate_duration = duration_frames(alternate["in"], alternate["out"])
+            if alternate_duration != main:
+                findings.append(
+                    _finding(
+                        "E8",
+                        str(segment["id"]),
+                        f"Alternate {index} runs {alternate_duration} frames but the main "
+                        f"take runs {main}; every alternate must match frame for frame.",
+                    )
+                )
+    return findings
+
+
+def _positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
+    """Each segment id to its computed ``(start, duration)`` — sequential V1, butt-joined."""
+    placed: dict[str, tuple[int, int]] = {}
+    at = 0
+    for segment in _segments(doc):
+        duration = duration_frames(segment["in"], segment["out"])
+        placed[str(segment["id"])] = (at, duration)
+        at += duration
+    return placed
+
+
+def total_frames(doc: dict[str, Any]) -> int:
+    """The V1 span: sequential segments, so the sum of their durations."""
+    return sum(duration_frames(s["in"], s["out"]) for s in _segments(doc))
+
+
+def _overlay_errors(doc: dict[str, Any]) -> list[Finding]:
+    """E9 and E10, both judged on absolute positions resolved from the anchors."""
+    placed = _positions(doc)
+    total = total_frames(doc)
+    findings: list[Finding] = []
+    spans: list[tuple[str, int, int]] = []
+
+    for overlay in _overlays(doc):
+        id = str(overlay["id"])
+        anchor = str(overlay["over"]["segment"])
+        offset = int(overlay["over"]["offset"])
+        if anchor not in placed:
+            findings.append(
+                _finding(
+                    "E9",
+                    id,
+                    f"Overlay {id!r} is anchored to segment {anchor!r}, which does not exist.",
+                )
+            )
+            continue
+        start, anchor_duration = placed[anchor]
+        if not 0 <= offset < anchor_duration:
+            findings.append(
+                _finding(
+                    "E9",
+                    id,
+                    f"Overlay {id!r} sits at offset {offset} of segment {anchor!r}, which "
+                    f"runs {anchor_duration} frames; the offset must land inside it.",
+                )
+            )
+            continue
+        duration = duration_frames(overlay["in"], overlay["out"])
+        at = start + offset
+        if at + duration > total:
+            findings.append(
+                _finding(
+                    "E9",
+                    id,
+                    f"Overlay {id!r} covers frames {at}-{at + duration} but the cut is "
+                    f"{total} frames long; it must land inside the cut.",
+                )
+            )
+            continue
+        spans.append((id, at, at + duration))
+
+    findings += _overlap_errors(spans)
+    return findings
+
+
+def _overlap_errors(spans: list[tuple[str, int, int]]) -> list[Finding]:
+    """E10: overlays share one V2 track, and Resolve will not overwrite on overlap."""
+    findings: list[Finding] = []
+    ordered = sorted(spans, key=lambda span: (span[1], span[2], span[0]))
+    for earlier, later in zip(ordered, ordered[1:], strict=False):
+        if ranges_overlap(earlier[1], earlier[2], later[1], later[2]):
+            findings.append(
+                _finding(
+                    "E10",
+                    later[0],
+                    f"Overlays {earlier[0]!r} ({earlier[1]}-{earlier[2]}) and {later[0]!r} "
+                    f"({later[1]}-{later[2]}) cover the same frames.",
+                )
+            )
+    return findings
+
+
+def _segment_length_warnings(doc: dict[str, Any], minimum: int) -> list[Finding]:
+    """W1: a flash frame is usually a typo, occasionally the point. Never a block."""
+    findings: list[Finding] = []
+    for segment in _segments(doc):
+        duration = duration_frames(segment["in"], segment["out"])
+        if duration < minimum:
+            findings.append(
+                _finding(
+                    "W1",
+                    str(segment["id"]),
+                    f"Segment {segment['id']!r} runs {duration} frames, under the "
+                    f"{minimum}-frame flash guard.",
+                )
+            )
+    return findings
+
+
+def _audio_span_warnings(doc: dict[str, Any]) -> list[Finding]:
+    """W2: a cold open or a tail is legal, so this reports and never blocks."""
+    audio = doc.get("audio")
+    if not isinstance(audio, dict):
+        return []
+    span = duration_frames(audio["in"], audio["out"])
+    total = total_frames(doc)
+    if span == total:
+        return []
+    return [
+        _finding(
+            "W2",
+            None,
+            f"The cut runs {total} frames over a {span}-frame master-audio span.",
+        )
+    ]
+
+
+# --- the project pass -------------------------------------------------------------------
+
+
+def validate_project(doc: Any, clips: Sequence[ClipFacts]) -> list[Finding]:
+    """Every rule that needs the media pool, over facts already gathered from it.
+
+    ``clips`` is every clip in the pool. Aliases are matched here rather than by
+    ``find_clip`` because validation reports *all* the failures at once — the agent
+    should not have to fix one alias per round trip.
+    """
+    if _shape_is_unreadable(doc):
+        return []
+    resolved, findings = _resolve_aliases(doc, clips)
+    findings += _bounds_errors(doc, resolved)
+    findings += _rate_errors(doc, resolved)
+    findings += _audio_errors(doc, resolved)
+    return _order(findings)
+
+
+def _shape_is_unreadable(doc: Any) -> bool:
+    return bool(list(_shape_errors(doc)))
+
+
+def _resolve_aliases(
+    doc: dict[str, Any], clips: Sequence[ClipFacts]
+) -> tuple[dict[str, ClipFacts], list[Finding]]:
+    """E4: alias -> exactly one clip. Ambiguity lists the bins the candidates sit in."""
+    resolved: dict[str, ClipFacts] = {}
+    findings: list[Finding] = []
+    for alias, source in doc["sources"].items():
+        name = str(source["clip"])
+        declared_bin = source.get("bin")
+        matches = [
+            clip
+            for clip in clips
+            if clip.name == name and (declared_bin is None or clip.bin_path == declared_bin)
+        ]
+        if len(matches) == 1:
+            resolved[alias] = matches[0]
+        elif not matches:
+            where = f" in the bin {declared_bin!r}" if declared_bin else ""
+            findings.append(
+                _finding(
+                    "E4",
+                    alias,
+                    f"The alias {alias!r} names the clip {name!r}{where}, which is not in "
+                    f"the media pool.",
+                    fix_hint="Import the clip, or fix the name or bin in 'sources'.",
+                )
+            )
+        else:
+            bins = _listed([str(clip.bin_path) for clip in matches])
+            findings.append(
+                _finding(
+                    "E4",
+                    alias,
+                    f"The alias {alias!r} names {name!r}, which is in {len(matches)} bins: "
+                    f"{bins}.",
+                    fix_hint="Add a 'bin' to the source alias to say which one you mean.",
+                )
+            )
+    return resolved, findings
+
+
+def _bounds_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[Finding]:
+    """E5: every range has to name frames the media actually has."""
+    findings: list[Finding] = []
+    for segment in _segments(doc):
+        id = str(segment["id"])
+        findings += _bounds_error(segment, resolved, id, f"Segment {id!r}")
+        for index, alternate in enumerate(segment.get("alternates") or []):
+            findings += _bounds_error(
+                alternate, resolved, id, f"Alternate {index} of segment {id!r}"
+            )
+    for overlay in _overlays(doc):
+        id = str(overlay["id"])
+        findings += _bounds_error(overlay, resolved, id, f"Overlay {id!r}")
+    return findings
+
+
+def _bounds_error(
+    item: dict[str, Any],
+    resolved: dict[str, ClipFacts],
+    id: str,
+    subject: str,
+) -> list[Finding]:
+    clip = resolved.get(str(item["source"]))
+    if clip is None:
+        return []
+    if clip.is_still:
+        # A still has one frame of media and any duration on a timeline — the
+        # end-frame workaround is what makes that exact. Bounds do not apply.
+        return []
+    if item["in"] >= clip.start and item["out"] <= clip.end_exclusive:
+        return []
+    return [
+        _finding(
+            "E5",
+            id,
+            f"{subject} asks for frames {item['in']}-{item['out']} of {clip.name!r}, whose "
+            f"media runs {clip.start}-{clip.end_exclusive}.",
+        )
+    ]
+
+
+def _rate_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[Finding]:
+    """E6: a source at another rate would be silently retimed on the timeline.
+
+    Stills are exempt by rule; a clip whose rate Resolve does not report (audio, and
+    anything it declines to answer for) is logged rather than failed — an unknown is not
+    a mismatch, and failing on it would block cuts that are fine.
+    """
+    timeline_fps = float(doc["timeline"]["fps"])
+    used = {alias for alias, _ in _alias_uses(doc)}
+    findings: list[Finding] = []
+    for alias in sorted(used):
+        clip = resolved.get(alias)
+        if clip is None or clip.is_still:
+            continue
+        if clip.fps is None:
+            log.info("No frame rate reported for %s; E6 not checked", clip.name)
+            continue
+        if abs(clip.fps - timeline_fps) > FPS_TOLERANCE:
+            findings.append(
+                _finding(
+                    "E6",
+                    alias,
+                    f"The source {alias!r} ({clip.name}) is {clip.fps} fps but the timeline "
+                    f"is {timeline_fps} fps.",
+                )
+            )
+    return findings
+
+
+def _audio_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[Finding]:
+    """E7: the master-audio substrate every segment is laid over."""
+    audio = doc.get("audio")
+    if not isinstance(audio, dict):
+        return []
+    alias = str(audio["source"])
+    clip = resolved.get(alias)
+    if clip is None:
+        return []  # already reported as E4 or an undeclared-alias E7
+    findings: list[Finding] = []
+    if not clip.has_audio:
+        findings.append(
+            _finding("E7", None, f"The audio source {alias!r} ({clip.name}) has no audio.")
+        )
+    if audio["in"] < clip.start or audio["out"] > clip.end_exclusive:
+        findings.append(
+            _finding(
+                "E7",
+                None,
+                f"The audio block asks for frames {audio['in']}-{audio['out']} of "
+                f"{clip.name!r}, whose media runs {clip.start}-{clip.end_exclusive}.",
+            )
+        )
+    return findings
+
+
+__all__ = [
+    "DEFAULT_MIN_SEGMENT_FRAMES",
+    "RULE_DESCRIPTIONS",
+    "ClipFacts",
+    "Finding",
+    "locked_track_finding",
+    "parse_failure_finding",
+    "total_frames",
+    "validate_project",
+    "validate_structure",
+]

--- a/src/resolve_mcp/naming.py
+++ b/src/resolve_mcp/naming.py
@@ -1,13 +1,18 @@
-"""Names for the files the server writes.
+"""Names for the files the server writes, and for the timelines it materializes.
 
 Snapshots and spilled listings both land in the cache directory named after something the
 director chose — a project, a bin — and both have to survive Windows filename rules and a
 second write in the same session. One rule, one place.
+
+Built timelines are named ``<base> v<N>``: every build makes a new version and no build
+ever touches an old one, so which number is next is a question about names that already
+exist. The scan lives here with the other naming rules.
 """
 
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from datetime import datetime
 
 UNSAFE_IN_FILENAME = re.compile(r"[^A-Za-z0-9._-]+")
@@ -24,3 +29,32 @@ def timestamped_name(
     stamp = (now or datetime.now()).strftime(STAMP_FORMAT)
     slug = UNSAFE_IN_FILENAME.sub("-", label).strip("-") or fallback
     return f"{slug}-{stamp}{suffix}"
+
+
+def version_pattern(base: str) -> re.Pattern[str]:
+    """Matches exactly ``<base> v<N>`` — a name that merely starts with the base is not one."""
+    return re.compile(rf"^{re.escape(base)} v(\d+)$")
+
+
+def version_number(base: str, name: str) -> int | None:
+    """The version ``name`` carries for ``base``, or ``None`` if it is not a version of it."""
+    found = version_pattern(base).match(name)
+    return int(found.group(1)) if found else None
+
+
+def latest_version(base: str, existing: Iterable[str]) -> int:
+    """The highest version already built for ``base``; ``0`` when there is none.
+
+    Max rather than count: a deleted v2 must not hand v3's number out a second time.
+    """
+    numbers = [
+        found
+        for found in (version_number(base, name) for name in existing)
+        if found is not None
+    ]
+    return max(numbers, default=0)
+
+
+def next_version_name(base: str, existing: Iterable[str]) -> str:
+    """The name the next build takes: ``<base> v<latest + 1>``."""
+    return f"{base} v{latest_version(base, existing) + 1}"

--- a/src/resolve_mcp/naming.py
+++ b/src/resolve_mcp/naming.py
@@ -31,14 +31,14 @@ def timestamped_name(
     return f"{slug}-{stamp}{suffix}"
 
 
-def version_pattern(base: str) -> re.Pattern[str]:
+def _version_pattern(base: str) -> re.Pattern[str]:
     """Matches exactly ``<base> v<N>`` — a name that merely starts with the base is not one."""
     return re.compile(rf"^{re.escape(base)} v(\d+)$")
 
 
 def version_number(base: str, name: str) -> int | None:
     """The version ``name`` carries for ``base``, or ``None`` if it is not a version of it."""
-    found = version_pattern(base).match(name)
+    found = _version_pattern(base).match(name)
     return int(found.group(1)) if found else None
 
 

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -1,0 +1,137 @@
+"""Serving the cut-file contract and enforcing it.
+
+Two jobs, one file, because they are two halves of the same promise: the agent is told
+exactly what the format is, and is then held to it before Resolve is touched.
+
+* :func:`get_cut_schema` needs no project and no connection — the contract is a constant.
+* :func:`validate_cut` is the dry run. It reads the file, runs the structural rules, and
+  only then reaches into the media pool for the rules that need real clips. Which is also
+  the order that keeps a malformed file from costing a round trip to Resolve.
+
+``build_timeline`` runs the same :func:`validate_cut` pre-flight, so a file that passes
+here is a file that will not abort a build on validation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..cut.document import LoadedCut, read_cut_file
+from ..cut.schema import ANNOTATED_EXAMPLE, SCHEMA_DOC, SCHEMA_VERSION
+from ..cut.validate import (
+    DEFAULT_MIN_SEGMENT_FRAMES,
+    RULE_DESCRIPTIONS,
+    ClipFacts,
+    Finding,
+    total_frames,
+    validate_project,
+    validate_structure,
+)
+from ..logging_config import get_logger
+from ..timing import dual_time
+from . import media
+from .connection import ResolveConnection
+
+log = get_logger("cut")
+
+Clip = Any
+Pool = Any
+
+
+def get_cut_schema() -> dict[str, Any]:
+    """The cut-file contract: the schema document, its annotated example, and the rules."""
+    return {
+        "schema": SCHEMA_VERSION,
+        "document": SCHEMA_DOC,
+        "annotated_example": ANNOTATED_EXAMPLE,
+        "rules": [
+            {
+                "rule": rule,
+                "severity": "warning" if rule.startswith("W") else "error",
+                "description": description,
+            }
+            for rule, description in RULE_DESCRIPTIONS.items()
+        ],
+    }
+
+
+def validate_cut(
+    connection: ResolveConnection,
+    cut_file: str,
+    min_segment_frames: int = DEFAULT_MIN_SEGMENT_FRAMES,
+) -> dict[str, Any]:
+    """Dry-run ``cut_file``: every rule, every failure, before anything is built."""
+    loaded = read_cut_file(cut_file)
+    if loaded.parse_error is not None:
+        return _report(loaded, None, [loaded.parse_error])
+
+    findings = validate_structure(loaded.doc, min_segment_frames=min_segment_frames)
+    if any(finding.rule == "E1" for finding in findings):
+        log.info("Cut file %s is not schema-valid; the media pool was not read", loaded.path)
+        return _report(loaded, None, findings)
+
+    findings = [*findings, *validate_project(loaded.doc, clip_facts(connection, loaded.doc))]
+    return _report(loaded, loaded.doc, findings)
+
+
+def clip_facts(connection: ResolveConnection, doc: dict[str, Any]) -> list[ClipFacts]:
+    """Read the media pool for the clips this cut names, and nothing else.
+
+    Only the aliased names are looked up: a concert pool holds thousands of clips, and a
+    cut references a handful, so properties are read for the handful.
+    """
+    pool = media.media_pool(connection)
+    wanted = {str(source["clip"]) for source in doc["sources"].values()}
+    located = media.clips_named(pool, wanted)
+    log.info("Cut validation resolved %d of %d aliased clip names", len(located), len(wanted))
+    return [_facts(found.bin_path, found.clip) for found in located]
+
+
+def _facts(bin_path: str, clip: Clip) -> ClipFacts:
+    reported = media.properties(clip)
+    start, out = media.frame_bounds(reported)
+    channels = media.audio_channels(reported)
+    return ClipFacts(
+        name=str(clip.GetName() or ""),
+        bin_path=bin_path,
+        start=start if start is not None else 0,
+        end_exclusive=out if out is not None else 0,
+        fps=media.frame_rate(reported),
+        # An unreported channel count must not fail a cut that is fine: E7 blocks the
+        # build, and "Resolve did not say" is not evidence of silence.
+        has_audio=channels is None or channels > 0,
+        is_still=media.is_still(reported),
+    )
+
+
+def _report(
+    loaded: LoadedCut,
+    doc: dict[str, Any] | None,
+    findings: list[Finding],
+) -> dict[str, Any]:
+    errors = [finding for finding in findings if finding.severity == "error"]
+    warnings = [finding for finding in findings if finding.severity == "warning"]
+    return {
+        "cut_file": str(loaded.path),
+        "content_hash": loaded.content_hash,
+        "valid": not errors,
+        "errors": [finding.as_dict() for finding in errors],
+        "warnings": [finding.as_dict() for finding in warnings],
+        "cut": _summary(doc),
+    }
+
+
+def _summary(doc: dict[str, Any] | None) -> dict[str, Any] | None:
+    """What the cut says it is — only ever built from a document that passed E1."""
+    if doc is None:
+        return None
+    fps = float(doc["timeline"]["fps"])
+    return {
+        "timeline": doc["timeline"]["name"],
+        "segments": len(doc["segments"]),
+        "overlays": len(doc.get("overlays") or []),
+        "duration": dual_time(total_frames(doc), fps),
+    }
+
+
+__all__ = ["clip_facts", "get_cut_schema", "validate_cut"]

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -23,6 +23,7 @@ from ..cut.validate import (
     RULE_DESCRIPTIONS,
     ClipFacts,
     Finding,
+    severity_of,
     total_frames,
     validate_project,
     validate_structure,
@@ -37,6 +38,9 @@ log = get_logger("cut")
 Clip = Any
 Pool = Any
 
+MIN_SEGMENT_FRAMES = DEFAULT_MIN_SEGMENT_FRAMES
+"""Re-exported so the tool layer takes its default from the wrapper it calls."""
+
 
 def get_cut_schema() -> dict[str, Any]:
     """The cut-file contract: the schema document, its annotated example, and the rules."""
@@ -47,7 +51,7 @@ def get_cut_schema() -> dict[str, Any]:
         "rules": [
             {
                 "rule": rule,
-                "severity": "warning" if rule.startswith("W") else "error",
+                "severity": severity_of(rule),
                 "description": description,
             }
             for rule, description in RULE_DESCRIPTIONS.items()
@@ -58,7 +62,7 @@ def get_cut_schema() -> dict[str, Any]:
 def validate_cut(
     connection: ResolveConnection,
     cut_file: str,
-    min_segment_frames: int = DEFAULT_MIN_SEGMENT_FRAMES,
+    min_segment_frames: int = MIN_SEGMENT_FRAMES,
 ) -> dict[str, Any]:
     """Dry-run ``cut_file``: every rule, every failure, before anything is built."""
     loaded = read_cut_file(cut_file)
@@ -88,11 +92,17 @@ def clip_facts(connection: ResolveConnection, doc: dict[str, Any]) -> list[ClipF
 
 
 def _facts(bin_path: str, clip: Clip) -> ClipFacts:
+    name = str(clip.GetName() or "")
     reported = media.properties(clip)
     start, out = media.frame_bounds(reported)
     channels = media.audio_channels(reported)
+    if channels is None:
+        # E7's has-audio leg reads an undocumented property key. If Resolve renames it
+        # the rule silently passes everything, and no fake can catch that — so say so
+        # here, where a live session's log is the only place it can be noticed.
+        log.info("No %r property on %s; E7 cannot check for audio", media.AUDIO_CHANNELS, name)
     return ClipFacts(
-        name=str(clip.GetName() or ""),
+        name=name,
         bin_path=bin_path,
         start=start if start is not None else 0,
         end_exclusive=out if out is not None else 0,
@@ -134,4 +144,4 @@ def _summary(doc: dict[str, Any] | None) -> dict[str, Any] | None:
     }
 
 
-__all__ = ["clip_facts", "get_cut_schema", "validate_cut"]
+__all__ = ["MIN_SEGMENT_FRAMES", "clip_facts", "get_cut_schema", "validate_cut"]

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -100,7 +100,7 @@ def _facts(bin_path: str, clip: Clip) -> ClipFacts:
         # E7's has-audio leg reads an undocumented property key. If Resolve renames it
         # the rule silently passes everything, and no fake can catch that — so say so
         # here, where a live session's log is the only place it can be noticed.
-        log.info("No %r property on %s; E7 cannot check for audio", media.AUDIO_CHANNELS, name)
+        log.info("No usable %r on %s; E7 cannot check for audio", media.AUDIO_CHANNELS, name)
     return ClipFacts(
         name=name,
         bin_path=bin_path,

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -21,7 +21,7 @@ rather than API calls, and are the reason this file exists at all:
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -57,6 +57,7 @@ END = "End"
 OUT = "Out"
 TYPE = "Type"
 RESOLUTION = "Resolution"
+AUDIO_CHANNELS = "Audio Ch"
 
 Clip = Any
 Folder = Any
@@ -210,6 +211,20 @@ def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> LocatedClip
     return matches[0]
 
 
+def clips_named(pool: Pool, names: Iterable[str]) -> list[LocatedClip]:
+    """Every clip anywhere in the pool whose name is one of ``names``.
+
+    Unlike :func:`find_clip` this reports the duplicates instead of raising on them: a
+    validation pass has to name every ambiguity at once, not stop at the first.
+    """
+    wanted = set(names)
+    return [
+        found
+        for found in _clips_under(find_bin(pool, None), recursive=True)
+        if str(found.clip.GetName() or "") in wanted
+    ]
+
+
 _logged_property_keys = False
 
 
@@ -237,11 +252,40 @@ def _number(reported: dict[str, str], key: str) -> int | None:
         return None
 
 
-def _rate(reported: dict[str, str]) -> float | None:
+def frame_rate(reported: dict[str, str]) -> float | None:
+    """The clip's frame rate, or ``None`` when Resolve does not report one (audio, stills)."""
     try:
         return float(reported.get(FPS, ""))
     except (TypeError, ValueError):
         return None
+
+
+def frame_bounds(reported: dict[str, str]) -> tuple[int | None, int | None]:
+    """Media bounds as half-open ``[start, out)``.
+
+    Resolve reports ``End`` as the last frame; every range in this server is half-open, so
+    the out point is that frame plus one. Frame count is the fallback when ``End`` is
+    missing. The rule lives here so bounds mean the same thing to a listing and to a cut.
+    """
+    start = _number(reported, START)
+    end = _number(reported, END)
+    frames = _number(reported, FRAMES)
+    out = end + 1 if end is not None else (start + frames if start is not None and frames else None)
+    return start, out
+
+
+def audio_channels(reported: dict[str, str]) -> int | None:
+    """How many audio channels the clip carries, or ``None`` when Resolve does not say."""
+    return _number(reported, AUDIO_CHANNELS)
+
+
+def is_still(reported: dict[str, str]) -> bool:
+    """Whether the clip is an image rather than moving footage.
+
+    Judged by file suffix: the ``Type`` property does not separate a still from a
+    sequence, and the suffix is what the still-duration workaround already keys off.
+    """
+    return _looks_like_image(reported.get(FILE_PATH, ""))
 
 
 def is_offline(file_path: str) -> bool:
@@ -269,7 +313,7 @@ def summarise(bin_path: str, clip: Clip, reported: dict[str, str] | None = None)
         "file_path": file_path,
         "type": reported.get(TYPE, ""),
         "frames": _number(reported, FRAMES),
-        "fps": _rate(reported),
+        "fps": frame_rate(reported),
         "resolution": reported.get(RESOLUTION, ""),
         "offline": is_offline(file_path),
     }
@@ -323,7 +367,7 @@ def apply_still_workaround(clip: Clip, reported: dict[str, str]) -> bool:
     lands at the default still duration — until any out point has been written to the clip.
     The value does not matter, only that the write happened.
     """
-    if not _looks_like_image(reported.get(FILE_PATH, "")):
+    if not is_still(reported):
         return False
     end = _number(reported, END)
     if end is None:
@@ -505,12 +549,11 @@ def _bounds(clip: Clip, reported: dict[str, str]) -> dict[str, Any]:
     Resolve reports ``End`` as the last frame; the cut file's convention is half-open, so
     the out point is that frame plus one and ``duration = out - in`` everywhere.
     """
-    fps = _rate(reported)
-    start = _number(reported, START)
-    end = _number(reported, END)
-    frames = _number(reported, FRAMES)
-    out = end + 1 if end is not None else (start + frames if start is not None and frames else None)
-    duration = out - start if out is not None and start is not None else frames
+    fps = frame_rate(reported)
+    start, out = frame_bounds(reported)
+    duration = (
+        out - start if out is not None and start is not None else _number(reported, FRAMES)
+    )
 
     marks: dict[str, Any] = {}
     try:

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from . import __version__
 from .config import get_config
 from .logging_config import configure_logging, get_logger
-from .tools import escape_hatch, media, project
+from .tools import cut, escape_hatch, media, project
 
 log = get_logger("server")
 
@@ -23,6 +23,9 @@ Call get_status first to see what Resolve has open — every result echoes the c
 project, timeline and fps, so watch that context for switches. Take a snapshot_project
 backup before any big or risky operation. Failures come back as ok:false with a cause and
 a fix; act on the fix rather than retrying blindly.
+
+Editing is declarative: you author a cut file, the server builds it. Call get_cut_schema
+before writing one and validate_cut after every edit — do not guess the format.
 """
 
 
@@ -33,7 +36,7 @@ def build_server() -> FastMCP:
         instructions=INSTRUCTIONS,
         version=__version__,
     )
-    for fn in (*project.TOOLS, *media.TOOLS, *escape_hatch.TOOLS):
+    for fn in (*project.TOOLS, *media.TOOLS, *cut.TOOLS, *escape_hatch.TOOLS):
         mcp.tool(fn)
     return mcp
 

--- a/src/resolve_mcp/timing.py
+++ b/src/resolve_mcp/timing.py
@@ -6,13 +6,29 @@ here, once, tested; nothing else in the server is allowed to reimplement it.
 
 Timecode is non-drop-frame: frames are counted at the nearest whole rate (59.94 counts at
 60), which is what Resolve's own frame numbering does. Drop-frame notation is not v1.
+
+Ranges are half-open ``[in, out)`` everywhere: duration is ``out - in``, and adjacent
+takes share a boundary frame without either owning it twice.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import math
+from typing import Any, Literal
 
 SECONDS_PRECISION = 3
+
+Snap = Literal["floor", "ceil"]
+"""Which way a seconds value that lands between frames is resolved."""
+
+IN_POINT: Snap = "floor"
+"""In points snap back: the frame the moment falls on is included."""
+
+OUT_POINT: Snap = "ceil"
+"""Out points snap forward: half-open, so the moment stays inside the range."""
+
+_BOUNDARY_TOLERANCE = 9
+"""Decimal places kept before snapping — enough to kill float noise, not a real fraction."""
 
 
 def timecode(frames: int, fps: float) -> str:
@@ -22,6 +38,32 @@ def timecode(frames: int, fps: float) -> str:
     minutes, seconds = divmod(whole_seconds, 60)
     hours, minutes = divmod(minutes, 60)
     return f"{hours:02d}:{minutes:02d}:{seconds:02d}:{frame:02d}"
+
+
+def frames_from_seconds(seconds: float, fps: float, snap: Snap) -> int:
+    """Seconds to frames, snapped the way the caller asked — never silently rounded.
+
+    A seconds value the director typed almost never lands on a frame boundary, and which
+    way it moves changes the cut: an in point that rounded up would drop the frame the
+    moment happens on. So the direction is a required argument, not a default.
+
+    A value already on a boundary stays put in both directions; the tolerance below only
+    absorbs binary representation error, never a real fraction of a frame.
+    """
+    if fps <= 0:
+        raise ValueError(f"fps must be positive to convert seconds to frames, got {fps!r}")
+    exact = round(seconds * fps, _BOUNDARY_TOLERANCE)
+    return int(math.floor(exact) if snap == "floor" else math.ceil(exact))
+
+
+def duration_frames(in_frame: int, out_frame: int) -> int:
+    """Frames covered by the half-open range ``[in, out)``."""
+    return int(out_frame) - int(in_frame)
+
+
+def ranges_overlap(a_in: int, a_out: int, b_in: int, b_out: int) -> bool:
+    """Whether two half-open ranges share a frame. Touching at a boundary does not."""
+    return a_in < b_out and b_in < a_out
 
 
 def dual_time(frames: int | None, fps: float | None) -> dict[str, Any] | None:

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -1,0 +1,49 @@
+"""The cut-file tools: the contract, and the dry run that holds you to it.
+
+A cut file is yours — you author it, the server never writes it. These two tools are how
+you find out what it must contain and whether the one you wrote will build.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..cut.validate import DEFAULT_MIN_SEGMENT_FRAMES
+from ..resolve import cut
+from ..resolve.connection import get_connection
+from .envelope import tool
+
+
+@tool
+def get_cut_schema() -> dict[str, Any]:
+    """Return the cut-file schema v1, its annotated example, and the validation rules.
+
+    Read this before authoring or editing a cut file — the format is not guessable and
+    the example is the contract. `rules` lists every error that blocks a build and every
+    warning that does not. Needs no project open.
+    """
+    return cut.get_cut_schema()
+
+
+@tool
+def validate_cut(
+    cut_file: str,
+    min_segment_frames: int = DEFAULT_MIN_SEGMENT_FRAMES,
+) -> dict[str, Any]:
+    """Dry-run a cut file and return every error and warning it has, with fix hints.
+
+    Run this after every edit: build_timeline runs the identical checks pre-flight, so a
+    file that is valid here will not abort a build. Each finding names the rule, the
+    segment or overlay id, what is wrong and how to fix it — all of them at once, not the
+    first. `min_segment_frames` tunes the W1 flash-frame warning only; it never blocks.
+    """
+    connection = get_connection()
+    return cut.validate_cut(connection, cut_file, min_segment_frames)
+
+
+TOOLS: tuple[Any, ...] = (
+    get_cut_schema,
+    validate_cut,
+)
+
+__all__ = ["TOOLS", "get_cut_schema", "validate_cut"]

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..cut.validate import DEFAULT_MIN_SEGMENT_FRAMES
 from ..resolve import cut
 from ..resolve.connection import get_connection
 from .envelope import tool
@@ -28,7 +27,7 @@ def get_cut_schema() -> dict[str, Any]:
 @tool
 def validate_cut(
     cut_file: str,
-    min_segment_frames: int = DEFAULT_MIN_SEGMENT_FRAMES,
+    min_segment_frames: int = cut.MIN_SEGMENT_FRAMES,
 ) -> dict[str, Any]:
     """Dry-run a cut file and return every error and warning it has, with fix hints.
 

--- a/tests/test_cut_tools.py
+++ b/tests/test_cut_tools.py
@@ -188,6 +188,18 @@ def test_a_master_clip_with_no_audio_is_reported(attach: Attach, tmp_path: Path)
     assert [error["rule"] for error in result["errors"]] == ["E7"]
 
 
+def test_a_channel_count_resolve_will_not_report_fails_open(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """E7 reads an undocumented property key; an unreadable one must not block a good cut."""
+    attach(studio(pool=a_pool(master={"Audio Ch": ""})))
+
+    result = validate_cut(a_cut(tmp_path, valid_doc()))
+
+    assert result["valid"] is True
+    assert result["errors"] == []
+
+
 def test_a_short_segment_warns_without_blocking(attach: Attach, tmp_path: Path) -> None:
     attach(studio(pool=a_pool()))
     doc = valid_doc()

--- a/tests/test_cut_tools.py
+++ b/tests/test_cut_tools.py
@@ -54,7 +54,7 @@ def a_pool(**overrides: dict[str, str]) -> Any:
     return media_pool({"Angles": [angle], "": [master]})
 
 
-# --- get_cut_schema -------------------------------------------------------------------
+# --- get_cut_schema ---------------------------------------------------------------------
 
 
 def test_the_schema_is_served_with_its_annotated_example_verbatim(attach: Attach) -> None:
@@ -96,7 +96,7 @@ def test_the_schema_serves_without_resolve(attach: Attach) -> None:
     assert result["context"]["connected"] is False
 
 
-# --- validate_cut: the clean case -----------------------------------------------------
+# --- validate_cut: the clean case -------------------------------------------------------
 
 
 def test_a_valid_cut_file_passes_clean(attach: Attach, tmp_path: Path) -> None:
@@ -143,7 +143,7 @@ def test_the_report_echoes_the_hash_of_the_bytes_it_validated(
     assert validate_cut(cut_file)["content_hash"] == first["content_hash"]
 
 
-# --- validate_cut: failures -----------------------------------------------------------
+# --- validate_cut: failures -------------------------------------------------------------
 
 
 def test_a_missing_clip_is_reported_against_its_alias(attach: Attach, tmp_path: Path) -> None:
@@ -208,7 +208,7 @@ def test_the_flash_frame_threshold_is_tunable(attach: Attach, tmp_path: Path) ->
     assert [warning["rule"] for warning in result["warnings"]] == ["W1"]
 
 
-# --- validate_cut: files that are not cut files ---------------------------------------
+# --- validate_cut: files that are not cut files -----------------------------------------
 
 
 def test_a_file_that_is_not_json_fails_e1_and_is_still_hashed(
@@ -256,7 +256,7 @@ def test_a_cut_file_that_is_not_there_is_a_request_failure(
     assert result["error"]["fix"]
 
 
-# --- connection behaviour -------------------------------------------------------------
+# --- connection behaviour ---------------------------------------------------------------
 
 
 def test_validation_survives_resolve_dying_mid_call(attach: Attach, tmp_path: Path) -> None:

--- a/tests/test_cut_tools.py
+++ b/tests/test_cut_tools.py
@@ -1,0 +1,270 @@
+"""The cut tools at the Resolve seam: what the schema serves, what the dry run reports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.cut.schema import ANNOTATED_EXAMPLE, SCHEMA_DOC
+from resolve_mcp.tools.cut import get_cut_schema, validate_cut
+
+from .conftest import Attach
+from .fakes import FakeMediaPoolItem, media_pool, studio
+
+
+def a_cut(tmp_path: Path, doc: Any, name: str = "sunset-set.cut.json") -> str:
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def valid_doc() -> dict[str, Any]:
+    return {
+        "schema": 1,
+        "timeline": {"name": "sunset-set", "fps": 59.94},
+        "sources": {
+            "gtr_close": {"clip": "C0012.mp4", "bin": "Angles"},
+            "master_mix": {"clip": "sunset-master.wav"},
+        },
+        "audio": {"source": "master_mix", "in": 0, "out": 178},
+        "segments": [{"id": "s001", "source": "gtr_close", "in": 14032, "out": 14210}],
+    }
+
+
+def a_pool(**overrides: dict[str, str]) -> Any:
+    """The media pool :func:`valid_doc` validates against."""
+    angle = FakeMediaPoolItem(
+        "C0012.mp4",
+        file_path="D:/media/C0012.mp4",
+        properties={"Frames": "20000", "Start": "0", "End": "19999", **overrides.get("angle", {})},
+    )
+    master = FakeMediaPoolItem(
+        "sunset-master.wav",
+        file_path="D:/media/sunset-master.wav",
+        properties={
+            "Type": "Audio",
+            "FPS": "",
+            "Frames": "400",
+            "Start": "0",
+            "End": "399",
+            **overrides.get("master", {}),
+        },
+    )
+    return media_pool({"Angles": [angle], "": [master]})
+
+
+# --- get_cut_schema -------------------------------------------------------------------
+
+
+def test_the_schema_is_served_with_its_annotated_example_verbatim(attach: Attach) -> None:
+    attach(studio())
+
+    result = get_cut_schema()
+
+    assert result["ok"] is True
+    assert result["schema"] == 1
+    assert result["annotated_example"] == ANNOTATED_EXAMPLE
+    assert result["document"] == SCHEMA_DOC
+    assert ANNOTATED_EXAMPLE in result["document"]
+
+
+def test_the_served_example_carries_its_annotations() -> None:
+    """The comments are the point — a stripped example teaches the agent nothing."""
+    assert "// source-clip frames, half-open [in, out)" in ANNOTATED_EXAMPLE
+    assert "// optional; same duration as main" in ANNOTATED_EXAMPLE
+
+
+def test_the_schema_lists_every_rule_with_its_severity(attach: Attach) -> None:
+    attach(studio())
+
+    rules = {rule["rule"]: rule["severity"] for rule in get_cut_schema()["rules"]}
+
+    assert [rule for rule, severity in rules.items() if severity == "error"] == [
+        f"E{number}" for number in range(1, 12)
+    ]
+    assert [rule for rule, severity in rules.items() if severity == "warning"] == ["W1", "W2"]
+
+
+def test_the_schema_serves_without_resolve(attach: Attach) -> None:
+    """The contract is a constant; needing a project to read it would be absurd."""
+    attach(None)
+
+    result = get_cut_schema()
+
+    assert result["ok"] is True
+    assert result["context"]["connected"] is False
+
+
+# --- validate_cut: the clean case -----------------------------------------------------
+
+
+def test_a_valid_cut_file_passes_clean(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=a_pool()))
+
+    result = validate_cut(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is True
+    assert result["valid"] is True
+    assert result["errors"] == []
+    assert result["warnings"] == []
+
+
+def test_a_valid_cut_file_reports_what_it_describes(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=a_pool()))
+
+    result = validate_cut(a_cut(tmp_path, valid_doc()))
+
+    assert result["cut"] == {
+        "timeline": "sunset-set",
+        "segments": 1,
+        "overlays": 0,
+        "duration": {
+            "frames": 178,
+            "seconds": 2.97,
+            "timecode": "00:00:02:58",
+            "fps": 59.94,
+        },
+    }
+
+
+def test_the_report_echoes_the_hash_of_the_bytes_it_validated(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(pool=a_pool()))
+    cut_file = a_cut(tmp_path, valid_doc())
+
+    first = validate_cut(cut_file)
+    edited = valid_doc()
+    edited["segments"][0]["out"] = 14200
+    second = validate_cut(a_cut(tmp_path, edited, "edited.cut.json"))
+
+    assert first["content_hash"] != second["content_hash"]
+    assert validate_cut(cut_file)["content_hash"] == first["content_hash"]
+
+
+# --- validate_cut: failures -----------------------------------------------------------
+
+
+def test_a_missing_clip_is_reported_against_its_alias(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=media_pool({})))
+
+    result = validate_cut(a_cut(tmp_path, valid_doc()))
+
+    assert result["valid"] is False
+    reported = {error["id"]: error for error in result["errors"]}
+    assert set(reported) == {"gtr_close", "master_mix"}, "every failure, not just the first"
+    assert reported["gtr_close"]["rule"] == "E4"
+    assert "C0012.mp4" in reported["gtr_close"]["message"]
+    assert reported["gtr_close"]["fix_hint"]
+
+
+def test_a_range_past_the_end_of_the_media_is_reported_against_its_segment(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(pool=a_pool()))
+    doc = valid_doc()
+    doc["segments"][0]["out"] = 30000
+
+    result = validate_cut(a_cut(tmp_path, doc))
+
+    assert [error["rule"] for error in result["errors"]] == ["E5"]
+    assert result["errors"][0]["id"] == "s001"
+
+
+def test_a_source_at_the_wrong_rate_is_reported(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=a_pool(angle={"FPS": "29.97"})))
+
+    result = validate_cut(a_cut(tmp_path, valid_doc()))
+
+    assert [error["rule"] for error in result["errors"]] == ["E6"]
+
+
+def test_a_master_clip_with_no_audio_is_reported(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=a_pool(master={"Audio Ch": "0"})))
+
+    result = validate_cut(a_cut(tmp_path, valid_doc()))
+
+    assert [error["rule"] for error in result["errors"]] == ["E7"]
+
+
+def test_a_short_segment_warns_without_blocking(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=a_pool()))
+    doc = valid_doc()
+    doc["segments"][0]["out"] = 14036  # four frames
+
+    result = validate_cut(a_cut(tmp_path, doc))
+
+    assert result["valid"] is True
+    assert [warning["rule"] for warning in result["warnings"]] == ["W1", "W2"]
+
+
+def test_the_flash_frame_threshold_is_tunable(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=a_pool()))
+
+    result = validate_cut(a_cut(tmp_path, valid_doc()), min_segment_frames=200)
+
+    assert result["valid"] is True
+    assert [warning["rule"] for warning in result["warnings"]] == ["W1"]
+
+
+# --- validate_cut: files that are not cut files ---------------------------------------
+
+
+def test_a_file_that_is_not_json_fails_e1_and_is_still_hashed(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(pool=a_pool()))
+    path = tmp_path / "broken.cut.json"
+    path.write_text("{ this is not json", encoding="utf-8")
+
+    result = validate_cut(str(path))
+
+    assert result["ok"] is True
+    assert result["valid"] is False
+    assert [error["rule"] for error in result["errors"]] == ["E1"]
+    assert result["content_hash"]
+    assert result["cut"] is None
+
+
+def test_a_schema_invalid_file_never_reaches_the_media_pool(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A malformed file must not cost a round trip to Resolve."""
+    pool = a_pool()
+    attach(studio(pool=pool))
+    doc = valid_doc()
+    doc["schema"] = 2
+    pool.calls.clear()
+
+    result = validate_cut(a_cut(tmp_path, doc))
+
+    assert [error["rule"] for error in result["errors"]] == ["E1"]
+    assert pool.calls == []
+
+
+def test_a_cut_file_that_is_not_there_is_a_request_failure(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(pool=a_pool()))
+
+    result = validate_cut(str(tmp_path / "nope.cut.json"))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert "nope.cut.json" in result["error"]["cause"]
+    assert result["error"]["fix"]
+
+
+# --- connection behaviour -------------------------------------------------------------
+
+
+def test_validation_survives_resolve_dying_mid_call(attach: Attach, tmp_path: Path) -> None:
+    dying = studio(pool=a_pool())
+    dying.die_after(1)
+    attach(dying, studio(pool=a_pool()))
+
+    result = validate_cut(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is True
+    assert result["valid"] is True

--- a/tests/test_cut_validate.py
+++ b/tests/test_cut_validate.py
@@ -89,7 +89,7 @@ def only(findings: list[Finding], rule: str) -> Finding:
     return matches[0]
 
 
-# --- the clean case -------------------------------------------------------
+# --- the clean case ---------------------------------------------------------------------
 
 
 def test_valid_document_passes_clean() -> None:
@@ -100,7 +100,7 @@ def test_valid_document_passes_the_project_pass_clean() -> None:
     assert validate_project(valid_doc(), clip_facts()) == []
 
 
-# --- E1: parses, schema-valid, version supported --------------------------
+# --- E1: parses, schema-valid, version supported ----------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -124,7 +124,9 @@ def test_valid_document_passes_the_project_pass_clean() -> None:
 def test_e1_rejects_structurally_invalid_documents(mutate: Any) -> None:
     doc = valid_doc()
     mutate(doc)
+
     findings = validate_structure(doc)
+
     assert "E1" in rules(findings)
 
 
@@ -136,25 +138,34 @@ def test_e1_stops_before_later_rules_run() -> None:
     """A malformed document cannot be meaningfully checked for E2-E10."""
     doc = valid_doc()
     doc["segments"] = "not a list"
-    assert set(rules(validate_structure(doc))) == {"E1"}
+
+    findings = validate_structure(doc)
+
+    assert set(rules(findings)) == {"E1"}
 
 
-# --- E2: ids unique across segments and overlays --------------------------
+# --- E2: ids unique across segments and overlays ----------------------------------------
 
 
 def test_e2_catches_duplicate_segment_ids() -> None:
     doc = valid_doc()
     doc["segments"][1]["id"] = "s001"
-    assert only(validate_structure(doc), "E2").id == "s001"
+
+    finding = only(validate_structure(doc), "E2")
+
+    assert finding.id == "s001"
 
 
 def test_e2_shares_one_namespace_with_overlays() -> None:
     doc = valid_doc()
     doc["overlays"][0]["id"] = "s002"
-    assert only(validate_structure(doc), "E2").id == "s002"
+
+    finding = only(validate_structure(doc), "E2")
+
+    assert finding.id == "s002"
 
 
-# --- E3: in < out everywhere ----------------------------------------------
+# --- E3: in < out everywhere ------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -168,28 +179,39 @@ def test_e3_catches_non_positive_ranges(path: Any, expected_id: str) -> None:
     doc = valid_doc()
     target = doc[path[0]][path[1]]
     target["out"] = target["in"]
-    assert only(validate_structure(doc), "E3").id == expected_id
+
+    finding = only(validate_structure(doc), "E3")
+
+    assert finding.id == expected_id
 
 
 def test_e3_covers_alternates() -> None:
     doc = valid_doc()
     doc["segments"][0]["alternates"][0]["out"] = 8000
-    assert "E3" in rules(validate_structure(doc))
+
+    findings = validate_structure(doc)
+
+    assert "E3" in rules(findings)
 
 
 def test_e3_covers_the_audio_block() -> None:
     doc = valid_doc()
     doc["audio"]["out"] = 0
-    assert "E3" in rules(validate_structure(doc))
+
+    findings = validate_structure(doc)
+
+    assert "E3" in rules(findings)
 
 
-# --- E4: aliases resolve to exactly one media-pool clip -------------------
+# --- E4: aliases resolve to exactly one media-pool clip ---------------------------------
 
 
 def test_e4_catches_an_alias_that_is_not_declared_in_sources() -> None:
     doc = valid_doc()
     doc["segments"][1]["source"] = "nope"
+
     finding = only(validate_structure(doc), "E4")
+
     assert "nope" in finding.message
     assert finding.fix_hint
 
@@ -197,7 +219,9 @@ def test_e4_catches_an_alias_that_is_not_declared_in_sources() -> None:
 def test_e4_catches_an_alias_with_no_matching_clip() -> None:
     doc = valid_doc()
     facts = [c for c in clip_facts() if c.name != "C0013.mp4"]
+
     finding = only(validate_project(doc, facts), "E4")
+
     assert "C0013.mp4" in finding.message
 
 
@@ -208,30 +232,40 @@ def test_e4_lists_candidates_when_an_alias_is_ambiguous() -> None:
         *clip_facts(),
         ClipFacts(name="C0012.mp4", bin_path="Backup", start=0, end_exclusive=20000, fps=59.94),
     ]
+
     finding = only(validate_project(doc, facts), "E4")
+
     assert "Angles" in finding.message and "Backup" in finding.message
 
 
 def test_e4_matches_on_bin_when_one_is_declared() -> None:
     doc = valid_doc()
     doc["sources"]["gtr_close"]["bin"] = "Elsewhere"
-    assert "E4" in rules(validate_project(doc, clip_facts()))
+
+    findings = validate_project(doc, clip_facts())
+
+    assert "E4" in rules(findings)
 
 
-# --- E5: in/out inside clip media bounds ----------------------------------
+# --- E5: in/out inside clip media bounds ------------------------------------------------
 
 
 def test_e5_catches_an_out_point_past_the_end_of_the_media() -> None:
     doc = valid_doc()
     doc["segments"][0]["out"] = 99999
+
     finding = only(validate_project(doc, clip_facts()), "E5")
+
     assert finding.id == "s001"
 
 
 def test_e5_catches_an_in_point_before_the_start_of_the_media() -> None:
     doc = valid_doc()
     doc["segments"][0]["in"] = -5
-    assert "E5" in rules(validate_project(doc, clip_facts()))
+
+    findings = validate_project(doc, clip_facts())
+
+    assert "E5" in rules(findings)
 
 
 def test_e5_treats_the_range_as_half_open() -> None:
@@ -240,7 +274,10 @@ def test_e5_treats_the_range_as_half_open() -> None:
     doc["segments"][0]["in"] = 19800
     doc["segments"][0]["out"] = 20000
     doc["segments"][0]["alternates"] = []
-    assert validate_project(doc, clip_facts()) == []
+
+    findings = validate_project(doc, clip_facts())
+
+    assert findings == []
 
 
 def test_e5_exempts_stills_which_have_one_frame_and_any_duration() -> None:
@@ -252,29 +289,40 @@ def test_e5_exempts_stills_which_have_one_frame_and_any_duration() -> None:
         for c in clip_facts()
     ]
 
-    assert "E5" not in rules(validate_project(doc, facts))
+    findings = validate_project(doc, facts)
+
+    assert "E5" not in rules(findings)
 
 
 def test_e5_covers_alternates_and_overlays() -> None:
     doc = valid_doc()
     doc["segments"][0]["alternates"][0]["out"] = 99999
     doc["overlays"][0]["out"] = 99999
-    assert rules(validate_project(doc, clip_facts())).count("E5") == 2
+
+    findings = validate_project(doc, clip_facts())
+
+    assert rules(findings).count("E5") == 2
 
 
-# --- E6: source fps matches timeline fps ----------------------------------
+# --- E6: source fps matches timeline fps ------------------------------------------------
 
 
 def test_e6_catches_a_source_at_a_different_frame_rate() -> None:
     doc = valid_doc()
     facts = [c if c.name != "C0013.mp4" else replace(c, fps=29.97) for c in clip_facts()]
-    assert "E6" in rules(validate_project(doc, facts))
+
+    findings = validate_project(doc, facts)
+
+    assert "E6" in rules(findings)
 
 
 def test_e6_tolerates_float_noise_in_the_reported_rate() -> None:
     doc = valid_doc()
     facts = [c if c.fps is None else replace(c, fps=59.9400599) for c in clip_facts()]
-    assert validate_project(doc, facts) == []
+
+    findings = validate_project(doc, facts)
+
+    assert findings == []
 
 
 def test_e6_exempts_stills() -> None:
@@ -283,10 +331,13 @@ def test_e6_exempts_stills() -> None:
         c if c.name != "C0013.mp4" else replace(c, fps=29.97, is_still=True)
         for c in clip_facts()
     ]
-    assert "E6" not in rules(validate_project(doc, facts))
+
+    findings = validate_project(doc, facts)
+
+    assert "E6" not in rules(findings)
 
 
-# --- E7: the audio block resolves, has audio, bounds valid ----------------
+# --- E7: the audio block resolves, has audio, bounds valid ------------------------------
 
 
 def test_e7_catches_a_master_clip_with_no_audio() -> None:
@@ -294,58 +345,82 @@ def test_e7_catches_a_master_clip_with_no_audio() -> None:
     facts = [
         c if c.name != "sunset-master.wav" else replace(c, has_audio=False) for c in clip_facts()
     ]
-    assert "E7" in rules(validate_project(doc, facts))
+
+    findings = validate_project(doc, facts)
+
+    assert "E7" in rules(findings)
 
 
 def test_e7_catches_audio_bounds_past_the_end_of_the_master_clip() -> None:
     doc = valid_doc()
     doc["audio"]["out"] = 99999
-    assert "E7" in rules(validate_project(doc, clip_facts()))
+
+    findings = validate_project(doc, clip_facts())
+
+    assert "E7" in rules(findings)
 
 
 def test_e7_catches_an_audio_alias_that_is_not_declared() -> None:
     doc = valid_doc()
     doc["audio"]["source"] = "nope"
-    assert "E7" in rules(validate_structure(doc))
+
+    findings = validate_structure(doc)
+
+    assert "E7" in rules(findings)
 
 
 def test_a_document_without_an_audio_block_is_legal() -> None:
     doc = valid_doc()
     doc.pop("audio")
-    assert validate_structure(doc) == []
-    assert validate_project(doc, clip_facts()) == []
+
+    structural_findings = validate_structure(doc)
+    project_findings = validate_project(doc, clip_facts())
+
+    assert structural_findings == []
+    assert project_findings == []
 
 
-# --- E8: alternate duration equals main duration --------------------------
+# --- E8: alternate duration equals main duration ----------------------------------------
 
 
 def test_e8_catches_an_alternate_of_a_different_duration() -> None:
     doc = valid_doc()
     doc["segments"][0]["alternates"][0]["out"] = 8250
+
     finding = only(validate_structure(doc), "E8")
+
     assert finding.id == "s001"
     assert "200" in finding.message and "150" in finding.message
 
 
-# --- E9: overlay anchoring ------------------------------------------------
+# --- E9: overlay anchoring --------------------------------------------------------------
 
 
 def test_e9_catches_an_anchor_that_does_not_exist() -> None:
     doc = valid_doc()
     doc["overlays"][0]["over"]["segment"] = "s999"
-    assert only(validate_structure(doc), "E9").id == "b03"
+
+    finding = only(validate_structure(doc), "E9")
+
+    assert finding.id == "b03"
 
 
 def test_e9_catches_an_offset_past_the_end_of_its_anchor() -> None:
     doc = valid_doc()
     doc["overlays"][0]["over"]["offset"] = 500
-    assert "E9" in rules(validate_structure(doc))
+
+    findings = validate_structure(doc)
+
+    assert "E9" in rules(findings)
 
 
 def test_e9_catches_a_negative_offset() -> None:
     doc = valid_doc()
     doc["overlays"][0]["over"]["offset"] = -1
-    assert "E9" in rules(validate_structure(doc))
+
+    findings = validate_structure(doc)
+
+    assert "E9" in rules(findings)
 
 
 def test_e9_allows_an_overlay_running_past_its_anchor() -> None:
@@ -353,17 +428,23 @@ def test_e9_allows_an_overlay_running_past_its_anchor() -> None:
     doc = valid_doc()
     doc["overlays"][0]["over"]["offset"] = 190
     doc["overlays"][0]["out"] = 1300  # 100 frames, anchor ends 10 frames in
-    assert validate_structure(doc) == []
+
+    findings = validate_structure(doc)
+
+    assert findings == []
 
 
 def test_e9_catches_an_overlay_running_past_the_end_of_the_cut() -> None:
     doc = valid_doc()
     doc["overlays"][0]["over"]["offset"] = 190
     doc["overlays"][0]["out"] = 1600  # 400 frames from frame 190 of a 400-frame cut
-    assert "E9" in rules(validate_structure(doc))
+
+    findings = validate_structure(doc)
+
+    assert "E9" in rules(findings)
 
 
-# --- E10: overlays do not overlap each other ------------------------------
+# --- E10: overlays do not overlap each other --------------------------------------------
 
 
 def test_e10_catches_two_overlays_covering_the_same_frames() -> None:
@@ -377,7 +458,9 @@ def test_e10_catches_two_overlays_covering_the_same_frames() -> None:
             "over": {"segment": "s001", "offset": 100},
         }
     )
+
     finding = only(validate_structure(doc), "E10")
+
     assert "b03" in finding.message and "b04" in finding.message
 
 
@@ -393,7 +476,37 @@ def test_e10_allows_overlays_that_touch_at_a_boundary() -> None:
             "over": {"segment": "s001", "offset": 124},
         }
     )
-    assert validate_structure(doc) == []
+
+    findings = validate_structure(doc)
+
+    assert findings == []
+
+
+def test_e10_catches_an_overlay_sitting_wholly_inside_a_longer_one() -> None:
+    """Sorted by start, a contained overlay is not adjacent to the one covering it."""
+    doc = valid_doc()
+    doc["overlays"][0]["over"]["offset"] = 0
+    doc["overlays"][0]["out"] = 1500  # b03 covers 0-300
+    doc["overlays"] += [
+        {
+            "id": "b04",
+            "source": "broll_pan",
+            "in": 1200,
+            "out": 1210,
+            "over": {"segment": "s001", "offset": 10},
+        },
+        {
+            "id": "b05",
+            "source": "broll_pan",
+            "in": 1200,
+            "out": 1210,
+            "over": {"segment": "s001", "offset": 30},
+        },
+    ]
+
+    findings = validate_structure(doc)
+
+    assert [f.id for f in findings if f.rule == "E10"] == ["b04", "b05"]
 
 
 def test_e10_compares_positions_across_different_anchors() -> None:
@@ -409,14 +522,18 @@ def test_e10_compares_positions_across_different_anchors() -> None:
             "over": {"segment": "s001", "offset": 150},
         }
     )
-    assert "E10" in rules(validate_structure(doc))
+
+    findings = validate_structure(doc)
+
+    assert "E10" in rules(findings)
 
 
-# --- E11: build-time, target tracks unlocked ------------------------------
+# --- E11: build-time, target tracks unlocked --------------------------------------------
 
 
 def test_e11_shapes_a_locked_track_finding_like_every_other_rule() -> None:
     finding = locked_track_finding("V1")
+
     assert finding.rule == "E11"
     assert finding.id == "V1"
     assert finding.fix_hint
@@ -428,13 +545,15 @@ def test_e11_shapes_a_locked_track_finding_like_every_other_rule() -> None:
     }
 
 
-# --- W1: flash-frame guard ------------------------------------------------
+# --- W1: flash-frame guard --------------------------------------------------------------
 
 
 def test_w1_warns_on_a_segment_shorter_than_the_minimum() -> None:
     doc = valid_doc()
     doc["segments"][1]["out"] = doc["segments"][1]["in"] + 5
+
     finding = only(validate_structure(doc), "W1")
+
     assert finding.id == "s002"
     assert finding.severity == "warning"
 
@@ -442,17 +561,23 @@ def test_w1_warns_on_a_segment_shorter_than_the_minimum() -> None:
 def test_w1_threshold_defaults_to_twelve_frames_and_is_tunable() -> None:
     doc = valid_doc()
     doc["segments"][1]["out"] = doc["segments"][1]["in"] + 12
-    assert "W1" not in rules(validate_structure(doc))
-    assert "W1" in rules(validate_structure(doc, min_segment_frames=13))
+
+    default_findings = validate_structure(doc)
+    tuned_findings = validate_structure(doc, min_segment_frames=13)
+
+    assert "W1" not in rules(default_findings)
+    assert "W1" in rules(tuned_findings)
 
 
-# --- W2: V1 total against the master-audio span ---------------------------
+# --- W2: V1 total against the master-audio span -----------------------------------------
 
 
 def test_w2_warns_when_the_cut_does_not_match_the_master_audio_span() -> None:
     doc = valid_doc()
     doc["audio"]["out"] = 900
+
     finding = only(validate_structure(doc), "W2")
+
     assert finding.severity == "warning"
     assert "400" in finding.message and "900" in finding.message
 
@@ -460,17 +585,23 @@ def test_w2_warns_when_the_cut_does_not_match_the_master_audio_span() -> None:
 def test_w2_is_silent_without_an_audio_block() -> None:
     doc = valid_doc()
     doc.pop("audio")
-    assert "W2" not in rules(validate_structure(doc))
+
+    findings = validate_structure(doc)
+
+    assert "W2" not in rules(findings)
 
 
-# --- findings are structured ----------------------------------------------
+# --- findings are structured ------------------------------------------------------------
 
 
 def test_every_finding_carries_a_rule_message_and_fix_hint() -> None:
     doc = valid_doc()
     doc["segments"][1]["id"] = "s001"
     doc["segments"][1]["out"] = doc["segments"][1]["in"]
-    for finding in validate_structure(doc):
+
+    findings = validate_structure(doc)
+
+    for finding in findings:
         assert finding.rule and finding.message and finding.fix_hint
         assert set(finding.as_dict()) == {"rule", "id", "message", "fix_hint"}
 
@@ -480,7 +611,9 @@ def test_findings_are_ordered_by_rule_with_warnings_last() -> None:
     doc["segments"][1]["id"] = "s001"  # E2
     doc["segments"][0]["out"] = doc["segments"][0]["in"]  # E3, and a zero-length cascade
 
-    assert rules(validate_structure(doc)) == ["E2", "E3", "E8", "W1", "W2"]
+    findings = validate_structure(doc)
+
+    assert rules(findings) == ["E2", "E3", "E8", "W1", "W2"]
 
 
 def test_rule_numbers_order_numerically_not_lexicographically() -> None:
@@ -497,12 +630,16 @@ def test_rule_numbers_order_numerically_not_lexicographically() -> None:
         }
     )  # E10
 
-    assert rules(validate_structure(doc)) == ["E3", "E10", "W2"]
+    findings = validate_structure(doc)
+
+    assert rules(findings) == ["E3", "E10", "W2"]
 
 
 def test_validation_does_not_mutate_the_document() -> None:
     doc = valid_doc()
     before = copy.deepcopy(doc)
+
     validate_structure(doc)
     validate_project(doc, clip_facts())
+
     assert doc == before

--- a/tests/test_cut_validate.py
+++ b/tests/test_cut_validate.py
@@ -1,0 +1,508 @@
+"""Pure-function tests for the cut-file validation rules E1-E11 and warnings W1-W2.
+
+No Resolve, no fakes: the structural pass takes a parsed document, the project
+pass takes gathered clip facts. Both are plain functions over plain data.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from resolve_mcp.cut.validate import (
+    ClipFacts,
+    Finding,
+    locked_track_finding,
+    validate_project,
+    validate_structure,
+)
+
+
+def valid_doc() -> dict[str, Any]:
+    """A cut file that passes every rule."""
+    return {
+        "schema": 1,
+        "timeline": {"name": "sunset-set", "fps": 59.94, "bin": "Cuts"},
+        "sources": {
+            "gtr_close": {"clip": "C0012.mp4", "bin": "Angles", "sync_offset": 1432},
+            "keys_wide": {"clip": "C0013.mp4", "bin": "Angles"},
+            "broll_pan": {"clip": "C0014.mp4"},
+            "master_mix": {"clip": "sunset-master.wav"},
+        },
+        "audio": {"source": "master_mix", "in": 0, "out": 400},
+        "segments": [
+            {
+                "id": "s001",
+                "source": "gtr_close",
+                "in": 1000,
+                "out": 1200,
+                "alternates": [{"source": "keys_wide", "in": 8100, "out": 8300}],
+                "note": "drum fill response",
+            },
+            {"id": "s002", "source": "keys_wide", "in": 2000, "out": 2200},
+        ],
+        "overlays": [
+            {
+                "id": "b03",
+                "source": "broll_pan",
+                "in": 1200,
+                "out": 1300,
+                "over": {"segment": "s001", "offset": 24},
+            }
+        ],
+    }
+
+
+def clip_facts() -> list[ClipFacts]:
+    """Media-pool facts matching :func:`valid_doc`."""
+    return [
+        ClipFacts(
+            name="C0012.mp4", bin_path="Angles", start=0, end_exclusive=20000, fps=59.94
+        ),
+        ClipFacts(
+            name="C0013.mp4", bin_path="Angles", start=0, end_exclusive=20000, fps=59.94
+        ),
+        ClipFacts(name="C0014.mp4", bin_path="Cuts", start=0, end_exclusive=20000, fps=59.94),
+        ClipFacts(
+            name="sunset-master.wav",
+            bin_path=None,
+            start=0,
+            end_exclusive=400,
+            fps=None,
+            has_audio=True,
+            is_still=False,
+        ),
+    ]
+
+
+def rules(findings: list[Finding]) -> list[str]:
+    return [f.rule for f in findings]
+
+
+def only(findings: list[Finding], rule: str) -> Finding:
+    """The single finding for ``rule`` — asserts exactly one fired."""
+    matches = [f for f in findings if f.rule == rule]
+    assert len(matches) == 1, f"expected exactly one {rule}, got {rules(findings)}"
+    return matches[0]
+
+
+# --- the clean case -------------------------------------------------------
+
+
+def test_valid_document_passes_clean() -> None:
+    assert validate_structure(valid_doc()) == []
+
+
+def test_valid_document_passes_the_project_pass_clean() -> None:
+    assert validate_project(valid_doc(), clip_facts()) == []
+
+
+# --- E1: parses, schema-valid, version supported --------------------------
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda d: d.pop("schema"), id="missing-schema"),
+        pytest.param(lambda d: d.update(schema=2), id="unsupported-version"),
+        pytest.param(lambda d: d.update(schema="1"), id="version-not-an-int"),
+        pytest.param(lambda d: d.pop("timeline"), id="missing-timeline"),
+        pytest.param(lambda d: d["timeline"].pop("name"), id="missing-timeline-name"),
+        pytest.param(lambda d: d["timeline"].update(fps=0), id="fps-not-positive"),
+        pytest.param(lambda d: d.pop("sources"), id="missing-sources"),
+        pytest.param(lambda d: d["sources"].update(gtr_close={}), id="source-without-clip"),
+        pytest.param(lambda d: d.update(segments=[]), id="no-segments"),
+        pytest.param(lambda d: d["segments"][0].pop("id"), id="segment-without-id"),
+        pytest.param(lambda d: d["segments"][0].update(**{"in": 1000.5}), id="in-not-an-int"),
+        pytest.param(lambda d: d["overlays"][0].pop("over"), id="overlay-without-anchor"),
+        pytest.param(lambda d: d["segments"][0].update(audio="yes"), id="audio-flag-not-bool"),
+    ],
+)
+def test_e1_rejects_structurally_invalid_documents(mutate: Any) -> None:
+    doc = valid_doc()
+    mutate(doc)
+    findings = validate_structure(doc)
+    assert "E1" in rules(findings)
+
+
+def test_e1_fires_when_the_document_is_not_an_object() -> None:
+    assert "E1" in rules(validate_structure([1, 2, 3]))
+
+
+def test_e1_stops_before_later_rules_run() -> None:
+    """A malformed document cannot be meaningfully checked for E2-E10."""
+    doc = valid_doc()
+    doc["segments"] = "not a list"
+    assert set(rules(validate_structure(doc))) == {"E1"}
+
+
+# --- E2: ids unique across segments and overlays --------------------------
+
+
+def test_e2_catches_duplicate_segment_ids() -> None:
+    doc = valid_doc()
+    doc["segments"][1]["id"] = "s001"
+    assert only(validate_structure(doc), "E2").id == "s001"
+
+
+def test_e2_shares_one_namespace_with_overlays() -> None:
+    doc = valid_doc()
+    doc["overlays"][0]["id"] = "s002"
+    assert only(validate_structure(doc), "E2").id == "s002"
+
+
+# --- E3: in < out everywhere ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_id"),
+    [
+        pytest.param(("segments", 0), "s001", id="segment"),
+        pytest.param(("overlays", 0), "b03", id="overlay"),
+    ],
+)
+def test_e3_catches_non_positive_ranges(path: Any, expected_id: str) -> None:
+    doc = valid_doc()
+    target = doc[path[0]][path[1]]
+    target["out"] = target["in"]
+    assert only(validate_structure(doc), "E3").id == expected_id
+
+
+def test_e3_covers_alternates() -> None:
+    doc = valid_doc()
+    doc["segments"][0]["alternates"][0]["out"] = 8000
+    assert "E3" in rules(validate_structure(doc))
+
+
+def test_e3_covers_the_audio_block() -> None:
+    doc = valid_doc()
+    doc["audio"]["out"] = 0
+    assert "E3" in rules(validate_structure(doc))
+
+
+# --- E4: aliases resolve to exactly one media-pool clip -------------------
+
+
+def test_e4_catches_an_alias_that_is_not_declared_in_sources() -> None:
+    doc = valid_doc()
+    doc["segments"][1]["source"] = "nope"
+    finding = only(validate_structure(doc), "E4")
+    assert "nope" in finding.message
+    assert finding.fix_hint
+
+
+def test_e4_catches_an_alias_with_no_matching_clip() -> None:
+    doc = valid_doc()
+    facts = [c for c in clip_facts() if c.name != "C0013.mp4"]
+    finding = only(validate_project(doc, facts), "E4")
+    assert "C0013.mp4" in finding.message
+
+
+def test_e4_lists_candidates_when_an_alias_is_ambiguous() -> None:
+    doc = valid_doc()
+    doc["sources"]["gtr_close"].pop("bin")
+    facts = [
+        *clip_facts(),
+        ClipFacts(name="C0012.mp4", bin_path="Backup", start=0, end_exclusive=20000, fps=59.94),
+    ]
+    finding = only(validate_project(doc, facts), "E4")
+    assert "Angles" in finding.message and "Backup" in finding.message
+
+
+def test_e4_matches_on_bin_when_one_is_declared() -> None:
+    doc = valid_doc()
+    doc["sources"]["gtr_close"]["bin"] = "Elsewhere"
+    assert "E4" in rules(validate_project(doc, clip_facts()))
+
+
+# --- E5: in/out inside clip media bounds ----------------------------------
+
+
+def test_e5_catches_an_out_point_past_the_end_of_the_media() -> None:
+    doc = valid_doc()
+    doc["segments"][0]["out"] = 99999
+    finding = only(validate_project(doc, clip_facts()), "E5")
+    assert finding.id == "s001"
+
+
+def test_e5_catches_an_in_point_before_the_start_of_the_media() -> None:
+    doc = valid_doc()
+    doc["segments"][0]["in"] = -5
+    assert "E5" in rules(validate_project(doc, clip_facts()))
+
+
+def test_e5_treats_the_range_as_half_open() -> None:
+    """out == end_exclusive is the last legal frame boundary, not an overrun."""
+    doc = valid_doc()
+    doc["segments"][0]["in"] = 19800
+    doc["segments"][0]["out"] = 20000
+    doc["segments"][0]["alternates"] = []
+    assert validate_project(doc, clip_facts()) == []
+
+
+def test_e5_exempts_stills_which_have_one_frame_and_any_duration() -> None:
+    doc = valid_doc()
+    doc["segments"][0]["out"] = 99999
+    doc["segments"][0]["alternates"] = []
+    facts = [
+        c if c.name != "C0012.mp4" else replace(c, end_exclusive=1, fps=None, is_still=True)
+        for c in clip_facts()
+    ]
+
+    assert "E5" not in rules(validate_project(doc, facts))
+
+
+def test_e5_covers_alternates_and_overlays() -> None:
+    doc = valid_doc()
+    doc["segments"][0]["alternates"][0]["out"] = 99999
+    doc["overlays"][0]["out"] = 99999
+    assert rules(validate_project(doc, clip_facts())).count("E5") == 2
+
+
+# --- E6: source fps matches timeline fps ----------------------------------
+
+
+def test_e6_catches_a_source_at_a_different_frame_rate() -> None:
+    doc = valid_doc()
+    facts = [c if c.name != "C0013.mp4" else replace(c, fps=29.97) for c in clip_facts()]
+    assert "E6" in rules(validate_project(doc, facts))
+
+
+def test_e6_tolerates_float_noise_in_the_reported_rate() -> None:
+    doc = valid_doc()
+    facts = [c if c.fps is None else replace(c, fps=59.9400599) for c in clip_facts()]
+    assert validate_project(doc, facts) == []
+
+
+def test_e6_exempts_stills() -> None:
+    doc = valid_doc()
+    facts = [
+        c if c.name != "C0013.mp4" else replace(c, fps=29.97, is_still=True)
+        for c in clip_facts()
+    ]
+    assert "E6" not in rules(validate_project(doc, facts))
+
+
+# --- E7: the audio block resolves, has audio, bounds valid ----------------
+
+
+def test_e7_catches_a_master_clip_with_no_audio() -> None:
+    doc = valid_doc()
+    facts = [
+        c if c.name != "sunset-master.wav" else replace(c, has_audio=False) for c in clip_facts()
+    ]
+    assert "E7" in rules(validate_project(doc, facts))
+
+
+def test_e7_catches_audio_bounds_past_the_end_of_the_master_clip() -> None:
+    doc = valid_doc()
+    doc["audio"]["out"] = 99999
+    assert "E7" in rules(validate_project(doc, clip_facts()))
+
+
+def test_e7_catches_an_audio_alias_that_is_not_declared() -> None:
+    doc = valid_doc()
+    doc["audio"]["source"] = "nope"
+    assert "E7" in rules(validate_structure(doc))
+
+
+def test_a_document_without_an_audio_block_is_legal() -> None:
+    doc = valid_doc()
+    doc.pop("audio")
+    assert validate_structure(doc) == []
+    assert validate_project(doc, clip_facts()) == []
+
+
+# --- E8: alternate duration equals main duration --------------------------
+
+
+def test_e8_catches_an_alternate_of_a_different_duration() -> None:
+    doc = valid_doc()
+    doc["segments"][0]["alternates"][0]["out"] = 8250
+    finding = only(validate_structure(doc), "E8")
+    assert finding.id == "s001"
+    assert "200" in finding.message and "150" in finding.message
+
+
+# --- E9: overlay anchoring ------------------------------------------------
+
+
+def test_e9_catches_an_anchor_that_does_not_exist() -> None:
+    doc = valid_doc()
+    doc["overlays"][0]["over"]["segment"] = "s999"
+    assert only(validate_structure(doc), "E9").id == "b03"
+
+
+def test_e9_catches_an_offset_past_the_end_of_its_anchor() -> None:
+    doc = valid_doc()
+    doc["overlays"][0]["over"]["offset"] = 500
+    assert "E9" in rules(validate_structure(doc))
+
+
+def test_e9_catches_a_negative_offset() -> None:
+    doc = valid_doc()
+    doc["overlays"][0]["over"]["offset"] = -1
+    assert "E9" in rules(validate_structure(doc))
+
+
+def test_e9_allows_an_overlay_running_past_its_anchor() -> None:
+    """Seam coverage: the overlay may outlast the segment it is anchored to."""
+    doc = valid_doc()
+    doc["overlays"][0]["over"]["offset"] = 190
+    doc["overlays"][0]["out"] = 1300  # 100 frames, anchor ends 10 frames in
+    assert validate_structure(doc) == []
+
+
+def test_e9_catches_an_overlay_running_past_the_end_of_the_cut() -> None:
+    doc = valid_doc()
+    doc["overlays"][0]["over"]["offset"] = 190
+    doc["overlays"][0]["out"] = 1600  # 400 frames from frame 190 of a 400-frame cut
+    assert "E9" in rules(validate_structure(doc))
+
+
+# --- E10: overlays do not overlap each other ------------------------------
+
+
+def test_e10_catches_two_overlays_covering_the_same_frames() -> None:
+    doc = valid_doc()
+    doc["overlays"].append(
+        {
+            "id": "b04",
+            "source": "broll_pan",
+            "in": 1400,
+            "out": 1500,
+            "over": {"segment": "s001", "offset": 100},
+        }
+    )
+    finding = only(validate_structure(doc), "E10")
+    assert "b03" in finding.message and "b04" in finding.message
+
+
+def test_e10_allows_overlays_that_touch_at_a_boundary() -> None:
+    """Half-open ranges: one ending where the next begins is not an overlap."""
+    doc = valid_doc()
+    doc["overlays"].append(
+        {
+            "id": "b04",
+            "source": "broll_pan",
+            "in": 1400,
+            "out": 1500,
+            "over": {"segment": "s001", "offset": 124},
+        }
+    )
+    assert validate_structure(doc) == []
+
+
+def test_e10_compares_positions_across_different_anchors() -> None:
+    """Anchored offsets resolve to absolute positions before overlap is judged."""
+    doc = valid_doc()
+    doc["overlays"][0]["over"] = {"segment": "s002", "offset": 0}
+    doc["overlays"].append(
+        {
+            "id": "b04",
+            "source": "broll_pan",
+            "in": 1400,
+            "out": 1500,
+            "over": {"segment": "s001", "offset": 150},
+        }
+    )
+    assert "E10" in rules(validate_structure(doc))
+
+
+# --- E11: build-time, target tracks unlocked ------------------------------
+
+
+def test_e11_shapes_a_locked_track_finding_like_every_other_rule() -> None:
+    finding = locked_track_finding("V1")
+    assert finding.rule == "E11"
+    assert finding.id == "V1"
+    assert finding.fix_hint
+    assert finding.as_dict() == {
+        "rule": "E11",
+        "id": "V1",
+        "message": finding.message,
+        "fix_hint": finding.fix_hint,
+    }
+
+
+# --- W1: flash-frame guard ------------------------------------------------
+
+
+def test_w1_warns_on_a_segment_shorter_than_the_minimum() -> None:
+    doc = valid_doc()
+    doc["segments"][1]["out"] = doc["segments"][1]["in"] + 5
+    finding = only(validate_structure(doc), "W1")
+    assert finding.id == "s002"
+    assert finding.severity == "warning"
+
+
+def test_w1_threshold_defaults_to_twelve_frames_and_is_tunable() -> None:
+    doc = valid_doc()
+    doc["segments"][1]["out"] = doc["segments"][1]["in"] + 12
+    assert "W1" not in rules(validate_structure(doc))
+    assert "W1" in rules(validate_structure(doc, min_segment_frames=13))
+
+
+# --- W2: V1 total against the master-audio span ---------------------------
+
+
+def test_w2_warns_when_the_cut_does_not_match_the_master_audio_span() -> None:
+    doc = valid_doc()
+    doc["audio"]["out"] = 900
+    finding = only(validate_structure(doc), "W2")
+    assert finding.severity == "warning"
+    assert "400" in finding.message and "900" in finding.message
+
+
+def test_w2_is_silent_without_an_audio_block() -> None:
+    doc = valid_doc()
+    doc.pop("audio")
+    assert "W2" not in rules(validate_structure(doc))
+
+
+# --- findings are structured ----------------------------------------------
+
+
+def test_every_finding_carries_a_rule_message_and_fix_hint() -> None:
+    doc = valid_doc()
+    doc["segments"][1]["id"] = "s001"
+    doc["segments"][1]["out"] = doc["segments"][1]["in"]
+    for finding in validate_structure(doc):
+        assert finding.rule and finding.message and finding.fix_hint
+        assert set(finding.as_dict()) == {"rule", "id", "message", "fix_hint"}
+
+
+def test_findings_are_ordered_by_rule_with_warnings_last() -> None:
+    doc = valid_doc()
+    doc["segments"][1]["id"] = "s001"  # E2
+    doc["segments"][0]["out"] = doc["segments"][0]["in"]  # E3, and a zero-length cascade
+
+    assert rules(validate_structure(doc)) == ["E2", "E3", "E8", "W1", "W2"]
+
+
+def test_rule_numbers_order_numerically_not_lexicographically() -> None:
+    """E10 sorts after E3 — the trap a plain string sort falls into."""
+    doc = valid_doc()
+    doc["audio"]["out"] = doc["audio"]["in"]  # E3 on the audio block, and W2
+    doc["overlays"].append(
+        {
+            "id": "b04",
+            "source": "broll_pan",
+            "in": 1400,
+            "out": 1500,
+            "over": {"segment": "s001", "offset": 100},
+        }
+    )  # E10
+
+    assert rules(validate_structure(doc)) == ["E3", "E10", "W2"]
+
+
+def test_validation_does_not_mutate_the_document() -> None:
+    doc = valid_doc()
+    before = copy.deepcopy(doc)
+    validate_structure(doc)
+    validate_project(doc, clip_facts())
+    assert doc == before

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,78 @@
+"""Names the server hands out: spilled files, and the ``<base> v<N>`` timeline versions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from resolve_mcp.naming import (
+    latest_version,
+    next_version_name,
+    timestamped_name,
+    version_number,
+)
+
+WHEN = datetime(2026, 8, 5, 14, 30, 5)
+
+
+# --- written files ----------------------------------------------------------------------
+
+
+def test_a_label_becomes_a_timestamped_filename() -> None:
+    name = timestamped_name("sunset set", ".drp", "project", WHEN)
+
+    assert name == "sunset-set-20260805-143005.drp"
+
+
+def test_a_label_that_slugs_to_nothing_falls_back() -> None:
+    assert timestamped_name("///", ".json", "media-pool", WHEN) == "media-pool-20260805-143005.json"
+
+
+# --- timeline versions ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        pytest.param("sunset-set v1", 1, id="first-version"),
+        pytest.param("sunset-set v12", 12, id="two-digits"),
+        pytest.param("sunset-set v03", 3, id="zero-padded"),
+        pytest.param("sunset-set", None, id="the-base-alone"),
+        pytest.param("sunset-set v2 copy", None, id="trailing-text"),
+        pytest.param("sunset-set  v2", None, id="two-spaces"),
+        pytest.param("sunset-set v", None, id="no-number"),
+        pytest.param("other-set v2", None, id="another-base"),
+        pytest.param("sunset-set v2 v3", None, id="two-suffixes"),
+    ],
+)
+def test_only_an_exact_version_name_carries_a_version(name: str, expected: int | None) -> None:
+    assert version_number("sunset-set", name) == expected
+
+
+def test_a_base_that_is_a_prefix_of_another_does_not_claim_its_versions() -> None:
+    assert version_number("sunset", "sunset-set v2") is None
+
+
+def test_a_base_with_regex_characters_is_matched_literally() -> None:
+    assert version_number("set (b).1", "set (b).1 v2") == 2
+    assert version_number("set (b).1", "set (b)x1 v2") is None
+
+
+def test_the_latest_version_is_the_highest_not_the_count() -> None:
+    """A deleted v2 must not hand v3's number out a second time."""
+    assert latest_version("sunset-set", ["sunset-set v1", "sunset-set v3"]) == 3
+
+
+def test_a_base_nobody_has_built_yet_is_at_version_zero() -> None:
+    assert latest_version("sunset-set", ["holiday-gig v4", "sunset-set"]) == 0
+
+
+def test_the_next_version_follows_the_highest_that_exists() -> None:
+    existing = ["sunset-set v1", "sunset-set v2", "holiday-gig v9", "sunset-set draft"]
+
+    assert next_version_name("sunset-set", existing) == "sunset-set v3"
+
+
+def test_the_first_build_of_a_base_is_v1() -> None:
+    assert next_version_name("sunset-set", []) == "sunset-set v1"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,7 +17,7 @@ def descriptions() -> dict[str, str]:
     return {tool.name: tool.description or "" for tool in tools}
 
 
-def test_registers_the_p1_session_and_media_tools() -> None:
+def test_registers_the_p1_session_media_and_cut_tools() -> None:
     assert tool_names() == {
         "get_status",
         "list_projects",
@@ -29,6 +29,8 @@ def test_registers_the_p1_session_and_media_tools() -> None:
         "set_clip_metadata",
         "organize_media",
         "relink_media",
+        "get_cut_schema",
+        "validate_cut",
         "run_python",
     }
 

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 import pytest
 
-from resolve_mcp.timing import dual_time, timecode
+from resolve_mcp.timing import (
+    IN_POINT,
+    OUT_POINT,
+    Snap,
+    dual_time,
+    duration_frames,
+    frames_from_seconds,
+    ranges_overlap,
+    timecode,
+)
 
 
 @pytest.mark.parametrize(
@@ -38,3 +47,63 @@ def test_dual_without_an_fps_still_reports_frames() -> None:
 
 def test_dual_of_nothing_is_nothing() -> None:
     assert dual_time(None, 24.0) is None
+
+
+# --- snapping ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("seconds", "fps", "snap", "expected"),
+    [
+        (1.0, 24.0, IN_POINT, 24),
+        (1.0, 24.0, OUT_POINT, 24),
+        (1.5, 24.0, IN_POINT, 36),
+        (1.01, 24.0, IN_POINT, 24),
+        (1.01, 24.0, OUT_POINT, 25),
+        (0.0, 59.94, IN_POINT, 0),
+        (10.0, 59.94, IN_POINT, 599),
+        (10.0, 59.94, OUT_POINT, 600),
+    ],
+)
+def test_seconds_snap_the_way_the_caller_asked(
+    seconds: float, fps: float, snap: Snap, expected: int
+) -> None:
+    assert frames_from_seconds(seconds, fps, snap) == expected
+
+
+def test_a_boundary_second_does_not_drift_up_on_a_ceil() -> None:
+    """0.1 * 3 is not 0.3 in binary; a moment on a frame must not gain one."""
+    assert frames_from_seconds(0.1 + 0.1 + 0.1, 10.0, OUT_POINT) == 3
+
+
+def test_snapping_needs_a_real_frame_rate() -> None:
+    with pytest.raises(ValueError, match="fps must be positive"):
+        frames_from_seconds(1.0, 0.0, IN_POINT)
+
+
+# --- half-open range math ---------------------------------------------------------------
+
+
+def test_duration_is_out_minus_in() -> None:
+    assert duration_frames(14032, 14210) == 178
+
+
+def test_a_range_that_names_no_frames_has_no_duration() -> None:
+    assert duration_frames(100, 100) == 0
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "overlap"),
+    [
+        pytest.param((0, 100), (100, 200), False, id="touching-at-a-boundary"),
+        pytest.param((0, 100), (99, 200), True, id="one-frame-of-overlap"),
+        pytest.param((0, 100), (0, 100), True, id="identical"),
+        pytest.param((0, 100), (20, 40), True, id="contained"),
+        pytest.param((100, 200), (0, 50), False, id="apart"),
+    ],
+)
+def test_half_open_ranges_overlap_only_when_they_share_a_frame(
+    a: tuple[int, int], b: tuple[int, int], overlap: bool
+) -> None:
+    assert ranges_overlap(*a, *b) is overlap
+    assert ranges_overlap(*b, *a) is overlap


### PR DESCRIPTION
Closes #27.

## What this does

`get_cut_schema` serves the settled schema v1 (#20) verbatim — the annotated
example character-for-character, the prose contract around it, and the rule
table with severities. `validate_cut` dry-runs a cut file on disk and returns
every finding as `{rule, id, message, fix_hint}`: all 11 hard errors, both
warnings, all of them at once rather than the first.

## Test seam

**Fake tier**, both halves, per CLAUDE.md:

- **Pure-function tier, no seam** (`tests/test_cut_validate.py`) — the rules
  are two pure passes. `validate_structure` reads the document alone;
  `validate_project` takes `ClipFacts` already gathered from the media pool.
  Splitting there is what makes E4–E7 testable without Resolve at all: the
  only impure part left is the gathering.
- **Resolve seam** (`tests/test_cut_tools.py`) — tools called directly with
  the fake substituted at the connection manager: schema serving offline,
  a clean pass, E4/E5/E6/E7 through real fake clip properties, W1, a
  non-JSON file, a missing file, and mid-call handle death.
- `tests/test_naming.py` and additions to `tests/test_timing.py` cover the
  other pure ACs: snapping, half-open range math, version-name scanning.

No live ACs on this ticket — nothing here touches Resolve except reading clip
properties, which the fakes already mimic. 210 fake-tier tests, mypy strict
and ruff clean.

## Decisions worth flagging

- **E11 is build-time.** A locked target track can only be observed on the
  timeline the build creates, so it cannot fire in a dry run. It lands here as
  `locked_track_finding()` with a unit test on its shape, so #28 reports it
  identically to every other rule. E11's second leg — connection and creation
  failures — is deferred to #28 with the build code that can raise it.
- **A file that fails E1 never reaches the media pool.** A malformed cut must
  not cost a round trip to Resolve; asserted directly.
- **E5 exempts stills.** #20 words E5 as "still endFrame workaround applied
  first", but that workaround *writes* an out point to the clip, and #22's
  user story 14 wants the dry run to report "before Resolve is ever touched".
  Validation therefore reads but never writes, and since a still takes any
  duration on a timeline once the build applies the workaround, its media
  bounds do not constrain the cut anyway.
- **E6 skips a rate Resolve does not report** (audio clips, and anything it
  declines to answer for) and logs instead. An unknown is not a mismatch, and
  failing on it would block cuts that are fine. Same for an unreported audio
  channel count in E7, which fails open with a log line — tested.
- **An undeclared alias is E4, not E1.** E1 is about JSON shape; alias
  resolution starts at the sources table, so that is where the failure belongs.
- `validate_cut` echoes the cut file's BLAKE2b content hash. It is taken on
  the same bytes that were parsed, and it is what #28's build report echoes —
  reading and hashing are one step, so it lives here.
- The media wrapper's clip readers (`frame_rate`, `frame_bounds`, `is_still`,
  `audio_channels`, `clips_named`) went public rather than being
  reimplemented in the cut layer; `_bounds` now uses `frame_bounds` too, so
  half-open media bounds have one implementation.
- **`Audio Ch` is the property key E7 reads**, matching the fakes. Undocumented
  in the real API — worth a glance during the first live session, though an
  unreadable key degrades to "assume it has audio" rather than a false block.

## Review findings (commit 302389a)

Two-axis review, Standards and Spec as parallel sub-agents.

**Spec — one correctness bug.** E10 compared each overlay span only with the
previous one after sorting, so an overlay sitting wholly inside a longer one
was never adjacent to it and passed silently: A(0-100), B(10-20), C(30-40)
reported B and waved C through. Fixed in 9078d9d by sweeping against the span
reaching furthest right, with the repro pinned as a test.

**Spec — served prose was a paraphrase.** #20 says `get_cut_schema` serves the
schema "verbatim". The annotated example was byte-identical, but the
surrounding prose had been reworded and dropped rationale (the
unclamped-recordFrame footgun; the untested-selector-length reason for equal
alternate durations). Restored to #20's wording, plus a §7 pointing at the
rules array.

**Spec — E7's has-audio leg fails open on an undocumented key**, which no fake
could catch. Added a log line so a live session surfaces it, and a test for
the fail-open path (d0888f6).

**Spec — answered, not changed:** the E5 stills exemption (rationale above),
E11's deferred second leg (#28's boundary), and the "speculative generality"
flag on `frames_from_seconds` / the version-scanning helpers /
`locked_track_finding` — ticket #27's ACs name all three explicitly.

**Standards.** Severity and the media-bounds comparison each existed twice —
both now have one implementation. The tool layer imported its default from the
domain package instead of the wrapper it calls. Test bodies in
`test_cut_validate.py` did not follow the house arrange/act/assert layout, and
section banners were padded to the wrong column. All fixed in 9078d9d; the
mechanical test-layout pass was diff-checked assertion by assertion.

Re-reviewed after the fixes: all six correct and complete, no new defects, one
untested branch which d0888f6 covers.

Review: clean — one correctness bug (E10 containment) and two fidelity findings fixed and re-reviewed; the rest answered from the spec.

## Merge of main (commit 6dfa001)

Main gained #25's timeline read tools while this PR was open; four files
conflicted (`server.py`, `timing.py`, `test_server.py`, `test_timing.py`),
all because both sides added to the same seams. Every hunk resolved as the
union — no behaviour invented, nothing dropped:

- `server.py` registers both tool families and carries both instruction
  paragraphs (frames-first time, then declarative editing).
- `timing.py` keeps main's `to_frames` (caller-input parsing, refuses bare
  seconds) alongside this branch's `frames_from_seconds` /
  `duration_frames` / `ranges_overlap` (internal half-open range math).
  Noted, not changed: both convert seconds to frames at different layers —
  `to_frames` without the float-noise tolerance `frames_from_seconds`
  carries. A follow-up could route one through the other.
- Test files: both suites side by side; registration test renamed to name
  all tool families.

Focused pass over the `--cc` resolution diff only, per the fix-diff rule.
Fake tier (306 tests), mypy strict, and ruff check all green on the merge.

Review: clean — conflict resolution is the pure union of two additive sides; checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
