### PR TITLE
P1: Timeline markers read/write (#31)

### DIFF
--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -180,6 +180,16 @@ class MediaOperationError(ResolveMcpError):
     )
 
 
+class TimelineOperationError(ResolveMcpError):
+    """Resolve refused a timeline write — a bare ``False``, with no reason given."""
+
+    code = "timeline_operation_failed"
+    default_fix = (
+        "Check the timeline is not locked or mid-render in the Resolve GUI, and that the "
+        "frame is inside it, then retry. run_python can reproduce the call for diagnosis."
+    )
+
+
 class InvalidRequestError(ResolveMcpError):
     """The request could not be acted on as written — a shape problem, not a Resolve one."""
 

--- a/src/resolve_mcp/resolve/markers.py
+++ b/src/resolve_mcp/resolve/markers.py
@@ -1,0 +1,393 @@
+"""Timeline markers — the review loop's transport, read and written.
+
+The director leaves notes as GUI markers on a built cut; the agent reads them as its work
+queue, and writes markers back to flag its own cut decisions and uncertainties. Three
+things here are decisions rather than API calls:
+
+* **Two clocks, and only one of them is Resolve's.** ``GetMarkers`` keys a marker by a
+  frame *relative to the timeline start*, while every other timeline reading in this
+  server — clip positions, ranges, the cut file — is in absolute record frames. Mixing
+  them puts a note an hour away from the shot it is about on any timeline that starts at
+  01:00:00:00. So the translation happens once, here: callers give and get record frames,
+  and each marker also carries ``frame``, Resolve's own key, for anyone reaching past this
+  server with ``run_python``.
+* **An existing marker is not overwritten unless asked.** ``AddMarker`` refuses a frame
+  that already carries one, and the marker sitting there is usually the director's own
+  note. Reporting the collision (with the marker that caused it) is the useful answer;
+  ``replace`` is the explicit way to say otherwise.
+* **Colour and bounds are checked before Resolve sees them.** An unknown colour and a
+  frame past the end both come back from Resolve as a bare ``False`` with no reason, which
+  in a batch is indistinguishable from a locked timeline. Checking here turns both into a
+  cause the agent can act on, and keeps the failure to the one entry that caused it — one
+  bad marker never sinks the batch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..config import Config, get_config
+from ..errors import InvalidRequestError, ResolveMcpError, TimelineOperationError
+from ..logging_config import get_logger
+from ..spill import spill
+from ..timing import dual_time, to_frames
+from .connection import ResolveConnection
+from .session import frame_rate
+from .timeline import Timeline, find_timeline, open_project, read_frames
+
+log = get_logger("markers")
+
+# A marker with its note, both times and its custom data runs to roughly 300 characters of
+# JSON, so a review round of this size sits well inside the client's reply cap. Past it the
+# full set spills to disk and a colour or range filter narrows the next read.
+DEFAULT_MARKER_LIMIT = 200
+
+# Resolve's own marker colours, in its own spelling — the set the GUI offers. Anything else
+# is refused by AddMarker without a word.
+MARKER_COLORS = (
+    "Blue",
+    "Cyan",
+    "Green",
+    "Yellow",
+    "Red",
+    "Pink",
+    "Purple",
+    "Fuchsia",
+    "Rose",
+    "Lavender",
+    "Sky",
+    "Mint",
+    "Lemon",
+    "Sand",
+    "Cocoa",
+    "Cream",
+)
+_BY_LOWER_NAME = {color.lower(): color for color in MARKER_COLORS}
+
+# Resolve reports a marker's length in frames and never below one; a zero-length marker
+# would not be visible in the GUI, which is the only place a marker is for.
+MINIMUM_DURATION = 1
+
+
+class Placed:
+    """One timeline's marker plumbing: where it starts, how fast it runs, what it holds."""
+
+    def __init__(self, timeline: Timeline, fps: float | None) -> None:
+        self.timeline = timeline
+        self.fps = fps
+        self.name = str(timeline.GetName() or "")
+        self.start = _origin(timeline)
+        self.end = read_frames(timeline.GetEndFrame())
+
+    def record(self, relative: int) -> int:
+        """Resolve's marker key as an absolute record frame."""
+        return self.start + relative
+
+    def relative(self, record: int) -> int:
+        """A record frame as the key Resolve wants."""
+        return record - self.start
+
+
+def _origin(timeline: Timeline) -> int:
+    """The timeline's first frame — the offset every marker frame is counted from.
+
+    An unreadable start would silently shift every marker, so it is logged rather than
+    quietly taken as zero.
+    """
+    start = read_frames(timeline.GetStartFrame())
+    if start is None:
+        log.warning("Timeline %r reported no start frame; treating markers as absolute", timeline)
+        return 0
+    return start
+
+
+# --- read -------------------------------------------------------------------------------
+
+
+def _marker(relative: int, detail: dict[str, Any], placed: Placed) -> dict[str, Any]:
+    """One marker in both clocks, with the fields the GUI shows."""
+    duration = read_frames(detail.get("duration")) or MINIMUM_DURATION
+    record = placed.record(relative)
+    return {
+        "frame": relative,
+        "record": dual_time(record, placed.fps),
+        "end": dual_time(record + duration, placed.fps),
+        "duration": dual_time(duration, placed.fps),
+        "color": str(detail.get("color", "")),
+        "name": str(detail.get("name", "")),
+        "note": str(detail.get("note", "")),
+        "custom_data": str(detail.get("customData", "")),
+    }
+
+
+def _reported(timeline: Timeline) -> dict[int, dict[str, Any]]:
+    """Resolve's marker map, keyed by relative frame, with unreadable keys dropped.
+
+    A marker whose frame will not parse cannot be placed on either clock — reporting it at
+    a made-up position would be worse than leaving it out and saying so in the log.
+    """
+    reported = timeline.GetMarkers()
+    if not isinstance(reported, dict):
+        return {}
+    markers: dict[int, dict[str, Any]] = {}
+    for frame, detail in reported.items():
+        relative = read_frames(frame)
+        if relative is None:
+            log.warning("Skipping a marker at an unreadable frame %r", frame)
+            continue
+        markers[relative] = detail if isinstance(detail, dict) else {}
+    return markers
+
+
+def list_markers(
+    connection: ResolveConnection,
+    name: str | None = None,
+    color: str | None = None,
+    start: Any = None,
+    end: Any = None,
+    limit: int = DEFAULT_MARKER_LIMIT,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Every marker on a timeline, in record time, narrowed by colour and range."""
+    project = open_project(connection)
+    timeline = find_timeline(project, name)
+    placed = Placed(timeline, frame_rate(project, timeline))
+
+    markers = [
+        _marker(relative, detail, placed)
+        for relative, detail in sorted(_reported(timeline).items())
+    ]
+    window = _window(start, end, placed.fps)
+    wanted = [marker for marker in markers if _matches(marker, color) and _touches(marker, window)]
+
+    cap = max(int(limit), 0)
+    truncated = len(wanted) > cap
+    result: dict[str, Any] = {
+        "timeline": {
+            "name": placed.name,
+            "fps": placed.fps,
+            "start": dual_time(placed.start, placed.fps),
+            "end": dual_time(placed.end, placed.fps),
+        },
+        "count": len(wanted),
+        "markers": wanted[:cap] if truncated else wanted,
+        "colors": _colors(wanted),
+        "truncated": truncated,
+        "spilled_to": None,
+    }
+    if truncated:
+        full = {**result, "markers": wanted, "truncated": False, "spilled_to": None}
+        result["spilled_to"] = spill(
+            f"{placed.name} markers", full, config or get_config(), fallback="markers"
+        )
+    return result
+
+
+def _window(start: Any, end: Any, fps: float | None) -> tuple[int | None, int | None]:
+    """The record range to read, half-open ``[start, end)``, open at either end."""
+    first = to_frames(start, fps, field="start")
+    last = to_frames(end, fps, field="end")
+    if first is not None and last is not None and last < first:
+        raise InvalidRequestError(
+            cause=f"The range ends at {last} but starts at {first}.",
+            fix="Ranges are half-open [start, end) and run forwards; swap the two.",
+            detail={"start": first, "end": last},
+        )
+    return first, last
+
+
+def _touches(marker: dict[str, Any], window: tuple[int | None, int | None]) -> bool:
+    """Whether a marker overlaps the range — a marker with a length is a span, not a point."""
+    first, last = window
+    record = (marker["record"] or {}).get("frames")
+    finish = (marker["end"] or {}).get("frames")
+    if record is None or finish is None:
+        return True
+    return (last is None or record < last) and (first is None or finish > first)
+
+
+def _matches(marker: dict[str, Any], color: str | None) -> bool:
+    return color is None or marker["color"].lower() == color.lower()
+
+
+def _colors(markers: list[dict[str, Any]]) -> dict[str, int]:
+    """How many of each colour — a review round read at a glance."""
+    counts: dict[str, int] = {}
+    for marker in markers:
+        counts[marker["color"]] = counts.get(marker["color"], 0) + 1
+    return counts
+
+
+# --- write ------------------------------------------------------------------------------
+
+
+def set_markers(
+    connection: ResolveConnection,
+    markers: list[dict[str, Any]] | None,
+    name: str | None = None,
+    replace: bool = False,
+) -> dict[str, Any]:
+    """Write a batch of markers, each reported on its own. One bad entry sinks only itself."""
+    project = open_project(connection)
+    timeline = find_timeline(project, name)
+    placed = Placed(timeline, frame_rate(project, timeline))
+    held = _reported(timeline)
+
+    results: list[dict[str, Any]] = []
+    for entry in markers or []:
+        results.append(_write(placed, entry, held, replace))
+    added = sum(1 for result in results if result["ok"])
+    log.info(
+        "Wrote %d of %d markers to %s", added, len(results), placed.name or "the open timeline"
+    )
+    return {
+        "timeline": placed.name,
+        "results": results,
+        "added": added,
+        "failed": len(results) - added,
+    }
+
+
+def _write(
+    placed: Placed,
+    entry: Any,
+    held: dict[int, dict[str, Any]],
+    replace: bool,
+) -> dict[str, Any]:
+    """One marker: validated, placed on Resolve's clock, written, and reported."""
+    try:
+        request = _request(placed, entry, held, replace)
+    except ResolveMcpError as exc:
+        return {"ok": False, "record": None, "frame": None, "error": exc.payload()}
+
+    relative = request["frame"]
+    replaced = relative in held
+    if replaced and not placed.timeline.DeleteMarkerAtFrame(relative):
+        return _refused(
+            placed,
+            relative,
+            f"Resolve would not delete the marker at record frame {placed.record(relative)}.",
+        )
+    added = placed.timeline.AddMarker(
+        relative,
+        request["color"],
+        request["name"],
+        request["note"],
+        request["duration"],
+        request["custom_data"],
+    )
+    if not added:
+        return _refused(
+            placed,
+            relative,
+            f"Resolve refused a {request['color']} marker at record frame "
+            f"{placed.record(relative)}.",
+        )
+    held[relative] = {
+        "color": request["color"],
+        "name": request["name"],
+        "note": request["note"],
+        "duration": request["duration"],
+        "customData": request["custom_data"],
+    }
+    return {
+        "ok": True,
+        "record": dual_time(placed.record(relative), placed.fps),
+        "frame": relative,
+        "color": request["color"],
+        "name": request["name"],
+        "replaced": replaced,
+    }
+
+
+def _refused(placed: Placed, relative: int, cause: str) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "record": dual_time(placed.record(relative), placed.fps),
+        "frame": relative,
+        "error": TimelineOperationError(cause=cause).payload(),
+    }
+
+
+def _request(
+    placed: Placed,
+    entry: Any,
+    held: dict[int, dict[str, Any]],
+    replace: bool,
+) -> dict[str, Any]:
+    """A marker request read into the shape ``AddMarker`` takes, or a stated refusal."""
+    if not isinstance(entry, dict):
+        raise InvalidRequestError(
+            cause=f"{entry!r} is not a marker.",
+            fix='Each marker is an object: {"frame": 1200, "color": "Blue", "note": "…"}.',
+            detail={"entry": repr(entry)},
+        )
+
+    record = to_frames(entry.get("frame"), placed.fps, field="frame")
+    if record is None:
+        raise InvalidRequestError(
+            cause="A marker was given without a frame to sit on.",
+            fix=(
+                "Give frame as a record frame (1200) or as seconds with a snap "
+                '({"seconds": 20.0, "snap": "floor"}) — the same clock inspect_timeline reads.'
+            ),
+            detail={"entry": entry},
+        )
+    _within(placed, record)
+
+    duration = to_frames(entry.get("duration"), placed.fps, field="duration")
+    duration = MINIMUM_DURATION if duration is None else duration
+    if duration < MINIMUM_DURATION:
+        raise InvalidRequestError(
+            cause=f"A marker duration of {duration} frames is shorter than a frame.",
+            fix="Leave duration out for a single-frame marker, or give at least 1 frame.",
+            detail={"duration": duration},
+        )
+
+    relative = placed.relative(record)
+    if relative in held and not replace:
+        raise InvalidRequestError(
+            cause=f"A marker is already on record frame {record}.",
+            fix=(
+                "That marker is probably the director's own note. Pick another frame, or "
+                "pass replace=true to overwrite it deliberately."
+            ),
+            detail={"record": record, "frame": relative, "existing": held[relative]},
+        )
+
+    return {
+        "frame": relative,
+        "color": _color(entry.get("color")),
+        "name": str(entry.get("name") or ""),
+        "note": str(entry.get("note") or ""),
+        "duration": duration,
+        "custom_data": str(entry.get("custom_data") or ""),
+    }
+
+
+def _within(placed: Placed, record: int) -> None:
+    """A frame outside the timeline is refused here — Resolve just drops it silently."""
+    if placed.end is None:
+        return
+    if placed.start <= record < placed.end:
+        return
+    raise InvalidRequestError(
+        cause=f"Record frame {record} is outside {placed.name or 'the timeline'}.",
+        fix=(
+            f"Markers sit inside the timeline's own range, half-open "
+            f"[{placed.start}, {placed.end})."
+        ),
+        detail={"record": record, "bounds": {"start": placed.start, "end": placed.end}},
+    )
+
+
+def _color(requested: Any) -> str:
+    """Resolve's own spelling of a colour, whatever case it arrived in."""
+    color = _BY_LOWER_NAME.get(str(requested or "").strip().lower())
+    if color is None:
+        raise InvalidRequestError(
+            cause=f"{requested!r} is not a marker colour Resolve has.",
+            fix=f"Use one of: {', '.join(MARKER_COLORS)}.",
+            detail={"requested": requested, "available": list(MARKER_COLORS)},
+        )
+    return color

--- a/src/resolve_mcp/resolve/markers.py
+++ b/src/resolve_mcp/resolve/markers.py
@@ -14,7 +14,11 @@ things here are decisions rather than API calls:
 * **An existing marker is not overwritten unless asked.** ``AddMarker`` refuses a frame
   that already carries one, and the marker sitting there is usually the director's own
   note. Reporting the collision (with the marker that caused it) is the useful answer;
-  ``replace`` is the explicit way to say otherwise.
+  ``replace`` is the explicit way to say otherwise, and because a replacement is a delete
+  followed by an add that Resolve can still refuse, the displaced marker is put back if
+  the add does not land. A frame already carrying *the same marker* is neither a collision
+  nor a write: that is what the envelope's reconnect replay of a half-written batch looks
+  like, and calling the agent's own work a collision would be a lie.
 * **Colour and bounds are checked before Resolve sees them.** An unknown colour and a
   frame past the end both come back from Resolve as a bare ``False`` with no reason, which
   in a batch is indistinguishable from a locked timeline. Checking here turns both into a
@@ -33,7 +37,15 @@ from ..spill import spill
 from ..timing import dual_time, to_frames
 from .connection import ResolveConnection
 from .session import frame_rate
-from .timeline import Timeline, find_timeline, open_project, read_frames
+from .timeline import (
+    Reader,
+    Timeline,
+    find_timeline,
+    frame_window,
+    open_project,
+    overlaps,
+    read_frames,
+)
 
 log = get_logger("markers")
 
@@ -69,10 +81,16 @@ _BY_LOWER_NAME = {color.lower(): color for color in MARKER_COLORS}
 MINIMUM_DURATION = 1
 
 
-class Placed:
-    """One timeline's marker plumbing: where it starts, how fast it runs, what it holds."""
+class MarkerClock:
+    """A timeline's marker clock: where it starts, how fast it runs, and both frame numbers.
 
-    def __init__(self, timeline: Timeline, fps: float | None) -> None:
+    Every marker crosses between Resolve's clock and the record clock, and the crossing
+    needs the same three numbers each time — so they are read once, here, and the
+    conversion lives with them rather than at each call site.
+    """
+
+    def __init__(self, connection: ResolveConnection, timeline: Timeline, fps: float | None):
+        self.reader = Reader(connection)
         self.timeline = timeline
         self.fps = fps
         self.name = str(timeline.GetName() or "")
@@ -104,15 +122,15 @@ def _origin(timeline: Timeline) -> int:
 # --- read -------------------------------------------------------------------------------
 
 
-def _marker(relative: int, detail: dict[str, Any], placed: Placed) -> dict[str, Any]:
+def _marker(relative: int, detail: dict[str, Any], clock: MarkerClock) -> dict[str, Any]:
     """One marker in both clocks, with the fields the GUI shows."""
     duration = read_frames(detail.get("duration")) or MINIMUM_DURATION
-    record = placed.record(relative)
+    record = clock.record(relative)
     return {
         "frame": relative,
-        "record": dual_time(record, placed.fps),
-        "end": dual_time(record + duration, placed.fps),
-        "duration": dual_time(duration, placed.fps),
+        "record": dual_time(record, clock.fps),
+        "end": dual_time(record + duration, clock.fps),
+        "duration": dual_time(duration, clock.fps),
         "color": str(detail.get("color", "")),
         "name": str(detail.get("name", "")),
         "note": str(detail.get("note", "")),
@@ -120,13 +138,16 @@ def _marker(relative: int, detail: dict[str, Any], placed: Placed) -> dict[str, 
     }
 
 
-def _reported(timeline: Timeline) -> dict[int, dict[str, Any]]:
+def _reported(clock: MarkerClock) -> dict[int, dict[str, Any]]:
     """Resolve's marker map, keyed by relative frame, with unreadable keys dropped.
 
     A marker whose frame will not parse cannot be placed on either clock — reporting it at
     a made-up position would be worse than leaving it out and saying so in the log.
+
+    The read goes through ``Reader``: a build without ``GetMarkers`` should read as a
+    timeline with no markers, while a handle that died mid-read must still raise.
     """
-    reported = timeline.GetMarkers()
+    reported = clock.reader.optional(clock.timeline, "GetMarkers", None)
     if not isinstance(reported, dict):
         return {}
     markers: dict[int, dict[str, Any]] = {}
@@ -151,23 +172,22 @@ def list_markers(
     """Every marker on a timeline, in record time, narrowed by colour and range."""
     project = open_project(connection)
     timeline = find_timeline(project, name)
-    placed = Placed(timeline, frame_rate(project, timeline))
+    clock = MarkerClock(connection, timeline, frame_rate(project, timeline))
 
     markers = [
-        _marker(relative, detail, placed)
-        for relative, detail in sorted(_reported(timeline).items())
+        _marker(relative, detail, clock) for relative, detail in sorted(_reported(clock).items())
     ]
-    window = _window(start, end, placed.fps)
+    window = frame_window(start, end, clock.fps)
     wanted = [marker for marker in markers if _matches(marker, color) and _touches(marker, window)]
 
     cap = max(int(limit), 0)
     truncated = len(wanted) > cap
     result: dict[str, Any] = {
         "timeline": {
-            "name": placed.name,
-            "fps": placed.fps,
-            "start": dual_time(placed.start, placed.fps),
-            "end": dual_time(placed.end, placed.fps),
+            "name": clock.name,
+            "fps": clock.fps,
+            "start": dual_time(clock.start, clock.fps),
+            "end": dual_time(clock.end, clock.fps),
         },
         "count": len(wanted),
         "markers": wanted[:cap] if truncated else wanted,
@@ -178,32 +198,14 @@ def list_markers(
     if truncated:
         full = {**result, "markers": wanted, "truncated": False, "spilled_to": None}
         result["spilled_to"] = spill(
-            f"{placed.name} markers", full, config or get_config(), fallback="markers"
+            f"{clock.name} markers", full, config or get_config(), fallback="markers"
         )
     return result
 
 
-def _window(start: Any, end: Any, fps: float | None) -> tuple[int | None, int | None]:
-    """The record range to read, half-open ``[start, end)``, open at either end."""
-    first = to_frames(start, fps, field="start")
-    last = to_frames(end, fps, field="end")
-    if first is not None and last is not None and last < first:
-        raise InvalidRequestError(
-            cause=f"The range ends at {last} but starts at {first}.",
-            fix="Ranges are half-open [start, end) and run forwards; swap the two.",
-            detail={"start": first, "end": last},
-        )
-    return first, last
-
-
 def _touches(marker: dict[str, Any], window: tuple[int | None, int | None]) -> bool:
     """Whether a marker overlaps the range — a marker with a length is a span, not a point."""
-    first, last = window
-    record = (marker["record"] or {}).get("frames")
-    finish = (marker["end"] or {}).get("frames")
-    if record is None or finish is None:
-        return True
-    return (last is None or record < last) and (first is None or finish > first)
+    return overlaps(marker["record"]["frames"], marker["end"]["frames"], window)
 
 
 def _matches(marker: dict[str, Any], color: str | None) -> bool:
@@ -230,18 +232,16 @@ def set_markers(
     """Write a batch of markers, each reported on its own. One bad entry sinks only itself."""
     project = open_project(connection)
     timeline = find_timeline(project, name)
-    placed = Placed(timeline, frame_rate(project, timeline))
-    held = _reported(timeline)
+    clock = MarkerClock(connection, timeline, frame_rate(project, timeline))
+    existing = _reported(clock)
 
     results: list[dict[str, Any]] = []
     for entry in markers or []:
-        results.append(_write(placed, entry, held, replace))
+        results.append(_write(clock, entry, existing, replace))
     added = sum(1 for result in results if result["ok"])
-    log.info(
-        "Wrote %d of %d markers to %s", added, len(results), placed.name or "the open timeline"
-    )
+    log.info("Wrote %d of %d markers to %s", added, len(results), clock.name or "the open timeline")
     return {
-        "timeline": placed.name,
+        "timeline": clock.name,
         "results": results,
         "added": added,
         "failed": len(results) - added,
@@ -249,71 +249,160 @@ def set_markers(
 
 
 def _write(
-    placed: Placed,
+    clock: MarkerClock,
     entry: Any,
-    held: dict[int, dict[str, Any]],
+    existing: dict[int, dict[str, Any]],
     replace: bool,
 ) -> dict[str, Any]:
-    """One marker: validated, placed on Resolve's clock, written, and reported."""
+    """One marker: validated, put on Resolve's clock, written, and reported.
+
+    A replacement is a delete followed by an add, and Resolve can refuse the add after
+    taking the delete — so the marker that was there is carried through the write and put
+    back if the add does not land. Losing the director's note to a failed overwrite is the
+    one outcome this path must not have.
+    """
     try:
-        request = _request(placed, entry, held, replace)
+        request = _request(clock, entry)
     except ResolveMcpError as exc:
         return {"ok": False, "record": None, "frame": None, "error": exc.payload()}
 
     relative = request["frame"]
-    replaced = relative in held
-    if replaced and not placed.timeline.DeleteMarkerAtFrame(relative):
+    displaced = existing.get(relative)
+    if displaced is not None:
+        if _same(displaced, request):
+            return _already_there(clock, relative, request)
+        if not replace:
+            return _occupied(clock, relative, displaced)
+    if displaced is not None and not clock.timeline.DeleteMarkerAtFrame(relative):
         return _refused(
-            placed,
+            clock,
             relative,
-            f"Resolve would not delete the marker at record frame {placed.record(relative)}.",
+            f"Resolve would not delete the marker at record frame {clock.record(relative)}.",
         )
-    added = placed.timeline.AddMarker(
-        relative,
-        request["color"],
-        request["name"],
-        request["note"],
-        request["duration"],
-        request["custom_data"],
-    )
-    if not added:
+    if not _add(clock, relative, request):
         return _refused(
-            placed,
+            clock,
             relative,
             f"Resolve refused a {request['color']} marker at record frame "
-            f"{placed.record(relative)}.",
+            f"{clock.record(relative)}."
+            + (_restore(clock, relative, displaced) if displaced is not None else ""),
         )
-    held[relative] = {
+    existing[relative] = _as_reported(request)
+    return {
+        "ok": True,
+        "record": dual_time(clock.record(relative), clock.fps),
+        "frame": relative,
+        "color": request["color"],
+        "name": request["name"],
+        "replaced": displaced is not None,
+        "unchanged": False,
+    }
+
+
+def _add(clock: MarkerClock, relative: int, request: dict[str, Any]) -> bool:
+    return bool(
+        clock.timeline.AddMarker(
+            relative,
+            request["color"],
+            request["name"],
+            request["note"],
+            request["duration"],
+            request["custom_data"],
+        )
+    )
+
+
+def _restore(clock: MarkerClock, relative: int, displaced: dict[str, Any]) -> str:
+    """Put back the marker a refused replacement deleted, and say which way it went.
+
+    A marker Resolve reported without a colour is put back in the default one: a note in
+    the wrong colour is recoverable, a note that is gone is not.
+    """
+    put_back = clock.timeline.AddMarker(
+        relative,
+        str(displaced.get("color") or MARKER_COLORS[0]),
+        str(displaced.get("name") or ""),
+        str(displaced.get("note") or ""),
+        read_frames(displaced.get("duration")) or MINIMUM_DURATION,
+        str(displaced.get("customData") or ""),
+    )
+    if put_back:
+        return " The marker that was there has been put back."
+    log.error("Could not restore the marker at relative frame %d after a refused write", relative)
+    return " The marker that was there was deleted first and could not be put back."
+
+
+def _same(displaced: dict[str, Any], request: dict[str, Any]) -> bool:
+    """Whether the marker already there is the one being asked for, field for field."""
+    return _as_reported(request) == {
+        "color": str(displaced.get("color") or ""),
+        "name": str(displaced.get("name") or ""),
+        "note": str(displaced.get("note") or ""),
+        "duration": read_frames(displaced.get("duration")) or MINIMUM_DURATION,
+        "customData": str(displaced.get("customData") or ""),
+    }
+
+
+def _already_there(clock: MarkerClock, relative: int, request: dict[str, Any]) -> dict[str, Any]:
+    """The marker asked for is already on that frame, to the letter — so nothing to do.
+
+    This is what a batch replayed after a dropped connection looks like: the envelope
+    retries the whole call, and the markers the first attempt landed are still there.
+    Reporting those as collisions would accuse the agent of overwriting the director's
+    notes when they are its own work, unchanged.
+    """
+    return {
+        "ok": True,
+        "record": dual_time(clock.record(relative), clock.fps),
+        "frame": relative,
+        "color": request["color"],
+        "name": request["name"],
+        "replaced": False,
+        "unchanged": True,
+    }
+
+
+def _occupied(clock: MarkerClock, relative: int, displaced: dict[str, Any]) -> dict[str, Any]:
+    """A different marker holds that frame — usually the director's own note."""
+    record = clock.record(relative)
+    return {
+        "ok": False,
+        "record": dual_time(record, clock.fps),
+        "frame": relative,
+        "error": InvalidRequestError(
+            cause=f"A different marker is already on record frame {record}.",
+            fix=(
+                "That marker is probably the director's own note. Pick another frame, or "
+                "pass replace=true to overwrite it deliberately."
+            ),
+            detail={"record": record, "frame": relative, "existing": displaced},
+        ).payload(),
+    }
+
+
+def _as_reported(request: dict[str, Any]) -> dict[str, Any]:
+    """A written marker in the shape ``GetMarkers`` would report it back."""
+    return {
         "color": request["color"],
         "name": request["name"],
         "note": request["note"],
         "duration": request["duration"],
         "customData": request["custom_data"],
     }
-    return {
-        "ok": True,
-        "record": dual_time(placed.record(relative), placed.fps),
-        "frame": relative,
-        "color": request["color"],
-        "name": request["name"],
-        "replaced": replaced,
-    }
 
 
-def _refused(placed: Placed, relative: int, cause: str) -> dict[str, Any]:
+def _refused(clock: MarkerClock, relative: int, cause: str) -> dict[str, Any]:
     return {
         "ok": False,
-        "record": dual_time(placed.record(relative), placed.fps),
+        "record": dual_time(clock.record(relative), clock.fps),
         "frame": relative,
         "error": TimelineOperationError(cause=cause).payload(),
     }
 
 
 def _request(
-    placed: Placed,
+    clock: MarkerClock,
     entry: Any,
-    held: dict[int, dict[str, Any]],
-    replace: bool,
 ) -> dict[str, Any]:
     """A marker request read into the shape ``AddMarker`` takes, or a stated refusal."""
     if not isinstance(entry, dict):
@@ -323,7 +412,7 @@ def _request(
             detail={"entry": repr(entry)},
         )
 
-    record = to_frames(entry.get("frame"), placed.fps, field="frame")
+    record = to_frames(entry.get("frame"), clock.fps, field="frame")
     if record is None:
         raise InvalidRequestError(
             cause="A marker was given without a frame to sit on.",
@@ -333,9 +422,9 @@ def _request(
             ),
             detail={"entry": entry},
         )
-    _within(placed, record)
+    _within(clock, record)
 
-    duration = to_frames(entry.get("duration"), placed.fps, field="duration")
+    duration = to_frames(entry.get("duration"), clock.fps, field="duration")
     duration = MINIMUM_DURATION if duration is None else duration
     if duration < MINIMUM_DURATION:
         raise InvalidRequestError(
@@ -344,19 +433,8 @@ def _request(
             detail={"duration": duration},
         )
 
-    relative = placed.relative(record)
-    if relative in held and not replace:
-        raise InvalidRequestError(
-            cause=f"A marker is already on record frame {record}.",
-            fix=(
-                "That marker is probably the director's own note. Pick another frame, or "
-                "pass replace=true to overwrite it deliberately."
-            ),
-            detail={"record": record, "frame": relative, "existing": held[relative]},
-        )
-
     return {
-        "frame": relative,
+        "frame": clock.relative(record),
         "color": _color(entry.get("color")),
         "name": str(entry.get("name") or ""),
         "note": str(entry.get("note") or ""),
@@ -365,19 +443,18 @@ def _request(
     }
 
 
-def _within(placed: Placed, record: int) -> None:
+def _within(clock: MarkerClock, record: int) -> None:
     """A frame outside the timeline is refused here — Resolve just drops it silently."""
-    if placed.end is None:
+    if clock.end is None:
         return
-    if placed.start <= record < placed.end:
+    if clock.start <= record < clock.end:
         return
     raise InvalidRequestError(
-        cause=f"Record frame {record} is outside {placed.name or 'the timeline'}.",
+        cause=f"Record frame {record} is outside {clock.name or 'the timeline'}.",
         fix=(
-            f"Markers sit inside the timeline's own range, half-open "
-            f"[{placed.start}, {placed.end})."
+            f"Markers sit inside the timeline's own range, half-open [{clock.start}, {clock.end})."
         ),
-        detail={"record": record, "bounds": {"start": placed.start, "end": placed.end}},
+        detail={"record": record, "bounds": {"start": clock.start, "end": clock.end}},
     )
 
 

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -343,20 +343,46 @@ def _window(heading: dict[str, Any], start: Any, end: Any, fps: float | None) ->
     same bounds are two chances to disagree, and the range would then not be the range the
     reply says it is.
     """
-    asked_start = to_frames(start, fps, field="start")
-    asked_end = to_frames(end, fps, field="end")
+    asked_start, asked_end = frame_window(start, end, fps)
     bounds = {edge: (heading[edge] or {}).get("frames") for edge in ("start", "end")}
     first = asked_start if asked_start is not None else (bounds["start"] or 0)
     last = asked_end if asked_end is not None else bounds["end"]
     if last is None:
         last = first
     if last < first:
-        raise InvalidRequestError(
-            cause=f"The range ends at {last} but starts at {first}.",
-            fix="Ranges are half-open [start, end) and run forwards; swap the two.",
-            detail={"start": first, "end": last},
-        )
+        raise _backwards(first, last)
     return first, last
+
+
+def frame_window(start: Any, end: Any, fps: float | None) -> tuple[int | None, int | None]:
+    """A caller's range read as frames, order checked, either edge left open.
+
+    Shared with the marker reader: two half-open ranges parsed in two places would drift
+    apart, and a range that means something different per tool is worse than no range.
+    """
+    first = to_frames(start, fps, field="start")
+    last = to_frames(end, fps, field="end")
+    if first is not None and last is not None and last < first:
+        raise _backwards(first, last)
+    return first, last
+
+
+def _backwards(first: int, last: int) -> InvalidRequestError:
+    return InvalidRequestError(
+        cause=f"The range ends at {last} but starts at {first}.",
+        fix="Ranges are half-open [start, end) and run forwards; swap the two.",
+        detail={"start": first, "end": last},
+    )
+
+
+def overlaps(first: int, last: int, window: tuple[int | None, int | None]) -> bool:
+    """Whether ``[first, last)`` touches the window — an edge that only meets it does not.
+
+    An open edge of the window excludes nothing, which is what an unasked-for start or end
+    means.
+    """
+    start, end = window
+    return (end is None or first < end) and (start is None or last > start)
 
 
 def _read_track(
@@ -431,10 +457,9 @@ def _touches(placement: Placement, window: tuple[int, int]) -> bool:
     A shot whose position cannot be read is kept: dropping it would quietly shorten the
     reading of a cut, which is worse than one entry the agent has to look at twice.
     """
-    first, last = window
     if placement.start is None or placement.end is None:
         return True
-    return bool(placement.start < last and placement.end > first)
+    return overlaps(placement.start, placement.end, window)
 
 
 def _items_in_track(timeline: Timeline, track_type: str, index: int) -> list[TimelineItem]:

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -82,7 +82,7 @@ class Placement(NamedTuple):
 # --- reaching a timeline ------------------------------------------------------------------
 
 
-def _project(connection: ResolveConnection) -> Project:
+def open_project(connection: ResolveConnection) -> Project:
     manager = connection.handle().GetProjectManager()
     project = manager.GetCurrentProject() if manager is not None else None
     if project is None:
@@ -144,8 +144,8 @@ def version_of(name: str) -> tuple[str, int | None]:
 
 
 def _bounds(timeline: Timeline, fps: float | None) -> dict[str, Any]:
-    start = _frames(timeline.GetStartFrame())
-    end = _frames(timeline.GetEndFrame())
+    start = read_frames(timeline.GetStartFrame())
+    end = read_frames(timeline.GetEndFrame())
     duration = end - start if start is not None and end is not None else None
     return {
         "start": dual_time(start, fps),
@@ -154,7 +154,7 @@ def _bounds(timeline: Timeline, fps: float | None) -> dict[str, Any]:
     }
 
 
-def _frames(value: Any) -> int | None:
+def read_frames(value: Any) -> int | None:
     """A frame number as Resolve reports it — sometimes a string, sometimes nothing.
 
     Only the parsing is forgiving. A getter that *raises* is left to raise: that is what a
@@ -202,7 +202,7 @@ class Reader:
 def _track_counts(reader: Reader, timeline: Timeline) -> dict[str, int]:
     """How many tracks of each kind — the stack that identifies a sync reference."""
     return {
-        track_type: _frames(reader.optional(timeline, "GetTrackCount", 0, track_type)) or 0
+        track_type: read_frames(reader.optional(timeline, "GetTrackCount", 0, track_type)) or 0
         for track_type in TRACK_TYPES
     }
 
@@ -237,7 +237,7 @@ def list_timelines(
     config: Config | None = None,
 ) -> dict[str, Any]:
     """Every timeline in the project with its version, duration and track stack."""
-    project = _project(connection)
+    project = open_project(connection)
     reader = Reader(connection)
     current = project.GetCurrentTimeline()
     current_name = _name(current) if current is not None else None
@@ -297,7 +297,7 @@ def inspect_timeline(
             detail={"requested": detail, "available": list(DETAIL_LEVELS)},
         )
 
-    project = _project(connection)
+    project = open_project(connection)
     reader = Reader(connection)
     timeline = find_timeline(project, name)
     current = project.GetCurrentTimeline()
@@ -449,7 +449,7 @@ def _marker_count(reader: Reader, timeline: Timeline) -> int:
 
 def _placement(item: TimelineItem) -> Placement:
     """Where a shot sits, in the two numbers everything else is derived from."""
-    return Placement(_frames(item.GetStart()), _frames(item.GetDuration()))
+    return Placement(read_frames(item.GetStart()), read_frames(item.GetDuration()))
 
 
 def read_item(
@@ -498,14 +498,14 @@ def _source_bounds(
     The two routes are never mixed: an in point counted from the media start against an
     out point in absolute source frames would be a span that means nothing.
     """
-    start = _frames(reader.optional(item, "GetSourceStartFrame", None))
+    start = read_frames(reader.optional(item, "GetSourceStartFrame", None))
     if start is not None:
-        last = _frames(reader.optional(item, "GetSourceEndFrame", None))
+        last = read_frames(reader.optional(item, "GetSourceEndFrame", None))
         if last is not None:
             return start, last + 1
         return start, (start + duration if duration is not None else None)
 
-    offset = _frames(reader.optional(item, "GetLeftOffset", None))
+    offset = read_frames(reader.optional(item, "GetLeftOffset", None))
     if offset is None:
         return None, None
     return offset, (offset + duration if duration is not None else None)

--- a/src/resolve_mcp/tools/timeline.py
+++ b/src/resolve_mcp/tools/timeline.py
@@ -108,8 +108,9 @@ def set_markers(
 
     Colour must be one Resolve has (Blue, Cyan, Green, Yellow, Red, Pink, Purple, Fuchsia,
     Rose, Lavender, Sky, Mint, Lemon, Sand, Cocoa, Cream). A frame that already carries a
-    marker is refused with that marker in the error — it is usually the director's own note
-    — unless replace is true. Every entry is reported separately; one bad entry never sinks
+    different marker is refused with that marker in the error — it is usually the director's
+    own note — unless replace is true; a frame already carrying this exact marker comes back
+    ok with unchanged: true. Every entry is reported separately; one bad entry never sinks
     the batch.
     """
     connection = get_connection()

--- a/src/resolve_mcp/tools/timeline.py
+++ b/src/resolve_mcp/tools/timeline.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..resolve import markers as marker_wrapper
 from ..resolve import timeline as timelines
 from ..resolve.connection import get_connection
 from .envelope import tool
@@ -62,9 +63,64 @@ def inspect_timeline(
     )
 
 
+@tool
+def list_markers(
+    timeline: str | None = None,
+    color: str | None = None,
+    start: Any = None,
+    end: Any = None,
+    limit: int = marker_wrapper.DEFAULT_MARKER_LIMIT,
+) -> dict[str, Any]:
+    """Read a timeline's markers — the director's review notes — in record time.
+
+    Each marker carries record (where it sits on the timeline, dual time), end (record plus
+    its length, half-open), color, name, note and custom_data. frame is Resolve's own key
+    for the marker, counted from the timeline start rather than from zero; record is the
+    number to plan against, the same clock inspect_timeline reads.
+
+    color narrows to one colour (any case), start and end to a record range — frames (1200)
+    or seconds with an explicit snap. colors counts what came back, which is the shape of a
+    review round. Past limit markers the full set spills to disk (spilled_to).
+    """
+    connection = get_connection()
+    return marker_wrapper.list_markers(
+        connection,
+        name=timeline,
+        color=color,
+        start=start,
+        end=end,
+        limit=limit,
+    )
+
+
+@tool
+def set_markers(
+    markers: list[dict[str, Any]],
+    timeline: str | None = None,
+    replace: bool = False,
+) -> dict[str, Any]:
+    """Write markers onto a timeline — cut decisions, uncertainties, proposed song starts.
+
+    Each entry is {"frame": 1200, "color": "Blue", "name": "…", "note": "…"}, with optional
+    duration (frames, 1 by default) and custom_data. frame is a record frame — frames or
+    seconds with a snap — on the same clock list_markers and inspect_timeline report; this
+    server translates it to the frame Resolve keys markers by.
+
+    Colour must be one Resolve has (Blue, Cyan, Green, Yellow, Red, Pink, Purple, Fuchsia,
+    Rose, Lavender, Sky, Mint, Lemon, Sand, Cocoa, Cream). A frame that already carries a
+    marker is refused with that marker in the error — it is usually the director's own note
+    — unless replace is true. Every entry is reported separately; one bad entry never sinks
+    the batch.
+    """
+    connection = get_connection()
+    return marker_wrapper.set_markers(connection, markers, name=timeline, replace=replace)
+
+
 TOOLS: tuple[Any, ...] = (
     list_timelines,
     inspect_timeline,
+    list_markers,
+    set_markers,
 )
 
-__all__ = ["TOOLS", "inspect_timeline", "list_timelines"]
+__all__ = ["TOOLS", "inspect_timeline", "list_markers", "list_timelines", "set_markers"]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -164,7 +164,9 @@ class FakeTimeline:
         start_frame: int = 0,
         video: TrackSpec | None = None,
         audio: TrackSpec | None = None,
-        markers: dict[float, dict[str, Any]] | None = None,
+        # Marker keys come back across a C bridge as whatever Resolve put there — floats
+        # normally, but the type is not the fake's to promise, and the wrapper parses them.
+        markers: dict[Any, dict[str, Any]] | None = None,
         end_frame: int | None = None,
         owner: FakeResolve | None = None,
     ) -> None:
@@ -177,8 +179,10 @@ class FakeTimeline:
             "audio": _as_tracks(audio, "Audio"),
             "subtitle": [],
         }
-        self._markers = markers or {}
+        self._markers = dict(markers or {})
         self._owner = owner
+        self.marker_writes: list[dict[str, Any]] = []
+        self.refuse_markers = False
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
@@ -253,9 +257,46 @@ class FakeTimeline:
         track = self._track(track_type, index)
         return bool(track and track.locked)
 
-    def GetMarkers(self) -> dict[float, dict[str, Any]]:  # noqa: N802
+    def GetMarkers(self) -> dict[Any, dict[str, Any]]:  # noqa: N802
+        """Markers keyed by frame *relative to the timeline start*, as Resolve keys them."""
         self._check()
-        return dict(self._markers)
+        return {frame: dict(marker) for frame, marker in self._markers.items()}
+
+    def AddMarker(  # noqa: N802
+        self,
+        frame: float,
+        color: str,
+        name: str,
+        note: str,
+        duration: float,
+        custom_data: str = "",
+    ) -> bool:
+        """Add one marker, refusing a frame that already carries one — as Resolve does."""
+        self._check()
+        if self.refuse_markers or float(frame) in self._markers:
+            return False
+        self.marker_writes.append(
+            {
+                "frame": float(frame),
+                "color": color,
+                "name": name,
+                "note": note,
+                "duration": duration,
+                "customData": custom_data,
+            }
+        )
+        self._markers[float(frame)] = {
+            "color": color,
+            "name": name,
+            "note": note,
+            "duration": duration,
+            "customData": custom_data,
+        }
+        return True
+
+    def DeleteMarkerAtFrame(self, frame: float) -> bool:  # noqa: N802
+        self._check()
+        return self._markers.pop(float(frame), None) is not None
 
 
 IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"}

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -183,6 +183,10 @@ class FakeTimeline:
         self._owner = owner
         self.marker_writes: list[dict[str, Any]] = []
         self.refuse_markers = False
+        # Refusing one marker by name is how a failed *replacement* is staged: Resolve
+        # takes the delete, refuses the add, and the restore of the displaced marker has
+        # to be free to succeed or the test could not tell a restore from a loss.
+        self.refuse_marker_names: set[str] = set()
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
@@ -273,7 +277,9 @@ class FakeTimeline:
     ) -> bool:
         """Add one marker, refusing a frame that already carries one — as Resolve does."""
         self._check()
-        if self.refuse_markers or float(frame) in self._markers:
+        if self.refuse_markers or name in self.refuse_marker_names:
+            return False
+        if float(frame) in self._markers:
             return False
         self.marker_writes.append(
             {

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -18,7 +18,7 @@ import pytest
 from resolve_mcp.tools.escape_hatch import run_python
 from resolve_mcp.tools.media import inspect_clip, list_media
 from resolve_mcp.tools.project import get_status, list_projects, snapshot_project
-from resolve_mcp.tools.timeline import inspect_timeline, list_timelines
+from resolve_mcp.tools.timeline import inspect_timeline, list_markers, list_timelines
 
 pytestmark = pytest.mark.live
 
@@ -130,6 +130,31 @@ def test_the_frame_math_holds_on_a_real_timeline() -> None:
                     item["sync_offset"]["frames"]
                     == record["in"]["frames"] - item["source"]["in"]["frames"]
                 )
+
+
+def test_hand_placed_markers_read_back_on_the_clock_the_agent_plans_in() -> None:
+    """The one thing no fake can settle: which frame Resolve keys a GUI marker by.
+
+    The wrapper takes ``GetMarkers`` keys as relative to the timeline start and reports a
+    record frame from them. If that assumption is wrong, every marker on a timeline
+    starting at 01:00:00:00 lands an hour away from the shot it is about — and this is
+    where it shows. Add a marker by hand in the GUI over a known shot first; the check is
+    that the record frame lands inside the timeline, next to that shot.
+    """
+    if get_status()["context"]["timeline"] is None:
+        pytest.skip("No timeline open in Resolve")
+
+    result = list_markers()
+    assert result["ok"] is True
+    if not result["markers"]:
+        pytest.skip("No markers on the open timeline — add one in the GUI and rerun")
+
+    bounds = result["timeline"]
+    for marker in result["markers"]:
+        assert bounds["start"]["frames"] <= marker["record"]["frames"] < bounds["end"]["frames"]
+        assert marker["record"]["frames"] == bounds["start"]["frames"] + marker["frame"]
+        assert marker["end"]["frames"] > marker["record"]["frames"]
+        assert marker["color"]
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -135,11 +135,16 @@ def test_the_frame_math_holds_on_a_real_timeline() -> None:
 def test_hand_placed_markers_read_back_on_the_clock_the_agent_plans_in() -> None:
     """The one thing no fake can settle: which frame Resolve keys a GUI marker by.
 
-    The wrapper takes ``GetMarkers`` keys as relative to the timeline start and reports a
-    record frame from them. If that assumption is wrong, every marker on a timeline
-    starting at 01:00:00:00 lands an hour away from the shot it is about — and this is
-    where it shows. Add a marker by hand in the GUI over a known shot first; the check is
-    that the record frame lands inside the timeline, next to that shot.
+    The wrapper takes ``GetMarkers`` keys as relative to the timeline start and adds the
+    start frame to reach a record frame. If that assumption is wrong the addition happens
+    twice, and every marker on a timeline starting at 01:00:00:00 lands an hour past the
+    end — which is exactly what the bounds check below catches. On a timeline starting at
+    frame 0 the two clocks coincide and nothing is proved, so that case skips rather than
+    passing emptily.
+
+    Place a marker by hand in the GUI over a known shot first, then read the printed table
+    against what the GUI shows: colour, name and note are the agent's work queue, and only
+    a human at the machine can confirm they came back as typed.
     """
     if get_status()["context"]["timeline"] is None:
         pytest.skip("No timeline open in Resolve")
@@ -150,9 +155,15 @@ def test_hand_placed_markers_read_back_on_the_clock_the_agent_plans_in() -> None
         pytest.skip("No markers on the open timeline — add one in the GUI and rerun")
 
     bounds = result["timeline"]
+    if bounds["start"]["frames"] == 0:
+        pytest.skip("Timeline starts at frame 0, where both marker clocks agree — use 01:00:00:00")
+
     for marker in result["markers"]:
+        print(  # noqa: T201 - the human at the machine compares this against the GUI
+            f"{marker['record']['timecode']} {marker['color']:<10} "
+            f"{marker['name']!r} {marker['note']!r}"
+        )
         assert bounds["start"]["frames"] <= marker["record"]["frames"] < bounds["end"]["frames"]
-        assert marker["record"]["frames"] == bounds["start"]["frames"] + marker["frame"]
         assert marker["end"]["frames"] > marker["record"]["frames"]
         assert marker["color"]
 

--- a/tests/test_marker_tools.py
+++ b/tests/test_marker_tools.py
@@ -205,6 +205,21 @@ def test_read_skips_a_marker_it_cannot_place_rather_than_inventing_a_frame(
     assert result["markers"][0]["record"]["frames"] == 140
 
 
+def test_read_of_a_build_without_the_marker_getter_is_empty_not_a_failure(
+    attach: Attach,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An old Resolve missing a getter costs that field; only a dead handle stops the read."""
+    cut = a_reviewed_cut()
+    monkeypatch.delattr(type(cut), "GetMarkers")
+    attach(studio(timeline=cut))
+
+    result = list_markers()
+
+    assert result["ok"] is True
+    assert result["count"] == 0
+
+
 def test_read_needs_a_project(attach: Attach) -> None:
     attach(studio(project=None))
 
@@ -232,6 +247,7 @@ def test_set_writes_a_marker_with_colour_name_and_note_at_a_record_frame(
     assert written["ok"] is True
     assert written["record"]["frames"] == 220
     assert written["frame"] == 120
+    assert written["unchanged"] is False
     # The relative frame is what reaches Resolve, and a one-frame default duration is what
     # makes the marker visible in the GUI at all.
     assert cut.marker_writes == [
@@ -386,6 +402,50 @@ def test_set_replaces_an_existing_marker_when_told_to(attach: Attach) -> None:
     assert result["results"][0]["replaced"] is True
     assert cut.GetMarkers()[20.0]["name"] == "mine"
     assert len(cut.GetMarkers()) == 2
+
+
+def test_a_refused_replacement_puts_the_directors_marker_back(attach: Attach) -> None:
+    """A replacement is a delete then an add, and Resolve can refuse the second half."""
+    cut = a_reviewed_cut()
+    attach(studio(timeline=cut))
+    cut.refuse_marker_names = {"mine"}
+
+    result = set_markers([{"frame": 120, "color": "Blue", "name": "mine"}], replace=True)
+
+    assert result["added"] == 0
+    assert result["results"][0]["error"]["code"] == "timeline_operation_failed"
+    assert "has been put back" in result["results"][0]["error"]["cause"]
+    assert cut.GetMarkers()[20.0]["name"] == "cut early"
+    assert cut.GetMarkers()[20.0]["note"] == "come off the wide two bars sooner"
+
+
+def test_writing_the_same_marker_twice_is_not_a_collision_with_the_director(
+    attach: Attach,
+) -> None:
+    """What a batch replayed after a dropped connection looks like: its own work, still there."""
+    cut = a_reviewed_cut(markers={})
+    attach(studio(timeline=cut))
+    entry = {"frame": 220, "color": "Blue", "name": "Encore", "note": "song starts"}
+
+    set_markers([entry])
+    again = set_markers([entry])
+
+    assert again["ok"] is True
+    assert again["added"] == 1
+    assert again["results"][0]["unchanged"] is True
+    assert len(cut.marker_writes) == 1
+    assert len(cut.GetMarkers()) == 1
+
+
+def test_a_different_marker_on_the_same_frame_is_still_a_collision(attach: Attach) -> None:
+    cut = a_reviewed_cut(markers={})
+    attach(studio(timeline=cut))
+    set_markers([{"frame": 220, "color": "Blue", "name": "Encore"}])
+
+    result = set_markers([{"frame": 220, "color": "Blue", "name": "Encore II"}])
+
+    assert result["failed"] == 1
+    assert result["results"][0]["error"]["detail"]["existing"]["name"] == "Encore"
 
 
 def test_set_reports_a_refusal_from_resolve_rather_than_claiming_success(

--- a/tests/test_marker_tools.py
+++ b/tests/test_marker_tools.py
@@ -1,0 +1,469 @@
+"""The marker tools — the review loop's transport — against the fake Resolve seam.
+
+The one thing worth stating twice: Resolve keys timeline markers by a frame *relative to
+the timeline start*, while every other timeline reading here is in absolute record frames.
+These tests use a timeline that starts at frame 100 throughout, so a reading that confused
+the two clocks cannot pass.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.tools.timeline import list_markers, set_markers
+
+from .conftest import Attach
+from .fakes import FakeTimeline, FakeTimelineItem, FakeTrack, studio
+
+REVIEW_NOTES: dict[Any, dict[str, Any]] = {
+    20.0: {
+        "color": "Red",
+        "name": "cut early",
+        "note": "come off the wide two bars sooner",
+        "duration": 1.0,
+        "customData": "round-1",
+    },
+    140.0: {
+        "color": "Blue",
+        "name": "Sunset Boulevard",
+        "note": "song starts here",
+        "duration": 30.0,
+        "customData": "",
+    },
+}
+
+
+def a_reviewed_cut(
+    name: str = "sunset-set v3",
+    markers: dict[Any, dict[str, Any]] | None = None,
+) -> FakeTimeline:
+    """A built cut starting at frame 100, carrying the director's GUI review notes."""
+    return FakeTimeline(
+        name,
+        start_frame=100,
+        end_frame=400,
+        markers=REVIEW_NOTES if markers is None else markers,
+        video=[FakeTrack("Cam A", [FakeTimelineItem("C0012.mp4", 100, 300, source_start=1000)])],
+    )
+
+
+# --- read -----------------------------------------------------------------------------------
+
+
+def test_read_returns_every_marker_with_colour_name_note_and_dual_time(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut()))
+
+    result = list_markers()
+
+    assert result["ok"] is True
+    assert result["count"] == 2
+    first, second = result["markers"]
+    assert first["color"] == "Red"
+    assert first["name"] == "cut early"
+    assert first["note"] == "come off the wide two bars sooner"
+    assert first["custom_data"] == "round-1"
+    assert first["record"]["frames"] == 120
+    assert first["record"]["timecode"] == "00:00:02:00"
+    assert first["record"]["fps"] == 59.94
+    assert first["duration"]["frames"] == 1
+    assert second["name"] == "Sunset Boulevard"
+    assert second["record"]["frames"] == 240
+
+
+def test_read_reports_resolve_own_relative_frame_alongside_the_record_frame(
+    attach: Attach,
+) -> None:
+    """Both clocks, named: the agent plans in record frames, run_python sees the other."""
+    attach(studio(timeline=a_reviewed_cut()))
+
+    result = list_markers()
+
+    assert [marker["frame"] for marker in result["markers"]] == [20, 140]
+    assert [marker["record"]["frames"] for marker in result["markers"]] == [120, 240]
+    assert result["timeline"]["start"]["frames"] == 100
+
+
+def test_read_ends_a_marker_with_duration_half_open(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut()))
+
+    span = list_markers()["markers"][1]
+
+    assert span["record"]["frames"] == 240
+    assert span["end"]["frames"] == 270
+
+
+def test_read_counts_the_colours_so_a_review_round_is_visible_at_a_glance(
+    attach: Attach,
+) -> None:
+    attach(studio(timeline=a_reviewed_cut()))
+
+    result = list_markers()
+
+    assert result["colors"] == {"Blue": 1, "Red": 1}
+
+
+def test_read_can_narrow_to_one_colour(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut()))
+
+    result = list_markers(color="blue")
+
+    assert result["count"] == 1
+    assert result["markers"][0]["name"] == "Sunset Boulevard"
+
+
+def test_read_can_narrow_to_a_range_in_record_frames(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut()))
+
+    result = list_markers(start=200, end=300)
+
+    assert [marker["name"] for marker in result["markers"]] == ["Sunset Boulevard"]
+
+
+def test_read_takes_a_range_in_seconds_with_an_explicit_snap(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut()))
+
+    result = list_markers(start={"seconds": 3.0, "snap": "floor"})
+
+    assert [marker["name"] for marker in result["markers"]] == ["Sunset Boulevard"]
+
+
+def test_read_refuses_seconds_without_a_snap(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut()))
+
+    result = list_markers(start={"seconds": 3.0})
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+
+
+def test_read_of_a_timeline_with_no_markers_is_empty_not_an_error(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut(markers={})))
+
+    result = list_markers()
+
+    assert result["ok"] is True
+    assert result["count"] == 0
+    assert result["markers"] == []
+    assert result["colors"] == {}
+
+
+def test_read_names_a_timeline_other_than_the_open_one(attach: Attach) -> None:
+    other = a_reviewed_cut("sunset-set v2", markers={10.0: {"color": "Green", "note": "old"}})
+    attach(studio(timeline=a_reviewed_cut(), timelines=[a_reviewed_cut(), other]))
+
+    result = list_markers(timeline="sunset-set v2")
+
+    assert result["timeline"]["name"] == "sunset-set v2"
+    assert result["markers"][0]["note"] == "old"
+
+
+def test_read_of_a_timeline_that_is_not_there_says_which_ones_are(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut()))
+
+    result = list_markers(timeline="sunset-set v9")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_not_found"
+
+
+def test_read_spills_past_the_cap_rather_than_flooding_the_reply(attach: Attach) -> None:
+    many = {float(frame): {"color": "Red", "note": f"note {frame}"} for frame in range(0, 50)}
+    attach(studio(timeline=a_reviewed_cut(markers=many)))
+
+    result = list_markers(limit=10)
+
+    assert result["count"] == 50
+    assert result["truncated"] is True
+    assert len(result["markers"]) == 10
+    spilled = Path(result["spilled_to"])
+    assert len(json.loads(spilled.read_text(encoding="utf-8"))["markers"]) == 50
+
+
+def test_read_survives_a_marker_resolve_describes_with_nothing(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut(markers={"30": {}})))
+
+    marker = list_markers()["markers"][0]
+
+    assert marker["record"]["frames"] == 130
+    assert marker["color"] == ""
+    assert marker["note"] == ""
+    assert marker["duration"]["frames"] == 1
+
+
+def test_read_skips_a_marker_it_cannot_place_rather_than_inventing_a_frame(
+    attach: Attach,
+) -> None:
+    attach(studio(timeline=a_reviewed_cut(markers={"nowhere": {"note": "?"}, 40.0: {}})))
+
+    result = list_markers()
+
+    assert result["count"] == 1
+    assert result["markers"][0]["record"]["frames"] == 140
+
+
+def test_read_needs_a_project(attach: Attach) -> None:
+    attach(studio(project=None))
+
+    result = list_markers()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "no_project_open"
+
+
+# --- write ----------------------------------------------------------------------------------
+
+
+def test_set_writes_a_marker_with_colour_name_and_note_at_a_record_frame(
+    attach: Attach,
+) -> None:
+    cut = a_reviewed_cut(markers={})
+    attach(studio(timeline=cut))
+
+    result = set_markers([{"frame": 220, "color": "Yellow", "name": "soft", "note": "unsure"}])
+
+    assert result["ok"] is True
+    assert result["added"] == 1
+    assert result["failed"] == 0
+    written = result["results"][0]
+    assert written["ok"] is True
+    assert written["record"]["frames"] == 220
+    assert written["frame"] == 120
+    # The relative frame is what reaches Resolve, and a one-frame default duration is what
+    # makes the marker visible in the GUI at all.
+    assert cut.marker_writes == [
+        {
+            "frame": 120.0,
+            "color": "Yellow",
+            "name": "soft",
+            "note": "unsure",
+            "duration": 1,
+            "customData": "",
+        }
+    ]
+
+
+def test_a_written_marker_reads_back_through_the_read_tool(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut(markers={})))
+
+    set_markers([{"frame": 220, "color": "Blue", "name": "Encore", "note": "song starts"}])
+
+    marker = list_markers()["markers"][0]
+    assert marker["record"]["frames"] == 220
+    assert marker["name"] == "Encore"
+    assert marker["color"] == "Blue"
+
+
+def test_set_carries_duration_and_custom_data_when_asked(attach: Attach) -> None:
+    cut = a_reviewed_cut(markers={})
+    attach(studio(timeline=cut))
+
+    result = set_markers(
+        [
+            {
+                "frame": {"seconds": 2.0, "snap": "floor"},
+                "color": "Blue",
+                "name": "Sunset Boulevard",
+                "duration": 30,
+                "custom_data": "songs.json:sunset",
+            }
+        ]
+    )
+
+    assert result["ok"] is True
+    written = cut.marker_writes[0]
+    assert written["frame"] == 19.0  # 2.0s at 59.94 is record frame 119, start frame 100
+    assert written["duration"] == 30
+    assert written["customData"] == "songs.json:sunset"
+
+
+def test_set_writes_a_batch_and_reports_each_one(attach: Attach) -> None:
+    cut = a_reviewed_cut(markers={})
+    attach(studio(timeline=cut))
+
+    result = set_markers(
+        [
+            {"frame": 120, "color": "Blue", "name": "one"},
+            {"frame": 240, "color": "Blue", "name": "two"},
+        ]
+    )
+
+    assert result["added"] == 2
+    assert [entry["record"]["frames"] for entry in result["results"]] == [120, 240]
+    assert len(cut.marker_writes) == 2
+
+
+def test_one_bad_entry_never_sinks_the_batch(attach: Attach) -> None:
+    cut = a_reviewed_cut(markers={})
+    attach(studio(timeline=cut))
+
+    result = set_markers(
+        [
+            {"frame": 120, "color": "Blue", "name": "good"},
+            {"frame": 130, "color": "Puce", "name": "bad colour"},
+            {"frame": 140, "color": "Blue", "name": "also good"},
+        ]
+    )
+
+    assert result["ok"] is True
+    assert result["added"] == 2
+    assert result["failed"] == 1
+    assert [entry["ok"] for entry in result["results"]] == [True, False, True]
+    assert result["results"][1]["error"]["code"] == "invalid_request"
+    assert "Puce" in result["results"][1]["error"]["cause"]
+
+
+def test_set_refuses_a_colour_resolve_does_not_have(attach: Attach) -> None:
+    """Resolve answers an unknown colour with a bare False, so the check happens here."""
+    attach(studio(timeline=a_reviewed_cut(markers={})))
+
+    result = set_markers([{"frame": 120, "color": "Puce", "note": "n"}])
+
+    assert result["added"] == 0
+    error = result["results"][0]["error"]
+    assert error["code"] == "invalid_request"
+    assert "Blue" in error["fix"]
+
+
+def test_set_takes_a_colour_in_any_case_and_writes_resolve_own_spelling(attach: Attach) -> None:
+    cut = a_reviewed_cut(markers={})
+    attach(studio(timeline=cut))
+
+    set_markers([{"frame": 120, "color": "bLuE", "note": "n"}])
+
+    assert cut.marker_writes[0]["color"] == "Blue"
+
+
+def test_set_needs_a_colour(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut(markers={})))
+
+    result = set_markers([{"frame": 120, "note": "no colour given"}])
+
+    assert result["results"][0]["ok"] is False
+    assert result["results"][0]["error"]["code"] == "invalid_request"
+
+
+def test_set_refuses_a_frame_outside_the_timeline(attach: Attach) -> None:
+    """Resolve drops a marker past the end silently; the bounds are checked here instead."""
+    cut = a_reviewed_cut(markers={})
+    attach(studio(timeline=cut))
+
+    result = set_markers([{"frame": 900, "color": "Blue", "note": "past the end"}])
+
+    assert result["results"][0]["ok"] is False
+    assert result["results"][0]["error"]["code"] == "invalid_request"
+    assert result["results"][0]["error"]["detail"]["bounds"] == {"start": 100, "end": 400}
+    assert cut.marker_writes == []
+
+
+def test_set_leaves_a_directors_marker_alone_unless_told_to_replace_it(attach: Attach) -> None:
+    """The director's own note is the one thing an agent must never overwrite by accident."""
+    cut = a_reviewed_cut()
+    attach(studio(timeline=cut))
+
+    result = set_markers([{"frame": 120, "color": "Blue", "name": "mine"}])
+
+    assert result["added"] == 0
+    assert result["failed"] == 1
+    error = result["results"][0]["error"]
+    assert error["code"] == "invalid_request"
+    assert error["detail"]["existing"]["name"] == "cut early"
+    assert cut.GetMarkers()[20.0]["name"] == "cut early"
+
+
+def test_set_replaces_an_existing_marker_when_told_to(attach: Attach) -> None:
+    cut = a_reviewed_cut()
+    attach(studio(timeline=cut))
+
+    result = set_markers(
+        [{"frame": 120, "color": "Blue", "name": "mine", "note": "handled"}], replace=True
+    )
+
+    assert result["added"] == 1
+    assert result["results"][0]["replaced"] is True
+    assert cut.GetMarkers()[20.0]["name"] == "mine"
+    assert len(cut.GetMarkers()) == 2
+
+
+def test_set_reports_a_refusal_from_resolve_rather_than_claiming_success(
+    attach: Attach,
+) -> None:
+    cut = a_reviewed_cut(markers={})
+    cut.refuse_markers = True
+    attach(studio(timeline=cut))
+
+    result = set_markers([{"frame": 120, "color": "Blue", "note": "n"}])
+
+    assert result["ok"] is True
+    assert result["added"] == 0
+    assert result["results"][0]["ok"] is False
+    assert result["results"][0]["error"]["code"] == "timeline_operation_failed"
+
+
+def test_set_refuses_a_time_it_cannot_read(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut(markers={})))
+
+    result = set_markers([{"frame": "somewhere", "color": "Blue"}])
+
+    assert result["results"][0]["ok"] is False
+    assert result["results"][0]["error"]["code"] == "invalid_request"
+
+
+def test_set_refuses_a_duration_shorter_than_a_frame(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut(markers={})))
+
+    result = set_markers([{"frame": 120, "color": "Blue", "duration": 0}])
+
+    assert result["results"][0]["ok"] is False
+    assert result["results"][0]["error"]["code"] == "invalid_request"
+
+
+def test_set_of_nothing_is_not_an_error(attach: Attach) -> None:
+    attach(studio(timeline=a_reviewed_cut()))
+
+    result = set_markers([])
+
+    assert result["ok"] is True
+    assert result["added"] == 0
+    assert result["results"] == []
+
+
+def test_set_needs_a_timeline(attach: Attach) -> None:
+    attach(studio(timeline=None, timelines=[]))
+
+    result = set_markers([{"frame": 120, "color": "Blue"}])
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "no_timeline_open"
+
+
+def test_markers_survive_resolve_quitting_mid_read(attach: Attach) -> None:
+    """A dead handle is a stated failure, never a half-empty marker list."""
+    dying = studio(timeline=a_reviewed_cut())
+    dying.die_after(1)
+    second = studio(timeline=a_reviewed_cut())
+    second.drop()
+    attach(dying, second)
+
+    result = list_markers()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "resolve_unavailable"
+
+
+@pytest.mark.parametrize("survives", range(1, 12))
+def test_a_death_part_way_through_a_read_never_returns_half_the_notes(
+    attach: Attach, survives: int
+) -> None:
+    dying = studio(timeline=a_reviewed_cut())
+    dying.die_after(survives)
+    attach(dying, studio(timeline=a_reviewed_cut()))
+
+    result = list_markers()
+
+    assert result["ok"] is True
+    assert result["count"] == 2
+    assert result["markers"][0]["note"] == "come off the wide two bars sooner"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -31,6 +31,8 @@ def test_registers_the_p1_session_media_and_timeline_tools() -> None:
         "relink_media",
         "list_timelines",
         "inspect_timeline",
+        "list_markers",
+        "set_markers",
         "run_python",
     }
 


### PR DESCRIPTION
Closes #31.

## What this adds

`list_markers` and `set_markers` — the review loop's transport. The director leaves notes as GUI markers on a built cut; the agent reads them as its work queue and writes markers back to flag its own cut decisions and uncertainties.

**The decision that matters:** Resolve keys timeline markers by a frame *relative to the timeline start*, while every other reading in this server — clip positions, ranges, the cut file — is in absolute record frames. Mixing them puts a note an hour away from the shot it is about on any timeline starting at 01:00:00:00. The translation happens once, in `resolve/markers.py`: callers give and get record frames, and each marker also carries `frame`, Resolve's own key, for anyone reaching past this server with `run_python`.

Two refusals happen before Resolve sees them, because it answers both with a bare `False`: an unknown colour, and a frame outside the timeline. A frame that already carries a *different* marker is refused with that marker in the error — it is usually the director's own note — unless `replace` is asked for.

`_project`/`_frames` in the timeline wrapper became `open_project`/`read_frames`, and the half-open range parser and overlap test moved there as `frame_window`/`overlaps`, so the marker reader shares them rather than copying them.

## Test seam

Fake tier (`tests/test_marker_tools.py`, 46 tests) — every decision: both clocks, the colour and bounds checks, the collision rule, batch isolation, spill past the cap, and the dropped-handle walk. The fake timeline gained `AddMarker`/`DeleteMarkerAtFrame` mimicking the real API's refusal-on-occupied-frame. Live smoke gains the one thing no fake settles: which frame Resolve keys a GUI marker by.

## Review

`/code-review` (Standards and Spec as parallel sub-agents) against `origin/main`. Findings and what happened to them:

**Standards**
1. *`markers.py` bypassed the `Reader` degradation pattern for `GetMarkers`* — fixed: the read goes through `Reader`, so a build without the getter reads as a timeline with no markers while a dead handle still raises. Test added.
2. *`_window`/`_touches` duplicated the timeline wrapper's versions, error strings included* — fixed: both now live once in `resolve/timeline.py` as `frame_window` and `overlaps`, used by both readers.
3. *`Placed` was a mysterious name; `held` and `_reported` were two names for one map* — fixed: `MarkerClock` and `existing`.
4. *Dead `None` guard in `_touches` on a value that is never `None`* — fixed, inlined.
5. *`marker_wrapper` breaks the module-import idiom* — kept: `wrapper` is the repo's own word for that layer (`tests/test_timeline_tools.py` imports it as `wrapper`), and the plain `markers` alias collides with the tool's agent-facing `markers` parameter.
6. *No live test for `set_markers`* — deliberate, following the media tier's precedent that mutating live ACs are run by hand rather than by a test that writes into a real project. Named in the ticket's close comment.

**Spec**
1. *A refused replacement lost the director's marker* (delete succeeded, add refused) — fixed: the displaced marker is carried through the write and put back if the add does not land, and the error says which way it went. Test added.
2. *The envelope's reconnect replays the whole batch, so markers the first attempt wrote came back as collisions accusing the agent of overwriting the director* — fixed: an identical marker on the frame is neither a collision nor a write, and reports `unchanged: true`. A *different* marker there is still a collision. Tests added for both.
3. *The live AC's central assertion was tautological* — fixed: dropped the assertion that re-derived the wrapper's own arithmetic, kept the bounds check (which is what actually catches a doubled offset), skipped the frame-0 case where both clocks agree and nothing is proved, and printed the marker table for the human to compare against the GUI.
4. *`replace`, `duration` and `custom_data` are beyond "set a marker with color/name/note"* — kept deliberately: `replace` is the escape valve that makes the refuse-by-default rule usable, `duration` is what a song-start marker needs, and both are guarded. Flagged here rather than silently.
5. *`_within` treats `GetEndFrame()` as exclusive, so a marker on the final frame would be wrongly refused if Resolve reports it inclusively* — left as is: it matches the existing `_bounds` convention, and the live tier is where that convention is checked. Named in the ticket.

Fix diff re-checked in a focused pass; fake tier (243 tests), mypy strict and ruff all green.

Review: clean — both axes' findings fixed or answered above, fix diff re-checked.


---

Merge of origin/main (post-#64/#65) resolved on-branch: unioned both tool sets in tools/timeline.py into one TOOLS tuple; rebuilt test_live_smoke.py as main's file with the marker smoke test inserted (the hunks split mid-docstring, so a plain union was unsafe); straight unions in fakes.py and test_server.py; main's open_project docstring kept. Focused pass over the resolution diff; 411 fake-tier tests, mypy strict and ruff all green.

Review: clean — merge-resolution diff, focused pass
