### PR TITLE
feat: timeline interchange (OTIO/FCPXML/DRT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build contract: [issue #22](https://github.com/danielbaldwin47/resolve-mcp/issue
 ## Status
 
 P1 in progress. Shipped so far: the server skeleton, the session/project tools, the media
-pool tools, and the `run_python` escape hatch.
+pool tools, the timeline read and interchange tools, and the `run_python` escape hatch.
 
 | Tool | What it does |
 | --- | --- |
@@ -22,11 +22,21 @@ pool tools, and the `run_python` escape hatch.
 | `set_clip_metadata` | Batch metadata writes, each field routed by what the clip reports |
 | `organize_media` | Batch bin operations: create nested bins, move clips |
 | `relink_media` | Points offline clips at media that moved (folder relink or file replace) |
+| `list_timelines` | Timelines with version, duration, fps and track stack; names the newest cut |
+| `inspect_timeline` | One timeline at a chosen detail and range, in dual time |
+| `export_timeline` | Writes a timeline out as OTIO, FCPXML or DRT |
+| `import_timeline` | Materialises a **new** timeline from such a file — never overwrites one |
 | `run_python` | Escape hatch: runs scripting-API Python in the server process |
 
 Bin paths are slash-separated from the media pool root (`Concert/Angles`) and
 case-sensitive. A clip counts as **offline** when it has a file path that is not on
 disk — Resolve's scripting API exposes no offline flag.
+
+Interchange is the **structural escape hatch**. The scripting API cannot cut a transition,
+so a dissolve is made by exporting the cut to OTIO, editing the transition into that
+document, and importing it back. An import is always given a name no timeline in the
+project answers to — colliding names walk the `<base> v<N>` convention — so the cut that is
+already there is never the thing that gets written over.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ disk — Resolve's scripting API exposes no offline flag.
 
 Interchange is the **structural escape hatch**. The scripting API cannot cut a transition,
 so a dissolve is made by exporting the cut to OTIO, editing the transition into that
-document, and importing it back. An import is always given a name no timeline in the
-project answers to — colliding names walk the `<base> v<N>` convention — so the cut that is
-already there is never the thing that gets written over.
+document, and importing it back. An `.otio` or `.fcpxml` import is given a name no timeline
+in the project answers to — colliding names walk the `<base> v<N>` convention. A `.drt` is
+Resolve's own document and accepts no import options at all, so it names its own timeline;
+what holds there is the check on the way out. Either way the cut already in the project is
+never the thing that gets written over.
 
 ## Requirements
 

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -60,6 +60,16 @@ class Config:
         """Where listings too big to return inline spill to."""
         return self.cache_dir / "listings"
 
+    @property
+    def interchange_dir(self) -> Path:
+        """Where exported timelines (OTIO, FCPXML, DRT) land when no path is given.
+
+        Unlike a snapshot these are meant to be opened and edited — an injected dissolve is
+        a hand edit to an exported file — so they keep their own folder rather than sitting
+        among the opaque restore points.
+        """
+        return self.cache_dir / "interchange"
+
 
 _config: Config | None = None
 

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -96,6 +96,27 @@ class TimelineNotFoundError(ResolveMcpError):
         )
 
 
+class TimelineExportFailedError(ResolveMcpError):
+    """Resolve would not write the interchange file, or wrote nothing."""
+
+    code = "timeline_export_failed"
+    default_fix = (
+        "Check the target directory is writable from the machine Resolve runs on, then "
+        "retry. Another format may be supported where this one is not: otio, fcpxml, drt."
+    )
+
+
+class TimelineImportFailedError(ResolveMcpError):
+    """Resolve would not materialise a timeline from the file."""
+
+    code = "timeline_import_failed"
+    default_fix = (
+        "Check the file is a timeline Resolve can read (.otio, .fcpxml, .drt) and is "
+        "readable from the machine Resolve runs on. If it was hand-edited, an invalid "
+        "document imports as nothing — validate the edit and retry."
+    )
+
+
 class SnapshotFailedError(ResolveMcpError):
     code = "snapshot_failed"
     default_fix = (

--- a/src/resolve_mcp/naming.py
+++ b/src/resolve_mcp/naming.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
+from pathlib import Path
 
 UNSAFE_IN_FILENAME = re.compile(r"[^A-Za-z0-9._-]+")
 STAMP_FORMAT = "%Y%m%d-%H%M%S"
@@ -24,3 +25,28 @@ def timestamped_name(
     stamp = (now or datetime.now()).strftime(STAMP_FORMAT)
     slug = UNSAFE_IN_FILENAME.sub("-", label).strip("-") or fallback
     return f"{slug}-{stamp}{suffix}"
+
+
+def write_target(
+    path: str | Path | None,
+    label: str,
+    suffix: str,
+    default_dir: Path,
+    fallback: str,
+) -> Path:
+    """Where a file the server writes goes, whether or not the caller named a path.
+
+    A path the caller gave keeps its folder and stem but never a suffix that disagrees with
+    what is about to be written: a ``.drp`` holding OTIO, or an ``.xml`` holding FCPXML,
+    gets opened by the wrong thing weeks later. Without a path the file lands under the
+    cache directory this kind of write owns, named for what it came from.
+
+    Creating the directory is left to the caller: only the caller knows which failure the
+    agent should be told about when it cannot be created.
+    """
+    if path is None:
+        return default_dir / timestamped_name(label, suffix, fallback)
+    target = Path(path)
+    if target.suffix.lower() != suffix:
+        target = target.with_suffix(suffix)
+    return target

--- a/src/resolve_mcp/resolve/interchange.py
+++ b/src/resolve_mcp/resolve/interchange.py
@@ -8,9 +8,9 @@ Four things are decisions rather than API calls:
 
 * **A format name is not an export constant.** ``Timeline.Export`` takes a number that
   lives on the Resolve app object, and which numbers exist depends on the build — FCPXML
-  alone has had eight versions. So a format maps to an ordered list of constant names and
-  the newest one this build has wins; a build that has none of them fails naming what it
-  looked for, rather than throwing ``AttributeError`` from inside a wrapper. The lookup
+  has gained a constant per version of the format. So a format maps to an ordered list of
+  constant names and the newest one this build has wins; a build with none of them fails
+  naming what it looked for, not with an ``AttributeError`` from inside a wrapper. The lookup
   tests against ``None`` and never against truthiness, because the first constant Resolve
   defines has the value 0.
 * **The export is confirmed on disk, not by the return value.** ``Export`` answers a bool,
@@ -198,7 +198,7 @@ def import_timeline(
     connection: ResolveConnection,
     path: str | Path,
     name: str | None = None,
-    import_source_clips: bool = True,
+    import_source_clips: bool | None = None,
     source_media_path: str | Path | None = None,
 ) -> dict[str, Any]:
     """Materialise a new timeline from an interchange file. Never lands on an existing one."""
@@ -216,8 +216,9 @@ def import_timeline(
     project = project_of(connection)
     pool = pool_of(project)
     existing = set(timeline_names(project))
+    native = source.suffix.lower() == NATIVE_SUFFIX
     requested, options = _import_options(
-        source, name, import_source_clips, source_media_path, existing
+        source, native, name, import_source_clips, source_media_path, existing
     )
 
     imported = pool.ImportTimelineFromFile(str(source), options)
@@ -234,11 +235,7 @@ def import_timeline(
                 f"Resolve handed back {landed!r}, a timeline the project already had, "
                 f"rather than a new one."
             ),
-            fix=(
-                f"Snapshot the project and check whether {landed!r} still holds the cut it "
-                "did before. A .drt names its own timeline — Resolve chose that name, not "
-                "this server — so re-export the cut as .otio to choose it here."
-            ),
+            fix=_collision_fix(native, landed, options),
             detail={"path": str(source), "timeline": landed, "options": options},
         )
 
@@ -255,31 +252,35 @@ def import_timeline(
 
 def _import_options(
     source: Path,
+    native: bool,
     name: str | None,
-    import_source_clips: bool,
+    import_source_clips: bool | None,
     source_media_path: str | Path | None,
     existing: set[str],
 ) -> tuple[str | None, dict[str, Any]]:
     """The options to send, and the name asked for — ``None`` when the file chooses it.
 
-    A ``.drt`` is sent no options because Resolve honours none of them; a caller who
-    explicitly asked for one is told rather than left to discover it from a reply that
-    quietly disagrees with the request. ``import_source_clips`` is not that kind of ask —
-    it has a default, so a ``.drt`` import silently leaves it out rather than refusing a
-    value the caller may never have chosen.
+    A ``.drt`` is sent no options because Resolve honours none of them. Every option is
+    therefore ``None`` by default and refused when given: a request that was made and
+    dropped is worse than one that was refused, because the reply then quietly disagrees
+    with what was asked for and the caller has no reason to look.
     """
-    if source.suffix.lower() == NATIVE_SUFFIX:
-        refused = {"name": name, "source_media_path": source_media_path}
+    if native:
+        refused = {
+            "name": name,
+            "import_source_clips": import_source_clips,
+            "source_media_path": source_media_path,
+        }
         given = [key for key, value in refused.items() if value is not None]
         if given:
             raise InvalidRequestError(
                 cause=(
                     f"A .drt carries its own timeline name and media links, so "
-                    f"{' and '.join(given)} cannot be honoured for one."
+                    f"{', '.join(given)} cannot be honoured for one."
                 ),
                 fix=(
                     "Import the .drt as it is — the reply names the timeline Resolve made — "
-                    "or use an .otio or .fcpxml export, where both are honoured."
+                    "or use an .otio or .fcpxml export, where all three are honoured."
                 ),
                 detail={"path": str(source), "ignored": given},
             )
@@ -288,8 +289,32 @@ def _import_options(
     requested = name or source.stem
     options: dict[str, Any] = {
         "timelineName": next_free_name(requested, existing),
-        "importSourceClips": bool(import_source_clips),
+        "importSourceClips": True if import_source_clips is None else bool(import_source_clips),
     }
     if source_media_path is not None:
         options["sourceClipsPath"] = str(source_media_path)
     return requested, options
+
+
+def _collision_fix(native: bool, landed: str, options: dict[str, Any]) -> str:
+    """What to do about an import that came back as a timeline the project already had.
+
+    The two routes leave the project in different states and must not be given the same
+    advice. On the ``.drt`` route Resolve chose the name, so both outcomes are open — it
+    may have replaced that cut or made a second one carrying the name. On the others a free
+    name was handed over and came back changed, which is Resolve disagreeing with a request
+    this server did make.
+    """
+    if native:
+        return (
+            f"A .drt names its own timeline, so Resolve chose {landed!r} — it may have "
+            f"replaced that cut or made a second one under the same name. Snapshot the "
+            f"project, check {landed!r} against the cut it held, and re-export as .otio to "
+            "choose the name here."
+        )
+    asked = options.get("timelineName")
+    return (
+        f"Resolve was asked for {asked!r} and answered with {landed!r} instead. Snapshot "
+        f"the project, check {landed!r} against the cut it held, and retry naming the "
+        "import explicitly."
+    )

--- a/src/resolve_mcp/resolve/interchange.py
+++ b/src/resolve_mcp/resolve/interchange.py
@@ -4,15 +4,15 @@ This is the structural escape hatch. The scripting API cannot cut a transition, 
 route around that wall is: export the cut, hand-edit a dissolve into the document, import
 it back. Everything here exists to make that round trip safe to take.
 
-Three things are decisions rather than API calls:
+Four things are decisions rather than API calls:
 
 * **A format name is not an export constant.** ``Timeline.Export`` takes a number that
   lives on the Resolve app object, and which numbers exist depends on the build — FCPXML
-  alone has eight versions. So a format maps to an ordered list of constant names and the
-  newest one this build has wins; a build that has none of them fails naming what it looked
-  for, rather than throwing ``AttributeError`` from inside a wrapper. The lookup tests
-  against ``None`` and never against truthiness, because the first constant Resolve defines
-  has the value 0.
+  alone has had eight versions. So a format maps to an ordered list of constant names and
+  the newest one this build has wins; a build that has none of them fails naming what it
+  looked for, rather than throwing ``AttributeError`` from inside a wrapper. The lookup
+  tests against ``None`` and never against truthiness, because the first constant Resolve
+  defines has the value 0.
 * **The export is confirmed on disk, not by the return value.** ``Export`` answers a bool,
   and a path in a successful reply that has nothing behind it is worse than a failure: the
   agent's next move is to open that file.
@@ -22,6 +22,12 @@ Three things are decisions rather than API calls:
   free name is computed first, from the project's own ``<base> v<N>`` convention, and the
   timeline that comes back is checked against the names that existed before the call. The
   reply says what was asked for and what was made, so a rename is never silent.
+* **A ``.drt`` is Resolve's own document and takes no import options at all.** Not the
+  name, not the source-clip handling — the API marks every one of them invalid for DRT, so
+  a ``.drt`` names its own timeline and this server cannot choose for it. Options are not
+  sent where they would be ignored, a caller who asked for one is told plainly it cannot be
+  honoured, and the check on the way out — the timeline that came back is not one that
+  existed before — is what holds the no-overwrite guarantee on that route.
 """
 
 from __future__ import annotations
@@ -36,40 +42,41 @@ from ..errors import (
     TimelineImportFailedError,
 )
 from ..logging_config import get_logger
-from ..naming import timestamped_name
+from ..naming import write_target
 from .connection import ResolveConnection
-from .media import media_pool
+from .media import pool_of
 from .timeline import (
     Reader,
     current_name,
     find_timeline,
     name_of,
+    next_free_name,
     project_of,
     summarise,
     timeline_names,
-    version_of,
 )
 
 log = get_logger("interchange")
 
-Timeline = Any
-
 
 class Format(NamedTuple):
-    """One interchange format: the file it writes, and the constants that ask for it."""
+    """One interchange format: what it is called, what it writes, what asks for it."""
 
+    key: str
     suffix: str
     export_types: tuple[str, ...]
 
 
-#: OTIO first: it is the one the transition-injection route runs through. FCPXML is listed
-#: newest version first — a newer document carries more of the cut, so the newest the build
-#: offers is the one to write.
+#: FCPXML is listed newest version first — a newer document carries more of the cut, so the
+#: newest the build offers is the one to write. Extend the head of that tuple when Resolve
+#: adds a version; a name this build does not define costs nothing and is skipped.
 FORMATS: dict[str, Format] = {
-    "otio": Format(".otio", ("EXPORT_OTIO",)),
+    "otio": Format("otio", ".otio", ("EXPORT_OTIO",)),
     "fcpxml": Format(
+        "fcpxml",
         ".fcpxml",
         (
+            "EXPORT_FCPXML_1_11",
             "EXPORT_FCPXML_1_10",
             "EXPORT_FCPXML_1_9",
             "EXPORT_FCPXML_1_8",
@@ -80,10 +87,12 @@ FORMATS: dict[str, Format] = {
             "EXPORT_FCPXML_1_3",
         ),
     ),
-    "drt": Format(".drt", ("EXPORT_DRT",)),
+    "drt": Format("drt", ".drt", ("EXPORT_DRT",)),
 }
 
 DEFAULT_FORMAT = "otio"
+#: Resolve's own timeline document. Every import option is documented as invalid for it.
+NATIVE_SUFFIX = ".drt"
 
 
 # --- export ------------------------------------------------------------------------------
@@ -97,14 +106,16 @@ def export_timeline(
     config: Config | None = None,
 ) -> dict[str, Any]:
     """Write one timeline (the open one by default) out as an interchange file."""
-    spec, key = _format(export_format)
+    spec = _format(export_format)
     resolve = connection.handle()
     project = project_of(connection)
     timeline = find_timeline(project, name)
     timeline_name = name_of(timeline)
 
-    export_type, constant = _export_type(resolve, spec, key)
-    target = _target(path, timeline_name, spec, config or get_config())
+    export_type, constant = _export_type(resolve, spec)
+    target = write_target(
+        path, timeline_name, spec.suffix, (config or get_config()).interchange_dir, "timeline"
+    )
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
@@ -115,8 +126,8 @@ def export_timeline(
     # would be a guess at what the export means.
     if not timeline.Export(str(target), export_type):
         raise TimelineExportFailedError(
-            cause=f"Resolve refused to export {timeline_name!r} as {key} to {target}.",
-            detail={"timeline": timeline_name, "format": key, "export_type": constant},
+            cause=f"Resolve refused to export {timeline_name!r} as {spec.key} to {target}.",
+            detail={"timeline": timeline_name, "format": spec.key, "export_type": constant},
         )
 
     written = _written_bytes(target)
@@ -130,22 +141,21 @@ def export_timeline(
                 "Check the path is writable from the machine Resolve runs on, and that no "
                 "dialog in the Resolve GUI is holding the export. Then retry."
             ),
-            detail={"timeline": timeline_name, "format": key, "path": str(target)},
+            detail={"timeline": timeline_name, "format": spec.key, "path": str(target)},
         )
 
     log.info("Exported %r as %s to %s (%d bytes)", timeline_name, constant, target, written)
     return {
         "timeline": timeline_name,
-        "format": key,
+        "format": spec.key,
         "export_type": constant,
         "path": str(target),
         "bytes": written,
     }
 
 
-def _format(export_format: str) -> tuple[Format, str]:
-    key = str(export_format).strip().lower()
-    spec = FORMATS.get(key)
+def _format(export_format: str) -> Format:
+    spec = FORMATS.get(str(export_format).strip().lower())
     if spec is None:
         raise InvalidRequestError(
             cause=f"{export_format!r} is not an interchange format this server writes.",
@@ -155,37 +165,23 @@ def _format(export_format: str) -> tuple[Format, str]:
             ),
             detail={"requested": export_format, "available": list(FORMATS)},
         )
-    return spec, key
+    return spec
 
 
-def _export_type(resolve: Any, spec: Format, key: str) -> tuple[Any, str]:
+def _export_type(resolve: Any, spec: Format) -> tuple[Any, str]:
     """The newest constant for this format that the attached Resolve actually defines."""
     for constant in spec.export_types:
         value = getattr(resolve, constant, None)
         if value is not None:
             return value, constant
     raise TimelineExportFailedError(
-        cause=f"This Resolve build defines no export type for {key}.",
+        cause=f"This Resolve build defines no export type for {spec.key}.",
         fix=(
             "Update Resolve, or export in another format — otio and drt are supported on "
             "every build this server attaches to."
         ),
-        detail={"format": key, "tried": list(spec.export_types)},
+        detail={"format": spec.key, "tried": list(spec.export_types)},
     )
-
-
-def _target(path: str | Path | None, timeline_name: str, spec: Format, config: Config) -> Path:
-    """Where the file goes: the cache's interchange folder, unless a path was given.
-
-    An explicit path keeps its folder and stem but not a suffix that disagrees with the
-    format — a ``.xml`` holding OTIO would be opened by the wrong thing later.
-    """
-    if path is None:
-        return config.interchange_dir / timestamped_name(timeline_name, spec.suffix, "timeline")
-    target = Path(path)
-    if target.suffix.lower() != spec.suffix:
-        target = target.with_suffix(spec.suffix)
-    return target
 
 
 def _written_bytes(target: Path) -> int:
@@ -218,23 +214,17 @@ def import_timeline(
         )
 
     project = project_of(connection)
-    pool = media_pool(connection)
+    pool = pool_of(project)
     existing = set(timeline_names(project))
-    requested = name or source.stem
-    free = _free_name(requested, existing)
-
-    options: dict[str, Any] = {
-        "timelineName": free,
-        "importSourceClips": bool(import_source_clips),
-    }
-    if source_media_path is not None:
-        options["sourceClipsPath"] = str(source_media_path)
+    requested, options = _import_options(
+        source, name, import_source_clips, source_media_path, existing
+    )
 
     imported = pool.ImportTimelineFromFile(str(source), options)
     if imported is None:
         raise TimelineImportFailedError(
             cause=f"Resolve materialised no timeline from {source}.",
-            detail={"path": str(source), "requested_name": requested, "asked_for": free},
+            detail={"path": str(source), "requested_name": requested, "options": options},
         )
 
     landed = name_of(imported)
@@ -245,10 +235,11 @@ def import_timeline(
                 f"rather than a new one."
             ),
             fix=(
-                "Nothing was imported under a new name. Snapshot the project, then check "
-                f"whether {landed!r} still holds the cut it did before importing again."
+                f"Snapshot the project and check whether {landed!r} still holds the cut it "
+                "did before. A .drt names its own timeline — Resolve chose that name, not "
+                "this server — so re-export the cut as .otio to choose it here."
             ),
-            detail={"path": str(source), "timeline": landed, "asked_for": free},
+            detail={"path": str(source), "timeline": landed, "options": options},
         )
 
     reader = Reader(connection)
@@ -257,23 +248,48 @@ def import_timeline(
     return {
         "path": str(source),
         "requested_name": requested,
-        "renamed": landed != requested,
+        "renamed": requested is not None and landed != requested,
         "timeline": heading,
     }
 
 
-def _free_name(requested: str, existing: set[str]) -> str:
-    """A name no timeline in the project answers to, following ``<base> v<N>``.
+def _import_options(
+    source: Path,
+    name: str | None,
+    import_source_clips: bool,
+    source_media_path: str | Path | None,
+    existing: set[str],
+) -> tuple[str | None, dict[str, Any]]:
+    """The options to send, and the name asked for — ``None`` when the file chooses it.
 
-    The project's own convention for a new cut from an old one is the next version number,
-    so a collision walks that sequence rather than inventing a suffix of its own — an
-    unversioned name starts the sequence at v2, which reads as what it is: the second thing
-    to carry that name.
+    A ``.drt`` is sent no options because Resolve honours none of them; a caller who
+    explicitly asked for one is told rather than left to discover it from a reply that
+    quietly disagrees with the request. ``import_source_clips`` is not that kind of ask —
+    it has a default, so a ``.drt`` import silently leaves it out rather than refusing a
+    value the caller may never have chosen.
     """
-    if requested not in existing:
-        return requested
-    base, version = version_of(requested)
-    number = (version or 1) + 1
-    while f"{base} v{number}" in existing:
-        number += 1
-    return f"{base} v{number}"
+    if source.suffix.lower() == NATIVE_SUFFIX:
+        refused = {"name": name, "source_media_path": source_media_path}
+        given = [key for key, value in refused.items() if value is not None]
+        if given:
+            raise InvalidRequestError(
+                cause=(
+                    f"A .drt carries its own timeline name and media links, so "
+                    f"{' and '.join(given)} cannot be honoured for one."
+                ),
+                fix=(
+                    "Import the .drt as it is — the reply names the timeline Resolve made — "
+                    "or use an .otio or .fcpxml export, where both are honoured."
+                ),
+                detail={"path": str(source), "ignored": given},
+            )
+        return None, {}
+
+    requested = name or source.stem
+    options: dict[str, Any] = {
+        "timelineName": next_free_name(requested, existing),
+        "importSourceClips": bool(import_source_clips),
+    }
+    if source_media_path is not None:
+        options["sourceClipsPath"] = str(source_media_path)
+    return requested, options

--- a/src/resolve_mcp/resolve/interchange.py
+++ b/src/resolve_mcp/resolve/interchange.py
@@ -1,0 +1,279 @@
+"""Timeline interchange: a cut out to a file, a file back in as a new cut.
+
+This is the structural escape hatch. The scripting API cannot cut a transition, so the
+route around that wall is: export the cut, hand-edit a dissolve into the document, import
+it back. Everything here exists to make that round trip safe to take.
+
+Three things are decisions rather than API calls:
+
+* **A format name is not an export constant.** ``Timeline.Export`` takes a number that
+  lives on the Resolve app object, and which numbers exist depends on the build — FCPXML
+  alone has eight versions. So a format maps to an ordered list of constant names and the
+  newest one this build has wins; a build that has none of them fails naming what it looked
+  for, rather than throwing ``AttributeError`` from inside a wrapper. The lookup tests
+  against ``None`` and never against truthiness, because the first constant Resolve defines
+  has the value 0.
+* **The export is confirmed on disk, not by the return value.** ``Export`` answers a bool,
+  and a path in a successful reply that has nothing behind it is worse than a failure: the
+  agent's next move is to open that file.
+* **An import is given a name no timeline answers to.** ``ImportTimelineFromFile`` takes a
+  ``timelineName`` and nothing on record says what it does with one already in use — and
+  the outcome that cannot be undone is it landing on the cut that is already there. So the
+  free name is computed first, from the project's own ``<base> v<N>`` convention, and the
+  timeline that comes back is checked against the names that existed before the call. The
+  reply says what was asked for and what was made, so a rename is never silent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from ..config import Config, get_config
+from ..errors import (
+    InvalidRequestError,
+    TimelineExportFailedError,
+    TimelineImportFailedError,
+)
+from ..logging_config import get_logger
+from ..naming import timestamped_name
+from .connection import ResolveConnection
+from .media import media_pool
+from .timeline import (
+    Reader,
+    current_name,
+    find_timeline,
+    name_of,
+    project_of,
+    summarise,
+    timeline_names,
+    version_of,
+)
+
+log = get_logger("interchange")
+
+Timeline = Any
+
+
+class Format(NamedTuple):
+    """One interchange format: the file it writes, and the constants that ask for it."""
+
+    suffix: str
+    export_types: tuple[str, ...]
+
+
+#: OTIO first: it is the one the transition-injection route runs through. FCPXML is listed
+#: newest version first — a newer document carries more of the cut, so the newest the build
+#: offers is the one to write.
+FORMATS: dict[str, Format] = {
+    "otio": Format(".otio", ("EXPORT_OTIO",)),
+    "fcpxml": Format(
+        ".fcpxml",
+        (
+            "EXPORT_FCPXML_1_10",
+            "EXPORT_FCPXML_1_9",
+            "EXPORT_FCPXML_1_8",
+            "EXPORT_FCPXML_1_7",
+            "EXPORT_FCPXML_1_6",
+            "EXPORT_FCPXML_1_5",
+            "EXPORT_FCPXML_1_4",
+            "EXPORT_FCPXML_1_3",
+        ),
+    ),
+    "drt": Format(".drt", ("EXPORT_DRT",)),
+}
+
+DEFAULT_FORMAT = "otio"
+
+
+# --- export ------------------------------------------------------------------------------
+
+
+def export_timeline(
+    connection: ResolveConnection,
+    name: str | None = None,
+    export_format: str = DEFAULT_FORMAT,
+    path: str | Path | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Write one timeline (the open one by default) out as an interchange file."""
+    spec, key = _format(export_format)
+    resolve = connection.handle()
+    project = project_of(connection)
+    timeline = find_timeline(project, name)
+    timeline_name = name_of(timeline)
+
+    export_type, constant = _export_type(resolve, spec, key)
+    target = _target(path, timeline_name, spec, config or get_config())
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise TimelineExportFailedError(cause=f"Could not create {target.parent}: {exc}") from exc
+
+    # Two arguments, not three: the subtype is Resolve's own optional argument and none of
+    # these three formats has one. Passing a subtype constant borrowed from AAF or EDL
+    # would be a guess at what the export means.
+    if not timeline.Export(str(target), export_type):
+        raise TimelineExportFailedError(
+            cause=f"Resolve refused to export {timeline_name!r} as {key} to {target}.",
+            detail={"timeline": timeline_name, "format": key, "export_type": constant},
+        )
+
+    written = _written_bytes(target)
+    if not written:
+        raise TimelineExportFailedError(
+            cause=(
+                f"Resolve reported the export of {timeline_name!r} succeeded but wrote "
+                f"nothing to {target}."
+            ),
+            fix=(
+                "Check the path is writable from the machine Resolve runs on, and that no "
+                "dialog in the Resolve GUI is holding the export. Then retry."
+            ),
+            detail={"timeline": timeline_name, "format": key, "path": str(target)},
+        )
+
+    log.info("Exported %r as %s to %s (%d bytes)", timeline_name, constant, target, written)
+    return {
+        "timeline": timeline_name,
+        "format": key,
+        "export_type": constant,
+        "path": str(target),
+        "bytes": written,
+    }
+
+
+def _format(export_format: str) -> tuple[Format, str]:
+    key = str(export_format).strip().lower()
+    spec = FORMATS.get(key)
+    if spec is None:
+        raise InvalidRequestError(
+            cause=f"{export_format!r} is not an interchange format this server writes.",
+            fix=(
+                "Use otio for a round trip (the route for hand-injected transitions), "
+                "fcpxml to hand a cut to another NLE, or drt for a Resolve-native timeline."
+            ),
+            detail={"requested": export_format, "available": list(FORMATS)},
+        )
+    return spec, key
+
+
+def _export_type(resolve: Any, spec: Format, key: str) -> tuple[Any, str]:
+    """The newest constant for this format that the attached Resolve actually defines."""
+    for constant in spec.export_types:
+        value = getattr(resolve, constant, None)
+        if value is not None:
+            return value, constant
+    raise TimelineExportFailedError(
+        cause=f"This Resolve build defines no export type for {key}.",
+        fix=(
+            "Update Resolve, or export in another format — otio and drt are supported on "
+            "every build this server attaches to."
+        ),
+        detail={"format": key, "tried": list(spec.export_types)},
+    )
+
+
+def _target(path: str | Path | None, timeline_name: str, spec: Format, config: Config) -> Path:
+    """Where the file goes: the cache's interchange folder, unless a path was given.
+
+    An explicit path keeps its folder and stem but not a suffix that disagrees with the
+    format — a ``.xml`` holding OTIO would be opened by the wrong thing later.
+    """
+    if path is None:
+        return config.interchange_dir / timestamped_name(timeline_name, spec.suffix, "timeline")
+    target = Path(path)
+    if target.suffix.lower() != spec.suffix:
+        target = target.with_suffix(spec.suffix)
+    return target
+
+
+def _written_bytes(target: Path) -> int:
+    try:
+        return target.stat().st_size
+    except OSError:
+        return 0
+
+
+# --- import ------------------------------------------------------------------------------
+
+
+def import_timeline(
+    connection: ResolveConnection,
+    path: str | Path,
+    name: str | None = None,
+    import_source_clips: bool = True,
+    source_media_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Materialise a new timeline from an interchange file. Never lands on an existing one."""
+    source = Path(path)
+    if not source.is_file():
+        raise InvalidRequestError(
+            cause=f"There is no file at {source}.",
+            fix=(
+                "Give the path to an .otio, .fcpxml or .drt file as it is seen from the "
+                "machine Resolve runs on. export_timeline reports the path it wrote."
+            ),
+            detail={"requested": str(source)},
+        )
+
+    project = project_of(connection)
+    pool = media_pool(connection)
+    existing = set(timeline_names(project))
+    requested = name or source.stem
+    free = _free_name(requested, existing)
+
+    options: dict[str, Any] = {
+        "timelineName": free,
+        "importSourceClips": bool(import_source_clips),
+    }
+    if source_media_path is not None:
+        options["sourceClipsPath"] = str(source_media_path)
+
+    imported = pool.ImportTimelineFromFile(str(source), options)
+    if imported is None:
+        raise TimelineImportFailedError(
+            cause=f"Resolve materialised no timeline from {source}.",
+            detail={"path": str(source), "requested_name": requested, "asked_for": free},
+        )
+
+    landed = name_of(imported)
+    if landed in existing:
+        raise TimelineImportFailedError(
+            cause=(
+                f"Resolve handed back {landed!r}, a timeline the project already had, "
+                f"rather than a new one."
+            ),
+            fix=(
+                "Nothing was imported under a new name. Snapshot the project, then check "
+                f"whether {landed!r} still holds the cut it did before importing again."
+            ),
+            detail={"path": str(source), "timeline": landed, "asked_for": free},
+        )
+
+    reader = Reader(connection)
+    heading = summarise(reader, imported, project, current_name(project))
+    log.info("Imported %s as %r (asked for %r)", source, landed, requested)
+    return {
+        "path": str(source),
+        "requested_name": requested,
+        "renamed": landed != requested,
+        "timeline": heading,
+    }
+
+
+def _free_name(requested: str, existing: set[str]) -> str:
+    """A name no timeline in the project answers to, following ``<base> v<N>``.
+
+    The project's own convention for a new cut from an old one is the next version number,
+    so a collision walks that sequence rather than inventing a suffix of its own — an
+    unversioned name starts the sequence at v2, which reads as what it is: the second thing
+    to carry that name.
+    """
+    if requested not in existing:
+        return requested
+    base, version = version_of(requested)
+    number = (version or 1) + 1
+    while f"{base} v{number}" in existing:
+        number += 1
+    return f"{base} v{number}"

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -62,6 +62,7 @@ RESOLUTION = "Resolution"
 Clip = Any
 Folder = Any
 Pool = Any
+Project = Any
 
 
 class LocatedClip(NamedTuple):
@@ -93,6 +94,16 @@ def media_pool(connection: ResolveConnection) -> Pool:
     project = manager.GetCurrentProject() if manager is not None else None
     if project is None:
         raise NoProjectOpenError(cause="No project is open, so there is no media pool to work in.")
+    return pool_of(project)
+
+
+def pool_of(project: Project) -> Pool:
+    """The pool of a project already in hand — the same walk, without repeating it.
+
+    A caller that has the project must not reach for it a second time: two walks are two
+    chances to land on different projects if the GUI switches between them, and the pool
+    would then not belong to the project the rest of the call is reading.
+    """
     pool = project.GetMediaPool()
     if pool is None:
         raise MediaPoolUnavailableError(

--- a/src/resolve_mcp/resolve/session.py
+++ b/src/resolve_mcp/resolve/session.py
@@ -12,7 +12,7 @@ from typing import Any
 from ..config import Config, get_config
 from ..errors import NoProjectOpenError, ProjectNotFoundError, SnapshotFailedError
 from ..logging_config import get_logger
-from ..naming import timestamped_name
+from ..naming import write_target
 from .connection import ResolveConnection
 
 log = get_logger("session")
@@ -116,13 +116,7 @@ def snapshot_project(
     name = str(project.GetName())
     if not manager.SaveProject():
         log.warning("SaveProject() returned false before snapshotting %s", name)
-    target = (
-        Path(path)
-        if path is not None
-        else config.snapshot_dir / timestamped_name(name, ".drp", "project")
-    )
-    if target.suffix.lower() != ".drp":
-        target = target.with_suffix(".drp")
+    target = write_target(path, name, ".drp", config.snapshot_dir, "project")
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -151,6 +151,23 @@ def version_of(name: str) -> tuple[str, int | None]:
     return match.group("base"), int(match.group("number"))
 
 
+def next_free_name(requested: str, existing: set[str]) -> str:
+    """A name no timeline in the project answers to, following ``<base> v<N>``.
+
+    The project's own convention for a new cut made from an old one is the next version
+    number, so a collision walks that sequence rather than inventing a suffix of its own —
+    and an unversioned name starts the sequence at v2, which reads as what it is: the
+    second thing to carry that name.
+    """
+    if requested not in existing:
+        return requested
+    base, version = version_of(requested)
+    number = (version or 1) + 1
+    while f"{base} v{number}" in existing:
+        number += 1
+    return f"{base} v{number}"
+
+
 # --- shape ---------------------------------------------------------------------------------
 
 

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -82,7 +82,7 @@ class Placement(NamedTuple):
 # --- reaching a timeline ------------------------------------------------------------------
 
 
-def _project(connection: ResolveConnection) -> Project:
+def project_of(connection: ResolveConnection) -> Project:
     manager = connection.handle().GetProjectManager()
     project = manager.GetCurrentProject() if manager is not None else None
     if project is None:
@@ -112,7 +112,7 @@ def _timelines(project: Project) -> list[Timeline]:
     return found
 
 
-def _name(timeline: Timeline) -> str:
+def name_of(timeline: Timeline) -> str:
     return str(timeline.GetName() or "")
 
 
@@ -127,9 +127,20 @@ def find_timeline(project: Project, name: str | None) -> Timeline:
         return current
     held = _timelines(project)
     for timeline in held:
-        if _name(timeline) == name:
+        if name_of(timeline) == name:
             return timeline
-    raise TimelineNotFoundError(name, [_name(timeline) for timeline in held])
+    raise TimelineNotFoundError(name, [name_of(timeline) for timeline in held])
+
+
+def timeline_names(project: Project) -> list[str]:
+    """Every timeline name the project holds — what a new name must not collide with."""
+    return [name_of(timeline) for timeline in _timelines(project)]
+
+
+def current_name(project: Project) -> str | None:
+    """The open timeline's name, or ``None`` when the project has nothing open."""
+    current = project.GetCurrentTimeline()
+    return name_of(current) if current is not None else None
 
 
 def version_of(name: str) -> tuple[str, int | None]:
@@ -214,7 +225,7 @@ def summarise(
     current: str | None,
 ) -> dict[str, Any]:
     """The one-line view of a timeline that list and inspect both open with."""
-    name = _name(timeline)
+    name = name_of(timeline)
     base, version = version_of(name)
     fps = frame_rate(project, timeline)
     return {
@@ -237,20 +248,17 @@ def list_timelines(
     config: Config | None = None,
 ) -> dict[str, Any]:
     """Every timeline in the project with its version, duration and track stack."""
-    project = _project(connection)
+    project = project_of(connection)
     reader = Reader(connection)
-    current = project.GetCurrentTimeline()
-    current_name = _name(current) if current is not None else None
+    current = current_name(project)
 
-    timelines = [
-        summarise(reader, timeline, project, current_name) for timeline in _timelines(project)
-    ]
+    timelines = [summarise(reader, timeline, project, current) for timeline in _timelines(project)]
 
     cap = max(int(limit), 0)
     truncated = len(timelines) > cap
     result: dict[str, Any] = {
         "count": len(timelines),
-        "current": current_name,
+        "current": current,
         "timelines": timelines[:cap] if truncated else timelines,
         "latest_versions": _latest_versions(timelines),
         "truncated": truncated,
@@ -297,11 +305,11 @@ def inspect_timeline(
             detail={"requested": detail, "available": list(DETAIL_LEVELS)},
         )
 
-    project = _project(connection)
+    project = project_of(connection)
     reader = Reader(connection)
     timeline = find_timeline(project, name)
-    current = project.GetCurrentTimeline()
-    heading = summarise(reader, timeline, project, _name(current) if current is not None else None)
+    current = current_name(project)
+    heading = summarise(reader, timeline, project, current)
     fps = heading["fps"]
 
     window = _window(heading, start, end, fps)

--- a/src/resolve_mcp/tools/timeline.py
+++ b/src/resolve_mcp/tools/timeline.py
@@ -103,6 +103,11 @@ def import_timeline(
     to media; pass source_media_path when the media sits somewhere other than where the
     document says. The reply is the new timeline's heading — version, fps, bounds, track
     stack; inspect_timeline reads what is on it.
+
+    A .drt is Resolve's own document and accepts none of these: it names its own timeline
+    and carries its own media links, so name and source_media_path are refused for one
+    rather than quietly ignored, and requested_name comes back null. The result is still
+    checked against the timelines the project already had, so a .drt cannot land on one.
     """
     connection = get_connection()
     return interchange.import_timeline(

--- a/src/resolve_mcp/tools/timeline.py
+++ b/src/resolve_mcp/tools/timeline.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..resolve import interchange
 from ..resolve import timeline as timelines
 from ..resolve.connection import get_connection
 from .envelope import tool
@@ -62,9 +63,68 @@ def inspect_timeline(
     )
 
 
+@tool
+def export_timeline(
+    timeline: str | None = None,
+    format: str = interchange.DEFAULT_FORMAT,  # noqa: A002 - the agent-facing word
+    path: str | None = None,
+) -> dict[str, Any]:
+    """Write a timeline (the open one by default) out as otio, fcpxml or drt.
+
+    This is the structural escape hatch: the scripting API cannot cut a transition, so a
+    dissolve is made by exporting to otio, editing the transition into that document by
+    hand, and importing it back with import_timeline — which materialises it as a real
+    transition. Use fcpxml to hand the cut to another NLE, drt for a Resolve-native copy.
+
+    Without a path the file lands in the server's cache under a timestamped name, and path
+    holds where it went. An explicit path keeps its folder but gets the format's own
+    suffix. export_type names the Resolve export constant used — fcpxml is versioned and
+    the newest one this build offers is written.
+    """
+    connection = get_connection()
+    return interchange.export_timeline(connection, name=timeline, export_format=format, path=path)
+
+
+@tool
+def import_timeline(
+    path: str,
+    name: str | None = None,
+    import_source_clips: bool = True,
+    source_media_path: str | None = None,
+) -> dict[str, Any]:
+    """Materialise a *new* timeline from an otio, fcpxml or drt file. Nothing is overwritten.
+
+    The name defaults to the file's own stem; a name already in the project is never
+    reused — the import lands on the next free version of it ("sunset-set v3" becomes
+    "sunset-set v5" when v4 is taken), and the reply gives requested_name alongside the
+    timeline that was actually made, with renamed saying whether the two differ.
+
+    Source clips are imported by default, which is what an OTIO round trip needs to relink
+    to media; pass source_media_path when the media sits somewhere other than where the
+    document says. The reply is the new timeline's heading — version, fps, bounds, track
+    stack; inspect_timeline reads what is on it.
+    """
+    connection = get_connection()
+    return interchange.import_timeline(
+        connection,
+        path,
+        name=name,
+        import_source_clips=import_source_clips,
+        source_media_path=source_media_path,
+    )
+
+
 TOOLS: tuple[Any, ...] = (
     list_timelines,
     inspect_timeline,
+    export_timeline,
+    import_timeline,
 )
 
-__all__ = ["TOOLS", "inspect_timeline", "list_timelines"]
+__all__ = [
+    "TOOLS",
+    "export_timeline",
+    "import_timeline",
+    "inspect_timeline",
+    "list_timelines",
+]

--- a/src/resolve_mcp/tools/timeline.py
+++ b/src/resolve_mcp/tools/timeline.py
@@ -89,7 +89,7 @@ def export_timeline(
 def import_timeline(
     path: str,
     name: str | None = None,
-    import_source_clips: bool = True,
+    import_source_clips: bool | None = None,
     source_media_path: str | None = None,
 ) -> dict[str, Any]:
     """Materialise a *new* timeline from an otio, fcpxml or drt file. Nothing is overwritten.
@@ -99,15 +99,16 @@ def import_timeline(
     "sunset-set v5" when v4 is taken), and the reply gives requested_name alongside the
     timeline that was actually made, with renamed saying whether the two differ.
 
-    Source clips are imported by default, which is what an OTIO round trip needs to relink
-    to media; pass source_media_path when the media sits somewhere other than where the
-    document says. The reply is the new timeline's heading — version, fps, bounds, track
-    stack; inspect_timeline reads what is on it.
+    Source clips are imported unless import_source_clips is false, which is what an OTIO
+    round trip needs to relink to media; pass source_media_path when the media sits
+    somewhere other than where the document says. The reply is the new timeline's heading —
+    version, fps, bounds, track stack; inspect_timeline reads what is on it.
 
     A .drt is Resolve's own document and accepts none of these: it names its own timeline
-    and carries its own media links, so name and source_media_path are refused for one
-    rather than quietly ignored, and requested_name comes back null. The result is still
-    checked against the timelines the project already had, so a .drt cannot land on one.
+    and carries its own media links, so name, import_source_clips and source_media_path are
+    refused for one rather than quietly ignored, and requested_name comes back null. The
+    result is still checked against the timelines the project already had, so an import
+    that came back as an existing cut is reported as a failure, never as a new timeline.
     """
     connection = get_connection()
     return interchange.import_timeline(

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -179,6 +179,9 @@ class FakeTimeline:
         }
         self._markers = markers or {}
         self._owner = owner
+        self.exports: list[tuple[str, Any, tuple[Any, ...]]] = []
+        self.export_result = True
+        self.export_writes_the_file = True
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
@@ -256,6 +259,22 @@ class FakeTimeline:
     def GetMarkers(self) -> dict[float, dict[str, Any]]:  # noqa: N802
         self._check()
         return dict(self._markers)
+
+    def Export(self, file_name: str, export_type: Any, *subtype: Any) -> bool:  # noqa: N802
+        """Write an interchange file. The subtype is variadic because Resolve's is optional.
+
+        ``export_writes_the_file=False`` models the failure the return value hides: Resolve
+        answers True and nothing lands on disk.
+        """
+        self._check()
+        self.exports.append((file_name, export_type, subtype))
+        if not self.export_result:
+            return False
+        if self.export_writes_the_file:
+            target = Path(file_name)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(f"fake-export of {self._name}", encoding="utf-8")
+        return True
 
 
 IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"}
@@ -384,6 +403,9 @@ class FakeMediaPool:
         self.relink_result: bool | None = None
         self.move_result = True
         self.calls: list[str] = []
+        self.timeline_imports: list[tuple[str, dict[str, Any]]] = []
+        self.imported_timeline: FakeTimeline | None = None
+        self.refuses_timeline_import = False
 
     def _check(self, method: str) -> None:
         self.calls.append(method)
@@ -451,6 +473,37 @@ class FakeMediaPool:
             self._current.clips.append(clip)
             imported.append(clip)
         return imported
+
+    def ImportTimelineFromFile(  # noqa: N802
+        self,
+        file_path: str,
+        options: dict[str, Any] | None = None,
+    ) -> FakeTimeline | None:
+        """Materialise a timeline from an interchange file, as the real pool does.
+
+        The filesystem is consulted for the same reason ``ImportMedia`` consults it: a path
+        Resolve cannot read imports nothing and says so only by returning ``None``.
+        ``imported_timeline`` overrides the result — set it to a timeline the project
+        already holds to model the one outcome this must never be mistaken for, an import
+        that landed on an existing cut.
+        """
+        self._check("ImportTimelineFromFile")
+        asked = dict(options or {})
+        self.timeline_imports.append((file_path, asked))
+        if self.refuses_timeline_import or not Path(file_path).exists():
+            return None
+        if self.imported_timeline is not None:
+            return self.imported_timeline
+        timeline = FakeTimeline(
+            str(asked.get("timelineName") or Path(file_path).stem),
+            video=[[FakeTimelineItem("C0012.mp4", 0, 60, source_start=1000)]],
+        )
+        if self._owner is not None:
+            timeline.adopt(self._owner)
+            project = self._owner.current_project
+            if project is not None:
+                project.add_timeline(timeline)
+        return timeline
 
     def RelinkClips(  # noqa: N802
         self,
@@ -560,6 +613,10 @@ class FakeProject:
     def GetMediaPool(self) -> FakeMediaPool | None:  # noqa: N802
         return self._media_pool
 
+    def add_timeline(self, timeline: FakeTimeline) -> None:
+        """What an import does to a project: one more timeline, nothing else touched."""
+        self._timelines.append(timeline)
+
 
 class FakeProjectManager:
     def __init__(self, owner: FakeResolve) -> None:
@@ -605,6 +662,25 @@ class FakeProjectManager:
         return self.export_result
 
 
+EXPORT_TYPES: tuple[str, ...] = (
+    # First in the tuple, so its value is 0 — the export constants are plain numbers and
+    # one of them is falsy, which is the trap a "constant or default" lookup falls into.
+    "EXPORT_AAF",
+    "EXPORT_DRT",
+    "EXPORT_EDL",
+    "EXPORT_FCP_7_XML",
+    "EXPORT_FCPXML_1_3",
+    "EXPORT_FCPXML_1_4",
+    "EXPORT_FCPXML_1_5",
+    "EXPORT_FCPXML_1_6",
+    "EXPORT_FCPXML_1_7",
+    "EXPORT_FCPXML_1_8",
+    "EXPORT_FCPXML_1_9",
+    "EXPORT_FCPXML_1_10",
+    "EXPORT_OTIO",
+)
+
+
 class FakeResolve:
     """A stand-in for the object ``scriptapp("Resolve")`` returns."""
 
@@ -613,10 +689,16 @@ class FakeResolve:
         projects: dict[str, FakeProject] | None = None,
         current: str | None = None,
         version: list[Any] | None = None,
+        export_types: Sequence[str] | None = None,
     ) -> None:
         self.projects: dict[str, FakeProject] = projects or {}
         self.current_project: FakeProject | None = self.projects.get(current or "")
         self.version = version or [21, 0, 3, 15, ""]
+        # Export types are attributes on the app object itself, and an older build simply
+        # does not have the newer ones — so a narrowed tuple models that build exactly.
+        self.export_types = tuple(EXPORT_TYPES if export_types is None else export_types)
+        for value, export_type in enumerate(self.export_types):
+            setattr(self, export_type, value)
         self.alive = True
         self.probe_count = 0
         self.fail_version_string = False
@@ -726,6 +808,7 @@ def studio(
     extra_projects: tuple[str, ...] = ("holiday-gig",),
     pool: FakeMediaPool | None = None,
     timelines: list[FakeTimeline | None] | None = None,
+    export_types: Sequence[str] | None = None,
 ) -> FakeResolve:
     """A conventional fake: Studio running, one project open, one timeline current.
 
@@ -751,7 +834,7 @@ def studio(
             media_pool=pool,
             timelines=timelines,
         )
-    resolve = FakeResolve(projects, current=project)
+    resolve = FakeResolve(projects, current=project, export_types=export_types)
     if pool is not None:
         pool.adopt(resolve)
     owned = [one for one in (timelines or []) if one is not None]

--- a/tests/otio.py
+++ b/tests/otio.py
@@ -1,0 +1,138 @@
+"""Hand-editing an exported OTIO document — the route around the no-transitions wall.
+
+The scripting API cannot cut a dissolve, so a transition is made by editing one into an
+exported OTIO document and importing that back. The spec calls that edit hand-made and the
+tool catalog has no injection tool, so this lives in the test support rather than in the
+server: the live tier uses it to take the whole round trip in one command, and the fake
+tier checks the document it produces without Resolve.
+
+An OTIO transition is not an item with a duration of its own — it sits *between* two items
+in a track's children and reaches ``in_offset`` frames back into the one before and
+``out_offset`` frames into the one after. Both neighbours therefore have to be long enough
+to give those frames up, which is what the length checks here are for.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+Document = dict[str, Any]
+Track = dict[str, Any]
+Item = dict[str, Any]
+
+DISSOLVE = "SMPTE_Dissolve"
+DEFAULT_RATE = 24.0
+
+
+def video_tracks(document: Document) -> list[Track]:
+    """The document's video tracks, in order — where a cut's transitions belong."""
+    stack = document.get("tracks") or {}
+    children = stack.get("children") or []
+    return [track for track in children if track.get("kind") == "Video"]
+
+
+def children_of(track: Track) -> list[Item]:
+    return list(track.get("children") or [])
+
+
+def is_clip(item: Item) -> bool:
+    return str(item.get("OTIO_SCHEMA", "")).startswith("Clip.")
+
+
+def is_gap(item: Item) -> bool:
+    return str(item.get("OTIO_SCHEMA", "")).startswith("Gap.")
+
+
+def is_transition(item: Item) -> bool:
+    return str(item.get("OTIO_SCHEMA", "")).startswith("Transition.")
+
+
+def inject_dissolve(track: Track, frames: int = 6) -> bool:
+    """Put a dissolve on the first cut between two clips that can carry it.
+
+    Returns whether one was injected — a track of one clip, or of clips too short to hand
+    over ``frames`` on each side, is left alone rather than given a transition that reaches
+    past the media it dissolves.
+    """
+    children = children_of(track)
+    for index in range(len(children) - 1):
+        before, after = children[index], children[index + 1]
+        if not (is_clip(before) and is_clip(after)):
+            continue
+        if _frames(before) <= frames or _frames(after) <= frames:
+            continue
+        children.insert(index + 1, _transition("Cross Dissolve", _rate(before), frames))
+        track["children"] = children
+        return True
+    return False
+
+
+def inject_fade_to_black(track: Track, frames: int = 6) -> bool:
+    """Put a transition at a clip↔gap boundary — the spec's open verification note.
+
+    A fade to black is a dissolve into nothing, so the boundary needs a gap on one side. An
+    existing clip→gap boundary is used where there is one; otherwise a gap is appended
+    after the last clip, which is where a fade to black belongs anyway.
+    """
+    children = children_of(track)
+    for index in range(len(children) - 1):
+        before, after = children[index], children[index + 1]
+        if is_clip(before) and is_gap(after) and _frames(before) > frames:
+            children.insert(index + 1, _transition("Fade to Black", _rate(before), frames))
+            track["children"] = children
+            return True
+
+    last = children[-1] if children else None
+    if last is None or not is_clip(last) or _frames(last) <= frames:
+        return False
+    rate = _rate(last)
+    children.append(_transition("Fade to Black", rate, frames))
+    children.append(_gap(rate, frames * 4))
+    track["children"] = children
+    return True
+
+
+def _transition(name: str, rate: float, frames: int) -> Item:
+    return {
+        "OTIO_SCHEMA": "Transition.1",
+        "name": name,
+        "metadata": {},
+        "transition_type": DISSOLVE,
+        "in_offset": _rational(rate, frames),
+        "out_offset": _rational(rate, frames),
+    }
+
+
+def _gap(rate: float, frames: int) -> Item:
+    return {
+        "OTIO_SCHEMA": "Gap.1",
+        "name": "gap",
+        "metadata": {},
+        "effects": [],
+        "markers": [],
+        "source_range": {
+            "OTIO_SCHEMA": "TimeRange.1",
+            "start_time": _rational(rate, 0),
+            "duration": _rational(rate, frames),
+        },
+    }
+
+
+def _rational(rate: float, value: int) -> dict[str, Any]:
+    return {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": value}
+
+
+def _rate(item: Item) -> float:
+    duration = ((item.get("source_range") or {}).get("duration")) or {}
+    try:
+        return float(duration.get("rate") or DEFAULT_RATE)
+    except (TypeError, ValueError):
+        return DEFAULT_RATE
+
+
+def _frames(item: Item) -> int:
+    duration = ((item.get("source_range") or {}).get("duration")) or {}
+    try:
+        return int(float(duration.get("value") or 0))
+    except (TypeError, ValueError):
+        return 0

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -11,14 +11,24 @@ place the direct-attach path itself is exercised.
 
 from __future__ import annotations
 
+import json
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from resolve_mcp.tools.escape_hatch import run_python
 from resolve_mcp.tools.media import inspect_clip, list_media
 from resolve_mcp.tools.project import get_status, list_projects, snapshot_project
-from resolve_mcp.tools.timeline import inspect_timeline, list_timelines
+from resolve_mcp.tools.timeline import (
+    export_timeline,
+    import_timeline,
+    inspect_timeline,
+    list_timelines,
+)
+
+from . import otio
 
 pytestmark = pytest.mark.live
 
@@ -130,6 +140,102 @@ def test_the_frame_math_holds_on_a_real_timeline() -> None:
                     item["sync_offset"]["frames"]
                     == record["in"]["frames"] - item["source"]["in"]["frames"]
                 )
+
+
+# --- interchange ---------------------------------------------------------------------------
+#
+# These two import timelines into the open project, so they leave "resolve-mcp smoke …"
+# timelines behind — delete them after the run. Take a snapshot_project first if the open
+# project is one you care about.
+
+
+def _shape(name: str | None = None) -> dict[str, Any]:
+    """The structure a round trip has to preserve: tracks, and the shots on each."""
+    reading = inspect_timeline(timeline=name, detail="clips")
+    assert reading["ok"] is True, reading.get("error")
+    assert reading["truncated"] is False, "the timeline is too long to compare in one read"
+    return {
+        "duration": reading["timeline"]["duration"]["frames"],
+        "tracks": {
+            f"{track['type']}{track['index']}": [
+                (item["record"]["in"]["frames"], item["record"]["duration"]["frames"])
+                for item in track["items"]
+            ]
+            for track in reading["tracks"]
+        },
+    }
+
+
+def _smoke_name(what: str) -> str:
+    return f"resolve-mcp smoke {what} {datetime.now().strftime('%H%M%S')}"
+
+
+def test_an_otio_round_trip_preserves_the_timeline_structure(tmp_path: Path) -> None:
+    """AC: export to OTIO, import it back, and the cut is the same cut.
+
+    The fakes prove the naming and the error shaping; only Resolve proves that what it
+    wrote is what it reads back, which is the whole basis of the transition route.
+    """
+    if get_status()["context"]["timeline"] is None:
+        pytest.skip("No timeline open in Resolve")
+    before = _shape()
+
+    exported = export_timeline(path=str(tmp_path / "round-trip.otio"))
+    assert exported["ok"] is True, exported.get("error")
+    assert exported["export_type"] == "EXPORT_OTIO"
+
+    imported = import_timeline(exported["path"], name=_smoke_name("round-trip"))
+    assert imported["ok"] is True, imported.get("error")
+
+    after = _shape(imported["timeline"]["name"])
+    assert after["duration"] == before["duration"]
+    for track, shots in before["tracks"].items():
+        assert after["tracks"].get(track) == shots, f"{track} came back differently"
+
+
+def test_a_hand_injected_dissolve_imports_as_a_transition(tmp_path: Path) -> None:
+    """AC: a dissolve edited into an exported OTIO comes back as a real transition.
+
+    Transitions are the wall this route exists to get around, and the scripting API has no
+    getter for them — so what is asserted here is that Resolve accepted the edited document
+    and rebuilt the cut from it. **The dissolve and the fade to black themselves are
+    confirmed by eye in the Resolve GUI on the imported timeline**, and the result goes on
+    the ticket; a run that stops at green here has verified half the AC.
+    """
+    if get_status()["context"]["timeline"] is None:
+        pytest.skip("No timeline open in Resolve")
+
+    exported = export_timeline(path=str(tmp_path / "injected.otio"))
+    assert exported["ok"] is True, exported.get("error")
+    document = json.loads(Path(exported["path"]).read_text(encoding="utf-8"))
+
+    tracks = otio.video_tracks(document)
+    if not tracks:
+        pytest.skip("The open timeline has no video track to inject into")
+    dissolved = any(otio.inject_dissolve(track, frames=6) for track in tracks)
+    faded = otio.inject_fade_to_black(tracks[0], frames=6)
+    if not dissolved:
+        pytest.skip("No cut between two clips long enough to carry a dissolve")
+    Path(exported["path"]).write_text(json.dumps(document, indent=2), encoding="utf-8")
+
+    imported = import_timeline(exported["path"], name=_smoke_name("dissolve"))
+
+    assert imported["ok"] is True, imported.get("error")
+    assert faded, "the fade-to-black half of the AC was not injected — check by eye anyway"
+    landed = _shape(imported["timeline"]["name"])
+    assert landed["tracks"], "the injected document imported as an empty timeline"
+
+
+def test_the_interchange_formats_all_write_a_file(tmp_path: Path) -> None:
+    """AC: export to OTIO, FCPXML and DRT. Read-only — nothing is imported back."""
+    if get_status()["context"]["timeline"] is None:
+        pytest.skip("No timeline open in Resolve")
+
+    for export_format in ("otio", "fcpxml", "drt"):
+        result = export_timeline(format=export_format, path=str(tmp_path / "export"))
+
+        assert result["ok"] is True, result.get("error")
+        assert Path(result["path"]).stat().st_size == result["bytes"] > 0
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -31,6 +31,8 @@ def test_registers_the_p1_session_media_and_timeline_tools() -> None:
         "relink_media",
         "list_timelines",
         "inspect_timeline",
+        "export_timeline",
+        "import_timeline",
         "run_python",
     }
 

--- a/tests/test_timeline_interchange.py
+++ b/tests/test_timeline_interchange.py
@@ -1,0 +1,455 @@
+"""Timeline interchange: export a cut to a file, import a file as a *new* cut.
+
+Round-trip fidelity is a live question — only Resolve can say whether the OTIO it wrote
+comes back as the same cut. What verifies here is every decision around that: which export
+constant a format maps to on this build, where the file lands, and the rule that an import
+never lands on a timeline the project already has.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.config import Config, set_config
+from resolve_mcp.tools.timeline import export_timeline, import_timeline
+
+from . import otio
+from .conftest import Attach
+from .fakes import (
+    FakeTimeline,
+    FakeTimelineItem,
+    FakeTrack,
+    media_pool,
+    studio,
+)
+
+
+def a_cut(name: str = "sunset-set v3", fps: str = "59.94") -> FakeTimeline:
+    return FakeTimeline(
+        name,
+        fps,
+        video=[FakeTrack("Video 1", [FakeTimelineItem("C0012.mp4", 0, 60, source_start=1000)])],
+        audio=[FakeTrack("Master", [FakeTimelineItem("master_mix.wav", 0, 60)])],
+    )
+
+
+def an_interchange_file(tmp_path: Path, name: str = "sunset-set v3.otio") -> Path:
+    target = tmp_path / name
+    target.write_text('{"OTIO_SCHEMA": "Timeline.1"}', encoding="utf-8")
+    return target
+
+
+# --- export ------------------------------------------------------------------------------
+
+
+def test_export_writes_the_open_timeline_and_names_the_type_it_used(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    cut = a_cut()
+    fake = studio(timeline=cut)
+    attach(fake)
+    set_config(Config.from_env({"RESOLVE_MCP_CACHE": str(tmp_path / "cache")}))
+
+    result = export_timeline()
+
+    assert result["ok"] is True
+    assert result["timeline"] == "sunset-set v3"
+    assert result["format"] == "otio"
+    assert result["export_type"] == "EXPORT_OTIO"
+    written = Path(result["path"])
+    assert written.parent == tmp_path / "cache" / "interchange"
+    assert written.suffix == ".otio"
+    assert "sunset-set" in written.name
+    assert written.exists()
+    assert result["bytes"] > 0
+    assert cut.exports[0][0] == str(written)
+    assert cut.exports[0][1] == fake.EXPORT_OTIO  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    ("export_format", "suffix", "export_type"),
+    [
+        ("otio", ".otio", "EXPORT_OTIO"),
+        ("fcpxml", ".fcpxml", "EXPORT_FCPXML_1_10"),
+        ("drt", ".drt", "EXPORT_DRT"),
+    ],
+)
+def test_export_maps_each_format_to_its_resolve_type(
+    attach: Attach,
+    export_format: str,
+    suffix: str,
+    export_type: str,
+) -> None:
+    cut = a_cut()
+    attach(studio(timeline=cut))
+
+    result = export_timeline(format=export_format)
+
+    assert result["ok"] is True
+    assert result["export_type"] == export_type
+    assert Path(result["path"]).suffix == suffix
+
+
+def test_export_falls_back_to_the_newest_fcpxml_this_build_has(attach: Attach) -> None:
+    """FCPXML is versioned and Resolve gained versions over time.
+
+    The newest one this build offers is the one to write; an older build must export rather
+    than fail on a constant it never had.
+    """
+    attach(studio(timeline=a_cut(), export_types=("EXPORT_DRT", "EXPORT_FCPXML_1_8")))
+
+    result = export_timeline(format="fcpxml")
+
+    assert result["ok"] is True
+    assert result["export_type"] == "EXPORT_FCPXML_1_8"
+
+
+def test_export_uses_a_type_whose_value_is_zero(attach: Attach) -> None:
+    """The constants are plain numbers, and the first of them is 0.
+
+    A lookup that treated a falsy constant as "this build does not have it" would refuse the
+    one format the build does support.
+    """
+    fake = studio(timeline=a_cut(), export_types=("EXPORT_OTIO",))
+    attach(fake)
+
+    result = export_timeline(format="otio")
+
+    assert result["ok"] is True
+    assert fake.EXPORT_OTIO == 0  # type: ignore[attr-defined]
+
+
+def test_export_says_which_types_it_looked_for_when_the_build_has_none(attach: Attach) -> None:
+    attach(studio(timeline=a_cut(), export_types=("EXPORT_OTIO", "EXPORT_DRT")))
+
+    result = export_timeline(format="fcpxml")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_export_failed"
+    assert result["error"]["detail"]["tried"][0] == "EXPORT_FCPXML_1_10"
+    assert result["error"]["fix"]
+
+
+def test_export_rejects_a_format_it_does_not_know(attach: Attach) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = export_timeline(format="edl")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert result["error"]["detail"]["available"] == ["otio", "fcpxml", "drt"]
+
+
+def test_export_takes_a_named_timeline_and_says_when_it_is_not_there(attach: Attach) -> None:
+    reference = FakeTimeline("sunset-set sync")
+    attach(studio(timelines=[reference, a_cut()], timeline=a_cut()))
+
+    found = export_timeline(timeline="sunset-set sync")
+    missing = export_timeline(timeline="sunset-set v9")
+
+    assert found["ok"] is True
+    assert found["timeline"] == "sunset-set sync"
+    assert missing["ok"] is False
+    assert missing["error"]["code"] == "timeline_not_found"
+
+
+def test_export_honours_an_explicit_path_and_corrects_the_suffix(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    attach(studio(timeline=a_cut()))
+    asked = tmp_path / "handoff" / "for-the-editor.xml"
+
+    result = export_timeline(format="fcpxml", path=str(asked))
+
+    assert result["ok"] is True
+    assert Path(result["path"]) == asked.with_suffix(".fcpxml")
+    assert Path(result["path"]).exists()
+
+
+def test_export_reports_a_refusal_from_resolve(attach: Attach) -> None:
+    cut = a_cut()
+    cut.export_result = False
+    attach(studio(timeline=cut))
+
+    result = export_timeline()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_export_failed"
+    assert result["error"]["fix"]
+
+
+def test_export_does_not_report_a_file_that_was_never_written(attach: Attach) -> None:
+    """Resolve can answer True and write nothing — a path in the reply would be a lie."""
+    cut = a_cut()
+    cut.export_writes_the_file = False
+    attach(studio(timeline=cut))
+
+    result = export_timeline()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_export_failed"
+    assert "wrote" in result["error"]["cause"]
+
+
+def test_export_needs_a_project(attach: Attach) -> None:
+    attach(studio(project=None))
+
+    result = export_timeline()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "no_project_open"
+
+
+# --- import ------------------------------------------------------------------------------
+
+
+def test_import_materialises_a_new_timeline(attach: Attach, tmp_path: Path) -> None:
+    pool = media_pool()
+    project_timelines: list[FakeTimeline | None] = [a_cut()]
+    attach(studio(pool=pool, timelines=project_timelines, timeline=project_timelines[0]))
+    source = an_interchange_file(tmp_path, "encore.otio")
+
+    result = import_timeline(str(source))
+
+    assert result["ok"] is True
+    assert result["timeline"]["name"] == "encore"
+    assert result["requested_name"] == "encore"
+    assert result["renamed"] is False
+    assert result["path"] == str(source)
+    assert result["timeline"]["tracks"]["video"] == 1
+    assert pool.timeline_imports[0][0] == str(source)
+
+
+def test_import_never_lands_on_a_timeline_the_project_already_has(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """The name is made free *before* the call, not repaired afterwards.
+
+    Nothing on record says what Resolve does with a colliding timelineName, and the one
+    outcome that cannot be undone is it landing on the cut that is already there — so the
+    name handed over is one no existing timeline answers to.
+    """
+    pool = media_pool()
+    existing: list[FakeTimeline | None] = [a_cut("sunset-set v3"), a_cut("sunset-set v4")]
+    attach(studio(pool=pool, timelines=existing, timeline=existing[0]))
+    source = an_interchange_file(tmp_path, "sunset-set v3.otio")
+
+    result = import_timeline(str(source))
+
+    assert result["ok"] is True
+    assert result["requested_name"] == "sunset-set v3"
+    assert result["renamed"] is True
+    assert result["timeline"]["name"] == "sunset-set v5"
+    assert pool.timeline_imports[0][1]["timelineName"] == "sunset-set v5"
+
+
+def test_import_versions_an_unversioned_name_that_collides(attach: Attach, tmp_path: Path) -> None:
+    pool = media_pool()
+    existing: list[FakeTimeline | None] = [FakeTimeline("sunset-set sync")]
+    attach(studio(pool=pool, timelines=existing, timeline=existing[0]))
+    source = an_interchange_file(tmp_path, "sunset-set sync.otio")
+
+    result = import_timeline(str(source))
+
+    assert result["ok"] is True
+    assert result["timeline"]["name"] == "sunset-set sync v2"
+
+
+def test_import_refuses_a_result_that_is_an_existing_timeline(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """The AC as a runtime check: if Resolve hands back the old cut, that is not an import."""
+    pool = media_pool()
+    cut = a_cut("sunset-set v3")
+    attach(studio(pool=pool, timelines=[cut], timeline=cut))
+    pool.imported_timeline = cut
+    source = an_interchange_file(tmp_path)
+
+    result = import_timeline(str(source), name="encore")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_import_failed"
+    assert "sunset-set v3" in result["error"]["cause"]
+
+
+def test_import_reports_a_file_that_is_not_there(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=media_pool(), timelines=[a_cut()]))
+
+    result = import_timeline(str(tmp_path / "nothing-here.otio"))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert "nothing-here.otio" in result["error"]["cause"]
+
+
+def test_import_reports_a_refusal_from_resolve(attach: Attach, tmp_path: Path) -> None:
+    pool = media_pool()
+    attach(studio(pool=pool, timelines=[a_cut()]))
+    pool.refuses_timeline_import = True
+
+    result = import_timeline(str(an_interchange_file(tmp_path)))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_import_failed"
+    assert result["error"]["fix"]
+
+
+def test_import_passes_the_media_options_through(attach: Attach, tmp_path: Path) -> None:
+    pool = media_pool()
+    attach(studio(pool=pool, timelines=[a_cut()]))
+    source = an_interchange_file(tmp_path)
+
+    result = import_timeline(
+        str(source),
+        name="encore v1",
+        import_source_clips=False,
+        source_media_path=str(tmp_path / "media"),
+    )
+
+    assert result["ok"] is True
+    asked = pool.timeline_imports[0][1]
+    assert asked["timelineName"] == "encore v1"
+    assert asked["importSourceClips"] is False
+    assert asked["sourceClipsPath"] == str(tmp_path / "media")
+
+
+def test_import_leaves_source_clips_on_by_default(attach: Attach, tmp_path: Path) -> None:
+    """An OTIO round trip that skipped its media would materialise a cut of nothing."""
+    pool = media_pool()
+    attach(studio(pool=pool, timelines=[a_cut()]))
+
+    import_timeline(str(an_interchange_file(tmp_path)))
+
+    asked = pool.timeline_imports[0][1]
+    assert asked["importSourceClips"] is True
+    assert "sourceClipsPath" not in asked
+
+
+def test_import_needs_a_project(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(project=None))
+
+    result = import_timeline(str(an_interchange_file(tmp_path)))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "no_project_open"
+
+
+# --- the hand-injected transition ----------------------------------------------------------
+#
+# What the live tier carries into Resolve. Whether Resolve reads these back as real
+# dissolves is the live question; whether the document says what it means to say is this
+# one, and it is the half that would otherwise be debugged by eye at the Resolve machine.
+
+
+def a_document(*durations: int, rate: float = 24.0) -> dict[str, Any]:
+    """An OTIO timeline of one video track holding clips of the given lengths."""
+    return {
+        "OTIO_SCHEMA": "Timeline.1",
+        "name": "sunset-set v3",
+        "tracks": {
+            "OTIO_SCHEMA": "Stack.1",
+            "children": [
+                {
+                    "OTIO_SCHEMA": "Track.1",
+                    "kind": "Video",
+                    "children": [
+                        a_clip(f"C{index:04d}.mp4", frames, rate)
+                        for index, frames in enumerate(durations)
+                    ],
+                },
+                {"OTIO_SCHEMA": "Track.1", "kind": "Audio", "children": []},
+            ],
+        },
+    }
+
+
+def a_clip(name: str, frames: int, rate: float = 24.0) -> dict[str, Any]:
+    return {
+        "OTIO_SCHEMA": "Clip.1",
+        "name": name,
+        "source_range": {
+            "OTIO_SCHEMA": "TimeRange.1",
+            "start_time": {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": 0},
+            "duration": {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": frames},
+        },
+    }
+
+
+def a_gap(frames: int, rate: float = 24.0) -> dict[str, Any]:
+    return {
+        "OTIO_SCHEMA": "Gap.1",
+        "name": "gap",
+        "source_range": {
+            "OTIO_SCHEMA": "TimeRange.1",
+            "start_time": {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": 0},
+            "duration": {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": frames},
+        },
+    }
+
+
+def test_a_dissolve_lands_between_the_two_clips_it_joins() -> None:
+    document = a_document(60, 90, rate=59.94)
+    track = otio.video_tracks(document)[0]
+
+    assert otio.inject_dissolve(track, frames=12) is True
+
+    children = otio.children_of(track)
+    assert [child["OTIO_SCHEMA"] for child in children] == ["Clip.1", "Transition.1", "Clip.1"]
+    transition = children[1]
+    assert transition["transition_type"] == otio.DISSOLVE
+    assert transition["in_offset"] == {"OTIO_SCHEMA": "RationalTime.1", "rate": 59.94, "value": 12}
+    assert transition["out_offset"] == transition["in_offset"]
+
+
+def test_a_dissolve_is_not_cut_into_clips_too_short_to_carry_it() -> None:
+    """A transition reaches into both neighbours; one that reaches past them is not a cut."""
+    track = otio.video_tracks(a_document(4, 4))[0]
+
+    assert otio.inject_dissolve(track, frames=6) is False
+    assert len(otio.children_of(track)) == 2
+
+
+def test_a_dissolve_needs_two_clips() -> None:
+    track = otio.video_tracks(a_document(60))[0]
+
+    assert otio.inject_dissolve(track) is False
+
+
+def test_a_fade_to_black_uses_a_gap_the_cut_already_has() -> None:
+    document = a_document(60, 60)
+    track = otio.video_tracks(document)[0]
+    track["children"].insert(1, a_gap(24))
+
+    assert otio.inject_fade_to_black(track, frames=6) is True
+
+    children = otio.children_of(track)
+    assert [child["OTIO_SCHEMA"] for child in children] == [
+        "Clip.1",
+        "Transition.1",
+        "Gap.1",
+        "Clip.1",
+    ]
+
+
+def test_a_fade_to_black_makes_the_gap_when_the_cut_ends_on_a_clip() -> None:
+    """The end of the cut is a clip↔gap boundary once there is a gap to fade into."""
+    track = otio.video_tracks(a_document(60, 60))[0]
+
+    assert otio.inject_fade_to_black(track, frames=6) is True
+
+    children = otio.children_of(track)
+    assert [child["OTIO_SCHEMA"] for child in children[-3:]] == ["Clip.1", "Transition.1", "Gap.1"]
+    assert children[-1]["source_range"]["duration"]["value"] == 24
+
+
+def test_an_empty_track_gets_no_fade() -> None:
+    track = otio.video_tracks(a_document())[0]
+
+    assert otio.inject_fade_to_black(track) is False

--- a/tests/test_timeline_interchange.py
+++ b/tests/test_timeline_interchange.py
@@ -43,6 +43,11 @@ def an_interchange_file(tmp_path: Path, name: str = "sunset-set v3.otio") -> Pat
     return target
 
 
+def test_every_format_answers_to_the_name_it_is_filed_under() -> None:
+    """The key is in the reply and in every error detail, so the two must not drift."""
+    assert all(key == spec.key for key, spec in interchange.FORMATS.items())
+
+
 # --- export ------------------------------------------------------------------------------
 
 
@@ -280,6 +285,7 @@ def test_import_refuses_a_result_that_is_an_existing_timeline(
     assert result["ok"] is False
     assert result["error"]["code"] == "timeline_import_failed"
     assert "sunset-set v3" in result["error"]["cause"]
+    assert "asked for 'encore'" in result["error"]["fix"]
 
 
 def test_import_reports_a_file_that_is_not_there(attach: Attach, tmp_path: Path) -> None:
@@ -360,18 +366,27 @@ def test_a_drt_is_sent_no_options_because_resolve_honours_none(
     assert result["timeline"]["name"] == "encore"
 
 
-def test_a_drt_refuses_the_options_it_cannot_honour(attach: Attach, tmp_path: Path) -> None:
-    """Told, not quietly ignored: a reply naming a timeline the caller did not ask for
-    reads as a rename, and the caller would carry on believing the name was theirs."""
+def test_a_drt_refuses_every_option_it_cannot_honour(attach: Attach, tmp_path: Path) -> None:
+    """Told, not quietly ignored: a request that was made and dropped leaves the caller
+    believing it took, and the reply gives them no reason to look."""
     pool = media_pool()
     attach(studio(pool=pool, timelines=[a_cut()]))
     source = an_interchange_file(tmp_path, "encore.drt")
 
-    result = import_timeline(str(source), name="my cut", source_media_path=str(tmp_path))
+    result = import_timeline(
+        str(source),
+        name="my cut",
+        import_source_clips=False,
+        source_media_path=str(tmp_path),
+    )
 
     assert result["ok"] is False
     assert result["error"]["code"] == "invalid_request"
-    assert result["error"]["detail"]["ignored"] == ["name", "source_media_path"]
+    assert result["error"]["detail"]["ignored"] == [
+        "name",
+        "import_source_clips",
+        "source_media_path",
+    ]
     assert pool.timeline_imports == []
 
 
@@ -390,6 +405,9 @@ def test_a_drt_import_that_lands_on_an_existing_cut_is_a_failure(
     assert result["ok"] is False
     assert result["error"]["code"] == "timeline_import_failed"
     assert "sunset-set v3" in result["error"]["cause"]
+    # Route-specific: on this one Resolve chose the name, so both outcomes are open and the
+    # fix must not claim the import was a no-op the way the .otio route's can.
+    assert ".drt names its own timeline" in result["error"]["fix"]
 
 
 def test_import_needs_a_project(attach: Attach, tmp_path: Path) -> None:

--- a/tests/test_timeline_interchange.py
+++ b/tests/test_timeline_interchange.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 
 from resolve_mcp.config import Config, set_config
+from resolve_mcp.resolve import interchange
 from resolve_mcp.tools.timeline import export_timeline, import_timeline
 
 from . import otio
@@ -130,7 +131,9 @@ def test_export_says_which_types_it_looked_for_when_the_build_has_none(attach: A
 
     assert result["ok"] is False
     assert result["error"]["code"] == "timeline_export_failed"
-    assert result["error"]["detail"]["tried"][0] == "EXPORT_FCPXML_1_10"
+    # The whole ladder, so the reply says what was looked for rather than only that
+    # something was missing — the version names are the thing a Resolve upgrade changes.
+    assert result["error"]["detail"]["tried"] == list(interchange.FORMATS["fcpxml"].export_types)
     assert result["error"]["fix"]
 
 
@@ -330,6 +333,63 @@ def test_import_leaves_source_clips_on_by_default(attach: Attach, tmp_path: Path
     asked = pool.timeline_imports[0][1]
     assert asked["importSourceClips"] is True
     assert "sourceClipsPath" not in asked
+
+
+# --- import: the .drt route ----------------------------------------------------------------
+#
+# Resolve's own document takes none of the import options — not the name, not the source
+# clip handling. So the collision-free name this server computes is inert on that route,
+# and what holds the never-overwrite guarantee is the check on the way out.
+
+
+def test_a_drt_is_sent_no_options_because_resolve_honours_none(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    pool = media_pool()
+    existing: list[FakeTimeline | None] = [a_cut("sunset-set v3")]
+    attach(studio(pool=pool, timelines=existing, timeline=existing[0]))
+    source = an_interchange_file(tmp_path, "encore.drt")
+
+    result = import_timeline(str(source))
+
+    assert result["ok"] is True
+    assert pool.timeline_imports[0][1] == {}
+    assert result["requested_name"] is None
+    assert result["renamed"] is False
+    assert result["timeline"]["name"] == "encore"
+
+
+def test_a_drt_refuses_the_options_it_cannot_honour(attach: Attach, tmp_path: Path) -> None:
+    """Told, not quietly ignored: a reply naming a timeline the caller did not ask for
+    reads as a rename, and the caller would carry on believing the name was theirs."""
+    pool = media_pool()
+    attach(studio(pool=pool, timelines=[a_cut()]))
+    source = an_interchange_file(tmp_path, "encore.drt")
+
+    result = import_timeline(str(source), name="my cut", source_media_path=str(tmp_path))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert result["error"]["detail"]["ignored"] == ["name", "source_media_path"]
+    assert pool.timeline_imports == []
+
+
+def test_a_drt_import_that_lands_on_an_existing_cut_is_a_failure(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """The guarantee on the route where the name cannot be chosen in advance."""
+    pool = media_pool()
+    cut = a_cut("sunset-set v3")
+    attach(studio(pool=pool, timelines=[cut], timeline=cut))
+    pool.imported_timeline = cut
+
+    result = import_timeline(str(an_interchange_file(tmp_path, "sunset-set v3.drt")))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_import_failed"
+    assert "sunset-set v3" in result["error"]["cause"]
 
 
 def test_import_needs_a_project(attach: Attach, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #26.

The structural escape hatch: `export_timeline` writes a cut as OTIO, FCPXML or DRT;
`import_timeline` materialises a **new** timeline from such a file. The scripting API
cannot cut a transition, so a dissolve is made by exporting to OTIO, hand-editing the
transition in, and importing that document back.

**Seam** (per CLAUDE.md): the fake tier verifies every decision — format→export-constant
mapping and its fallback ladder, the falsy-constant trap, path defaulting and suffix
correction, the collision-free import name, the `.drt` option contract, and both failure
shapes. Round-trip fidelity and the injected dissolve are live-tier by nature and are
written and marked `live`. `tests/otio.py` holds the hand-injection the live run carries
into Resolve (a dissolve between two clips, a fade to black at a clip/gap boundary); the
server does not inject — the catalog has no such tool — so it lives in test support, and
the document it produces is checked at the fake tier so the live run is one command.

228 fake-tier tests pass; mypy strict and ruff clean.

## Review

`/code-review` (Standards and Spec as parallel sub-agents), run on the branch before this
PR existed. Two rounds of findings, all fixed — no findings held.

**Spec axis**

1. *`ImportTimelineFromFile` options are documented invalid for DRT* — `timelineName`
   included, so the collision-free name this server computes was inert on that route, and
   the failure text claimed "nothing was imported under a new name", which the code cannot
   know. Fixed: a `.drt` is sent no options, a caller who asked for one is told it cannot
   be honoured rather than discovering it from the reply, `requested_name` comes back null,
   and the check on the way out — the timeline that came back is not one that existed
   before — is what holds the never-overwrite AC on that route.
2. *FCPXML ladder may stop a version short* — `EXPORT_FCPXML_1_11` added at its head; a
   constant a build does not define costs nothing and is skipped.
3. *AC 4 asserted only as "import succeeded"* — correct, no scripting getter exists for
   transitions; the live test docstring says so and the ticket close names it.

**Standards axis** — unused type alias dropped; the format key folded into the `Format`
tuple so it stops travelling beside it; the free-name rule moved next to `version_of`, the
convention it follows; the media pool taken from the project already in hand rather than
walking to the current project twice; and the shared "default path or the caller's, suffix
corrected" shape pulled out of snapshot and export into `naming.write_target`, which is
what that module's own docstring asks for.

**Fix-diff pass** (focused, on the fix commit): the collision failure was giving `.drt`
advice on every route — the same class of defect as finding 1 — now branched per route;
`import_source_clips` joined the refused-for-DRT options rather than being silently
dropped; a test now holds each format's key equal to the dict key it is filed under.

Review: clean

---

Merge of origin/main (post-#65) resolved on-branch: kept main's public `open_project`
name (build.py already imports it) and pointed interchange.py at it; unioned the parallel
additions in naming.py, fakes.py, test_live_smoke.py, test_server.py; dropped the
duplicate `timeline_names`/`add_timeline` the union produced. Focused pass over the
resolution diff; pytest, mypy strict and ruff all green.

Review: clean — merge-resolution diff, focused pass
