### PR TITLE
P1: build_timeline core (sequential V1 to versioned timeline)

### DIFF
--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -461,8 +461,13 @@ def _alternate_duration_errors(doc: dict[str, Any]) -> list[Finding]:
     return findings
 
 
-def _positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
-    """Each segment id to its computed ``(start, duration)`` — sequential V1, butt-joined."""
+def positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
+    """Each segment id to its computed ``(start, duration)`` — sequential V1, butt-joined.
+
+    The overlay rules and the build both place against these numbers, and they have to be
+    the same numbers: an offset validated against one layout and built against another
+    would put the overlay somewhere nobody checked.
+    """
     placed: dict[str, tuple[int, int]] = {}
     at = 0
     for segment in _segments(doc):
@@ -479,7 +484,7 @@ def total_frames(doc: dict[str, Any]) -> int:
 
 def _overlay_errors(doc: dict[str, Any]) -> list[Finding]:
     """E9 and E10, both judged on absolute positions resolved from the anchors."""
-    placed = _positions(doc)
+    placed = positions(doc)
     total = total_frames(doc)
     findings: list[Finding] = []
     spans: list[tuple[str, int, int]] = []
@@ -598,7 +603,7 @@ def validate_project(doc: Any, clips: Sequence[ClipFacts]) -> list[Finding]:
     """
     if _shape_is_unreadable(doc):
         return []
-    resolved, findings = _resolve_aliases(doc, clips)
+    resolved, findings = resolve_aliases(doc, clips)
     findings += _bounds_errors(doc, resolved)
     findings += _rate_errors(doc, resolved)
     findings += _audio_errors(doc, resolved)
@@ -609,10 +614,14 @@ def _shape_is_unreadable(doc: Any) -> bool:
     return bool(list(_shape_errors(doc)))
 
 
-def _resolve_aliases(
+def resolve_aliases(
     doc: dict[str, Any], clips: Sequence[ClipFacts]
 ) -> tuple[dict[str, ClipFacts], list[Finding]]:
-    """E4: alias -> exactly one clip. Ambiguity lists the bins the candidates sit in."""
+    """E4: alias -> exactly one clip. Ambiguity lists the bins the candidates sit in.
+
+    Public because the build has to place the same clip the rules passed: resolving the
+    alias a second way is how a cut gets validated against one clip and built from another.
+    """
     resolved: dict[str, ClipFacts] = {}
     findings: list[Finding] = []
     for alias, source in doc["sources"].items():
@@ -751,6 +760,8 @@ __all__ = [
     "Finding",
     "locked_track_finding",
     "parse_failure_finding",
+    "positions",
+    "resolve_aliases",
     "severity_of",
     "total_frames",
     "validate_project",

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -186,6 +186,40 @@ class InvalidRequestError(ResolveMcpError):
     code = "invalid_request"
 
 
+class CutInvalidError(ResolveMcpError):
+    """The cut file did not pass the rules, so nothing was built. ``detail`` holds them all."""
+
+    code = "cut_invalid"
+    default_fix = (
+        "Fix every error in detail.errors and build again — validate_cut runs the identical "
+        "checks without touching Resolve."
+    )
+
+
+class UnsupportedCutFeatureError(ResolveMcpError):
+    """The cut is valid but describes something this build cannot place yet.
+
+    Refused rather than partially built: a timeline missing a part of the cut that made it
+    is the half-built outcome the pre-flight exists to prevent.
+    """
+
+    code = "unsupported_cut_feature"
+
+
+class BuildFailedError(ResolveMcpError):
+    """Resolve would not build the cut — creation refused, a locked track, a clip astray.
+
+    ``detail`` names the timeline it was building when it stopped, because that timeline
+    may exist and be incomplete: the earlier versions are untouched, this one is scrap.
+    """
+
+    code = "build_failed"
+    default_fix = (
+        "Fix what detail names in the Resolve GUI (unlock the track, clear the timeline), "
+        "delete the incomplete version if one was made, and build again."
+    )
+
+
 class PythonExecutionError(ResolveMcpError):
     """The escape-hatch code raised. The traceback is logged, not returned."""
 

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -1,0 +1,333 @@
+"""Materialising a cut file: sequential V1 over one master-audio clip, as a new version.
+
+The one write primitive Resolve gives us is append-with-exact-placement, and the #18 spike
+found it full of silent failures. Everything in this file exists to make one guarantee:
+*either the timeline holds the cut exactly, or the build says why it does not.*
+
+* **Nothing starts on a file that will not build.** The same rules ``validate_cut`` runs
+  run here first, over the same pool reading, and a single error aborts before a timeline
+  is created. A cut that is valid but describes something this build cannot place is
+  refused for the same reason — a timeline missing part of its own cut is the half-built
+  outcome the pre-flight exists to prevent.
+* **A new version every time.** The name is ``<base> v<N+1>`` scanned off the project's
+  existing names, so no build ever writes into a timeline someone has already reviewed.
+* **Resolve's answer is never the evidence.** An append onto a locked track returns
+  TimelineItems and places nothing; an append that overlaps existing media slides to the
+  next free frame and reports success; a still ignores ``endFrame`` until an out point has
+  been written to it once. So tracks are checked for locks before the append, stills are
+  unlocked before it, and every placement is read back off the track afterwards.
+* **Record frames are absolute.** ``recordFrame`` counts from the timeline's own start
+  (an hour of timecode on a normal project) and is not clamped — a cut frame of 0 would
+  land before the timeline begins. Every position is the timeline start plus the cut
+  offset, and ``mediaType`` always travels with ``trackIndex``, which Resolve otherwise
+  honours by dropping the clip.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from ..cut.validate import locked_track_finding, positions
+from ..errors import BuildFailedError, CutInvalidError, UnsupportedCutFeatureError
+from ..logging_config import get_logger
+from ..naming import next_version_name
+from . import cut, media
+from . import timeline as timeline_read
+from .connection import ResolveConnection
+
+log = get_logger("build")
+
+Clip = Any
+Pool = Any
+Project = Any
+Timeline = Any
+
+MEDIA_TYPES: Final[dict[str, int]] = {"video": 1, "audio": 2}
+"""Resolve's ``mediaType``: 1 appends video only, 2 audio only. Never omitted."""
+
+TRACK_INDEX: Final = 1
+"""Sequential V1 is one video track and one audio track; both are the first of their kind."""
+
+TRACK_LABELS: Final[dict[str, str]] = {"video": "V1", "audio": "A1"}
+
+AUDIO_TRACK_TYPE: Final = "stereo"
+"""What a master mix is. ``AddTrack`` defaults to mono, which would fold a stereo mix."""
+
+MISPLACED_CAP: Final = 20
+"""A drifted build misplaces everything downstream of the blockage; the count says how many."""
+
+
+@dataclass(frozen=True)
+class Shot:
+    """One append: which frames of which clip land where, on which kind of track."""
+
+    id: str
+    track_type: str
+    clip: Clip
+    name: str
+    source_in: int
+    record: int
+    duration: int
+
+    @property
+    def source_out(self) -> int:
+        """Half-open, and exactly what Resolve's ``endFrame`` means (#18 spike (a))."""
+        return self.source_in + self.duration
+
+    def clip_info(self) -> dict[str, Any]:
+        return {
+            "mediaPoolItem": self.clip,
+            "startFrame": self.source_in,
+            "endFrame": self.source_out,
+            "mediaType": MEDIA_TYPES[self.track_type],
+            "trackIndex": TRACK_INDEX,
+            "recordFrame": self.record,
+        }
+
+
+def build_timeline(
+    connection: ResolveConnection,
+    cut_file: str,
+    min_segment_frames: int = cut.MIN_SEGMENT_FRAMES,
+) -> dict[str, Any]:
+    """Build ``cut_file`` as a fresh ``<name> v<N>`` timeline and report what landed."""
+    checked = cut.preflight(connection, cut_file, min_segment_frames)
+    if checked.errors:
+        raise CutInvalidError(
+            cause=f"The cut file has {len(checked.errors)} error(s), so nothing was built.",
+            detail={
+                "cut_file": str(checked.loaded.path),
+                "content_hash": checked.loaded.content_hash,
+                "errors": [finding.as_dict() for finding in checked.errors],
+                "warnings": [finding.as_dict() for finding in checked.warnings],
+            },
+        )
+    # E1 is an error, so a pre-flight with no errors has a document that parsed and matched
+    # the schema — every read of it below is a field the rules have already been over.
+    doc: dict[str, Any] = checked.loaded.doc
+    _refuse_what_cannot_be_placed(doc)
+
+    project = timeline_read.open_project(connection)
+    pool = media.media_pool(connection)
+    name = next_version_name(
+        str(doc["timeline"]["name"]),
+        timeline_read.timeline_names(project),
+    )
+    clips = cut.clips_by_alias(checked)
+    _unlock_stills(clips)
+
+    built = _create(pool, project, name)
+    shots = _shots(doc, clips, _start_frame(built))
+    _make_tracks(built, shots)
+    _refuse_locked_tracks(built, shots, name)
+    _append(pool, shots, name)
+    _verify(built, shots, name)
+
+    log.info("Built %s: %d clips from %s", name, len(shots), checked.loaded.content_hash)
+    return {
+        "cut_file": str(checked.loaded.path),
+        "content_hash": checked.loaded.content_hash,
+        "timeline": timeline_read.summarise(timeline_read.Reader(connection), built, project, name),
+        "placed": {
+            "segments": sum(1 for shot in shots if shot.track_type == "video"),
+            "audio": any(shot.track_type == "audio" for shot in shots),
+        },
+        "warnings": [finding.as_dict() for finding in checked.warnings],
+    }
+
+
+# --- what this build will not attempt ------------------------------------------------------
+
+
+def _refuse_what_cannot_be_placed(doc: dict[str, Any]) -> None:
+    """Overlays validate, but only the V1 substrate is built here — say so, build nothing."""
+    overlays = doc.get("overlays") or []
+    if not overlays:
+        return
+    raise UnsupportedCutFeatureError(
+        cause=f"This cut has {len(overlays)} overlay(s); build_timeline places the sequential "
+        f"V1 and the master audio only.",
+        fix="Remove the overlays block to build the V1 cut now — anchored overlays are placed "
+        "by a later tool, and building without them would leave a timeline that does not "
+        "match its own cut file.",
+        detail={"overlays": [str(overlay["id"]) for overlay in overlays]},
+    )
+
+
+# --- placement ------------------------------------------------------------------------------
+
+
+def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int) -> list[Shot]:
+    """Every append the cut asks for, positioned absolutely from the timeline start."""
+    placed = positions(doc)
+    shots = [
+        _shot(
+            id=str(segment["id"]),
+            track_type="video",
+            located=clips[str(segment["source"])],
+            source_in=int(segment["in"]),
+            record=start + placed[str(segment["id"])][0],
+            duration=placed[str(segment["id"])][1],
+        )
+        for segment in doc["segments"]
+    ]
+    audio = doc.get("audio")
+    if isinstance(audio, dict):
+        # One continuous clip under the whole cut: the substrate the segments are laid over,
+        # and the reason a concert cut stays in sync with the mix the director approved.
+        shots.append(
+            _shot(
+                id="audio",
+                track_type="audio",
+                located=clips[str(audio["source"])],
+                source_in=int(audio["in"]),
+                record=start,
+                duration=int(audio["out"]) - int(audio["in"]),
+            )
+        )
+    return shots
+
+
+def _shot(
+    id: str,
+    track_type: str,
+    located: media.LocatedClip,
+    source_in: int,
+    record: int,
+    duration: int,
+) -> Shot:
+    return Shot(
+        id=id,
+        track_type=track_type,
+        clip=located.clip,
+        name=str(located.clip.GetName() or ""),
+        source_in=source_in,
+        record=record,
+        duration=duration,
+    )
+
+
+def _start_frame(timeline: Timeline) -> int:
+    """The timeline's own first frame. A record frame below it is *not* clamped (#18 (d))."""
+    try:
+        return int(float(timeline.GetStartFrame()))
+    except (TypeError, ValueError):
+        log.warning("Resolve gave an unreadable start frame; placing from 0")
+        return 0
+
+
+# --- the writes -------------------------------------------------------------------------------
+
+
+def _create(pool: Pool, project: Project, name: str) -> Timeline:
+    """The empty timeline this build fills, made current so appends can reach it."""
+    created = pool.CreateEmptyTimeline(name)
+    if not created:
+        raise BuildFailedError(
+            cause=f"Resolve refused to create the timeline {name!r}.",
+            detail={"timeline": name},
+        )
+    if not project.SetCurrentTimeline(created):
+        # AppendToTimeline writes to whatever is current, so a failed switch would build
+        # the cut into someone else's timeline. Stop while the new one is still empty.
+        raise BuildFailedError(
+            cause=f"Resolve created {name!r} but would not open it, so nothing was appended.",
+            fix="Close any modal dialog in the Resolve GUI, delete the empty timeline, and "
+            "build again.",
+            detail={"timeline": name},
+        )
+    log.info("Created and opened timeline %s", name)
+    return created
+
+
+def _make_tracks(timeline: Timeline, shots: list[Shot]) -> None:
+    """Pre-create the tracks the cut needs: an index past the next free one is dropped."""
+    for track_type in sorted({shot.track_type for shot in shots}):
+        # Only an audio track has a sub-type, and its default is mono — which would fold a
+        # stereo master mix down on the way in.
+        extra = (AUDIO_TRACK_TYPE,) if track_type == "audio" else ()
+        while int(timeline.GetTrackCount(track_type) or 0) < TRACK_INDEX:
+            timeline.AddTrack(track_type, *extra)
+            log.info("Added a %s track to %s", track_type, timeline.GetName())
+
+
+def _refuse_locked_tracks(timeline: Timeline, shots: list[Shot], name: str) -> None:
+    """E11: a locked track accepts the append, reports items, and places nothing."""
+    locked = [
+        locked_track_finding(TRACK_LABELS[track_type])
+        for track_type in sorted({shot.track_type for shot in shots})
+        if timeline.GetIsTrackLocked(track_type, TRACK_INDEX)
+    ]
+    if not locked:
+        return
+    raise BuildFailedError(
+        cause=f"{len(locked)} target track(s) of {name!r} are locked, so nothing was appended.",
+        fix="Unlock the track in the timeline header and build again.",
+        detail={"timeline": name, "errors": [finding.as_dict() for finding in locked]},
+    )
+
+
+def _unlock_stills(clips: dict[str, media.LocatedClip]) -> None:
+    """Write each still's out point once, so its ``endFrame`` is honoured exactly (#18 (a))."""
+    seen: set[int] = set()
+    for located in clips.values():
+        if id(located.clip) in seen:
+            continue
+        seen.add(id(located.clip))
+        if media.apply_still_workaround(located.clip, media.properties(located.clip)):
+            log.info("Unlocked exact durations on the still %s", located.clip.GetName())
+
+
+def _append(pool: Pool, shots: list[Shot], name: str) -> None:
+    """One call for the whole cut. Its return value is counted, never believed."""
+    appended = pool.AppendToTimeline([shot.clip_info() for shot in shots])
+    if not appended:
+        raise BuildFailedError(
+            cause=f"Resolve appended nothing to {name!r}.",
+            detail={"timeline": name, "clips": len(shots)},
+        )
+    log.info("Appended %d clips to %s; Resolve returned %d", len(shots), name, len(appended))
+
+
+def _verify(timeline: Timeline, shots: list[Shot], name: str) -> None:
+    """Read the tracks back: the only way to know an append landed where it was told to."""
+    misplaced = [shot for track in TRACK_LABELS for shot in _adrift(timeline, shots, track)]
+    if not misplaced:
+        return
+    raise BuildFailedError(
+        cause=f"{len(misplaced)} of {len(shots)} clips did not land where the cut puts them in "
+        f"{name!r}, so the timeline does not match the cut file.",
+        fix="Resolve slides an append that overlaps existing media and drops one onto a track "
+        "it cannot reach, both while reporting success. Delete the timeline it made, check "
+        "the cut file's ranges, and build again.",
+        detail={
+            "timeline": name,
+            "misplaced": [_expected(shot) for shot in misplaced[:MISPLACED_CAP]],
+            "misplaced_total": len(misplaced),
+        },
+    )
+
+
+def _adrift(timeline: Timeline, shots: list[Shot], track_type: str) -> list[Shot]:
+    wanted = [shot for shot in shots if shot.track_type == track_type]
+    if not wanted:
+        return []
+    landed = {
+        (item.GetStart(), item.GetDuration())
+        for item in timeline.GetItemListInTrack(track_type, TRACK_INDEX) or []
+    }
+    return [shot for shot in wanted if (shot.record, shot.duration) not in landed]
+
+
+def _expected(shot: Shot) -> dict[str, Any]:
+    return {
+        "id": shot.id,
+        "clip": shot.name,
+        "track": TRACK_LABELS[shot.track_type],
+        "record_frame": shot.record,
+        "duration": shot.duration,
+    }
+
+
+__all__ = ["Shot", "build_timeline"]

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -119,7 +119,7 @@ def build_timeline(
 
     built = _create(pool, project, name)
     shots = _shots(doc, clips, _start_frame(built))
-    _make_tracks(built, shots)
+    _make_tracks(built, shots, name)
     _refuse_locked_tracks(built, shots, name)
     _append(pool, shots, name)
     _verify(built, shots, name)
@@ -161,17 +161,20 @@ def _refuse_what_cannot_be_placed(doc: dict[str, Any]) -> None:
 def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int) -> list[Shot]:
     """Every append the cut asks for, positioned absolutely from the timeline start."""
     placed = positions(doc)
-    shots = [
-        _shot(
-            id=str(segment["id"]),
-            track_type="video",
-            located=clips[str(segment["source"])],
-            source_in=int(segment["in"]),
-            record=start + placed[str(segment["id"])][0],
-            duration=placed[str(segment["id"])][1],
+    shots = []
+    for segment in doc["segments"]:
+        id = str(segment["id"])
+        offset, duration = placed[id]
+        shots.append(
+            _shot(
+                id=id,
+                track_type="video",
+                located=clips[str(segment["source"])],
+                source_in=int(segment["in"]),
+                record=start + offset,
+                duration=duration,
+            )
         )
-        for segment in doc["segments"]
-    ]
     audio = doc.get("audio")
     if isinstance(audio, dict):
         # One continuous clip under the whole cut: the substrate the segments are laid over,
@@ -241,22 +244,64 @@ def _create(pool: Pool, project: Project, name: str) -> Timeline:
     return created
 
 
-def _make_tracks(timeline: Timeline, shots: list[Shot]) -> None:
-    """Pre-create the tracks the cut needs: an index past the next free one is dropped."""
-    for track_type in sorted({shot.track_type for shot in shots}):
-        # Only an audio track has a sub-type, and its default is mono — which would fold a
-        # stereo master mix down on the way in.
+def _make_tracks(timeline: Timeline, shots: list[Shot], name: str) -> None:
+    """Pre-create the tracks the cut needs: an index past the next free one is dropped.
+
+    A track this build adds is made stereo, because ``AddTrack`` defaults to mono and a
+    master mix folded to one channel is a silent wrong answer. A track the new timeline
+    came with keeps whatever the project's timeline template gave it — the API cannot
+    restyle an existing track, so the layout is logged rather than assumed.
+    """
+    for track_type in _track_types(shots):
+        # Only an audio track takes a sub-type; passing one to video is meaningless.
         extra = (AUDIO_TRACK_TYPE,) if track_type == "audio" else ()
-        while int(timeline.GetTrackCount(track_type) or 0) < TRACK_INDEX:
-            timeline.AddTrack(track_type, *extra)
-            log.info("Added a %s track to %s", track_type, timeline.GetName())
+        while _track_count(timeline, track_type) < TRACK_INDEX:
+            if not timeline.AddTrack(track_type, *extra):
+                # Refused rather than merely unanswered: retrying would spin forever, and
+                # appending to a track that is not there drops the clip silently.
+                raise BuildFailedError(
+                    cause=f"Resolve refused to add a {track_type} track to {name!r}.",
+                    fix="Close any modal dialog in the Resolve GUI, delete the empty "
+                    "timeline, and build again.",
+                    detail={"timeline": name, "track_type": track_type},
+                )
+            log.info("Added a %s track to %s", track_type, name)
+    log.info(
+        "%s targets %s (%d video, %d audio tracks)",
+        name,
+        ", ".join(TRACK_LABELS[track_type] for track_type in _track_types(shots)),
+        _track_count(timeline, "video"),
+        _track_count(timeline, "audio"),
+    )
+
+
+def _track_count(timeline: Timeline, track_type: str) -> int:
+    try:
+        return int(timeline.GetTrackCount(track_type) or 0)
+    except (TypeError, ValueError):
+        log.warning("Resolve gave an unreadable %s track count", track_type)
+        return 0
+
+
+def _track_types(shots: list[Shot]) -> list[str]:
+    """The kinds of track this cut needs, in a fixed order so the logs read the same way."""
+    return [
+        track_type
+        for track_type in TRACK_LABELS
+        if any(shot.track_type == track_type for shot in shots)
+    ]
 
 
 def _refuse_locked_tracks(timeline: Timeline, shots: list[Shot], name: str) -> None:
-    """E11: a locked track accepts the append, reports items, and places nothing."""
+    """E11: a locked track accepts the append, reports items, and places nothing.
+
+    A timeline this build just created should have no locked track — but it is created
+    from the project's timeline template, which is the director's to configure, and the
+    check costs one call against a failure mode that leaves no trace anywhere else.
+    """
     locked = [
         locked_track_finding(TRACK_LABELS[track_type])
-        for track_type in sorted({shot.track_type for shot in shots})
+        for track_type in _track_types(shots)
         if timeline.GetIsTrackLocked(track_type, TRACK_INDEX)
     ]
     if not locked:
@@ -292,7 +337,11 @@ def _append(pool: Pool, shots: list[Shot], name: str) -> None:
 
 def _verify(timeline: Timeline, shots: list[Shot], name: str) -> None:
     """Read the tracks back: the only way to know an append landed where it was told to."""
-    misplaced = [shot for track in TRACK_LABELS for shot in _adrift(timeline, shots, track)]
+    misplaced = [
+        shot
+        for track_type in _track_types(shots)
+        for shot in _adrift(timeline, shots, track_type)
+    ]
     if not misplaced:
         return
     raise BuildFailedError(

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -60,19 +60,24 @@ def get_cut_schema() -> dict[str, Any]:
     }
 
 
-class Preflight(NamedTuple):
-    """One pass of the rules, and the pool reading they were judged against.
+class Source(NamedTuple):
+    """One pool clip, as the rules see it and as the build has to place it.
 
-    The build needs both halves: the findings to decide whether to start at all, and the
-    clips themselves to place. Handing them back together is what keeps the build from
-    reading the pool a second time and resolving an alias to a different clip than the one
-    the rules passed.
+    The two travel as a pair rather than as two lists: the rules are judged on the facts
+    and the append is made with the handle, and a cut validated against one clip and built
+    from another is the failure this pairing makes impossible.
     """
+
+    facts: ClipFacts
+    located: media.LocatedClip
+
+
+class Preflight(NamedTuple):
+    """One pass of the rules, and the pool reading they were judged against."""
 
     loaded: LoadedCut
     findings: list[Finding]
-    clips: list[media.LocatedClip]
-    facts: list[ClipFacts]
+    sources: list[Source]
 
     @property
     def errors(self) -> list[Finding]:
@@ -81,6 +86,10 @@ class Preflight(NamedTuple):
     @property
     def warnings(self) -> list[Finding]:
         return [finding for finding in self.findings if finding.severity == "warning"]
+
+    @property
+    def facts(self) -> list[ClipFacts]:
+        return [source.facts for source in self.sources]
 
 
 def preflight(
@@ -91,16 +100,19 @@ def preflight(
     """Read ``cut_file`` and run every rule on it. The dry run and the build share this."""
     loaded = read_cut_file(cut_file)
     if loaded.parse_error is not None:
-        return Preflight(loaded, [loaded.parse_error], [], [])
+        return Preflight(loaded, [loaded.parse_error], [])
 
     findings = validate_structure(loaded.doc, min_segment_frames=min_segment_frames)
     if any(finding.rule == "E1" for finding in findings):
         log.info("Cut file %s is not schema-valid; the media pool was not read", loaded.path)
-        return Preflight(loaded, findings, [], [])
+        return Preflight(loaded, findings, [])
 
-    located = _located(connection, loaded.doc)
-    facts = [_facts(found.bin_path, found.clip) for found in located]
-    return Preflight(loaded, [*findings, *validate_project(loaded.doc, facts)], located, facts)
+    sources = [
+        Source(_facts(found.bin_path, found.clip), found)
+        for found in _located(connection, loaded.doc)
+    ]
+    facts = [source.facts for source in sources]
+    return Preflight(loaded, [*findings, *validate_project(loaded.doc, facts)], sources)
 
 
 def validate_cut(
@@ -112,22 +124,16 @@ def validate_cut(
     return _report(preflight(connection, cut_file, min_segment_frames))
 
 
-def clip_facts(connection: ResolveConnection, doc: dict[str, Any]) -> list[ClipFacts]:
-    """Read the media pool for the clips this cut names, and nothing else."""
-    return [_facts(found.bin_path, found.clip) for found in _located(connection, doc)]
-
-
-def clips_by_alias(preflighted: Preflight) -> dict[str, media.LocatedClip]:
+def clips_by_alias(checked: Preflight) -> dict[str, media.LocatedClip]:
     """Alias -> the pool clip the rules resolved it to, ready to append.
 
-    The pairing runs through the facts rather than a second lookup, so the clip that is
-    placed is the clip E4-E7 passed. Two clips that are alike in every fact are the same
-    clip as far as every rule is concerned, so collapsing them here changes nothing.
+    The alias is resolved by the same E4 rule the dry run uses, and the clip that comes
+    back is the very object those facts were read from — not a second lookup that could
+    land on a different one.
     """
-    doc = preflighted.loaded.doc
-    resolved, _ = resolve_aliases(doc, preflighted.facts)
-    handles = dict(zip(preflighted.facts, preflighted.clips, strict=True))
-    return {alias: handles[fact] for alias, fact in resolved.items()}
+    resolved, _ = resolve_aliases(checked.loaded.doc, checked.facts)
+    handles = {id(source.facts): source.located for source in checked.sources}
+    return {alias: handles[id(facts)] for alias, facts in resolved.items()}
 
 
 def _located(connection: ResolveConnection, doc: dict[str, Any]) -> list[media.LocatedClip]:
@@ -173,11 +179,11 @@ def _report(checked: Preflight) -> dict[str, Any]:
         "valid": not checked.errors,
         "errors": [finding.as_dict() for finding in checked.errors],
         "warnings": [finding.as_dict() for finding in checked.warnings],
-        "cut": _summary(readable_doc(checked)),
+        "cut": _summary(_readable_doc(checked)),
     }
 
 
-def readable_doc(checked: Preflight) -> dict[str, Any] | None:
+def _readable_doc(checked: Preflight) -> dict[str, Any] | None:
     """The document, or ``None`` when E1 fired and nothing about it can be trusted."""
     if any(finding.rule == "E1" for finding in checked.findings):
         return None
@@ -201,10 +207,9 @@ def _summary(doc: dict[str, Any] | None) -> dict[str, Any] | None:
 __all__ = [
     "MIN_SEGMENT_FRAMES",
     "Preflight",
-    "clip_facts",
+    "Source",
     "clips_by_alias",
     "get_cut_schema",
     "preflight",
-    "readable_doc",
     "validate_cut",
 ]

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -14,7 +14,7 @@ here is a file that will not abort a build on validation.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, NamedTuple
 
 from ..cut.document import LoadedCut, read_cut_file
 from ..cut.schema import ANNOTATED_EXAMPLE, SCHEMA_DOC, SCHEMA_VERSION
@@ -23,6 +23,7 @@ from ..cut.validate import (
     RULE_DESCRIPTIONS,
     ClipFacts,
     Finding,
+    resolve_aliases,
     severity_of,
     total_frames,
     validate_project,
@@ -59,27 +60,78 @@ def get_cut_schema() -> dict[str, Any]:
     }
 
 
+class Preflight(NamedTuple):
+    """One pass of the rules, and the pool reading they were judged against.
+
+    The build needs both halves: the findings to decide whether to start at all, and the
+    clips themselves to place. Handing them back together is what keeps the build from
+    reading the pool a second time and resolving an alias to a different clip than the one
+    the rules passed.
+    """
+
+    loaded: LoadedCut
+    findings: list[Finding]
+    clips: list[media.LocatedClip]
+    facts: list[ClipFacts]
+
+    @property
+    def errors(self) -> list[Finding]:
+        return [finding for finding in self.findings if finding.severity == "error"]
+
+    @property
+    def warnings(self) -> list[Finding]:
+        return [finding for finding in self.findings if finding.severity == "warning"]
+
+
+def preflight(
+    connection: ResolveConnection,
+    cut_file: str,
+    min_segment_frames: int = MIN_SEGMENT_FRAMES,
+) -> Preflight:
+    """Read ``cut_file`` and run every rule on it. The dry run and the build share this."""
+    loaded = read_cut_file(cut_file)
+    if loaded.parse_error is not None:
+        return Preflight(loaded, [loaded.parse_error], [], [])
+
+    findings = validate_structure(loaded.doc, min_segment_frames=min_segment_frames)
+    if any(finding.rule == "E1" for finding in findings):
+        log.info("Cut file %s is not schema-valid; the media pool was not read", loaded.path)
+        return Preflight(loaded, findings, [], [])
+
+    located = _located(connection, loaded.doc)
+    facts = [_facts(found.bin_path, found.clip) for found in located]
+    return Preflight(loaded, [*findings, *validate_project(loaded.doc, facts)], located, facts)
+
+
 def validate_cut(
     connection: ResolveConnection,
     cut_file: str,
     min_segment_frames: int = MIN_SEGMENT_FRAMES,
 ) -> dict[str, Any]:
     """Dry-run ``cut_file``: every rule, every failure, before anything is built."""
-    loaded = read_cut_file(cut_file)
-    if loaded.parse_error is not None:
-        return _report(loaded, None, [loaded.parse_error])
-
-    findings = validate_structure(loaded.doc, min_segment_frames=min_segment_frames)
-    if any(finding.rule == "E1" for finding in findings):
-        log.info("Cut file %s is not schema-valid; the media pool was not read", loaded.path)
-        return _report(loaded, None, findings)
-
-    findings = [*findings, *validate_project(loaded.doc, clip_facts(connection, loaded.doc))]
-    return _report(loaded, loaded.doc, findings)
+    return _report(preflight(connection, cut_file, min_segment_frames))
 
 
 def clip_facts(connection: ResolveConnection, doc: dict[str, Any]) -> list[ClipFacts]:
-    """Read the media pool for the clips this cut names, and nothing else.
+    """Read the media pool for the clips this cut names, and nothing else."""
+    return [_facts(found.bin_path, found.clip) for found in _located(connection, doc)]
+
+
+def clips_by_alias(preflighted: Preflight) -> dict[str, media.LocatedClip]:
+    """Alias -> the pool clip the rules resolved it to, ready to append.
+
+    The pairing runs through the facts rather than a second lookup, so the clip that is
+    placed is the clip E4-E7 passed. Two clips that are alike in every fact are the same
+    clip as far as every rule is concerned, so collapsing them here changes nothing.
+    """
+    doc = preflighted.loaded.doc
+    resolved, _ = resolve_aliases(doc, preflighted.facts)
+    handles = dict(zip(preflighted.facts, preflighted.clips, strict=True))
+    return {alias: handles[fact] for alias, fact in resolved.items()}
+
+
+def _located(connection: ResolveConnection, doc: dict[str, Any]) -> list[media.LocatedClip]:
+    """The pool clips this cut names, and nothing else.
 
     Only the aliased names are looked up: a concert pool holds thousands of clips, and a
     cut references a handful, so properties are read for the handful.
@@ -88,7 +140,7 @@ def clip_facts(connection: ResolveConnection, doc: dict[str, Any]) -> list[ClipF
     wanted = {str(source["clip"]) for source in doc["sources"].values()}
     located = media.clips_named(pool, wanted)
     log.info("Cut validation resolved %d of %d aliased clip names", len(located), len(wanted))
-    return [_facts(found.bin_path, found.clip) for found in located]
+    return located
 
 
 def _facts(bin_path: str, clip: Clip) -> ClipFacts:
@@ -114,21 +166,23 @@ def _facts(bin_path: str, clip: Clip) -> ClipFacts:
     )
 
 
-def _report(
-    loaded: LoadedCut,
-    doc: dict[str, Any] | None,
-    findings: list[Finding],
-) -> dict[str, Any]:
-    errors = [finding for finding in findings if finding.severity == "error"]
-    warnings = [finding for finding in findings if finding.severity == "warning"]
+def _report(checked: Preflight) -> dict[str, Any]:
     return {
-        "cut_file": str(loaded.path),
-        "content_hash": loaded.content_hash,
-        "valid": not errors,
-        "errors": [finding.as_dict() for finding in errors],
-        "warnings": [finding.as_dict() for finding in warnings],
-        "cut": _summary(doc),
+        "cut_file": str(checked.loaded.path),
+        "content_hash": checked.loaded.content_hash,
+        "valid": not checked.errors,
+        "errors": [finding.as_dict() for finding in checked.errors],
+        "warnings": [finding.as_dict() for finding in checked.warnings],
+        "cut": _summary(readable_doc(checked)),
     }
+
+
+def readable_doc(checked: Preflight) -> dict[str, Any] | None:
+    """The document, or ``None`` when E1 fired and nothing about it can be trusted."""
+    if any(finding.rule == "E1" for finding in checked.findings):
+        return None
+    doc: dict[str, Any] = checked.loaded.doc
+    return doc
 
 
 def _summary(doc: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -144,4 +198,13 @@ def _summary(doc: dict[str, Any] | None) -> dict[str, Any] | None:
     }
 
 
-__all__ = ["MIN_SEGMENT_FRAMES", "clip_facts", "get_cut_schema", "validate_cut"]
+__all__ = [
+    "MIN_SEGMENT_FRAMES",
+    "Preflight",
+    "clip_facts",
+    "clips_by_alias",
+    "get_cut_schema",
+    "preflight",
+    "readable_doc",
+    "validate_cut",
+]

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -82,12 +82,18 @@ class Placement(NamedTuple):
 # --- reaching a timeline ------------------------------------------------------------------
 
 
-def _project(connection: ResolveConnection) -> Project:
+def open_project(connection: ResolveConnection) -> Project:
+    """The open project, or a structured refusal — never a ``None`` to trip over later."""
     manager = connection.handle().GetProjectManager()
     project = manager.GetCurrentProject() if manager is not None else None
     if project is None:
         raise NoProjectOpenError(cause="No project is open, so there are no timelines to read.")
     return project
+
+
+def timeline_names(project: Project) -> list[str]:
+    """Every timeline name the project holds — what a version scan counts against."""
+    return [_name(timeline) for timeline in _timelines(project)]
 
 
 def _timelines(project: Project) -> list[Timeline]:
@@ -237,7 +243,7 @@ def list_timelines(
     config: Config | None = None,
 ) -> dict[str, Any]:
     """Every timeline in the project with its version, duration and track stack."""
-    project = _project(connection)
+    project = open_project(connection)
     reader = Reader(connection)
     current = project.GetCurrentTimeline()
     current_name = _name(current) if current is not None else None
@@ -297,7 +303,7 @@ def inspect_timeline(
             detail={"requested": detail, "available": list(DETAIL_LEVELS)},
         )
 
-    project = _project(connection)
+    project = open_project(connection)
     reader = Reader(connection)
     timeline = find_timeline(project, name)
     current = project.GetCurrentTimeline()

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..resolve import cut
+from ..resolve import build, cut
 from ..resolve.connection import get_connection
 from .envelope import tool
 
@@ -40,9 +40,31 @@ def validate_cut(
     return cut.validate_cut(connection, cut_file, min_segment_frames)
 
 
+@tool
+def build_timeline(
+    cut_file: str,
+    min_segment_frames: int = cut.MIN_SEGMENT_FRAMES,
+) -> dict[str, Any]:
+    """Build a cut file into a new `<name> v<N>` timeline and report what landed.
+
+    Every build makes a new version and never touches an earlier one, so rebuilding after
+    an edit is always safe. The segments land butt-joined in document order over one
+    continuous master-audio clip; positions are computed, so gaps cannot happen.
+
+    The validate_cut rules run first: a single error aborts before any timeline is created,
+    and comes back with the same per-segment findings. The report echoes the cut file's
+    content hash, which is what ties the timeline back to the exact cut that made it —
+    record it if you note the version anywhere. A failure names what did not land; a
+    partially built version, if one was made, is scrap and can be deleted.
+    """
+    connection = get_connection()
+    return build.build_timeline(connection, cut_file, min_segment_frames)
+
+
 TOOLS: tuple[Any, ...] = (
     get_cut_schema,
     validate_cut,
+    build_timeline,
 )
 
-__all__ = ["TOOLS", "get_cut_schema", "validate_cut"]
+__all__ = ["TOOLS", "build_timeline", "get_cut_schema", "validate_cut"]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -257,6 +257,20 @@ class FakeTimeline:
         self._check()
         return dict(self._markers)
 
+    def AddTrack(self, track_type: str, *_: Any) -> bool:  # noqa: N802
+        self._check()
+        tracks = self._tracks.setdefault(track_type, [])
+        tracks.append(FakeTrack(f"{track_type.capitalize()} {len(tracks) + 1}"))
+        return True
+
+    def place(self, track_type: str, index: int, item: FakeTimelineItem) -> None:
+        """Put an item on a track, in start order — the pool's append reaches through here."""
+        track = self._track(track_type, index)
+        if track is None:
+            return
+        track.items.append(item)
+        track.items.sort(key=lambda placed: placed.GetStart())
+
 
 IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"}
 
@@ -384,6 +398,17 @@ class FakeMediaPool:
         self.relink_result: bool | None = None
         self.move_result = True
         self.calls: list[str] = []
+        self._project: FakeProject | None = None
+        self.create_timeline_result: bool = True
+        self.new_timeline_start = 0
+        self.new_timeline_tracks: tuple[int, int] = (1, 1)
+        self.new_timeline_locked = False
+        self.new_timeline_items: list[FakeTimelineItem] = []
+        self.appends: list[dict[str, Any]] = []
+
+    def attach_project(self, project: FakeProject) -> None:
+        """The project this pool belongs to — appends land on *its* current timeline."""
+        self._project = project
 
     def _check(self, method: str) -> None:
         self.calls.append(method)
@@ -469,11 +494,135 @@ class FakeMediaPool:
                 relinked = True
         return relinked
 
+    def CreateEmptyTimeline(self, name: str) -> FakeTimeline | None:  # noqa: N802
+        """A fresh timeline, added to the project and made current — as Resolve does."""
+        self._check("CreateEmptyTimeline")
+        if not self.create_timeline_result:
+            return None
+        video, audio = self.new_timeline_tracks
+        project_fps = (
+            self._project.GetSetting("timelineFrameRate") if self._project is not None else None
+        )
+        timeline = FakeTimeline(
+            name,
+            fps=project_fps or "59.94",
+            start_frame=self.new_timeline_start,
+            video=[
+                FakeTrack(
+                    f"Video {index + 1}",
+                    list(self.new_timeline_items) if index == 0 else None,
+                    locked=self.new_timeline_locked,
+                )
+                for index in range(video)
+            ],
+            audio=[
+                FakeTrack(f"Audio {index + 1}", locked=self.new_timeline_locked)
+                for index in range(audio)
+            ],
+            owner=self._owner,
+        )
+        if self._project is not None:
+            self._project.add_timeline(timeline)
+            self._project.SetCurrentTimeline(timeline)
+        return timeline
+
+    def AppendToTimeline(  # noqa: N802
+        self,
+        clips: list[dict[str, Any]],
+    ) -> list[FakeTimelineItem]:
+        """Append onto the project's *current* timeline, footguns and all (#18 spike (d)).
+
+        Every confirmed failure mode is modelled, because each one returns a truthy item
+        either way: the caller cannot tell an append that landed from one that vanished
+        without re-reading the track, and that re-read is what the wrapper is for.
+        """
+        self._check("AppendToTimeline")
+        timeline = self._project.GetCurrentTimeline() if self._project is not None else None
+        if timeline is None:
+            return []
+        placed = []
+        for info in clips:
+            self.appends.append(dict(info))
+            placed.append(self._append_one(timeline, info))
+        return placed
+
+    def _append_one(self, timeline: FakeTimeline, info: dict[str, Any]) -> FakeTimelineItem:
+        clip: FakeMediaPoolItem = info["mediaPoolItem"]
+        source_start = int(info.get("startFrame", 0))
+        duration = _appended_duration(clip, source_start, info.get("endFrame"))
+        media_type = info.get("mediaType")
+        track_type = "audio" if media_type == AUDIO_TYPE else "video"
+        index = int(info.get("trackIndex", 1))
+        record = int(info.get("recordFrame", _track_end(timeline, track_type, index)))
+
+        item = FakeTimelineItem(
+            clip.GetName(),
+            record,
+            duration,
+            source_start=source_start,
+            media_item=clip,
+            owner=self._owner,
+        )
+        # An explicit track index without a media type: Resolve reports success and drops it.
+        if media_type is None and "trackIndex" in info:
+            return item
+        count = timeline.GetTrackCount(track_type)
+        if index == count + 1:
+            timeline.AddTrack(track_type)
+        elif index > count + 1:
+            return item  # past the next free track: reported placed, never placed
+        if timeline.GetIsTrackLocked(track_type, index):
+            return item  # the silent one: a locked track swallows the append
+        # No overwrite on overlap — the clip slides to the first free frame after the
+        # blocker, so a placement is only exact if nothing was in the way.
+        for existing in timeline.GetItemListInTrack(track_type, index) or []:
+            if record < existing.GetStart() + existing.GetDuration() and existing.GetStart() < (
+                record + duration
+            ):
+                record = existing.GetStart() + existing.GetDuration()
+                item = FakeTimelineItem(
+                    clip.GetName(),
+                    record,
+                    duration,
+                    source_start=source_start,
+                    media_item=clip,
+                    owner=self._owner,
+                )
+        timeline.place(track_type, index, item)
+        return item
+
     def _walk(self, folder: FakeFolder) -> list[FakeFolder]:
         found = [folder]
         for sub in folder.subfolders:
             found.extend(self._walk(sub))
         return found
+
+
+AUDIO_TYPE = 2
+STILL_DEFAULT_FRAMES = 120
+
+
+def _appended_duration(clip: FakeMediaPoolItem, source_start: int, end_frame: Any) -> int:
+    """``endFrame - startFrame``, except on a still that has never had an out point written.
+
+    That is the (a) spike verbatim: a freshly imported still ignores ``endFrame`` entirely
+    and lands at the default duration until any ``Out`` write unlocks it.
+    """
+    still = Path(str(clip.GetClipProperty("File Path") or "")).suffix.lower() in IMAGE_SUFFIXES
+    unlocked = any(key == "Out" for key, _ in clip.property_writes)
+    if still and not unlocked:
+        return STILL_DEFAULT_FRAMES
+    if end_frame is None:
+        return STILL_DEFAULT_FRAMES if still else 1
+    return max(int(end_frame) - source_start, 1)
+
+
+def _track_end(timeline: FakeTimeline, track_type: str, index: int) -> int:
+    ends = [
+        item.GetStart() + item.GetDuration()
+        for item in timeline.GetItemListInTrack(track_type, index) or []
+    ]
+    return max(ends, default=timeline.GetStartFrame())
 
 
 def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
@@ -538,12 +687,23 @@ class FakeProject:
             self._timelines = list(timelines)
         else:
             self._timelines = [timeline] if timeline is not None else []
+        if media_pool is not None:
+            media_pool.attach_project(self)
 
     def GetName(self) -> str:  # noqa: N802
         return self._name
 
     def GetCurrentTimeline(self) -> FakeTimeline | None:  # noqa: N802
         return self._timeline
+
+    def SetCurrentTimeline(self, timeline: FakeTimeline) -> bool:  # noqa: N802
+        """Resolve only appends to the current timeline, so the build has to set it."""
+        self._timeline = timeline
+        return True
+
+    def add_timeline(self, timeline: FakeTimeline) -> None:
+        """What creating a timeline does to a project — the pool reaches through here."""
+        self._timelines.append(timeline)
 
     def GetTimelineCount(self) -> int:  # noqa: N802
         return len(self._timelines)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -179,6 +179,7 @@ class FakeTimeline:
         }
         self._markers = markers or {}
         self._owner = owner
+        self.add_track_result = True
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
@@ -259,6 +260,8 @@ class FakeTimeline:
 
     def AddTrack(self, track_type: str, *_: Any) -> bool:  # noqa: N802
         self._check()
+        if not self.add_track_result:
+            return False
         tracks = self._tracks.setdefault(track_type, [])
         tracks.append(FakeTrack(f"{track_type.capitalize()} {len(tracks) + 1}"))
         return True
@@ -404,6 +407,7 @@ class FakeMediaPool:
         self.new_timeline_tracks: tuple[int, int] = (1, 1)
         self.new_timeline_locked = False
         self.new_timeline_items: list[FakeTimelineItem] = []
+        self.add_track_result = True
         self.appends: list[dict[str, Any]] = []
 
     def attach_project(self, project: FakeProject) -> None:
@@ -521,6 +525,7 @@ class FakeMediaPool:
             ],
             owner=self._owner,
         )
+        timeline.add_track_result = self.add_track_result
         if self._project is not None:
             self._project.add_timeline(timeline)
             self._project.SetCurrentTimeline(timeline)

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -401,7 +401,7 @@ def test_a_locked_target_track_is_reported_instead_of_silently_dropping_the_cut(
     assert result["error"]["code"] == "build_failed"
     findings = result["error"]["detail"]["errors"]
     assert [finding["rule"] for finding in findings] == ["E11", "E11"]
-    assert [finding["id"] for finding in findings] == ["A1", "V1"]
+    assert [finding["id"] for finding in findings] == ["V1", "A1"]
     assert "AppendToTimeline" not in pool.calls
 
 
@@ -454,6 +454,43 @@ def test_a_refused_timeline_creation_is_a_structured_failure(
     assert result["ok"] is False
     assert result["error"]["code"] == "build_failed"
     assert "sunset-set v1" in result["error"]["cause"]
+
+
+def test_a_refused_track_add_stops_rather_than_appending_into_nothing(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """An append onto a track that is not there is dropped silently, so this must not loop."""
+    pool = a_pool()
+    pool.new_timeline_tracks = (0, 0)
+    pool.add_track_result = False
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    assert "AppendToTimeline" not in pool.calls
+
+
+def test_resolve_quitting_mid_build_is_a_structured_failure(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A build cannot be resumed, so a death mid-write must not be smoothed into success.
+
+    The version it was making is scrap and the agent has to be told so — as a cause and a
+    fix like every other failure, never as a traceback across the tool boundary.
+    """
+    versions: list[FakeTimeline | None] = [FakeTimeline("sunset-set v1", "59.94")]
+    resolve = studio(timeline=None, timelines=versions, pool=a_pool())
+    attach(resolve, None)
+    resolve.die_after(14)
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is False
+    assert result["error"]["cause"]
+    assert result["error"]["fix"]
+    assert result["error"]["code"] in {"resolve_unavailable", "build_failed", "internal_error"}
 
 
 def test_a_missing_video_track_is_created_before_the_append(

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -1,0 +1,472 @@
+"""build_timeline at the Resolve seam: what lands on the timeline, and what never starts.
+
+Two things are under test here and nothing else matters as much:
+
+* a valid cut becomes a *new* version with frame-exact placements, and
+* everything that could half-build one — an invalid file, a locked track, a refused
+  creation, an append that slid somewhere else — stops with a structured failure.
+
+The fake models the append footguns the #18 spike confirmed on live Resolve (truthy
+returns that place nothing, relocation on overlap, stills ignoring ``endFrame``), so a
+wrapper that trusted Resolve's return value fails these tests rather than a real cut.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.cut.document import content_hash
+from resolve_mcp.tools.cut import build_timeline
+
+from .conftest import Attach
+from .fakes import FakeMediaPoolItem, FakeTimeline, FakeTimelineItem, FakeTrack, media_pool, studio
+
+
+def a_cut(tmp_path: Path, doc: Any, name: str = "sunset-set.cut.json") -> str:
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def valid_doc(**overrides: Any) -> dict[str, Any]:
+    """Three shots over one continuous master mix — the concert substrate, in miniature."""
+    doc: dict[str, Any] = {
+        "schema": 1,
+        "timeline": {"name": "sunset-set", "fps": 59.94},
+        "sources": {
+            "gtr_close": {"clip": "C0012.mp4", "bin": "Angles"},
+            "keys_wide": {"clip": "C0031.mp4", "bin": "Angles"},
+            "master_mix": {"clip": "sunset-master.wav"},
+        },
+        "audio": {"source": "master_mix", "in": 0, "out": 240},
+        "segments": [
+            {"id": "s001", "source": "gtr_close", "in": 1000, "out": 1100},
+            {"id": "s002", "source": "keys_wide", "in": 4000, "out": 4080},
+            {"id": "s003", "source": "gtr_close", "in": 2500, "out": 2560},
+        ],
+    }
+    doc.update(overrides)
+    return doc
+
+
+SEGMENT_DURATIONS = (100, 80, 60)
+TOTAL_FRAMES = sum(SEGMENT_DURATIONS)
+
+
+def a_pool(**clips: FakeMediaPoolItem) -> Any:
+    """The pool :func:`valid_doc` builds against; ``clips`` swaps one out by alias."""
+    angle = clips.get(
+        "gtr_close",
+        FakeMediaPoolItem(
+            "C0012.mp4",
+            file_path="D:/media/C0012.mp4",
+            properties={"Frames": "20000", "Start": "0", "End": "19999"},
+        ),
+    )
+    keys = clips.get(
+        "keys_wide",
+        FakeMediaPoolItem(
+            "C0031.mp4",
+            file_path="D:/media/C0031.mp4",
+            properties={"Frames": "20000", "Start": "0", "End": "19999"},
+        ),
+    )
+    master = clips.get(
+        "master_mix",
+        FakeMediaPoolItem(
+            "sunset-master.wav",
+            file_path="D:/media/sunset-master.wav",
+            properties={"Type": "Audio", "FPS": "", "Frames": "600", "Start": "0", "End": "599"},
+        ),
+    )
+    return media_pool({"Angles": [angle, keys], "": [master]})
+
+
+def empty_project(pool: Any, **kwargs: Any) -> Any:
+    """A project with a media pool and no timelines yet."""
+    return studio(timeline=None, timelines=[], pool=pool, **kwargs)
+
+
+def built(resolve: Any, name: str) -> FakeTimeline:
+    """The timeline the build made, read back off the project."""
+    project = resolve.current_project
+    found = [
+        project.GetTimelineByIndex(index)
+        for index in range(1, project.GetTimelineCount() + 1)
+        if project.GetTimelineByIndex(index) is not None
+    ]
+    match: FakeTimeline = next(timeline for timeline in found if timeline.GetName() == name)
+    return match
+
+
+def placements(
+    timeline: FakeTimeline,
+    track_type: str = "video",
+    index: int = 1,
+) -> list[tuple[str, int, int]]:
+    return [
+        (item.GetName(), item.GetStart(), item.GetDuration())
+        for item in timeline.GetItemListInTrack(track_type, index) or []
+    ]
+
+
+# --- the clean build ----------------------------------------------------------------------
+
+
+def test_a_valid_cut_builds_the_first_version(attach: Attach, tmp_path: Path) -> None:
+    attach(empty_project(a_pool()))
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is True
+    assert result["timeline"]["name"] == "sunset-set v1"
+    assert result["timeline"]["base_name"] == "sunset-set"
+    assert result["timeline"]["version"] == 1
+
+
+def test_segments_land_butt_joined_in_document_order(attach: Attach, tmp_path: Path) -> None:
+    """Sequential V1: positions are computed, so gaps cannot happen and must not appear."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert placements(built(resolve, "sunset-set v1")) == [
+        ("C0012.mp4", 0, 100),
+        ("C0031.mp4", 100, 80),
+        ("C0012.mp4", 180, 60),
+    ]
+
+
+def test_each_segment_takes_the_source_frames_the_cut_named(attach: Attach, tmp_path: Path) -> None:
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    build_timeline(a_cut(tmp_path, valid_doc()))
+
+    items = built(resolve, "sunset-set v1").GetItemListInTrack("video", 1) or []
+    assert [item.GetSourceStartFrame() for item in items] == [1000, 4000, 2500]
+
+
+def test_the_master_audio_is_one_continuous_clip_under_the_cut(
+    attach: Attach, tmp_path: Path
+) -> None:
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert placements(built(resolve, "sunset-set v1"), "audio") == [
+        ("sunset-master.wav", 0, TOTAL_FRAMES)
+    ]
+
+
+def test_record_frames_are_absolute_from_the_timeline_start(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A one-hour start timecode is the norm; a recordFrame of 0 would land before it (#18 d)."""
+    pool = a_pool()
+    pool.new_timeline_start = 3600
+    resolve = empty_project(pool)
+    attach(resolve)
+
+    build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert [start for _, start, _ in placements(built(resolve, "sunset-set v1"))] == [
+        3600,
+        3700,
+        3780,
+    ]
+
+
+def test_every_append_names_its_media_type_and_track(attach: Attach, tmp_path: Path) -> None:
+    """``trackIndex`` without ``mediaType`` returns True and drops the clip — never send one."""
+    pool = a_pool()
+    attach(empty_project(pool))
+
+    build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert pool.appends
+    assert all("mediaType" in append and "trackIndex" in append for append in pool.appends)
+    assert {append["mediaType"] for append in pool.appends} == {1, 2}
+
+
+def test_a_cut_without_audio_builds_video_alone(attach: Attach, tmp_path: Path) -> None:
+    """A rough cut has no master mix; that is a shape, not an error."""
+    doc = valid_doc()
+    del doc["audio"]
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is True
+    assert result["placed"] == {"segments": 3, "audio": False}
+    assert placements(built(resolve, "sunset-set v1"), "audio") == []
+
+
+def test_the_report_echoes_the_cut_hash_and_where_it_came_from(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Provenance: the built timeline is traceable to the exact bytes that built it."""
+    attach(empty_project(a_pool()))
+    cut_file = a_cut(tmp_path, valid_doc())
+
+    result = build_timeline(cut_file)
+
+    assert result["content_hash"] == content_hash(Path(cut_file).read_bytes())
+    assert result["cut_file"] == cut_file
+    assert result["context"]["project"] == "sunset-set"
+    assert result["context"]["timeline"] == "sunset-set v1"
+
+
+def test_the_built_timeline_reports_its_own_span(attach: Attach, tmp_path: Path) -> None:
+    attach(empty_project(a_pool()))
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["timeline"]["duration"]["frames"] == TOTAL_FRAMES
+    assert result["timeline"]["fps"] == 59.94
+    assert result["placed"] == {"segments": 3, "audio": True}
+
+
+def test_the_build_opens_the_timeline_it_made(attach: Attach, tmp_path: Path) -> None:
+    """Resolve appends to the *current* timeline, so the build has to switch to it."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert resolve.current_project.GetCurrentTimeline().GetName() == "sunset-set v1"
+
+
+# --- versions -----------------------------------------------------------------------------
+
+
+def test_a_rebuild_takes_the_next_version_and_leaves_the_old_ones_alone(
+    attach: Attach, tmp_path: Path
+) -> None:
+    earlier = FakeTimeline(
+        "sunset-set v3",
+        "59.94",
+        video=[FakeTrack("Video 1", [FakeTimelineItem("C0012.mp4", 0, 500)])],
+    )
+    resolve = studio(
+        timeline=None,
+        timelines=[FakeTimeline("sunset-set v1", "59.94"), earlier],
+        pool=a_pool(),
+    )
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["timeline"]["name"] == "sunset-set v4"
+    assert placements(earlier) == [("C0012.mp4", 0, 500)]
+
+
+def test_a_deleted_version_does_not_hand_its_number_out_twice(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Max, not count: v2 deleted must still leave v4 as the next name after v3."""
+    resolve = studio(
+        timeline=None,
+        timelines=[FakeTimeline("sunset-set v1", "59.94"), FakeTimeline("sunset-set v3", "59.94")],
+        pool=a_pool(),
+    )
+    attach(resolve)
+
+    assert build_timeline(a_cut(tmp_path, valid_doc()))["timeline"]["name"] == "sunset-set v4"
+
+
+def test_another_cuts_versions_do_not_move_this_ones_number(
+    attach: Attach, tmp_path: Path
+) -> None:
+    resolve = studio(
+        timeline=None,
+        timelines=[FakeTimeline("holiday-gig v7", "59.94"), FakeTimeline("sunset-set", "59.94")],
+        pool=a_pool(),
+    )
+    attach(resolve)
+
+    assert build_timeline(a_cut(tmp_path, valid_doc()))["timeline"]["name"] == "sunset-set v1"
+
+
+# --- pre-flight: nothing starts on a bad file ---------------------------------------------
+
+
+def test_an_invalid_cut_aborts_before_resolve_is_touched(attach: Attach, tmp_path: Path) -> None:
+    doc = valid_doc()
+    doc["segments"][1]["out"] = doc["segments"][1]["in"]
+    pool = a_pool()
+    resolve = empty_project(pool)
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "cut_invalid"
+    assert [finding["rule"] for finding in result["error"]["detail"]["errors"]] == ["E3"]
+    assert resolve.current_project.GetTimelineCount() == 0
+    assert "CreateEmptyTimeline" not in pool.calls
+
+
+def test_the_abort_reports_every_error_at_once(attach: Attach, tmp_path: Path) -> None:
+    doc = valid_doc()
+    doc["segments"][0]["out"] = doc["segments"][0]["in"]
+    doc["segments"][1]["source"] = "no_such_alias"
+    attach(empty_project(a_pool()))
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert {finding["rule"] for finding in result["error"]["detail"]["errors"]} == {"E3", "E4"}
+    assert result["error"]["detail"]["content_hash"]
+
+
+def test_a_file_that_is_not_json_aborts_as_a_validation_finding(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(empty_project(a_pool()))
+    path = tmp_path / "broken.cut.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    result = build_timeline(str(path))
+
+    assert result["ok"] is False
+    assert result["error"]["detail"]["errors"][0]["rule"] == "E1"
+
+
+def test_warnings_are_reported_and_do_not_block(attach: Attach, tmp_path: Path) -> None:
+    """W1 is a creative call, not a rule; the flash frame builds and is named."""
+    doc = valid_doc()
+    doc["segments"][2]["out"] = doc["segments"][2]["in"] + 4
+    doc["audio"]["out"] = 184
+    attach(empty_project(a_pool()))
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is True
+    assert [finding["rule"] for finding in result["warnings"]] == ["W1"]
+
+
+def test_overlays_are_refused_rather_than_silently_dropped(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Anchored overlays are a later tool; building the V1 alone would be a half-built cut."""
+    doc = valid_doc()
+    doc["overlays"] = [
+        {
+            "id": "b01",
+            "source": "keys_wide",
+            "in": 4000,
+            "out": 4020,
+            "over": {"segment": "s001", "offset": 10},
+        }
+    ]
+    pool = a_pool()
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "unsupported_cut_feature"
+    assert "CreateEmptyTimeline" not in pool.calls
+
+
+def test_no_project_open_fails_before_anything_else(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(project=None))
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "no_project_open"
+
+
+# --- the footguns -------------------------------------------------------------------------
+
+
+def test_a_locked_target_track_is_reported_instead_of_silently_dropping_the_cut(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Resolve returns items for an append onto a locked track and places nothing (#18 d)."""
+    pool = a_pool()
+    pool.new_timeline_locked = True
+    resolve = empty_project(pool)
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    findings = result["error"]["detail"]["errors"]
+    assert [finding["rule"] for finding in findings] == ["E11", "E11"]
+    assert [finding["id"] for finding in findings] == ["A1", "V1"]
+    assert "AppendToTimeline" not in pool.calls
+
+
+def test_a_still_gets_its_out_written_once_so_endframe_is_honoured(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Without the one-time Out write every still lands at the default duration (#18 a)."""
+    still = FakeMediaPoolItem(
+        "backdrop.png",
+        file_path="D:/media/backdrop.png",
+        properties={"Type": "Still", "FPS": "", "Frames": "1", "Start": "0", "End": "0"},
+    )
+    doc = valid_doc()
+    doc["sources"]["keys_wide"] = {"clip": "backdrop.png", "bin": "Angles"}
+    resolve = empty_project(a_pool(keys_wide=still))
+    attach(resolve)
+
+    build_timeline(a_cut(tmp_path, doc))
+
+    assert ("Out", "0") in still.property_writes
+    assert placements(built(resolve, "sunset-set v1"))[1] == ("backdrop.png", 100, 80)
+
+
+def test_an_append_that_landed_somewhere_else_fails_the_build(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """No overwrite on overlap: a blocked clip slides, so placement is verified, not trusted."""
+    pool = a_pool()
+    pool.new_timeline_items = [FakeTimelineItem("stray.mp4", 0, 50)]
+    resolve = empty_project(pool)
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    assert "sunset-set v1" in result["error"]["detail"]["timeline"]
+    assert result["error"]["detail"]["misplaced"]
+
+
+def test_a_refused_timeline_creation_is_a_structured_failure(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = a_pool()
+    pool.create_timeline_result = False
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    assert "sunset-set v1" in result["error"]["cause"]
+
+
+def test_a_missing_video_track_is_created_before_the_append(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A track index past the next free one is accepted and dropped, so tracks are pre-made."""
+    pool = a_pool()
+    pool.new_timeline_tracks = (0, 0)
+    resolve = empty_project(pool)
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is True
+    assert len(placements(built(resolve, "sunset-set v1"))) == 3
+    assert placements(built(resolve, "sunset-set v1"), "audio")

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -11,16 +11,22 @@ place the direct-attach path itself is exercised.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+from resolve_mcp.tools.cut import build_timeline, validate_cut
 from resolve_mcp.tools.escape_hatch import run_python
 from resolve_mcp.tools.media import inspect_clip, list_media
 from resolve_mcp.tools.project import get_status, list_projects, snapshot_project
 from resolve_mcp.tools.timeline import inspect_timeline, list_timelines
 
 pytestmark = pytest.mark.live
+
+SMOKE_CUT = "resolve-mcp-smoke"
+"""Every build here materialises a new version of this name; delete them when you are done."""
 
 
 @pytest.fixture(autouse=True)
@@ -130,6 +136,118 @@ def test_the_frame_math_holds_on_a_real_timeline() -> None:
                     item["sync_offset"]["frames"]
                     == record["in"]["frames"] - item["source"]["in"]["frames"]
                 )
+
+
+# --- build_timeline: the footgun wraps, on the only API that can confirm them --------------
+
+
+def a_source_clip() -> dict[str, Any]:
+    """A pool clip long enough to cut three shots out of, with a rate the cut can declare."""
+    listing = list_media()
+    if not listing["ok"]:
+        pytest.skip("No media pool")
+    for entry in listing["clips"]:
+        clip = inspect_clip(entry["name"], bin=entry["bin"] or None)
+        if not clip["ok"]:
+            continue
+        media = clip["bounds"]["media"]
+        fps = clip["properties"].get("FPS")
+        if media["duration"] is None or media["duration"]["frames"] < 200 or not fps:
+            continue
+        return {
+            "name": entry["name"],
+            "bin": entry["bin"] or None,
+            "fps": float(fps),
+            "start": media["start"]["frames"],
+        }
+    pytest.skip("No pool clip long enough to cut a smoke timeline from")
+
+
+def a_smoke_cut(tmp_path: Path, source: dict[str, Any], durations: tuple[int, ...]) -> str:
+    """A rough-cut shaped file (no master audio) built from one real clip."""
+    at = source["start"]
+    segments = []
+    for index, length in enumerate(durations):
+        segments.append(
+            {
+                "id": f"s{index:03d}",
+                "source": "angle",
+                "in": at,
+                "out": at + length,
+            }
+        )
+        at += length
+    angle = {"clip": source["name"]}
+    if source["bin"] is not None:
+        angle["bin"] = source["bin"]
+    doc = {
+        "schema": 1,
+        "timeline": {"name": SMOKE_CUT, "fps": source["fps"]},
+        "sources": {"angle": angle},
+        "segments": segments,
+    }
+    path = tmp_path / "smoke.cut.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it(tmp_path: Path) -> None:
+    """The one check no fake can make: that Resolve honours the placement we send it.
+
+    Four #18 footguns land here at once — an absolute recordFrame against a one-hour start
+    timecode, mediaType travelling with trackIndex, exact endFrame durations, and no
+    silent relocation — because every one of them shows up as a placement that is off.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    source = a_source_clip()
+    durations = (48, 24, 36)
+    cut_file = a_smoke_cut(tmp_path, source, durations)
+    assert validate_cut(cut_file)["valid"] is True
+
+    result = build_timeline(cut_file)
+
+    assert result["ok"] is True, result.get("error")
+    assert result["placed"] == {"segments": 3, "audio": False}
+    built = inspect_timeline(result["timeline"]["name"], detail="clips")
+    assert built["ok"] is True
+    video = [track for track in built["tracks"] if track["type"] == "video"][0]
+    starts = [item["record"]["in"]["frames"] for item in video["items"]]
+    timeline_start = built["timeline"]["start"]["frames"]
+    assert [item["record"]["duration"]["frames"] for item in video["items"]] == list(durations)
+    assert starts == [timeline_start, timeline_start + 48, timeline_start + 72]
+
+
+def test_a_rebuild_makes_the_next_version_and_leaves_the_last_one_alone(tmp_path: Path) -> None:
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    source = a_source_clip()
+    first = build_timeline(a_smoke_cut(tmp_path, source, (48, 24, 36)))
+    assert first["ok"] is True, first.get("error")
+
+    second = build_timeline(a_smoke_cut(tmp_path, source, (60, 30)))
+
+    assert second["ok"] is True, second.get("error")
+    assert second["timeline"]["version"] == first["timeline"]["version"] + 1
+    earlier = inspect_timeline(first["timeline"]["name"], detail="summary")
+    assert earlier["timeline"]["duration"]["frames"] == 108
+
+
+def test_an_invalid_cut_creates_no_timeline_on_a_real_project(tmp_path: Path) -> None:
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    source = a_source_clip()
+    cut_file = Path(a_smoke_cut(tmp_path, source, (48, 24, 36)))
+    doc = json.loads(cut_file.read_text(encoding="utf-8"))
+    doc["segments"][1]["out"] = doc["segments"][1]["in"]
+    cut_file.write_text(json.dumps(doc), encoding="utf-8")
+    before = {entry["name"] for entry in list_timelines()["timelines"]}
+
+    result = build_timeline(str(cut_file))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "cut_invalid"
+    assert {entry["name"] for entry in list_timelines()["timelines"]} == before
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -28,6 +28,24 @@ pytestmark = pytest.mark.live
 SMOKE_CUT = "resolve-mcp-smoke"
 """Every build here materialises a new version of this name; delete them when you are done."""
 
+LOCKED_TRACK_PROBE = """
+pool = project.GetMediaPool()
+timeline = pool.CreateEmptyTimeline("resolve-mcp-lock-probe")
+project.SetCurrentTimeline(timeline)
+timeline.SetTrackLock("video", 1, True)
+clips = [c for c in pool.GetRootFolder().GetClipList() if c.GetName() == {name}]
+returned = pool.AppendToTimeline([
+    {{"mediaPoolItem": clips[0], "startFrame": {start}, "endFrame": {end},
+      "mediaType": 1, "trackIndex": 1, "recordFrame": timeline.GetStartFrame()}}
+]) if clips else None
+result = {{
+    "found": bool(clips),
+    "returned_truthy": bool(returned),
+    "items_on_track": len(timeline.GetItemListInTrack("video", 1) or []),
+}}
+"""
+"""Spike #18 (d), reduced to its claim: a locked track reports a placement it did not make."""
+
 
 @pytest.fixture(autouse=True)
 def _requires_resolve() -> None:
@@ -231,6 +249,63 @@ def test_a_rebuild_makes_the_next_version_and_leaves_the_last_one_alone(tmp_path
     assert second["timeline"]["version"] == first["timeline"]["version"] + 1
     earlier = inspect_timeline(first["timeline"]["name"], detail="summary")
     assert earlier["timeline"]["duration"]["frames"] == 108
+
+
+def test_a_still_lands_at_the_duration_the_cut_asked_for(tmp_path: Path) -> None:
+    """The one-time Out write, end to end: without it every still is 120 frames (#18 (a))."""
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    listing = list_media()
+    stills = [
+        entry
+        for entry in listing["clips"]
+        if Path(str(entry.get("file_path") or "")).suffix.lower() in {".png", ".jpg", ".jpeg"}
+    ]
+    if not stills:
+        pytest.skip("No still image in the media pool")
+    still = stills[0]
+    fps = get_status()["context"]["fps"] or 24.0
+    doc = {
+        "schema": 1,
+        "timeline": {"name": SMOKE_CUT, "fps": fps},
+        "sources": {"still": {"clip": still["name"]}},
+        "segments": [{"id": "s000", "source": "still", "in": 0, "out": 90}],
+    }
+    path = tmp_path / "still.cut.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+    result = build_timeline(str(path))
+
+    assert result["ok"] is True, result.get("error")
+    built = inspect_timeline(result["timeline"]["name"], detail="clips")
+    video = [track for track in built["tracks"] if track["type"] == "video"][0]
+    assert [item["record"]["duration"]["frames"] for item in video["items"]] == [90]
+
+
+def test_the_locked_track_footgun_is_still_real(tmp_path: Path) -> None:
+    """The spike's (d) probe, kept alive: an append onto a locked track reports success.
+
+    build_timeline cannot reach this through its own tools — it always creates a fresh,
+    unlocked timeline — so the guard it carries rests on this API behaviour rather than on
+    anything a fake can prove. If Resolve ever fixes it, this test is where that shows up,
+    and the E11 check can go.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    source = a_source_clip()
+    probe = run_python(
+        LOCKED_TRACK_PROBE.format(
+            name=repr(source["name"]),
+            start=source["start"],
+            end=source["start"] + 48,
+        )
+    )
+
+    assert probe["ok"] is True, probe.get("error")
+    if not probe["result"]["found"]:
+        pytest.skip("The chosen clip is not in the root folder, so the probe could not run")
+    assert probe["result"]["returned_truthy"] is True
+    assert probe["result"]["items_on_track"] == 0
 
 
 def test_an_invalid_cut_creates_no_timeline_on_a_real_project(tmp_path: Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,6 +33,7 @@ def test_registers_the_p1_session_media_timeline_and_cut_tools() -> None:
         "inspect_timeline",
         "get_cut_schema",
         "validate_cut",
+        "build_timeline",
         "run_python",
     }
 


### PR DESCRIPTION
Closes #28. **Stacked on #60 (`issue-27`)** — merge that first; this branch contains its commits.

## What this builds

`build_timeline` materializes a cut file as a fresh `<name> v<N>` timeline: sequential V1 segments, butt-joined at computed positions, over one continuous master-audio clip. The version number is scanned off the project's existing timeline names (max + 1), so no build ever touches a version someone has already reviewed.

The pre-flight is the *same* rule pass `validate_cut` runs — `cut.preflight` is now shared by both, over one media-pool reading, so the clip that gets placed is the clip the rules passed. A single error aborts before any timeline is created.

Every footgun spike #18 confirmed is wrapped and none are exposed: tracks are pre-created (and a refused `AddTrack` stops the build), stills get their one-time `Out` write so `endFrame` is honoured, `mediaType` always travels with `trackIndex`, record frames are absolute from the timeline's own start, and every placement is read back off the track — Resolve's truthy return is counted, never believed.

**One deliberate scope call:** a valid cut carrying `overlays` is *refused* (`unsupported_cut_feature`) rather than built as V1-only. Anchored overlays are #30; building without them would leave a timeline that does not match its own cut file, which is the half-built outcome the pre-flight exists to prevent.

## Test seam

Fake tier (`tests/test_build_timeline.py`, 26 tests). The fake now models the append footguns at the pool seam — a locked track returns items and places nothing, an overlapping append slides to the next free frame, a still ignores `endFrame` until `Out` is written, a track index past the next free one is dropped — so a wrapper that trusted Resolve's return value fails the suite rather than a real cut. Live tier gains 6 tests for what no fake can prove: that Resolve honours the placement.

Fake tier green, mypy strict clean, ruff clean.

## Review record

Two-axis review (`/code-review`, Standards + Spec as parallel sub-agents) against `origin/issue-27`. 12 findings, all resolved:

**Standards (6)** — two hard: (1) `AddTrack`'s return was discarded, so a refused add spun the wait loop forever and the append would have gone to a track that is not there → raises `BuildFailedError`, with a test; (2) nothing pinned a mid-build handle death → test added, pinning a cause and a fix rather than a traceback. Four judgement calls: `Preflight`'s parallel `clips`/`facts` lists (data clump) → `Source` pairs, with the alias lookup keyed on the fact object rather than equality; orphaned `clip_facts` and over-exported `readable_doc` → deleted / privatised; repeated track-type set → `_track_types`; a loop variable that called a track type a track → renamed.

**Spec (6)** — one partial AC: AC5's footgun coverage missed the locked track and the still `endFrame` bug at the live tier → added a live still-duration build and a locked-track API probe seeded from spike #18 (d). One correctness note: the stereo comment claimed more than the code does (only tracks this build *adds* are stereo; a track the new timeline came with keeps the project template's layout) → comment corrected and the layout logged. Overlay refusal was flagged as unasked-for behaviour and kept deliberately, as described above. The remaining findings confirmed no defect: the clipInfo shape, the `dur = endFrame - startFrame` convention, and the record-frame arithmetic all match the spike's verified facts.

## Live ACs (unrun)

AC1's frame-exact placement, AC4's rebuild, and AC5's footgun wraps all have live coverage that has not been run — it needs Resolve Studio on the Windows box. `uv run pytest -m live` when you are at that machine; the new tests leave `resolve-mcp-smoke v<N>` timelines behind for inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Review: clean — two-axis (Standards + Spec), 12 findings, all resolved
