### PR TITLE
P1: Job infrastructure + audio acquisition

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Build contract: [issue #22](https://github.com/danielbaldwin47/resolve-mcp/issue
 ## Status
 
 P1 in progress. Shipped so far: the server skeleton, the session/project tools, the media
-pool tools, and the `run_python` escape hatch.
+pool tools, the timeline read tools, the background-job infrastructure with audio
+acquisition, and the `run_python` escape hatch.
 
 | Tool | What it does |
 | --- | --- |
@@ -22,11 +23,24 @@ pool tools, and the `run_python` escape hatch.
 | `set_clip_metadata` | Batch metadata writes, each field routed by what the clip reports |
 | `organize_media` | Batch bin operations: create nested bins, move clips |
 | `relink_media` | Points offline clips at media that moved (folder relink or file replace) |
+| `list_timelines` | Timelines with version, duration, fps and track stack; names the latest version per cut |
+| `inspect_timeline` | One timeline at a chosen detail level and range, in dual time, with per-shot sync offsets |
+| `get_job` | Polls one background job: progress, result, or a structured failure |
+| `list_jobs` | Lists jobs newest first — how a restarted session finds what it started |
 | `run_python` | Escape hatch: runs scripting-API Python in the server process |
 
 Bin paths are slash-separated from the media pool root (`Concert/Angles`) and
 case-sensitive. A clip counts as **offline** when it has a file path that is not on
 disk — Resolve's scripting API exposes no offline flag.
+
+Heavy work runs as a background job: the starter returns a `job_id` immediately, `get_job`
+polls it, and results are cached under the cache root against the media and the parameters,
+so an unchanged rerun is instant. Job records live on disk, which is what lets `list_jobs`
+recover after a restart — a job that was still running when the server went down comes back
+`failed` with code `job_interrupted`. Audio acquisition is internal to the starters: a
+timeline is exported through Resolve's render queue (the only route that captures the
+timeline *mix*, 48 kHz/24-bit WAV), a single source clip is extracted with ffmpeg unless its
+audio mapping says the audio is linked or offset away from the file.
 
 ## Requirements
 
@@ -38,6 +52,8 @@ disk — Resolve's scripting API exposes no offline flag.
   server refuses to attach on one. [uv](https://docs.astral.sh/uv/) still manages the
   venv and the lockfile.
 - Resolve running, with a project open, before the first Resolve-touching tool call
+- **ffmpeg on PATH** for per-clip audio extraction (`RESOLVE_MCP_FFMPEG` points at it
+  elsewhere). Timeline-scope audio goes through Resolve's own render queue and needs none.
 
 ## Install
 
@@ -69,7 +85,8 @@ Zero-config by default; every path has an environment override.
 | --- | --- | --- |
 | `RESOLVE_SCRIPT_API` | `%PROGRAMDATA%\Blackmagic Design\DaVinci Resolve\Support\Developer\Scripting` | Scripting API root (holds `Modules/DaVinciResolveScript.py`) |
 | `RESOLVE_SCRIPT_LIB` | `C:\Program Files\Blackmagic Design\DaVinci Resolve\fusionscript.dll` | Scripting library |
-| `RESOLVE_MCP_CACHE` | `%LOCALAPPDATA%\resolve-mcp` | Cache root: snapshots, analysis artifacts, model weights |
+| `RESOLVE_MCP_CACHE` | `%LOCALAPPDATA%\resolve-mcp` | Cache root: snapshots, job records, cached results, acquired audio, model weights |
+| `RESOLVE_MCP_FFMPEG` | `ffmpeg` (found on PATH) | ffmpeg executable used for per-clip audio extraction |
 | `RESOLVE_MCP_LOG_LEVEL` | `INFO` | Log level for the stderr logger |
 | `RESOLVE_MCP_ALLOW_ANY_PYTHON` | unset | Bypass the interpreter check (see ADR 0001) |
 

--- a/src/resolve_mcp/audio/__init__.py
+++ b/src/resolve_mcp/audio/__init__.py
@@ -1,0 +1,1 @@
+"""Getting concert audio out of Resolve and onto disk, where the analysis workers read it."""

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -25,9 +25,8 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
-import os
 from collections.abc import Iterator
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 from ..config import Config, get_config
@@ -327,8 +326,13 @@ def mapping_conflict(mapping: dict[str, Any] | None, file_path: str) -> str | No
 
 
 def _normal(path: str) -> str:
-    """One spelling for a path, so D:\\media\\a.wav and D:/media/a.wav are the same file."""
-    return os.path.normcase(os.path.normpath(path))
+    """One spelling for a path, so D:\\media\\a.wav and D:/media/a.wav are the same file.
+
+    Windows rules regardless of the host: Resolve runs on Windows, but the fake tier runs
+    on ubuntu in CI, where ``os.path`` would leave the two spellings above unequal and this
+    comparison would mean something different there than in production.
+    """
+    return str(PureWindowsPath(path)).lower()
 
 
 def _walk(value: Any, path: tuple[str, ...] = ()) -> Iterator[tuple[tuple[str, ...], Any]]:
@@ -343,7 +347,7 @@ def _walk(value: Any, path: tuple[str, ...] = ()) -> Iterator[tuple[tuple[str, .
 
 
 def _looks_like_a_path(value: str) -> bool:
-    return ("/" in value or "\\" in value) and Path(value).suffix != ""
+    return ("/" in value or "\\" in value) and PureWindowsPath(value).suffix != ""
 
 
 # --- shared ------------------------------------------------------------------------------

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -15,14 +15,16 @@ Which route is chosen is not a preference, it is a correctness question:
 
 Caching follows the same split (see ``jobs.cache``): the source clip is fingerprinted
 cheaply, the acquired WAV is hashed for real, and that hash is what analysis jobs key off.
-A timeline has no bytes to fingerprint, so its identity is name, unique id, bounds, fps and
-track counts — a heuristic, which is why every starter takes ``refresh`` to force the
-export again when the director has changed something the heuristic cannot see.
+A timeline has no bytes to fingerprint, so its identity is name, unique id, bounds, track
+counts and a digest of the shots on it — still a heuristic, because a clip's audio level is
+not readable through the scripting API at all, which is why every starter takes ``refresh``
+to force the export again when the director changed something no reading can see.
 """
 
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import os
 from collections.abc import Iterator
 from pathlib import Path
@@ -33,11 +35,11 @@ from ..errors import AudioExportError, AudioExtractionError, AudioMappingError, 
 from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, start_job
 from ..logging_config import get_logger
-from ..naming import UNSAFE_IN_FILENAME
+from ..naming import slug
 from ..resolve import media, render
 from ..resolve.connection import ResolveConnection
 from ..resolve.session import current_project
-from ..resolve.timeline import find_timeline
+from ..resolve.timeline import Reader, find_timeline
 from . import ffmpeg, wav
 
 log = get_logger("audio")
@@ -53,6 +55,7 @@ CLIP_KIND = "acquire_clip_audio"
 
 RENDER_FORMAT = "wav"
 RENDER_CODEC = "lpcm"
+SINGLE_CLIP = 1
 
 EXPORT_FLOOR = 0.1
 EXPORT_CEILING = 0.9
@@ -63,17 +66,43 @@ OFFSET_HINT = ("offset", "delay")
 # --- timeline scope: the render queue ----------------------------------------------------
 
 
-def timeline_fingerprint(timeline: Timeline) -> dict[str, Any]:
-    """A timeline's identity, as far as anything outside Resolve can read it."""
-    reading: dict[str, Any] = {
-        "name": _text(timeline.GetName),
-        "unique_id": _text(getattr(timeline, "GetUniqueId", None)),
-        "start": _text(timeline.GetStartFrame),
-        "end": _text(timeline.GetEndFrame),
-        "audio_tracks": _text(lambda: timeline.GetTrackCount("audio")),
-        "video_tracks": _text(lambda: timeline.GetTrackCount("video")),
+def timeline_fingerprint(reader: Reader, timeline: Timeline) -> dict[str, Any]:
+    """A timeline's identity, as far as anything outside Resolve can read it.
+
+    Bounds and track counts alone would call a take swap or a reordered cut "unchanged" —
+    same duration, same stack — and hand back yesterday's mix, so the shots themselves are
+    digested too. What no reading can see is a clip's audio level, which the scripting API
+    does not expose at all; that is what ``refresh`` on the starter is for.
+
+    Nothing here smooths a failure into a default: a field that cannot be read while
+    Resolve is dying must not quietly produce a fingerprint, because every dead-handle
+    reading would collide on one key and serve one concert's audio for another.
+    """
+    return {
+        "name": str(timeline.GetName()),
+        "unique_id": reader.optional(timeline, "GetUniqueId", None),
+        "start": timeline.GetStartFrame(),
+        "end": timeline.GetEndFrame(),
+        "audio_tracks": timeline.GetTrackCount("audio"),
+        "video_tracks": timeline.GetTrackCount("video"),
+        "structure": _structure(reader, timeline),
     }
-    return reading
+
+
+def _structure(reader: Reader, timeline: Timeline) -> str:
+    """A digest of every shot on the cut: what it is, where it starts, how long it runs."""
+    digest = hashlib.sha256()
+    for track_type in ("video", "audio"):
+        count = int(timeline.GetTrackCount(track_type) or 0)
+        for index in range(1, count + 1):
+            items = reader.optional(timeline, "GetItemListInTrack", [], track_type, index) or []
+            digest.update(f"{track_type}{index}:".encode())
+            for item in items:
+                name = reader.optional(item, "GetName", "")
+                start = reader.optional(item, "GetStart", None)
+                duration = reader.optional(item, "GetDuration", None)
+                digest.update(f"{name}@{start}+{duration};".encode())
+    return digest.hexdigest()
 
 
 def acquire_timeline_audio(
@@ -88,14 +117,15 @@ def acquire_timeline_audio(
     config = config or get_config()
     project = current_project(connection, "No project is open, so there is no timeline to export.")
     found = find_timeline(project, timeline)
-    name = _text(found.GetName) or "timeline"
+    name = str(found.GetName() or "timeline")
     params = {
         "scope": "timeline",
         "timeline": name,
         "sample_rate": sample_rate,
         "bit_depth": bit_depth,
     }
-    key = cache.cache_key(TIMELINE_KIND, [timeline_fingerprint(found)], params)
+    fingerprint = timeline_fingerprint(Reader(connection), found)
+    key = cache.cache_key(TIMELINE_KIND, [fingerprint], params)
 
     def work(progress: Progress) -> JobOutput:
         return export_timeline_mix(project, found, key, params, progress, config)
@@ -128,6 +158,9 @@ def export_timeline_mix(
 
     progress(0.05, "queuing the audio export")
     with _current_timeline(project, timeline):
+        # One file for the whole timeline. The other mode renders a file per clip on it,
+        # which for a concert cut is hundreds of fragments instead of the mix.
+        project.SetCurrentRenderMode(SINGLE_CLIP)
         settings = {
             "SelectAllFrames": True,
             "TargetDir": str(target_dir),
@@ -142,10 +175,21 @@ def export_timeline_mix(
             job_id = render.submit(project, settings, RENDER_FORMAT, RENDER_CODEC)
             render.render(project, job_id, expecting, _scaled(progress))
         except RenderQueueError as exc:
-            raise AudioExportError(cause=exc.cause, detail=exc.detail) from exc
+            raise _as_export_failure(exc) from exc
 
     progress(0.95, "hashing the export")
     return JobOutput(_result(expecting, params), (expecting,))
+
+
+def _as_export_failure(exc: RenderQueueError) -> AudioExportError:
+    """Re-label a queue failure as an audio one, keeping any fix the queue was specific about.
+
+    The generic queue advice is worth replacing with "check the timeline has audio on it".
+    Advice the queue raised for one case — a modal dialog stalling the render — is not:
+    that is the more actionable of the two, so it survives the relabelling.
+    """
+    specific = exc.fix if exc.fix != RenderQueueError.default_fix else None
+    return AudioExportError(cause=exc.cause, fix=specific, detail=exc.detail)
 
 
 @contextlib.contextmanager
@@ -321,16 +365,4 @@ def _result(target: Path, params: dict[str, Any]) -> dict[str, Any]:
 
 def _stem(label: str, key: str) -> str:
     """Deterministic from the cache key, so a rerun overwrites instead of accumulating."""
-    slug = UNSAFE_IN_FILENAME.sub("-", label).strip("-") or "audio"
-    return f"{slug}-{key[:12]}"
-
-
-def _text(getter: Any) -> str | None:
-    if getter is None:
-        return None
-    try:
-        value = getter()
-    except Exception:  # noqa: BLE001 - a field the version does not have is not a failure
-        log.debug("Could not read a timeline field for its fingerprint", exc_info=True)
-        return None
-    return None if value is None else str(value)
+    return f"{slug(label, 'audio')}-{key[:12]}"

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -1,0 +1,336 @@
+"""Audio acquisition, both routes — the substrate every analysis job runs on.
+
+Which route is chosen is not a preference, it is a correctness question:
+
+* **Timeline scope goes through the render queue.** It is the only route that captures the
+  timeline *mix* — Resolve's own summing of the tracks, with the director's clip levels and
+  track mapping applied. Nothing outside Resolve can reproduce that. 48 kHz / 24-bit WAV,
+  audio only.
+
+* **A single source clip goes through ffmpeg.** The clip's File Path is a file on disk;
+  reading it directly is far faster than a render and leaves the GUI alone. This is only
+  truthful while Resolve is not doing anything to that audio, so the clip's audio mapping
+  is checked first and a linked or offset source is refused with a pointer at the timeline
+  route rather than quietly extracting the wrong thing.
+
+Caching follows the same split (see ``jobs.cache``): the source clip is fingerprinted
+cheaply, the acquired WAV is hashed for real, and that hash is what analysis jobs key off.
+A timeline has no bytes to fingerprint, so its identity is name, unique id, bounds, fps and
+track counts — a heuristic, which is why every starter takes ``refresh`` to force the
+export again when the director has changed something the heuristic cannot see.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from ..config import Config, get_config
+from ..errors import AudioExportError, AudioExtractionError, AudioMappingError, RenderQueueError
+from ..jobs import cache
+from ..jobs.runner import JobOutput, Progress, start_job
+from ..logging_config import get_logger
+from ..naming import UNSAFE_IN_FILENAME
+from ..resolve import media, render
+from ..resolve.connection import ResolveConnection
+from ..resolve.session import current_project
+from ..resolve.timeline import find_timeline
+from . import ffmpeg, wav
+
+log = get_logger("audio")
+
+Timeline = Any
+Project = Any
+
+DEFAULT_SAMPLE_RATE = 48_000
+DEFAULT_BIT_DEPTH = 24
+
+TIMELINE_KIND = "acquire_timeline_audio"
+CLIP_KIND = "acquire_clip_audio"
+
+RENDER_FORMAT = "wav"
+RENDER_CODEC = "lpcm"
+
+EXPORT_FLOOR = 0.1
+EXPORT_CEILING = 0.9
+
+OFFSET_HINT = ("offset", "delay")
+
+
+# --- timeline scope: the render queue ----------------------------------------------------
+
+
+def timeline_fingerprint(timeline: Timeline) -> dict[str, Any]:
+    """A timeline's identity, as far as anything outside Resolve can read it."""
+    reading: dict[str, Any] = {
+        "name": _text(timeline.GetName),
+        "unique_id": _text(getattr(timeline, "GetUniqueId", None)),
+        "start": _text(timeline.GetStartFrame),
+        "end": _text(timeline.GetEndFrame),
+        "audio_tracks": _text(lambda: timeline.GetTrackCount("audio")),
+        "video_tracks": _text(lambda: timeline.GetTrackCount("video")),
+    }
+    return reading
+
+
+def acquire_timeline_audio(
+    connection: ResolveConnection,
+    timeline: str | None = None,
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    bit_depth: int = DEFAULT_BIT_DEPTH,
+    refresh: bool = False,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Start a job that exports the timeline mix. Returns the job record, not the audio."""
+    config = config or get_config()
+    project = current_project(connection, "No project is open, so there is no timeline to export.")
+    found = find_timeline(project, timeline)
+    name = _text(found.GetName) or "timeline"
+    params = {
+        "scope": "timeline",
+        "timeline": name,
+        "sample_rate": sample_rate,
+        "bit_depth": bit_depth,
+    }
+    key = cache.cache_key(TIMELINE_KIND, [timeline_fingerprint(found)], params)
+
+    def work(progress: Progress) -> JobOutput:
+        return export_timeline_mix(project, found, key, params, progress, config)
+
+    return start_job(
+        TIMELINE_KIND,
+        params,
+        work,
+        cache_key=key,
+        touches_resolve=True,
+        refresh=refresh,
+        config=config,
+    )
+
+
+def export_timeline_mix(
+    project: Project,
+    timeline: Timeline,
+    key: str,
+    params: dict[str, Any],
+    progress: Progress,
+    config: Config | None = None,
+) -> JobOutput:
+    """The worker: queue an audio-only render of one timeline and wait for the WAV."""
+    config = config or get_config()
+    target_dir = config.audio_dir
+    target_dir.mkdir(parents=True, exist_ok=True)
+    stem = _stem(str(params["timeline"]), key)
+    expecting = target_dir / f"{stem}.wav"
+
+    progress(0.05, "queuing the audio export")
+    with _current_timeline(project, timeline):
+        settings = {
+            "SelectAllFrames": True,
+            "TargetDir": str(target_dir),
+            "CustomName": stem,
+            "ExportVideo": False,
+            "ExportAudio": True,
+            "AudioCodec": RENDER_CODEC,
+            "AudioBitDepth": int(params["bit_depth"]),
+            "AudioSampleRate": int(params["sample_rate"]),
+        }
+        try:
+            job_id = render.submit(project, settings, RENDER_FORMAT, RENDER_CODEC)
+            render.render(project, job_id, expecting, _scaled(progress))
+        except RenderQueueError as exc:
+            raise AudioExportError(cause=exc.cause, detail=exc.detail) from exc
+
+    progress(0.95, "hashing the export")
+    return JobOutput(_result(expecting, params), (expecting,))
+
+
+@contextlib.contextmanager
+def _current_timeline(project: Project, timeline: Timeline) -> Iterator[None]:
+    """Render what was asked for, and put the director's timeline back afterwards.
+
+    The render queue renders the *current* timeline, so acquiring audio for any other one
+    means switching. Leaving the switch in place would move the GUI out from under whoever
+    is sitting at it.
+    """
+    previous = project.GetCurrentTimeline()
+    switched = previous is not timeline
+    if switched:
+        project.SetCurrentTimeline(timeline)
+    try:
+        yield
+    finally:
+        if switched and previous is not None:
+            project.SetCurrentTimeline(previous)
+
+
+def _scaled(progress: Progress) -> Progress:
+    """Map the render's own 0-1 onto the part of the job the render actually is."""
+    span = EXPORT_CEILING - EXPORT_FLOOR
+
+    def scaled(fraction: float, step: str) -> None:
+        progress(EXPORT_FLOOR + span * fraction, step)
+
+    return scaled
+
+
+# --- clip scope: ffmpeg ------------------------------------------------------------------
+
+
+def acquire_clip_audio(
+    connection: ResolveConnection,
+    clip: str,
+    bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    bit_depth: int = DEFAULT_BIT_DEPTH,
+    refresh: bool = False,
+    runner: ffmpeg.Runner | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Start a job that extracts one source clip's audio. Returns the job record.
+
+    ``runner`` is the subprocess seam ``ffmpeg.extract`` documents: the default shells out
+    for real, and a caller can hand in its own to exercise the route without ffmpeg.
+    """
+    config = config or get_config()
+    pool = media.media_pool(connection)
+    located = media.find_clip(pool, clip, bin)
+    reported = media.properties(located.clip)
+    source = reported.get(media.FILE_PATH, "")
+    if not source or media.is_offline(source):
+        raise AudioExtractionError(
+            cause=f"{clip!r} has no readable file on disk.",
+            fix="relink_media points a clip back at its media; list_media shows what is offline.",
+            detail={"clip": clip, "file_path": source},
+        )
+
+    conflict = mapping_conflict(media.audio_mapping(located.clip), source)
+    if conflict is not None:
+        raise AudioMappingError(
+            cause=f"{clip!r} does not carry its own audio: {conflict}",
+            detail={"clip": clip, "file_path": source},
+        )
+
+    params = {
+        "scope": "clip",
+        "clip": clip,
+        "bin": located.bin_path,
+        "sample_rate": sample_rate,
+        "bit_depth": bit_depth,
+    }
+    key = cache.cache_key(CLIP_KIND, [cache.fingerprint(source)], params)
+
+    def work(progress: Progress) -> JobOutput:
+        return extract_clip_audio(source, key, params, progress, config, runner)
+
+    return start_job(CLIP_KIND, params, work, cache_key=key, refresh=refresh, config=config)
+
+
+def extract_clip_audio(
+    source: str,
+    key: str,
+    params: dict[str, Any],
+    progress: Progress,
+    config: Config | None = None,
+    runner: ffmpeg.Runner | None = None,
+) -> JobOutput:
+    """The worker: ffmpeg the clip's audio into the cache as a WAV."""
+    config = config or get_config()
+    target = config.audio_dir / f"{_stem(str(params['clip']), key)}.wav"
+
+    progress(0.1, "extracting audio with ffmpeg")
+    ffmpeg.extract(
+        source,
+        target,
+        sample_rate=int(params["sample_rate"]),
+        bit_depth=int(params["bit_depth"]),
+        runner=runner,
+        config=config,
+    )
+
+    progress(0.9, "hashing the extraction")
+    return JobOutput(_result(target, params), (target,))
+
+
+def mapping_conflict(mapping: dict[str, Any] | None, file_path: str) -> str | None:
+    """Why this clip's audio cannot be read from its own file, or ``None`` if it can.
+
+    ``GetAudioMapping`` returns JSON whose shape Blackmagic does not document and has
+    changed between versions, so this reads it structurally rather than by key: any path
+    that is not the clip's own file, and any non-zero offset, mean Resolve is doing
+    something to this audio that ffmpeg on the source file would not reproduce. Erring
+    toward refusing costs a slower export; erring the other way costs analysis of audio
+    that is not the audio in the cut.
+    """
+    if not mapping:
+        return None
+    own = _normal(file_path) if file_path else ""
+    for path, value in _walk(mapping):
+        name = path[-1].lower() if path else ""
+        if isinstance(value, str) and _looks_like_a_path(value) and own and _normal(value) != own:
+            return f"its audio mapping points at {value}."
+        if (
+            isinstance(value, int | float)
+            and not isinstance(value, bool)
+            and value
+            and any(hint in name for hint in OFFSET_HINT)
+        ):
+            return f"its audio mapping carries a {name} of {value}."
+    return None
+
+
+def _normal(path: str) -> str:
+    """One spelling for a path, so D:\\media\\a.wav and D:/media/a.wav are the same file."""
+    return os.path.normcase(os.path.normpath(path))
+
+
+def _walk(value: Any, path: tuple[str, ...] = ()) -> Iterator[tuple[tuple[str, ...], Any]]:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            yield from _walk(item, (*path, str(key)))
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk(item, path)
+    else:
+        yield path, value
+
+
+def _looks_like_a_path(value: str) -> bool:
+    return ("/" in value or "\\" in value) and Path(value).suffix != ""
+
+
+# --- shared ------------------------------------------------------------------------------
+
+
+def _result(target: Path, params: dict[str, Any]) -> dict[str, Any]:
+    """What the agent — and every analysis job after it — reads off a finished acquisition."""
+    reading = wav.describe(target)
+    reading["content_sha256"] = cache.content_hash(target)
+    reading["scope"] = params["scope"]
+    log.info(
+        "Acquired %.1fs of audio for %s scope at %s",
+        reading.get("duration_seconds") or 0.0,
+        params["scope"],
+        target,
+    )
+    return reading
+
+
+def _stem(label: str, key: str) -> str:
+    """Deterministic from the cache key, so a rerun overwrites instead of accumulating."""
+    slug = UNSAFE_IN_FILENAME.sub("-", label).strip("-") or "audio"
+    return f"{slug}-{key[:12]}"
+
+
+def _text(getter: Any) -> str | None:
+    if getter is None:
+        return None
+    try:
+        value = getter()
+    except Exception:  # noqa: BLE001 - a field the version does not have is not a failure
+        log.debug("Could not read a timeline field for its fingerprint", exc_info=True)
+        return None
+    return None if value is None else str(value)

--- a/src/resolve_mcp/audio/ffmpeg.py
+++ b/src/resolve_mcp/audio/ffmpeg.py
@@ -1,0 +1,122 @@
+"""The per-source-clip route: pull audio straight off the file Resolve points at.
+
+This never asks Resolve to do anything — the clip's File Path is a path on disk, and
+ffmpeg reads it far faster than a render queue would, in parallel with whatever the
+director is doing in the GUI. What it cannot see is anything Resolve does to that audio
+(track mapping, levels, a linked file); ``acquire`` checks for that before choosing this
+route.
+
+The subprocess call is a parameter (``runner``) so that command construction, failure
+shaping and the missing-binary case are all testable without ffmpeg installed — while the
+real thing stays one plain ``subprocess.run``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+from ..config import Config, get_config
+from ..errors import AudioExtractionError, FfmpegUnavailableError, InvalidRequestError
+from ..logging_config import get_logger
+
+log = get_logger("audio")
+
+CODECS = {16: "pcm_s16le", 24: "pcm_s24le", 32: "pcm_s32le"}
+STDERR_TAIL = 800
+
+
+class Completed(NamedTuple):
+    """What the runner reports back: ffmpeg says why it refused on stderr."""
+
+    returncode: int
+    stderr: str
+
+
+Runner = Callable[[Sequence[str]], Completed]
+
+
+def command(
+    executable: str,
+    source: Path | str,
+    target: Path | str,
+    sample_rate: int,
+    bit_depth: int,
+) -> list[str]:
+    """The ffmpeg invocation, as a list — never a shell string.
+
+    ``-map 0:a:0`` takes the first audio stream only. A clip whose audio is spread across
+    several streams is not this route's job; the timeline route captures the mix Resolve
+    makes of them.
+    """
+    codec = CODECS.get(bit_depth)
+    if codec is None:
+        raise InvalidRequestError(
+            cause=f"{bit_depth} is not a WAV bit depth this server writes.",
+            fix=f"Use one of {', '.join(str(depth) for depth in sorted(CODECS))}.",
+            detail={"requested": bit_depth, "supported": sorted(CODECS)},
+        )
+    return [
+        executable,
+        "-nostdin",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(source),
+        "-vn",
+        "-map",
+        "0:a:0",
+        "-acodec",
+        codec,
+        "-ar",
+        str(sample_rate),
+        str(target),
+    ]
+
+
+def _run(argv: Sequence[str]) -> Completed:
+    finished = subprocess.run(argv, capture_output=True, text=True, check=False)
+    return Completed(finished.returncode, finished.stderr or "")
+
+
+def extract(
+    source: Path | str,
+    target: Path | str,
+    sample_rate: int,
+    bit_depth: int,
+    runner: Runner | None = None,
+    config: Config | None = None,
+) -> Path:
+    """Write the clip's audio to ``target`` as a WAV, or fail with ffmpeg's own message."""
+    config = config or get_config()
+    destination = Path(target)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    argv = command(config.ffmpeg, source, destination, sample_rate, bit_depth)
+
+    try:
+        finished = (runner or _run)(argv)
+    except FileNotFoundError as exc:
+        raise FfmpegUnavailableError(
+            cause=f"No ffmpeg at {config.ffmpeg!r}.",
+            detail={"executable": config.ffmpeg},
+        ) from exc
+
+    if finished.returncode != 0:
+        raise AudioExtractionError(
+            cause=f"ffmpeg refused {Path(source).name} (exit {finished.returncode}).",
+            detail={
+                "source": str(source),
+                "exit_code": finished.returncode,
+                "stderr": finished.stderr[-STDERR_TAIL:],
+            },
+        )
+    if not destination.exists():
+        raise AudioExtractionError(
+            cause=f"ffmpeg reported success but wrote nothing to {destination}.",
+            detail={"expected": str(destination)},
+        )
+    log.info("Extracted audio from %s to %s", source, destination)
+    return destination

--- a/src/resolve_mcp/audio/wav.py
+++ b/src/resolve_mcp/audio/wav.py
@@ -1,0 +1,43 @@
+"""Reading back what we just wrote.
+
+Everything this server acquires is a WAV, and the standard library reads WAV headers — so
+duration, sample rate and channel count come from ``wave`` rather than from shelling out to
+ffprobe. One less external binary on the critical path, and it works for the render-queue
+route on a machine with no ffmpeg at all.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import wave
+from pathlib import Path
+from typing import Any
+
+from ..errors import AudioExtractionError
+
+BITS_PER_BYTE = 8
+
+
+def describe(path: Path | str) -> dict[str, Any]:
+    """Duration, sample rate, channels and bit depth of a WAV on disk."""
+    target = Path(path)
+    try:
+        with contextlib.closing(wave.open(str(target), "rb")) as handle:
+            frames = handle.getnframes()
+            rate = handle.getframerate()
+            channels = handle.getnchannels()
+            width = handle.getsampwidth()
+    except (OSError, wave.Error) as exc:
+        raise AudioExtractionError(
+            cause=f"{target.name} is not a readable WAV file ({exc}).",
+            fix="Delete it from the cache directory and run the job again.",
+            detail={"path": str(target)},
+        ) from exc
+    return {
+        "path": str(target),
+        "duration_seconds": round(frames / rate, 3) if rate else None,
+        "sample_rate": rate,
+        "channels": channels,
+        "bit_depth": width * BITS_PER_BYTE,
+        "bytes": target.stat().st_size,
+    }

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -16,6 +16,7 @@ DEFAULT_PROGRAMDATA = Path("C:/ProgramData")
 DEFAULT_SCRIPT_LIB = Path("C:/Program Files/Blackmagic Design/DaVinci Resolve/fusionscript.dll")
 DEFAULT_LOG_LEVEL = "INFO"
 CACHE_DIR_NAME = "resolve-mcp"
+DEFAULT_FFMPEG = "ffmpeg"
 
 
 TRUTHY = {"1", "true", "yes", "on"}
@@ -29,6 +30,7 @@ class Config:
     cache_dir: Path
     log_level: str
     allow_any_python: bool = False
+    ffmpeg: str = DEFAULT_FFMPEG
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> Config:
@@ -43,6 +45,7 @@ class Config:
             cache_dir=Path(env.get("RESOLVE_MCP_CACHE") or local_app_data / CACHE_DIR_NAME),
             log_level=env.get("RESOLVE_MCP_LOG_LEVEL") or DEFAULT_LOG_LEVEL,
             allow_any_python=(env.get(BYPASS_ENV) or "").lower() in TRUTHY,
+            ffmpeg=env.get("RESOLVE_MCP_FFMPEG") or DEFAULT_FFMPEG,
         )
 
     @property
@@ -59,6 +62,21 @@ class Config:
     def listing_dir(self) -> Path:
         """Where listings too big to return inline spill to."""
         return self.cache_dir / "listings"
+
+    @property
+    def job_dir(self) -> Path:
+        """One JSON record per job — the only thing that survives a server restart."""
+        return self.cache_dir / "jobs"
+
+    @property
+    def result_dir(self) -> Path:
+        """Cache entries, one per content+params key, pointing at the artifacts they own."""
+        return self.cache_dir / "results"
+
+    @property
+    def audio_dir(self) -> Path:
+        """Acquired WAVs. Analysis workers key off the content hash of what lands here."""
+        return self.cache_dir / "audio"
 
 
 _config: Config | None = None

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -196,6 +196,78 @@ class PythonExecutionError(ResolveMcpError):
     )
 
 
+class JobNotFoundError(ResolveMcpError):
+    code = "job_not_found"
+
+    def __init__(self, job_id: str) -> None:
+        super().__init__(
+            cause=f"No job with id {job_id!r}.",
+            fix="list_jobs shows every job this cache directory knows about, newest first.",
+            detail={"requested": job_id},
+        )
+
+
+class JobInterruptedError(ResolveMcpError):
+    """The server restarted while this job was running, so its thread died with it."""
+
+    code = "job_interrupted"
+    default_fix = (
+        "Start the job again. Anything it had already finished is in the result cache, "
+        "so completed work is not paid for twice."
+    )
+
+
+class RenderQueueError(ResolveMcpError):
+    """The render queue refused a job, failed one, or never produced the file."""
+
+    code = "render_queue_failed"
+    default_fix = (
+        "Open the Deliver page and check the render queue for a failed or cancelled job, "
+        "clear it, and retry. A render that reports success but writes nothing usually means "
+        "the target directory is not writable from the machine Resolve runs on."
+    )
+
+
+class AudioExportError(ResolveMcpError):
+    """Resolve's render queue would not produce the timeline mix."""
+
+    code = "audio_export_failed"
+    default_fix = (
+        "Check the render queue in the Deliver page for a stuck or failed job, make sure the "
+        "timeline has audio on it, then retry."
+    )
+
+
+class FfmpegUnavailableError(ResolveMcpError):
+    """ffmpeg is not on PATH — the per-clip extraction route cannot run without it."""
+
+    code = "ffmpeg_unavailable"
+    default_fix = (
+        "Install ffmpeg and put it on PATH, or point RESOLVE_MCP_FFMPEG at the executable. "
+        "The timeline route needs no ffmpeg if you only want the timeline mix."
+    )
+
+
+class AudioExtractionError(ResolveMcpError):
+    """ffmpeg ran and refused the file."""
+
+    code = "audio_extraction_failed"
+    default_fix = (
+        "Check the clip is online and holds an audio stream — inspect_clip reports both. "
+        "ffmpeg's own message is in detail.stderr."
+    )
+
+
+class AudioMappingError(ResolveMcpError):
+    """The clip's audio does not live in the clip's own file, so extracting it would lie."""
+
+    code = "audio_mapping_unsupported"
+    default_fix = (
+        "Acquire this audio from the timeline instead (scope=timeline): only the render "
+        "route captures audio Resolve has linked or offset away from the source file."
+    )
+
+
 class InternalError(ResolveMcpError):
     code = "internal_error"
     default_fix = (

--- a/src/resolve_mcp/jobs/__init__.py
+++ b/src/resolve_mcp/jobs/__init__.py
@@ -1,0 +1,1 @@
+"""Background jobs: start one, poll it, find it again after a restart."""

--- a/src/resolve_mcp/jobs/cache.py
+++ b/src/resolve_mcp/jobs/cache.py
@@ -82,15 +82,28 @@ def lookup(key: str, config: Config | None = None) -> dict[str, Any] | None:
         return None
     except (OSError, ValueError):
         log.warning("Discarding an unreadable cache entry: %s", path)
-        path.unlink(missing_ok=True)
+        _discard(path)
         return None
     missing = [one for one in entry.get("artifacts", []) if not Path(one).exists()]
     if missing:
         log.info("Cache entry %s lost its artifacts (%s); rerunning", key[:12], missing[0])
-        path.unlink(missing_ok=True)
+        _discard(path)
         return None
     result = entry.get("result")
     return result if isinstance(result, dict) else None
+
+
+def _discard(path: Path) -> None:
+    """Drop a cache entry that cannot be trusted. A miss must never raise on the way out.
+
+    The delete can fail for the same reason the read did — the cache directory is the
+    user's own, and they can leave anything in it. A cache that cannot clean up is still a
+    cache that missed, and the job it was asked about must go ahead and run.
+    """
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        log.warning("Could not remove the stale cache entry %s", path, exc_info=True)
 
 
 def remember(

--- a/src/resolve_mcp/jobs/cache.py
+++ b/src/resolve_mcp/jobs/cache.py
@@ -1,0 +1,115 @@
+"""Hash-keyed results, so analysis is paid for once per media state.
+
+Two kinds of identity live here, and the difference is the whole design:
+
+* **Source media is fingerprinted, not hashed.** A concert master is tens of gigabytes and
+  sits on the director's disk unchanged for months; reading all of it to prove that takes
+  minutes, every run. Path, size and mtime answer "is this the same file" well enough to
+  key an acquisition, and the acquisition is cheap to redo if the guess is ever wrong.
+
+* **Acquired audio is hashed for real.** The WAV this server wrote is the substrate every
+  analysis job keys off (#22: "workers key off content hash of cached audio + params
+  hash"), it is a manageable size, and a false cache hit there would silently attribute
+  one concert's beats to another.
+
+A hit is only a hit if the artifacts are still on disk. The cache directory is a user's
+local app data — they are allowed to delete things in it, and the agent must get a rerun
+rather than a path to a file that is gone.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from ..config import Config, get_config
+from ..logging_config import get_logger
+
+log = get_logger("jobs")
+
+CHUNK = 1 << 20
+
+
+def fingerprint(path: Path | str) -> dict[str, Any]:
+    """Cheap identity for a source file the server did not write."""
+    resolved = Path(path)
+    stat = resolved.stat()
+    return {
+        "path": str(resolved),
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+
+
+def content_hash(path: Path | str) -> str:
+    """sha256 of the file's bytes, read a megabyte at a time."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(CHUNK), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def cache_key(
+    kind: str,
+    inputs: Sequence[Mapping[str, Any]],
+    params: Mapping[str, Any],
+) -> str:
+    """One key over what was run, on what, with which settings."""
+    canonical = json.dumps(
+        {"kind": kind, "inputs": list(inputs), "params": params},
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _entry_path(key: str, config: Config) -> Path:
+    return config.result_dir / f"{key}.json"
+
+
+def lookup(key: str, config: Config | None = None) -> dict[str, Any] | None:
+    """The remembered result, or ``None`` — including when its artifacts went missing."""
+    config = config or get_config()
+    path = _entry_path(key, config)
+    try:
+        entry = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError):
+        log.warning("Discarding an unreadable cache entry: %s", path)
+        path.unlink(missing_ok=True)
+        return None
+    missing = [one for one in entry.get("artifacts", []) if not Path(one).exists()]
+    if missing:
+        log.info("Cache entry %s lost its artifacts (%s); rerunning", key[:12], missing[0])
+        path.unlink(missing_ok=True)
+        return None
+    result = entry.get("result")
+    return result if isinstance(result, dict) else None
+
+
+def remember(
+    key: str,
+    kind: str,
+    result: dict[str, Any],
+    artifacts: Iterable[Path | str],
+    config: Config | None = None,
+) -> None:
+    """Record a finished result against its key, naming the files it owns."""
+    config = config or get_config()
+    entry = {
+        "key": key,
+        "kind": kind,
+        "created_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "artifacts": [str(one) for one in artifacts],
+        "result": result,
+    }
+    path = _entry_path(key, config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entry, indent=2), encoding="utf-8")
+    log.info("Cached %s result under %s", kind, key[:12])

--- a/src/resolve_mcp/jobs/runner.py
+++ b/src/resolve_mcp/jobs/runner.py
@@ -12,7 +12,9 @@ Four decisions:
 
 * **Nothing escapes the worker.** There is no envelope around a thread — an exception here
   would vanish into a dead thread and leave a job running forever. Every failure is caught
-  and written into the record as the same ``cause``/``fix`` shape a tool returns.
+  and written into the record as the same ``cause``/``fix`` shape a tool returns, and that
+  includes writing the cache entry: a job that produced a result but could not record it is
+  a failed job, not a job that never ended.
 
 * **Only one job drives Resolve at a time.** The scripting API is one global application,
   and two jobs pushing the render queue at once corrupt it. Jobs that touch Resolve
@@ -132,6 +134,8 @@ def _work(record: JobRecord, work: Work, config: Config) -> None:
 
     try:
         output = work(progress)
+        if record.cache_key is not None:
+            cache.remember(record.cache_key, record.kind, output.result, output.artifacts, config)
     except ResolveMcpError as exc:
         store.finish(record, error=exc.payload(), config=config)
         return
@@ -144,8 +148,6 @@ def _work(record: JobRecord, work: Work, config: Config) -> None:
         )
         return
 
-    if record.cache_key is not None:
-        cache.remember(record.cache_key, record.kind, output.result, output.artifacts, config)
     store.finish(record, result=output.result, config=config)
 
 

--- a/src/resolve_mcp/jobs/runner.py
+++ b/src/resolve_mcp/jobs/runner.py
@@ -1,0 +1,162 @@
+"""Starting heavy work without stalling stdio.
+
+The rule the whole server hangs off: a tool call returns in the time one Resolve API call
+takes, never in the time a render takes. So a starter registers a job, hands back its id,
+and lets a daemon thread do the work — the agent keeps editing while a concert exports.
+
+Four decisions:
+
+* **A cache hit never starts a thread.** It comes back from the starter already completed,
+  with ``cached: true``, and is still a real job record so ``get_job`` and ``list_jobs``
+  read the same for a hit as for a run.
+
+* **Nothing escapes the worker.** There is no envelope around a thread — an exception here
+  would vanish into a dead thread and leave a job running forever. Every failure is caught
+  and written into the record as the same ``cause``/``fix`` shape a tool returns.
+
+* **Only one job drives Resolve at a time.** The scripting API is one global application,
+  and two jobs pushing the render queue at once corrupt it. Jobs that touch Resolve
+  serialise on one lock; pure compute (analysis on already-acquired audio) does not wait.
+
+* **Threads, not processes.** The heavy libraries are not loaded yet — they get imported
+  inside the workers that need them, so server startup stays fast either way — and a
+  worker driving the Resolve API has to live in the process holding the handle.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from ..config import Config, get_config
+from ..errors import InternalError, ResolveMcpError
+from ..logging_config import get_logger
+from . import cache, store
+from .store import JobRecord
+
+log = get_logger("jobs")
+
+WAIT_TIMEOUT = 30.0
+WAITING = "waiting for Resolve"
+
+RESOLVE_LOCK = threading.Lock()
+"""Held for the whole of any job that drives the Resolve application."""
+
+_threads: dict[str, threading.Thread] = {}
+_threads_lock = threading.Lock()
+
+
+class JobOutput(NamedTuple):
+    """What a worker returns: the result the agent reads, and the files it owns.
+
+    ``artifacts`` is what makes a cache entry verifiable — a hit is only a hit while the
+    files it names are still on disk.
+    """
+
+    result: dict[str, Any]
+    artifacts: tuple[Path, ...] = ()
+
+
+Progress = Callable[[float, str], None]
+Work = Callable[[Progress], JobOutput]
+
+
+def start_job(
+    kind: str,
+    params: dict[str, Any],
+    work: Work,
+    cache_key: str | None = None,
+    touches_resolve: bool = False,
+    refresh: bool = False,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Register the job and return its record now — completed already, on a cache hit.
+
+    ``refresh`` skips the lookup but not the write: a caller who believes the cache is
+    stale gets the work redone, and the fresh result replaces the entry.
+    """
+    config = config or get_config()
+    record = store.new_job(kind, params, cache_key=cache_key, config=config)
+
+    if cache_key is not None and not refresh:
+        hit = cache.lookup(cache_key, config)
+        if hit is not None:
+            record.cached = True
+            record.step = "cached"
+            log.info("Job %s answered from cache", record.job_id)
+            return store.finish(record, result=hit, config=config).payload()
+
+    if touches_resolve and RESOLVE_LOCK.locked():
+        record.step = WAITING
+        store.save(record, config)
+
+    thread = threading.Thread(
+        target=_run,
+        args=(record, work, touches_resolve, config),
+        name=f"job-{record.job_id}",
+        daemon=True,
+    )
+    with _threads_lock:
+        _forget_finished_threads()
+        _threads[record.job_id] = thread
+    thread.start()
+    return record.payload()
+
+
+def _forget_finished_threads() -> None:
+    """The registry only exists to join running work; finished entries are dead weight."""
+    for job_id in [one for one, thread in _threads.items() if not thread.is_alive()]:
+        del _threads[job_id]
+
+
+def _run(record: JobRecord, work: Work, touches_resolve: bool, config: Config) -> None:
+    if touches_resolve:
+        with RESOLVE_LOCK:
+            if record.step == WAITING:
+                record.step = ""
+                store.save(record, config)
+            _work(record, work, config)
+        return
+    _work(record, work, config)
+
+
+def _work(record: JobRecord, work: Work, config: Config) -> None:
+    """Run the worker, and turn whatever comes out of it into a closed job record."""
+
+    def progress(fraction: float, step: str) -> None:
+        record.progress = min(max(fraction, 0.0), 1.0)
+        record.step = step
+        store.save(record, config)
+
+    try:
+        output = work(progress)
+    except ResolveMcpError as exc:
+        store.finish(record, error=exc.payload(), config=config)
+        return
+    except Exception as exc:  # noqa: BLE001 - a dead thread must not swallow the failure
+        log.exception("Job %s raised unexpectedly", record.job_id)
+        store.finish(
+            record,
+            error=InternalError(cause=f"{type(exc).__name__}: {exc}").payload(),
+            config=config,
+        )
+        return
+
+    if record.cache_key is not None:
+        cache.remember(record.cache_key, record.kind, output.result, output.artifacts, config)
+    store.finish(record, result=output.result, config=config)
+
+
+def wait_for(job_id: str, timeout: float = WAIT_TIMEOUT, config: Config | None = None) -> JobRecord:
+    """Block until the job is off the thread pool — for chained work, and for tests.
+
+    A job started by an earlier server process has no thread here; its record already says
+    what happened to it, so the answer comes straight off disk.
+    """
+    with _threads_lock:
+        thread = _threads.get(job_id)
+    if thread is not None:
+        thread.join(timeout)
+    return store.load(job_id, config)

--- a/src/resolve_mcp/jobs/store.py
+++ b/src/resolve_mcp/jobs/store.py
@@ -1,0 +1,191 @@
+"""One JSON record per job, on disk. Four things here are decisions, not bookkeeping.
+
+* **Disk is the only source of truth.** An in-memory registry would be faster to read
+  and would vanish on restart, which is precisely the case ``list_jobs`` exists for. The
+  running thread updates its record as it goes; readers always read the file.
+
+* **A restart is detected by session, not by pid.** Every record carries the id of the
+  server process that wrote it. A record still marked ``running`` whose session is not
+  this one belongs to a server that is gone — its worker thread died with the process, so
+  nothing will ever finish it. pids get recycled; a per-process uuid cannot be mistaken.
+
+* **That verdict is written back.** The interrupted record is rewritten as failed under
+  this session, so the reasoning happens once and the log carries one line for it rather
+  than one per poll.
+
+* **A corrupt record loses itself, not the listing.** A record half-written when the
+  process died is skipped with a warning; one unreadable file must not hide every other
+  job from the agent.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from ..config import Config, get_config
+from ..errors import JobInterruptedError, JobNotFoundError
+from ..logging_config import get_logger
+from ..naming import UNSAFE_IN_FILENAME
+
+log = get_logger("jobs")
+
+RUNNING = "running"
+COMPLETED = "completed"
+FAILED = "failed"
+STATES = (RUNNING, COMPLETED, FAILED)
+
+SESSION = uuid.uuid4().hex
+"""This server process. Records written under any other session predate a restart."""
+
+_sequence = itertools.count()
+"""Breaks ties in "newest first": the Windows clock is coarser than two starts in a row."""
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="microseconds")
+
+
+@dataclass
+class JobRecord:
+    """What the agent sees through ``get_job``, and what a restart reads back."""
+
+    job_id: str
+    kind: str
+    state: str
+    params: dict[str, Any] = field(default_factory=dict)
+    session: str = SESSION
+    sequence: int = 0
+    started_at: str = ""
+    updated_at: str = ""
+    finished_at: str | None = None
+    progress: float = 0.0
+    step: str = ""
+    result: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+    cache_key: str | None = None
+    cached: bool = False
+
+    def payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _job_id(kind: str) -> str:
+    slug = UNSAFE_IN_FILENAME.sub("-", kind).strip("-") or "job"
+    return f"{slug}-{uuid.uuid4().hex[:12]}"
+
+
+def _path(job_id: str, config: Config) -> Path:
+    return config.job_dir / f"{job_id}.json"
+
+
+def new_job(
+    kind: str,
+    params: dict[str, Any],
+    cache_key: str | None = None,
+    config: Config | None = None,
+) -> JobRecord:
+    """Register a running job and write it before any work starts."""
+    stamp = _now()
+    record = JobRecord(
+        job_id=_job_id(kind),
+        kind=kind,
+        state=RUNNING,
+        params=params,
+        sequence=next(_sequence),
+        started_at=stamp,
+        updated_at=stamp,
+        cache_key=cache_key,
+    )
+    save(record, config)
+    log.info("Job %s started (%s)", record.job_id, kind)
+    return record
+
+
+def save(record: JobRecord, config: Config | None = None) -> None:
+    """Write the record atomically — a poll must never read a half-written file."""
+    config = config or get_config()
+    record.updated_at = _now()
+    target = _path(record.job_id, config)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    scratch = target.with_suffix(".writing")
+    scratch.write_text(json.dumps(record.payload(), indent=2), encoding="utf-8")
+    os.replace(scratch, target)
+
+
+def finish(
+    record: JobRecord,
+    result: dict[str, Any] | None = None,
+    error: dict[str, Any] | None = None,
+    config: Config | None = None,
+) -> JobRecord:
+    """Close the job out as completed or failed, and say so in the log."""
+    record.state = FAILED if error is not None else COMPLETED
+    record.result = result
+    record.error = error
+    record.finished_at = _now()
+    record.progress = 1.0 if error is None else record.progress
+    save(record, config)
+    if error is None:
+        log.info("Job %s completed", record.job_id)
+    else:
+        log.warning("Job %s failed: %s", record.job_id, error.get("cause"))
+    return record
+
+
+def load(job_id: str, config: Config | None = None) -> JobRecord:
+    """Read one record, converting a restart-orphaned job into an honest failure."""
+    config = config or get_config()
+    record = _read(_path(job_id, config))
+    if record is None:
+        raise JobNotFoundError(job_id)
+    return _recovered(record, config)
+
+
+def load_all(
+    state: str | None = None,
+    limit: int | None = None,
+    config: Config | None = None,
+) -> list[JobRecord]:
+    """Every job this cache directory knows about, newest first."""
+    config = config or get_config()
+    records = [_read(path) for path in sorted(config.job_dir.glob("*.json"))]
+    found = [_recovered(one, config) for one in records if one is not None]
+    found.sort(key=lambda one: (one.started_at, one.sequence), reverse=True)
+    if state is not None:
+        found = [one for one in found if one.state == state]
+    return found if limit is None else found[:limit]
+
+
+def _read(path: Path) -> JobRecord | None:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError):
+        log.warning("Skipping an unreadable job record: %s", path)
+        return None
+    if not isinstance(raw, dict) or "job_id" not in raw:
+        log.warning("Skipping a job record with no id: %s", path)
+        return None
+    known = {name: raw[name] for name in JobRecord.__dataclass_fields__ if name in raw}
+    return JobRecord(**known)
+
+
+def _recovered(record: JobRecord, config: Config) -> JobRecord:
+    """A job still running under a dead session cannot finish. Say so, once."""
+    if record.state != RUNNING or record.session == SESSION:
+        return record
+    log.info("Job %s was interrupted by a server restart", record.job_id)
+    interrupted = JobInterruptedError(
+        cause=f"The server restarted while {record.kind} was running, so the job died with it.",
+        detail={"job_id": record.job_id, "progress": record.progress, "step": record.step},
+    )
+    record.session = SESSION
+    return finish(record, error=interrupted.payload(), config=config)

--- a/src/resolve_mcp/jobs/store.py
+++ b/src/resolve_mcp/jobs/store.py
@@ -32,7 +32,7 @@ from typing import Any
 from ..config import Config, get_config
 from ..errors import JobInterruptedError, JobNotFoundError
 from ..logging_config import get_logger
-from ..naming import UNSAFE_IN_FILENAME
+from ..naming import slug
 
 log = get_logger("jobs")
 
@@ -77,8 +77,7 @@ class JobRecord:
 
 
 def _job_id(kind: str) -> str:
-    slug = UNSAFE_IN_FILENAME.sub("-", kind).strip("-") or "job"
-    return f"{slug}-{uuid.uuid4().hex[:12]}"
+    return f"{slug(kind, 'job')}-{uuid.uuid4().hex[:12]}"
 
 
 def _path(job_id: str, config: Config) -> Path:
@@ -148,19 +147,15 @@ def load(job_id: str, config: Config | None = None) -> JobRecord:
     return _recovered(record, config)
 
 
-def load_all(
-    state: str | None = None,
-    limit: int | None = None,
-    config: Config | None = None,
-) -> list[JobRecord]:
+def load_all(state: str | None = None, config: Config | None = None) -> list[JobRecord]:
     """Every job this cache directory knows about, newest first."""
     config = config or get_config()
     records = [_read(path) for path in sorted(config.job_dir.glob("*.json"))]
     found = [_recovered(one, config) for one in records if one is not None]
     found.sort(key=lambda one: (one.started_at, one.sequence), reverse=True)
-    if state is not None:
-        found = [one for one in found if one.state == state]
-    return found if limit is None else found[:limit]
+    if state is None:
+        return found
+    return [one for one in found if one.state == state]
 
 
 def _read(path: Path) -> JobRecord | None:

--- a/src/resolve_mcp/naming.py
+++ b/src/resolve_mcp/naming.py
@@ -14,6 +14,11 @@ UNSAFE_IN_FILENAME = re.compile(r"[^A-Za-z0-9._-]+")
 STAMP_FORMAT = "%Y%m%d-%H%M%S"
 
 
+def slug(label: str, fallback: str) -> str:
+    """A filename-safe version of something the director named, or ``fallback``."""
+    return UNSAFE_IN_FILENAME.sub("-", label).strip("-") or fallback
+
+
 def timestamped_name(
     label: str,
     suffix: str,
@@ -22,5 +27,4 @@ def timestamped_name(
 ) -> str:
     """``<slug>-<yyyymmdd-hhmmss><suffix>``, falling back when the label slugs to nothing."""
     stamp = (now or datetime.now()).strftime(STAMP_FORMAT)
-    slug = UNSAFE_IN_FILENAME.sub("-", label).strip("-") or fallback
-    return f"{slug}-{stamp}{suffix}"
+    return f"{slug(label, fallback)}-{stamp}{suffix}"

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -474,7 +474,7 @@ def _markers(clip: Clip) -> list[dict[str, Any]]:
     return sorted(markers, key=lambda marker: marker["frame"])
 
 
-def _audio_mapping(clip: Clip) -> dict[str, Any] | None:
+def audio_mapping(clip: Clip) -> dict[str, Any] | None:
     """``GetAudioMapping`` returns a JSON *string* — or nothing, on clips without audio."""
     try:
         reported = clip.GetAudioMapping()
@@ -548,7 +548,7 @@ def inspect_clip(
             if isinstance(metadata, dict)
             else {}
         ),
-        "audio_mapping": _audio_mapping(clip),
+        "audio_mapping": audio_mapping(clip),
         "markers": _markers(clip),
         "bounds": _bounds(clip, reported),
     }

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -1,0 +1,147 @@
+"""Driving Resolve's render queue: add a job, start it, watch it, take it back off.
+
+The queue is a global, stateful part of the application — settings are set on the project,
+not passed to a call — so three things here are decisions rather than API calls:
+
+* **The queue is left as it was found.** Every job this server adds is deleted once it has
+  finished, whatever the outcome. The director's own queue is theirs; an export for
+  analysis must not silently accumulate entries in it.
+
+* **Status is polled, never assumed.** ``StartRendering`` returns as soon as the job is
+  accepted. The only truthful completion signal is the job's own status going to Complete,
+  and a Failed or Cancelled status is a failure even though every call returned True.
+
+* **A completed render still has to have written the file.** Resolve reports success for
+  renders that land nothing on disk (an unwritable target directory does this). The caller
+  passes the path it expects, and its absence is a failure, not a cache entry.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..errors import RenderQueueError
+from ..logging_config import get_logger
+
+log = get_logger("render")
+
+Project = Any
+
+COMPLETE = "Complete"
+FAILED = ("Failed", "Cancelled")
+POLL_SECONDS = 1.0
+RENDER_TIMEOUT = 3600.0
+
+STATUS = "JobStatus"
+PERCENT = "CompletionPercentage"
+
+
+def submit(project: Project, settings: dict[str, Any], format_: str, codec: str) -> str:
+    """Push one job onto the queue and return its id.
+
+    ``SetRenderSettings`` and the format/codec pair are project-level state; they are set
+    immediately before the job is added so that the job captures them.
+    """
+    if not project.SetCurrentRenderFormatAndCodec(format_, codec):
+        raise RenderQueueError(
+            cause=f"Resolve would not render {format_}/{codec}.",
+            detail={"format": format_, "codec": codec},
+        )
+    if not project.SetRenderSettings(settings):
+        raise RenderQueueError(
+            cause="Resolve refused the render settings.",
+            detail={"settings": settings},
+        )
+    job_id = project.AddRenderJob()
+    if not job_id:
+        raise RenderQueueError(cause="Resolve would not add the job to the render queue.")
+    log.info("Queued render job %s", job_id)
+    return str(job_id)
+
+
+def render(
+    project: Project,
+    job_id: str,
+    expecting: Path,
+    progress: Callable[[float, str], None] | None = None,
+    poll: float = POLL_SECONDS,
+    timeout: float = RENDER_TIMEOUT,
+    now: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Path:
+    """Start the job, watch it to completion, and hand back the file it wrote.
+
+    ``now`` and ``sleep`` are parameters so the polling loop is testable without a test
+    that actually waits.
+    """
+    if not project.StartRendering(job_id):
+        _remove(project, job_id)
+        raise RenderQueueError(
+            cause="Resolve would not start the render.",
+            detail={"render_job_id": job_id},
+        )
+    try:
+        _watch(project, job_id, progress, poll, timeout, now, sleep)
+    finally:
+        _remove(project, job_id)
+
+    if not expecting.exists():
+        raise RenderQueueError(
+            cause=f"The render reported success but wrote nothing to {expecting}.",
+            detail={"expected": str(expecting)},
+        )
+    log.info("Render job %s wrote %s", job_id, expecting)
+    return expecting
+
+
+def _watch(
+    project: Project,
+    job_id: str,
+    progress: Callable[[float, str], None] | None,
+    poll: float,
+    timeout: float,
+    now: Callable[[], float],
+    sleep: Callable[[float], None],
+) -> None:
+    started = now()
+    while True:
+        reading = project.GetRenderJobStatus(job_id) or {}
+        status = str(reading.get(STATUS, ""))
+        percent = _percent(reading)
+        if progress is not None:
+            progress(percent, f"rendering ({int(percent * 100)}%)")
+        if status == COMPLETE:
+            return
+        if status in FAILED:
+            raise RenderQueueError(
+                cause=f"The render job ended {status}.",
+                detail={"render_job_id": job_id, "status": reading},
+            )
+        if now() - started > timeout:
+            raise RenderQueueError(
+                cause=f"The render job was still {status or 'unreported'} after {timeout:.0f}s.",
+                fix=(
+                    "Check the Deliver page — a modal dialog in the Resolve GUI stalls the "
+                    "queue. Cancel the job there, then retry."
+                ),
+                detail={"render_job_id": job_id, "timeout_seconds": timeout},
+            )
+        sleep(poll)
+
+
+def _percent(reading: dict[str, Any]) -> float:
+    try:
+        return min(max(float(reading.get(PERCENT, 0)) / 100.0, 0.0), 1.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _remove(project: Project, job_id: str) -> None:
+    """Take the job back off the queue. Failing to is not worth failing the render over."""
+    try:
+        project.DeleteRenderJob(job_id)
+    except Exception:  # noqa: BLE001 - a queue we could not tidy is not a lost render
+        log.warning("Could not remove render job %s from the queue", job_id, exc_info=True)

--- a/src/resolve_mcp/resolve/session.py
+++ b/src/resolve_mcp/resolve/session.py
@@ -68,6 +68,18 @@ def _read(getter: Any) -> str | None:
     return None if value is None else str(value)
 
 
+def current_project(
+    connection: ResolveConnection,
+    cause: str = "No project is open.",
+) -> Any:
+    """The open project, or a failure saying so. ``cause`` names what wanted it."""
+    manager = connection.handle().GetProjectManager()
+    project = manager.GetCurrentProject() if manager is not None else None
+    if project is None:
+        raise NoProjectOpenError(cause=cause)
+    return project
+
+
 def product_name(connection: ResolveConnection) -> str | None:
     """Which Resolve edition is attached. Raises if Resolve is unreachable."""
     resolve = connection.handle()

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -32,7 +32,6 @@ from typing import Any, NamedTuple
 from ..config import Config, get_config
 from ..errors import (
     InvalidRequestError,
-    NoProjectOpenError,
     NoTimelineOpenError,
     TimelineNotFoundError,
 )
@@ -40,7 +39,7 @@ from ..logging_config import get_logger
 from ..spill import spill
 from ..timing import dual_time, to_frames
 from .connection import ResolveConnection
-from .session import frame_rate
+from .session import current_project, frame_rate
 
 log = get_logger("timeline")
 
@@ -83,11 +82,7 @@ class Placement(NamedTuple):
 
 
 def _project(connection: ResolveConnection) -> Project:
-    manager = connection.handle().GetProjectManager()
-    project = manager.GetCurrentProject() if manager is not None else None
-    if project is None:
-        raise NoProjectOpenError(cause="No project is open, so there are no timelines to read.")
-    return project
+    return current_project(connection, "No project is open, so there are no timelines to read.")
 
 
 def _timelines(project: Project) -> list[Timeline]:

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from . import __version__
 from .config import get_config
 from .logging_config import configure_logging, get_logger
-from .tools import escape_hatch, media, project, timeline
+from .tools import escape_hatch, jobs, media, project, timeline
 
 log = get_logger("server")
 
@@ -27,6 +27,10 @@ a fix; act on the fix rather than retrying blindly.
 Time is frames-first: every position comes back as frames, seconds, timecode and fps
 together, ranges are half-open [in, out), and a time you give in seconds must say how to
 snap it to a frame ({"seconds": 2.52, "snap": "floor"}).
+
+Heavy work (renders, analysis) hands back a job_id straight away — carry on working and
+poll it with get_job; list_jobs finds what you started before a restart. Results are cached
+against the media and the parameters, so an unchanged rerun comes back instantly.
 """
 
 
@@ -37,7 +41,13 @@ def build_server() -> FastMCP:
         instructions=INSTRUCTIONS,
         version=__version__,
     )
-    for fn in (*project.TOOLS, *media.TOOLS, *timeline.TOOLS, *escape_hatch.TOOLS):
+    for fn in (
+        *project.TOOLS,
+        *media.TOOLS,
+        *timeline.TOOLS,
+        *jobs.TOOLS,
+        *escape_hatch.TOOLS,
+    ):
         mcp.tool(fn)
     return mcp
 

--- a/src/resolve_mcp/tools/jobs.py
+++ b/src/resolve_mcp/tools/jobs.py
@@ -45,9 +45,10 @@ def list_jobs(state: str | None = None, limit: int = DEFAULT_JOB_LIMIT) -> dict[
             detail={"requested": state, "states": list(store.STATES)},
         )
     found = store.load_all(state=state)
+    shown = found[:limit]
     return {
-        "jobs": [one.payload() for one in found[:limit]],
-        "count": len(found[:limit]),
+        "jobs": [one.payload() for one in shown],
+        "count": len(shown),
         "total": len(found),
     }
 

--- a/src/resolve_mcp/tools/jobs.py
+++ b/src/resolve_mcp/tools/jobs.py
@@ -1,0 +1,60 @@
+"""The two tools every heavy-compute starter shares: poll one job, or list them all.
+
+There is no start_job tool. Each heavy tool is its own typed starter (#12: "typed starters
++ one poller"), and audio acquisition is internal to those starters rather than a step the
+agent sequences by hand — so what belongs here is only the reading side.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..errors import InvalidRequestError
+from ..jobs import store
+from .envelope import tool
+
+DEFAULT_JOB_LIMIT = 50
+
+
+@tool
+def get_job(job_id: str) -> dict[str, Any]:
+    """Poll one job: running with progress, completed with its result, or failed with a fix.
+
+    progress is 0.0-1.0 and step says what the worker is doing now. A completed job carries
+    result — for anything curve-shaped or long that is a path on disk plus gist stats, so
+    read or grep the file rather than asking for it inline. A failed job carries the same
+    cause/fix shape as any other failure; cached is true when the result came back without
+    the work being redone.
+    """
+    return {"job": store.load(job_id).payload()}
+
+
+@tool
+def list_jobs(state: str | None = None, limit: int = DEFAULT_JOB_LIMIT) -> dict[str, Any]:
+    """List jobs newest first — how a restarted session picks up what it started.
+
+    state filters to running, completed or failed. Jobs survive a server restart because
+    their records live in the cache directory; one that was still running when the server
+    went down comes back failed with code job_interrupted, which means start it again —
+    finished work is already in the result cache and is not paid for twice.
+    """
+    if state is not None and state not in store.STATES:
+        raise InvalidRequestError(
+            cause=f"{state!r} is not a job state.",
+            fix=f"Use one of {', '.join(store.STATES)}, or leave state out for all of them.",
+            detail={"requested": state, "states": list(store.STATES)},
+        )
+    found = store.load_all(state=state)
+    return {
+        "jobs": [one.payload() for one in found[:limit]],
+        "count": len(found[:limit]),
+        "total": len(found),
+    }
+
+
+TOOLS: tuple[Any, ...] = (
+    get_job,
+    list_jobs,
+)
+
+__all__ = ["TOOLS", "get_job", "list_jobs"]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -11,6 +11,9 @@ come back as strings.
 
 from __future__ import annotations
 
+import contextlib
+import math
+import wave
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -521,6 +524,15 @@ def _sequence_exists(pattern: str, start: int) -> bool:
 
 
 class FakeProject:
+    """A project, including its render queue.
+
+    The queue models what makes the real one hard to drive: settings live on the project
+    rather than on the job, ``StartRendering`` returns before the render is done, and a job
+    reports a status per poll — so ``render_statuses`` is a sequence handed out one per
+    ``GetRenderJobStatus`` call, the last one repeating. ``render_writes_the_file=False``
+    models the failure the return value hides: every call answers True and nothing lands.
+    """
+
     def __init__(
         self,
         name: str,
@@ -538,6 +550,83 @@ class FakeProject:
             self._timelines = list(timelines)
         else:
             self._timelines = [timeline] if timeline is not None else []
+        self.render_settings: dict[str, Any] = {}
+        self.render_format: tuple[str, str] | None = None
+        self.render_mode: int | None = None
+        self.render_queue: list[str] = []
+        self.render_jobs: list[dict[str, Any]] = []
+        self.render_statuses: list[str] = ["Complete"]
+        self.render_seconds = 2.0
+        self.render_writes_the_file = True
+        self.accepts_format = True
+        self.accepts_settings = True
+        self.accepts_job = True
+        self.starts_rendering = True
+        self.timeline_switches: list[str] = []
+        self._status_calls = 0
+
+    def SetCurrentRenderMode(self, mode: int) -> bool:  # noqa: N802
+        self.render_mode = mode
+        return True
+
+    def SetCurrentRenderFormatAndCodec(self, format_: str, codec: str) -> bool:  # noqa: N802
+        if not self.accepts_format:
+            return False
+        self.render_format = (format_, codec)
+        return True
+
+    def SetRenderSettings(self, settings: dict[str, Any]) -> bool:  # noqa: N802
+        if not self.accepts_settings:
+            return False
+        self.render_settings = dict(settings)
+        return True
+
+    def AddRenderJob(self) -> str | None:  # noqa: N802
+        """Returns the new job's id, or ``None`` when Resolve refuses it."""
+        if not self.accepts_job:
+            return None
+        job_id = f"render-{len(self.render_jobs) + 1}"
+        self.render_jobs.append({"id": job_id, "settings": dict(self.render_settings)})
+        self.render_queue.append(job_id)
+        return job_id
+
+    def StartRendering(self, *job_ids: str) -> bool:  # noqa: N802
+        if not self.starts_rendering:
+            return False
+        if self.render_writes_the_file:
+            self._write_the_render()
+        return True
+
+    def GetRenderJobStatus(self, job_id: str) -> dict[str, Any]:  # noqa: N802
+        """One status per poll, the last one repeating — a render is watched, not awaited."""
+        index = min(self._status_calls, len(self.render_statuses) - 1)
+        self._status_calls += 1
+        status = self.render_statuses[index]
+        return {
+            "JobStatus": status,
+            "CompletionPercentage": 100 if status == "Complete" else index * 10,
+        }
+
+    def DeleteRenderJob(self, job_id: str) -> bool:  # noqa: N802
+        if job_id in self.render_queue:
+            self.render_queue.remove(job_id)
+            return True
+        return False
+
+    def _write_the_render(self) -> None:
+        target = Path(str(self.render_settings.get("TargetDir", "")))
+        name = str(self.render_settings.get("CustomName", "render"))
+        write_wav(
+            target / f"{name}.wav",
+            seconds=self.render_seconds,
+            sample_rate=int(self.render_settings.get("AudioSampleRate", 48000)),
+            bit_depth=int(self.render_settings.get("AudioBitDepth", 24)),
+        )
+
+    def SetCurrentTimeline(self, timeline: FakeTimeline) -> bool:  # noqa: N802
+        self.timeline_switches.append(str(timeline.GetName()))
+        self._timeline = timeline
+        return True
 
     def GetName(self) -> str:  # noqa: N802
         return self._name
@@ -680,6 +769,34 @@ class FakeConnector:
         if not self._handles:
             return None
         return self._handles.pop(0)
+
+
+def write_wav(
+    path: Path,
+    seconds: float = 2.0,
+    sample_rate: int = 48_000,
+    bit_depth: int = 24,
+    channels: int = 2,
+    frequency: float = 440.0,
+) -> Path:
+    """A real WAV of a sine tone — the fixture audio the worker tier is tested on.
+
+    Real audio rather than a stub file, because the workers read the header back: a fake
+    that wrote ``b"RIFF"`` would pass a duration assertion that means nothing.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    width = bit_depth // 8
+    peak = int(2 ** (bit_depth - 1) * 0.3)
+    frames = bytearray()
+    for index in range(int(seconds * sample_rate)):
+        sample = int(peak * math.sin(2 * math.pi * frequency * index / sample_rate))
+        frames.extend(sample.to_bytes(width, "little", signed=True) * channels)
+    with contextlib.closing(wave.open(str(path), "wb")) as handle:
+        handle.setnchannels(channels)
+        handle.setsampwidth(width)
+        handle.setframerate(sample_rate)
+        handle.writeframes(bytes(frames))
+    return path
 
 
 def media_pool(bins: dict[str, list[FakeMediaPoolItem]] | None = None) -> FakeMediaPool:

--- a/tests/test_audio_acquisition.py
+++ b/tests/test_audio_acquisition.py
@@ -16,13 +16,14 @@ from pathlib import Path
 import pytest
 
 from resolve_mcp.audio.acquire import (
+    _as_export_failure,
     acquire_clip_audio,
     acquire_timeline_audio,
     mapping_conflict,
 )
 from resolve_mcp.audio.ffmpeg import Completed, Runner
 from resolve_mcp.config import get_config
-from resolve_mcp.errors import AudioExtractionError, AudioMappingError
+from resolve_mcp.errors import AudioExtractionError, AudioMappingError, RenderQueueError
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.resolve.connection import get_connection
 
@@ -34,6 +35,7 @@ from .fakes import (
     FakeTimeline,
     media_pool,
     studio,
+    sync_reference,
     write_wav,
 )
 
@@ -121,6 +123,33 @@ def test_an_edited_timeline_is_a_different_key_and_exports_again(attach: Attach)
     assert second.result is not None
     assert first.result is not None
     assert second.result["path"] != first.result["path"]
+
+
+def test_a_take_swap_that_keeps_the_duration_still_exports_again(attach: Attach) -> None:
+    """Bounds and track counts alone would call a recut timeline unchanged."""
+    timeline = sync_reference()
+    resolve = studio(timeline=timeline)
+    attach(resolve)
+    first = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    shots = timeline.GetItemListInTrack("video", 1)
+    assert shots is not None
+    shots[0]._name = "Cam C.mp4"
+    second = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert first.state == "completed"
+    assert second.cached is False
+    assert len(_project(resolve).render_jobs) == 2
+
+
+def test_the_export_renders_one_file_for_the_whole_timeline(attach: Attach) -> None:
+    """The other render mode writes a file per clip — hundreds of fragments, not the mix."""
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    attach(resolve)
+
+    wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert _project(resolve).render_mode == 1
 
 
 def test_a_queue_that_refuses_the_job_fails_the_job_not_the_server(attach: Attach) -> None:
@@ -240,6 +269,19 @@ def test_real_ffmpeg_accepts_the_command_and_writes_the_wav(
     assert record.result["sample_rate"] == 48_000
     assert record.result["bit_depth"] == 24
     assert record.result["duration_seconds"] == pytest.approx(FIXTURE_SECONDS, abs=0.05)
+
+
+# --- the audio-mapping check ---------------------------------------------------------------
+
+
+def test_a_queue_failure_keeps_the_advice_the_queue_was_specific_about() -> None:
+    """A stalled queue names the dialog that stalled it; that beats the generic audio advice."""
+    stalled = RenderQueueError(cause="The render job was still Rendering.", fix="Check Deliver.")
+    refused = RenderQueueError(cause="Resolve would not add the job to the render queue.")
+
+    assert _as_export_failure(stalled).fix == "Check Deliver."
+    assert "audio on it" in _as_export_failure(refused).fix
+    assert _as_export_failure(refused).code == "audio_export_failed"
 
 
 # --- the audio-mapping check ---------------------------------------------------------------

--- a/tests/test_audio_acquisition.py
+++ b/tests/test_audio_acquisition.py
@@ -1,0 +1,304 @@
+"""Audio acquisition, both routes.
+
+The worker tier runs on seconds-long fixture audio — a real WAV written by ``fakes``, not
+a stub, because the workers read the header back. The ffmpeg route is exercised twice: once
+with the subprocess call substituted, which is where the decisions live (command shape,
+refusals, cache behaviour), and once against real ffmpeg when the machine has it, which is
+the only thing that proves the command is one ffmpeg accepts.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.audio.acquire import (
+    acquire_clip_audio,
+    acquire_timeline_audio,
+    mapping_conflict,
+)
+from resolve_mcp.audio.ffmpeg import Completed, Runner
+from resolve_mcp.config import get_config
+from resolve_mcp.errors import AudioExtractionError, AudioMappingError
+from resolve_mcp.jobs.runner import wait_for
+from resolve_mcp.resolve.connection import get_connection
+
+from .conftest import Attach
+from .fakes import (
+    FakeMediaPoolItem,
+    FakeProject,
+    FakeResolve,
+    FakeTimeline,
+    media_pool,
+    studio,
+    write_wav,
+)
+
+FIXTURE_SECONDS = 2.0
+
+
+@pytest.fixture
+def fixture_audio(tmp_path: Path) -> Path:
+    """Two seconds of tone standing in for a concert."""
+    return write_wav(tmp_path / "media" / "drums.wav", seconds=FIXTURE_SECONDS)
+
+
+# --- timeline scope ----------------------------------------------------------------------
+
+
+def test_the_timeline_mix_comes_off_the_render_queue_as_a_48k_24bit_wav(attach: Attach) -> None:
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    attach(resolve)
+
+    record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert record.state == "completed"
+    assert record.result is not None
+    assert Path(record.result["path"]).exists()
+    assert record.result["sample_rate"] == 48_000
+    assert record.result["bit_depth"] == 24
+    assert record.result["scope"] == "timeline"
+    assert record.result["content_sha256"]
+
+    project = _project(resolve)
+    assert project.render_format == ("wav", "lpcm")
+    assert project.render_settings["ExportVideo"] is False
+    assert project.render_settings["ExportAudio"] is True
+    assert project.render_settings["TargetDir"] == str(get_config().audio_dir)
+    assert project.render_queue == []
+
+
+def test_exporting_another_timeline_puts_the_directors_timeline_back(attach: Attach) -> None:
+    open_now = FakeTimeline("sunset-set v3", "59.94")
+    other = FakeTimeline("sunset-set v2", "59.94")
+    resolve = studio(timeline=open_now, timelines=[open_now, other])
+    attach(resolve)
+
+    wait_for(acquire_timeline_audio(get_connection(), timeline="sunset-set v2")["job_id"])
+
+    assert _project(resolve).timeline_switches == ["sunset-set v2", "sunset-set v3"]
+
+
+def test_a_rerun_with_an_unchanged_timeline_is_an_instant_cache_hit(attach: Attach) -> None:
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    attach(resolve)
+    first = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    again = acquire_timeline_audio(get_connection())
+
+    assert again["state"] == "completed"
+    assert again["cached"] is True
+    assert again["result"] == first.result
+    assert len(_project(resolve).render_jobs) == 1
+
+
+def test_refresh_exports_again_even_when_the_timeline_looks_unchanged(attach: Attach) -> None:
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    attach(resolve)
+    wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    again = wait_for(acquire_timeline_audio(get_connection(), refresh=True)["job_id"])
+
+    assert again.cached is False
+    assert again.state == "completed"
+    assert len(_project(resolve).render_jobs) == 2
+
+
+def test_an_edited_timeline_is_a_different_key_and_exports_again(attach: Attach) -> None:
+    """The fingerprint has to move when the cut does, or analysis reads yesterday's mix."""
+    timeline = FakeTimeline("sunset-set v3", "59.94")
+    resolve = studio(timeline=timeline)
+    attach(resolve)
+    first = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    timeline._end_frame = timeline.GetEndFrame() + 500
+    second = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert second.cached is False
+    assert second.result is not None
+    assert first.result is not None
+    assert second.result["path"] != first.result["path"]
+
+
+def test_a_queue_that_refuses_the_job_fails_the_job_not_the_server(attach: Attach) -> None:
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    _project(resolve).accepts_job = False
+    attach(resolve)
+
+    record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "audio_export_failed"
+    assert "audio on it" in record.error["fix"]
+
+
+# --- clip scope --------------------------------------------------------------------------
+
+
+def test_a_source_clip_is_extracted_straight_off_disk(attach: Attach, fixture_audio: Path) -> None:
+    attach(_studio_holding(fixture_audio))
+    calls: list[Sequence[str]] = []
+
+    record = wait_for(
+        acquire_clip_audio(get_connection(), "drums.wav", runner=_copying(calls))["job_id"]
+    )
+
+    assert record.state == "completed"
+    assert record.result is not None
+    assert record.result["duration_seconds"] == pytest.approx(FIXTURE_SECONDS, abs=0.01)
+    assert record.result["scope"] == "clip"
+    assert record.result["content_sha256"]
+    assert Path(record.result["path"]).parent == get_config().audio_dir
+    assert calls[0][0] == "ffmpeg"
+    assert "-vn" in calls[0]
+    assert "pcm_s24le" in calls[0]
+
+
+def test_the_same_unchanged_clip_never_runs_ffmpeg_twice(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    attach(_studio_holding(fixture_audio))
+    calls: list[Sequence[str]] = []
+    wait_for(acquire_clip_audio(get_connection(), "drums.wav", runner=_copying(calls))["job_id"])
+
+    again = acquire_clip_audio(get_connection(), "drums.wav", runner=_copying(calls))
+
+    assert again["cached"] is True
+    assert len(calls) == 1
+
+
+def test_a_clip_whose_media_is_gone_says_so_before_starting_a_job(attach: Attach) -> None:
+    attach(_studio_holding(Path("D:/gone/missing.wav")))
+
+    with pytest.raises(AudioExtractionError) as raised:
+        acquire_clip_audio(get_connection(), "missing.wav")
+
+    assert "relink_media" in raised.value.fix
+
+
+def test_a_clip_whose_audio_lives_somewhere_else_is_sent_to_the_timeline_route(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    """Extracting the source file would silently analyse audio that is not in the cut."""
+    linked = '{"linked_audio": [{"file_path": "D:/recorder/take-1.wav"}]}'
+    attach(_studio_holding(fixture_audio, audio_mapping=linked))
+
+    with pytest.raises(AudioMappingError) as raised:
+        acquire_clip_audio(get_connection(), "drums.wav")
+
+    assert "take-1.wav" in raised.value.cause
+    assert "scope=timeline" in raised.value.fix
+
+
+def test_no_ffmpeg_on_the_machine_is_a_named_failure(attach: Attach, fixture_audio: Path) -> None:
+    attach(_studio_holding(fixture_audio))
+
+    record = wait_for(
+        acquire_clip_audio(get_connection(), "drums.wav", runner=_absent)["job_id"]
+    )
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "ffmpeg_unavailable"
+    assert "RESOLVE_MCP_FFMPEG" in record.error["fix"]
+
+
+def test_ffmpegs_own_complaint_travels_back_with_the_failure(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    attach(_studio_holding(fixture_audio))
+
+    record = wait_for(
+        acquire_clip_audio(get_connection(), "drums.wav", runner=_refusing)["job_id"]
+    )
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "audio_extraction_failed"
+    assert "Stream map" in record.error["detail"]["stderr"]
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is not on PATH")
+def test_real_ffmpeg_accepts_the_command_and_writes_the_wav(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    """The one assertion the substituted runner cannot make: ffmpeg agrees with the argv."""
+    attach(_studio_holding(fixture_audio))
+
+    record = wait_for(acquire_clip_audio(get_connection(), "drums.wav")["job_id"])
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert record.result["sample_rate"] == 48_000
+    assert record.result["bit_depth"] == 24
+    assert record.result["duration_seconds"] == pytest.approx(FIXTURE_SECONDS, abs=0.05)
+
+
+# --- the audio-mapping check ---------------------------------------------------------------
+
+
+def test_an_ordinary_embedded_mapping_is_no_conflict() -> None:
+    mapping = {"embedded_audio_channels": 2, "track_info": [{"type": "stereo", "channel": [1, 2]}]}
+
+    assert mapping_conflict(mapping, "D:/media/drums.wav") is None
+    assert mapping_conflict(None, "D:/media/drums.wav") is None
+    assert mapping_conflict({}, "D:/media/drums.wav") is None
+
+
+def test_the_clips_own_path_written_a_different_way_is_no_conflict() -> None:
+    mapping = {"track_info": [{"source": "D:\\media\\drums.wav"}]}
+
+    assert mapping_conflict(mapping, "D:/media/drums.wav") is None
+
+
+def test_a_non_zero_offset_is_a_conflict() -> None:
+    mapping = {"track_info": [{"audio_offset": 1024}]}
+
+    assert mapping_conflict(mapping, "D:/media/drums.wav") is not None
+    assert mapping_conflict({"track_info": [{"audio_offset": 0}]}, "D:/media/drums.wav") is None
+
+
+# --- helpers -------------------------------------------------------------------------------
+
+
+def _project(resolve: FakeResolve) -> FakeProject:
+    project = resolve.current_project
+    assert project is not None
+    return project
+
+
+def _studio_holding(source: Path, audio_mapping: str | None = None) -> FakeResolve:
+    clip = FakeMediaPoolItem(
+        source.name,
+        file_path=str(source),
+        properties={"Type": "Audio", "Audio Ch": "2"},
+        audio_mapping=audio_mapping,
+    )
+    return studio(pool=media_pool({"": [clip]}))
+
+
+def _copying(calls: list[Sequence[str]]) -> Runner:
+    """Stand in for ffmpeg by copying the input — the transcode is not what is under test."""
+
+    def runner(argv: Sequence[str]) -> Completed:
+        calls.append(list(argv))
+        shutil.copyfile(argv[argv.index("-i") + 1], argv[-1])
+        return Completed(0, "")
+
+    return runner
+
+
+def _absent(argv: Sequence[str]) -> Completed:
+    raise FileNotFoundError(argv[0])
+
+
+def _refusing(argv: Sequence[str]) -> Completed:
+    return Completed(1, "Stream map '0:a:0' matches no streams.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,3 +71,13 @@ def test_artifacts_live_under_the_cache_root(tmp_path: Path) -> None:
     config = Config.from_env({"RESOLVE_MCP_CACHE": str(tmp_path)})
 
     assert config.snapshot_dir == tmp_path / "snapshots"
+    assert config.job_dir == tmp_path / "jobs"
+    assert config.result_dir == tmp_path / "results"
+    assert config.audio_dir == tmp_path / "audio"
+
+
+def test_ffmpeg_is_a_bare_name_on_path_until_told_otherwise() -> None:
+    assert Config.from_env({}).ffmpeg == "ffmpeg"
+    assert Config.from_env({"RESOLVE_MCP_FFMPEG": r"D:\tools\ffmpeg.exe"}).ffmpeg == (
+        r"D:\tools\ffmpeg.exe"
+    )

--- a/tests/test_job_cache.py
+++ b/tests/test_job_cache.py
@@ -1,0 +1,97 @@
+"""Cache keys and cache entries — what makes a rerun instant, and what must not.
+
+The cache is the reason an analysis is paid for once per media state, so the tests that
+matter are the ones about *missing*: a changed parameter, changed media, or an artifact
+someone deleted from the cache directory all have to miss.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from resolve_mcp.config import get_config
+from resolve_mcp.jobs import cache
+
+
+def test_the_key_ignores_the_order_the_parameters_were_written_in() -> None:
+    one = cache.cache_key("analyze_music", [{"sha256": "abc"}], {"beats": True, "energy": False})
+    two = cache.cache_key("analyze_music", [{"sha256": "abc"}], {"energy": False, "beats": True})
+
+    assert one == two
+
+
+def test_a_different_parameter_kind_or_input_is_a_different_key() -> None:
+    base = cache.cache_key("analyze_music", [{"sha256": "abc"}], {"beats": True})
+
+    assert cache.cache_key("analyze_music", [{"sha256": "abc"}], {"beats": False}) != base
+    assert cache.cache_key("separate_stems", [{"sha256": "abc"}], {"beats": True}) != base
+    assert cache.cache_key("analyze_music", [{"sha256": "def"}], {"beats": True}) != base
+
+
+def test_a_source_file_fingerprints_by_size_and_mtime_not_by_reading_it(tmp_path: Path) -> None:
+    """Hashing a concert master would take minutes; identity has to be cheap here."""
+    media = tmp_path / "master.mov"
+    media.write_bytes(b"pretend this is 40 GB")
+    before = cache.fingerprint(media)
+
+    os.utime(media, (0, 0))
+
+    assert before["size"] == len(b"pretend this is 40 GB")
+    assert cache.fingerprint(media) != before
+
+
+def test_acquired_audio_is_identified_by_its_bytes(tmp_path: Path) -> None:
+    """Downstream analysis keys off content, so two identical WAVs must share a hash."""
+    one = tmp_path / "a.wav"
+    two = tmp_path / "b.wav"
+    one.write_bytes(b"RIFF....WAVE")
+    two.write_bytes(b"RIFF....WAVE")
+
+    assert cache.content_hash(one) == cache.content_hash(two)
+
+    two.write_bytes(b"RIFF....WAVEx")
+    assert cache.content_hash(one) != cache.content_hash(two)
+
+
+def test_a_remembered_result_comes_straight_back(tmp_path: Path) -> None:
+    artifact = get_config().audio_dir / "mix.wav"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(b"RIFF")
+    cache.remember("key1", "extract_audio", {"path": str(artifact)}, [artifact])
+
+    hit = cache.lookup("key1")
+
+    assert hit == {"path": str(artifact)}
+
+
+def test_a_key_that_was_never_run_misses() -> None:
+    assert cache.lookup("nothing-here") is None
+
+
+def test_a_deleted_artifact_misses_rather_than_returning_a_dead_path() -> None:
+    artifact = get_config().audio_dir / "mix.wav"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(b"RIFF")
+    cache.remember("key1", "extract_audio", {"path": str(artifact)}, [artifact])
+    artifact.unlink()
+
+    assert cache.lookup("key1") is None
+
+
+def test_the_stale_entry_is_cleared_so_the_next_run_can_write_it_again() -> None:
+    artifact = get_config().audio_dir / "mix.wav"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(b"RIFF")
+    cache.remember("key1", "extract_audio", {"path": str(artifact)}, [artifact])
+    artifact.unlink()
+    cache.lookup("key1")
+
+    assert not (get_config().result_dir / "key1.json").exists()
+
+
+def test_an_unreadable_entry_misses_rather_than_raising() -> None:
+    get_config().result_dir.mkdir(parents=True, exist_ok=True)
+    (get_config().result_dir / "key1.json").write_text("{ truncated", encoding="utf-8")
+
+    assert cache.lookup("key1") is None

--- a/tests/test_job_cache.py
+++ b/tests/test_job_cache.py
@@ -95,3 +95,11 @@ def test_an_unreadable_entry_misses_rather_than_raising() -> None:
     (get_config().result_dir / "key1.json").write_text("{ truncated", encoding="utf-8")
 
     assert cache.lookup("key1") is None
+
+
+def test_a_cache_directory_that_is_not_a_directory_is_a_miss_not_a_crash() -> None:
+    """The cache root is the user's own; they can leave anything in it, including this."""
+    get_config().result_dir.parent.mkdir(parents=True, exist_ok=True)
+    get_config().result_dir.write_text("someone put a file here", encoding="utf-8")
+
+    assert cache.lookup("key1") is None

--- a/tests/test_job_runner.py
+++ b/tests/test_job_runner.py
@@ -1,0 +1,192 @@
+"""Starting a job and not waiting for it.
+
+Every test here blocks the worker on an ``Event`` rather than sleeping, so "the starter
+came back before the work did" is asserted, not timed. The one thing a stdio server can
+never do is stall, so that is the property under test.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.config import get_config
+from resolve_mcp.errors import MediaOperationError
+from resolve_mcp.jobs import cache, store
+from resolve_mcp.jobs.runner import JobOutput, Progress, start_job, wait_for
+
+
+def test_the_starter_returns_before_the_work_finishes() -> None:
+    release = threading.Event()
+
+    def work(progress: Progress) -> JobOutput:
+        release.wait(timeout=5)
+        return JobOutput({"done": True})
+
+    started = start_job("extract_audio", {"scope": "timeline"}, work)
+
+    assert started["state"] == "running"
+    assert store.load(started["job_id"]).state == "running"
+
+    release.set()
+    finished = wait_for(started["job_id"])
+
+    assert finished.state == "completed"
+    assert finished.result == {"done": True}
+
+
+def test_progress_from_the_worker_is_visible_to_a_poller() -> None:
+    reported = threading.Event()
+    release = threading.Event()
+
+    def work(progress: Progress) -> JobOutput:
+        progress(0.5, "exporting the timeline mix")
+        reported.set()
+        release.wait(timeout=5)
+        return JobOutput({})
+
+    started = start_job("extract_audio", {}, work)
+    assert reported.wait(timeout=5)
+
+    polled = store.load(started["job_id"])
+    assert polled.progress == pytest.approx(0.5)
+    assert polled.step == "exporting the timeline mix"
+    assert polled.state == "running"
+
+    release.set()
+    wait_for(started["job_id"])
+
+
+def test_a_refusal_inside_a_worker_arrives_as_a_structured_error() -> None:
+    def work(progress: Progress) -> JobOutput:
+        raise MediaOperationError(cause="Resolve refused the render job.")
+
+    record = wait_for(start_job("extract_audio", {}, work)["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "media_operation_failed"
+    assert record.error["cause"] == "Resolve refused the render job."
+
+
+def test_a_bug_in_a_worker_becomes_an_internal_error_not_a_lost_job() -> None:
+    def work(progress: Progress) -> JobOutput:
+        raise ValueError("off by one")
+
+    record = wait_for(start_job("extract_audio", {}, work)["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "internal_error"
+    assert "ValueError" in record.error["cause"]
+
+
+def test_a_finished_job_writes_its_result_into_the_cache() -> None:
+    artifact = _artifact("mix.wav")
+
+    def work(progress: Progress) -> JobOutput:
+        return JobOutput({"path": str(artifact)}, (artifact,))
+
+    wait_for(start_job("extract_audio", {}, work, cache_key="key1")["job_id"])
+
+    assert cache.lookup("key1") == {"path": str(artifact)}
+
+
+def test_a_rerun_with_unchanged_media_and_params_never_starts_a_worker() -> None:
+    artifact = _artifact("mix.wav")
+    cache.remember("key1", "extract_audio", {"path": str(artifact)}, [artifact])
+
+    def work(progress: Progress) -> JobOutput:
+        raise AssertionError("a cache hit must not run the work")
+
+    started = start_job("extract_audio", {}, work, cache_key="key1")
+
+    assert started["state"] == "completed"
+    assert started["cached"] is True
+    assert started["result"] == {"path": str(artifact)}
+
+
+def test_a_cache_hit_is_still_a_job_the_agent_can_poll_and_list() -> None:
+    artifact = _artifact("mix.wav")
+    cache.remember("key1", "extract_audio", {"path": str(artifact)}, [artifact])
+
+    started = start_job("extract_audio", {}, _never_runs, cache_key="key1")
+
+    assert store.load(started["job_id"]).cached is True
+    assert [one.job_id for one in store.load_all()] == [started["job_id"]]
+
+
+def test_a_failed_job_leaves_the_cache_alone() -> None:
+    def work(progress: Progress) -> JobOutput:
+        raise MediaOperationError(cause="Resolve refused the render job.")
+
+    wait_for(start_job("extract_audio", {}, work, cache_key="key1")["job_id"])
+
+    assert cache.lookup("key1") is None
+
+
+def test_only_one_job_at_a_time_drives_resolve() -> None:
+    """Two jobs on the render queue at once is a corrupted queue, not a faster export."""
+    entered: list[str] = []
+    release = threading.Event()
+    first_in = threading.Event()
+
+    def blocking(progress: Progress) -> JobOutput:
+        entered.append("first")
+        first_in.set()
+        release.wait(timeout=5)
+        return JobOutput({})
+
+    def second(progress: Progress) -> JobOutput:
+        entered.append("second")
+        return JobOutput({})
+
+    one = start_job("extract_audio", {}, blocking, touches_resolve=True)
+    assert first_in.wait(timeout=5)
+    two = start_job("extract_audio", {}, second, touches_resolve=True)
+
+    assert entered == ["first"]
+    assert store.load(two["job_id"]).step == "waiting for Resolve"
+
+    release.set()
+    wait_for(one["job_id"])
+    wait_for(two["job_id"])
+
+    assert entered == ["first", "second"]
+
+
+def test_a_job_that_does_not_touch_resolve_runs_alongside_one_that_does() -> None:
+    release = threading.Event()
+    holding = threading.Event()
+    ran = threading.Event()
+
+    def holds_resolve(progress: Progress) -> JobOutput:
+        holding.set()
+        release.wait(timeout=5)
+        return JobOutput({})
+
+    def pure_compute(progress: Progress) -> JobOutput:
+        ran.set()
+        return JobOutput({})
+
+    one = start_job("extract_audio", {}, holds_resolve, touches_resolve=True)
+    assert holding.wait(timeout=5)
+    two = start_job("analyze_music", {}, pure_compute)
+
+    assert ran.wait(timeout=5)
+    release.set()
+    wait_for(one["job_id"])
+    wait_for(two["job_id"])
+
+
+def _never_runs(progress: Progress) -> JobOutput:
+    raise AssertionError("a cache hit must not run the work")
+
+
+def _artifact(name: str) -> Path:
+    path = get_config().audio_dir / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"RIFF")
+    return path

--- a/tests/test_job_runner.py
+++ b/tests/test_job_runner.py
@@ -118,6 +118,22 @@ def test_a_cache_hit_is_still_a_job_the_agent_can_poll_and_list() -> None:
     assert [one.job_id for one in store.load_all()] == [started["job_id"]]
 
 
+def test_a_result_that_cannot_be_cached_fails_the_job_rather_than_stranding_it() -> None:
+    """A job left running forever is the one failure a poller can never diagnose."""
+    artifact = _artifact("mix.wav")
+    get_config().result_dir.parent.mkdir(parents=True, exist_ok=True)
+    get_config().result_dir.write_text("not a directory", encoding="utf-8")
+
+    def work(progress: Progress) -> JobOutput:
+        return JobOutput({"path": str(artifact)}, (artifact,))
+
+    record = wait_for(start_job("extract_audio", {}, work, cache_key="key1")["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "internal_error"
+
+
 def test_a_failed_job_leaves_the_cache_alone() -> None:
     def work(progress: Progress) -> JobOutput:
         raise MediaOperationError(cause="Resolve refused the render job.")

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -1,0 +1,122 @@
+"""The on-disk job records — the only thing that survives a server restart.
+
+Every assertion here is about what a *new* process sees, because that is the whole
+point of writing records to disk: a job the agent started before a restart has to be
+findable, and one that was still running has to be honest about having died.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.config import get_config
+from resolve_mcp.errors import JobNotFoundError
+from resolve_mcp.jobs import store
+
+
+def test_a_new_job_starts_running_and_lands_on_disk() -> None:
+    record = store.new_job("extract_audio", {"scope": "timeline"})
+
+    assert record.state == "running"
+    assert record.kind == "extract_audio"
+    assert record.job_id.startswith("extract_audio-")
+    assert store.load(record.job_id).params == {"scope": "timeline"}
+
+
+def test_progress_reads_back_from_disk_not_from_memory() -> None:
+    record = store.new_job("separate_stems", {})
+    record.progress = 0.4
+    record.step = "separating"
+    store.save(record)
+
+    reloaded = store.load(record.job_id)
+
+    assert reloaded.progress == pytest.approx(0.4)
+    assert reloaded.step == "separating"
+
+
+def test_an_unknown_job_id_names_the_tool_that_lists_them() -> None:
+    with pytest.raises(JobNotFoundError) as raised:
+        store.load("extract_audio-nosuchjob")
+
+    assert "list_jobs" in raised.value.fix
+
+
+def test_jobs_come_back_newest_first_and_filter_by_state() -> None:
+    first = store.new_job("render", {})
+    second = store.new_job("render", {})
+    store.finish(first, result={"path": "a.wav"})
+
+    listed = store.load_all()
+
+    assert [one.job_id for one in listed] == [second.job_id, first.job_id]
+    assert [one.job_id for one in store.load_all(state="completed")] == [first.job_id]
+    assert [one.job_id for one in store.load_all(state="running")] == [second.job_id]
+
+
+def test_two_jobs_started_in_the_same_clock_tick_still_list_in_order() -> None:
+    """The Windows clock is coarser than two starts in a row, so time alone cannot order them."""
+    first = store.new_job("render", {})
+    second = store.new_job("render", {})
+    for record in (first, second):
+        record.started_at = "2026-08-05T12:00:00.000000+00:00"
+        store.save(record)
+
+    assert [one.job_id for one in store.load_all()] == [second.job_id, first.job_id]
+
+
+def test_a_job_left_running_by_a_previous_server_reads_as_interrupted() -> None:
+    record = store.new_job("transcribe_audio", {})
+    _pretend_a_previous_server_wrote_it(record.job_id)
+
+    recovered = store.load(record.job_id)
+
+    assert recovered.state == "failed"
+    assert recovered.error is not None
+    assert recovered.error["code"] == "job_interrupted"
+    assert "cache" in recovered.error["fix"]
+
+
+def test_the_interruption_is_written_back_so_the_verdict_is_reached_once() -> None:
+    record = store.new_job("transcribe_audio", {})
+    _pretend_a_previous_server_wrote_it(record.job_id)
+
+    store.load(record.job_id)
+
+    on_disk = json.loads(_record_path(record.job_id).read_text(encoding="utf-8"))
+    assert on_disk["state"] == "failed"
+    assert on_disk["session"] == store.SESSION
+
+
+def test_a_finished_job_from_a_previous_server_is_left_alone() -> None:
+    record = store.new_job("render", {})
+    store.finish(record, result={"path": "a.wav"})
+    _pretend_a_previous_server_wrote_it(record.job_id)
+
+    assert store.load(record.job_id).state == "completed"
+
+
+def test_a_half_written_record_is_skipped_rather_than_sinking_the_listing() -> None:
+    good = store.new_job("render", {})
+    (get_config().job_dir / "render-truncated.json").write_text('{"job_id": "ren', encoding="utf-8")
+
+    assert [one.job_id for one in store.load_all()] == [good.job_id]
+
+
+def test_the_listing_is_empty_before_any_job_has_ever_run() -> None:
+    assert store.load_all() == []
+
+
+def _record_path(job_id: str) -> Path:
+    return get_config().job_dir / f"{job_id}.json"
+
+
+def _pretend_a_previous_server_wrote_it(job_id: str) -> None:
+    """Rewrite the record under a session id that is not this process's."""
+    path = _record_path(job_id)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["session"] = "a-server-that-has-since-exited"
+    path.write_text(json.dumps(raw), encoding="utf-8")

--- a/tests/test_job_tools.py
+++ b/tests/test_job_tools.py
@@ -1,0 +1,121 @@
+"""get_job and list_jobs through the tool seam — what a restarted session actually sees.
+
+These call the tool functions directly, envelope and all. Resolve is attached as "not
+running" throughout: polling a job must work whether or not Resolve is up, because a job
+that outlived the application is exactly the one worth asking about.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.config import get_config
+from resolve_mcp.jobs import store
+from resolve_mcp.jobs.runner import JobOutput, Progress, start_job, wait_for
+from resolve_mcp.tools.jobs import get_job, list_jobs
+
+from .conftest import Attach
+
+
+def test_polling_a_finished_job_returns_its_result(attach: Attach) -> None:
+    attach(None)
+    started = start_job("extract_audio", {"scope": "timeline"}, _produces({"path": "mix.wav"}))
+    wait_for(started["job_id"])
+
+    reply = get_job(started["job_id"])
+
+    assert reply["ok"] is True
+    assert reply["job"]["state"] == "completed"
+    assert reply["job"]["result"] == {"path": "mix.wav"}
+    assert reply["job"]["kind"] == "extract_audio"
+    assert reply["context"]["connected"] is False
+
+
+def test_polling_a_job_that_never_existed_is_a_structured_failure(attach: Attach) -> None:
+    attach(None)
+
+    reply = get_job("extract_audio-000000000000")
+
+    assert reply["ok"] is False
+    assert reply["error"]["code"] == "job_not_found"
+
+
+def test_listing_shows_the_newest_job_first(attach: Attach) -> None:
+    attach(None)
+    first = start_job("extract_audio", {}, _produces({}))
+    wait_for(first["job_id"])
+    second = start_job("analyze_music", {}, _produces({}))
+    wait_for(second["job_id"])
+
+    reply = list_jobs()
+
+    assert [one["job_id"] for one in reply["jobs"]] == [second["job_id"], first["job_id"]]
+    assert reply["total"] == 2
+
+
+def test_listing_filters_by_state_and_rejects_a_state_that_is_not_one(attach: Attach) -> None:
+    attach(None)
+    done = start_job("extract_audio", {}, _produces({}))
+    wait_for(done["job_id"])
+
+    assert [one["job_id"] for one in list_jobs(state="completed")["jobs"]] == [done["job_id"]]
+    assert list_jobs(state="failed")["jobs"] == []
+
+    refused = list_jobs(state="finished")
+    assert refused["ok"] is False
+    assert refused["error"]["code"] == "invalid_request"
+    assert "running" in refused["error"]["fix"]
+
+
+def test_the_listing_caps_at_the_limit_but_still_says_how_many_there_are(
+    attach: Attach,
+) -> None:
+    attach(None)
+    for _ in range(3):
+        wait_for(start_job("extract_audio", {}, _produces({}))["job_id"])
+
+    reply = list_jobs(limit=2)
+
+    assert reply["count"] == 2
+    assert reply["total"] == 3
+
+
+def test_a_job_the_previous_server_left_running_comes_back_interrupted(attach: Attach) -> None:
+    """The restart case: the record outlives the process, the worker thread does not."""
+    attach(None)
+    started = start_job("separate_stems", {"scope": "timeline"}, _produces({}))
+    wait_for(started["job_id"])
+    _rewrite_as_a_previous_server_left_it(started["job_id"])
+
+    listed = list_jobs()["jobs"]
+    polled = get_job(started["job_id"])["job"]
+
+    assert [one["state"] for one in listed] == ["failed"]
+    assert polled["error"]["code"] == "job_interrupted"
+    assert polled["params"] == {"scope": "timeline"}
+    assert polled["kind"] == "separate_stems"
+
+
+def _produces(result: dict[str, Any]) -> Any:
+    def work(progress: Progress) -> JobOutput:
+        return JobOutput(result)
+
+    return work
+
+
+def _rewrite_as_a_previous_server_left_it(job_id: str) -> None:
+    """Put the record back the way a server that died mid-job left it behind."""
+    path = Path(get_config().job_dir) / f"{job_id}.json"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw.update(
+        {
+            "state": store.RUNNING,
+            "session": "a-server-that-has-since-exited",
+            "result": None,
+            "finished_at": None,
+            "progress": 0.3,
+        }
+    )
+    path.write_text(json.dumps(raw), encoding="utf-8")

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -15,7 +15,11 @@ from pathlib import Path
 
 import pytest
 
+from resolve_mcp.audio.acquire import acquire_timeline_audio
+from resolve_mcp.jobs.runner import wait_for
+from resolve_mcp.resolve.connection import get_connection
 from resolve_mcp.tools.escape_hatch import run_python
+from resolve_mcp.tools.jobs import get_job, list_jobs
 from resolve_mcp.tools.media import inspect_clip, list_media
 from resolve_mcp.tools.project import get_status, list_projects, snapshot_project
 from resolve_mcp.tools.timeline import inspect_timeline, list_timelines
@@ -130,6 +134,38 @@ def test_the_frame_math_holds_on_a_real_timeline() -> None:
                     item["sync_offset"]["frames"]
                     == record["in"]["frames"] - item["source"]["in"]["frames"]
                 )
+
+
+def test_the_render_queue_exports_the_real_timeline_mix() -> None:
+    """The AC no seam can check: that these render-settings keys are the ones Resolve takes.
+
+    The fakes prove the job machinery, the caching and the failure shaping. Whether
+    ``SetRenderSettings`` accepts ``ExportVideo``/``AudioBitDepth``/``AudioSampleRate`` under
+    those names, and whether an audio-only wav/lpcm job renders at all, is only answerable
+    here. Slow: this renders the open timeline's audio in full.
+    """
+    if get_status()["context"]["timeline"] is None:
+        pytest.skip("No timeline open in Resolve")
+
+    started = acquire_timeline_audio(get_connection())
+    record = wait_for(started["job_id"], timeout=1800.0)
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    exported = Path(record.result["path"])
+    assert exported.exists()
+    assert exported.stat().st_size > 0
+    assert record.result["sample_rate"] == 48_000
+    assert record.result["bit_depth"] == 24
+    assert (record.result["duration_seconds"] or 0) > 0
+
+    polled = get_job(started["job_id"])
+    assert polled["ok"] is True
+    assert polled["job"]["state"] == "completed"
+    assert started["job_id"] in [one["job_id"] for one in list_jobs()["jobs"]]
+
+    again = acquire_timeline_audio(get_connection())
+    assert again["cached"] is True, "an unchanged timeline must be a cache hit"
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_render_queue.py
+++ b/tests/test_render_queue.py
@@ -1,0 +1,138 @@
+"""Driving the render queue: what counts as finished, and what gets left behind.
+
+The polling loop takes its clock and its sleep as parameters, so every wait here is
+instant and the timeout case is a test rather than an hour.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.errors import RenderQueueError
+from resolve_mcp.resolve import render
+
+from .fakes import FakeProject, write_wav
+
+
+def test_a_completed_render_hands_back_the_file_it_wrote(tmp_path: Path) -> None:
+    project = FakeProject("sunset-set")
+    expecting = tmp_path / "mix.wav"
+    write_wav(expecting, seconds=0.1)
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+
+    assert render.render(project, job_id, expecting, sleep=_no_sleep) == expecting
+    assert project.render_format == ("wav", "lpcm")
+
+
+def test_the_queue_is_left_as_it_was_found(tmp_path: Path) -> None:
+    project = FakeProject("sunset-set")
+    expecting = write_wav(tmp_path / "mix.wav", seconds=0.1)
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+
+    render.render(project, job_id, expecting, sleep=_no_sleep)
+
+    assert project.render_queue == []
+
+
+def test_a_failed_job_is_a_failure_even_though_every_call_returned_true(tmp_path: Path) -> None:
+    project = FakeProject("sunset-set")
+    project.render_statuses = ["Rendering", "Failed"]
+    expecting = write_wav(tmp_path / "mix.wav", seconds=0.1)
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.render(project, job_id, expecting, sleep=_no_sleep)
+
+    assert "Failed" in raised.value.cause
+    assert project.render_queue == []
+
+
+def test_a_render_that_writes_nothing_is_not_a_success(tmp_path: Path) -> None:
+    """Resolve reports Complete for renders that land nothing — an unwritable target does."""
+    project = FakeProject("sunset-set")
+    project.render_writes_the_file = False
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.render(project, job_id, tmp_path / "mix.wav", sleep=_no_sleep)
+
+    assert "wrote nothing" in raised.value.cause
+
+
+def test_a_queue_that_never_finishes_times_out_pointing_at_the_gui(tmp_path: Path) -> None:
+    project = FakeProject("sunset-set")
+    project.render_statuses = ["Rendering"]
+    clock = iter([0.0, 0.0, 10_000.0])
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.render(
+            project,
+            job_id,
+            tmp_path / "mix.wav",
+            timeout=60.0,
+            now=lambda: next(clock),
+            sleep=_no_sleep,
+        )
+
+    assert "still Rendering" in raised.value.cause
+    assert "Deliver" in raised.value.fix
+    assert project.render_queue == []
+
+
+def test_progress_comes_from_the_jobs_own_percentage(tmp_path: Path) -> None:
+    project = FakeProject("sunset-set")
+    project.render_statuses = ["Rendering", "Rendering", "Complete"]
+    expecting = write_wav(tmp_path / "mix.wav", seconds=0.1)
+    seen: list[float] = []
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+
+    render.render(
+        project,
+        job_id,
+        expecting,
+        progress=lambda fraction, step: seen.append(fraction),
+        sleep=_no_sleep,
+    )
+
+    assert seen == [0.0, 0.1, 1.0]
+
+
+@pytest.mark.parametrize(
+    ("refusal", "expected"),
+    [
+        ("accepts_format", "would not render"),
+        ("accepts_settings", "refused the render settings"),
+        ("accepts_job", "would not add the job"),
+    ],
+)
+def test_every_way_the_queue_can_refuse_a_job_says_which(
+    tmp_path: Path,
+    refusal: str,
+    expected: str,
+) -> None:
+    project = FakeProject("sunset-set")
+    setattr(project, refusal, False)
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+
+    assert expected in raised.value.cause
+
+
+def test_a_queue_that_will_not_start_takes_its_job_back_off(tmp_path: Path) -> None:
+    project = FakeProject("sunset-set")
+    project.starts_rendering = False
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.render(project, job_id, tmp_path / "mix.wav", sleep=_no_sleep)
+
+    assert "would not start" in raised.value.cause
+    assert project.render_queue == []
+
+
+def _no_sleep(seconds: float) -> None:
+    """The loop between polls, with the waiting taken out."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,7 +17,7 @@ def descriptions() -> dict[str, str]:
     return {tool.name: tool.description or "" for tool in tools}
 
 
-def test_registers_the_p1_session_media_and_timeline_tools() -> None:
+def test_registers_the_p1_session_media_timeline_and_job_tools() -> None:
     assert tool_names() == {
         "get_status",
         "list_projects",
@@ -31,6 +31,8 @@ def test_registers_the_p1_session_media_and_timeline_tools() -> None:
         "relink_media",
         "list_timelines",
         "inspect_timeline",
+        "get_job",
+        "list_jobs",
         "run_python",
     }
 


### PR DESCRIPTION
Closes #32.

Heavy compute stops blocking stdio. A starter registers a job, hands back its id, and a daemon thread does the work; `get_job` polls it and `list_jobs` recovers what a previous server left behind. Audio acquisition lands as the first two workers on top of it.

## What's here

- **`jobs/store.py`** — one JSON record per job, written atomically. Disk is the only source of truth, because an in-memory registry vanishes exactly when `list_jobs` is needed. A record still marked `running` under a session id that is not this process's belongs to a server that is gone, so it is rewritten as failed with code `job_interrupted` — pids get recycled, a per-process uuid does not.
- **`jobs/cache.py`** — results keyed by content hash + params. The split is deliberate: source media is *fingerprinted* (path/size/mtime) because hashing a concert master takes minutes every run, while the acquired WAV is *hashed* for real, since #22 has the analysis workers keying off exactly that. A hit whose artifacts someone deleted misses and clears itself.
- **`jobs/runner.py`** — cache hits never start a thread (they come back completed with `cached: true`, and are still real job records), nothing escapes a worker uncaught, and jobs that drive Resolve serialise on one lock so two of them cannot push the render queue at once.
- **`resolve/render.py`** — render-queue mechanics for this ticket and for #33: submit, poll to `Complete`, always take the job back off the queue, and treat a render that reports success but writes nothing as a failure (an unwritable target directory does this).
- **`audio/`** — both routes. Timeline scope goes through the render queue, the only route capturing the timeline mix (48 kHz/24-bit WAV), in single-clip render mode, restoring the director's open timeline afterwards. Clip scope goes through ffmpeg off the clip's File Path, but refuses when the audio mapping points at another file or carries an offset, pointing at the timeline route instead — extracting the source there would analyse audio that is not in the cut.
- **`tools/jobs.py`** — `get_job` and `list_jobs`, registered. No starter tool: #12 locks "typed starters + one poller", with audio export *internal* to the starters, so the starters arrive with the jobs that need them (#33–#37) and acquisition ships here as the layer they call.

## Which seam verifies it

Fake tier, except where noted:

| AC | Seam |
| --- | --- |
| Starter returns a job_id immediately | `tests/test_job_runner.py` — the worker blocks on an `Event`, so "returned before the work finished" is asserted, not timed |
| get_job reports running/progress/completed/failed | `tests/test_job_tools.py`, through the envelope |
| list_jobs recovers across a restart | `tests/test_job_store.py`, `tests/test_job_tools.py` — a record rewritten under a foreign session id is what a restart actually leaves behind |
| Unchanged media + params is an instant cache hit | `tests/test_job_cache.py`, `tests/test_audio_acquisition.py` |
| Both routes produce cached WAV artifacts | `tests/test_audio_acquisition.py` — the render queue is now part of the fake Resolve |
| Worker tier on seconds-long fixture audio | `tests/test_audio_acquisition.py` on a real 2s WAV written by `fakes.write_wav`, plus a pass against **real ffmpeg** when it is on PATH |

The ffmpeg subprocess is a parameter (like `now`/`sleep` in the render poll loop), so command shape, refusals and the missing-binary case are testable with no ffmpeg installed — and the real-ffmpeg test is the only thing that proves ffmpeg accepts the argv. It passed locally.

**Live smoke (unrun, needs the Windows box):** `test_the_render_queue_exports_the_real_timeline_mix` in `tests/test_live_smoke.py`. No seam can answer whether Resolve accepts `SetRenderSettings` under the key names used (`ExportVideo`, `AudioBitDepth`, `AudioSampleRate`) or whether a `wav`/`lpcm` audio-only job renders at all.

## Review

Two-axis review (`/code-review` — Standards and Spec as parallel sub-agents) against `main`, before this PR existed. Nine findings; the fixes are in `15ce019` and the fix diff was re-checked.

**Fixed — real defects:**
1. *(Spec)* A cache write that failed escaped the worker thread, leaving the job `running` forever — the one state a poller can never diagnose. The write now sits inside the same `try` as the work.
2. *(Standards)* The timeline fingerprint smoothed every unreadable field to `None`, so a handle dying mid-read produced a stable all-`None` key on which two different timelines would collide — one concert's mix served for another. It now reads through the repo's `Reader`, which re-raises on a dead handle and degrades only while Resolve is still there.
3. *(Spec)* Bounds and track counts alone called a take swap "unchanged". The fingerprint now digests the shots on the timeline too. A clip's audio level remains unreadable through the scripting API, which is what `refresh` exists for — stated in the module docstring.
4. *(Standards)* Wrapping a render-queue failure as an audio one kept the generic advice and dropped the specific; a stalled queue's "check the Deliver page for a modal dialog" now survives the relabelling.
5. *(Standards)* Slug logic was re-implemented in three places; `naming.slug` is now the one rule, as `naming.py`'s own docstring demands.
6. *(Standards)* Dropped the unused `limit` parameter on `store.load_all` (speculative generality); `list_jobs` slices once.
7. Set single-clip render mode on the export — the other mode writes a file per clip, which for a concert cut is hundreds of fragments rather than the mix. This also retired the one dead method on the fake render queue.

**Accepted, not changed:**
8. *(Spec)* `list_jobs` takes `state`, while #12's catalog line reads `status?`. Kept `state` so the filter and the record field are one word rather than two names for one thing.
9. *(Standards)* `AudioExportError` reads as `RenderQueueError` re-labelled. Kept: the fix text is what differs, and that is the part the agent acts on.

Also folded in: `list_timelines`/`inspect_timeline` were missing from the README tool table (shipped in #59), and the env table gains `RESOLVE_MCP_FFMPEG`.

258 → 262 fake-tier tests pass; mypy strict and ruff clean.

Review: clean — two-axis pass, nine findings, seven fixed and two accepted with reasons above.


---

**Post-open commits.** CI (ubuntu) failed the first run, and both failures were findings rather than test noise — fixed in `c1dc44d`, re-reviewed as a focused pass over that diff alone:

1. `mapping_conflict` compared paths with `os.path`, so on a POSIX host `D:\media\a.wav` and `D:/media/a.wav` were different files and a clip was refused for pointing at itself. It now compares with Windows rules whatever the host — the same reason `tests/test_config.py` asserts as `PureWindowsPath`. Only CI could have caught this: the product runs on Windows, where the bug is invisible.
2. `cache.lookup` deleted an entry it could not read, and that delete can fail for the same reason the read did (the cache root is the user's own directory). A cache that cannot clean up is still a cache that missed, so the delete no longer propagates and the job runs. Covered by `test_a_cache_directory_that_is_not_a_directory_is_a_miss_not_a_crash`.

263 fake-tier tests; both CI gates green.

Review: clean — focused re-review of the post-open fix diff (2 findings, both fixed, both from CI).


---

Merge of origin/main (post-#63/#64/#65) resolved on-branch: unions in README, config, server and test_server; main's open_project name kept over this branch's current_project delegation (body now delegates, name and docstring are main's); naming.py keeps the slug() refactor with main's write_target and version helpers; the two FakeProject SetCurrentTimeline definitions merged into one that records the switch and sets the timeline; test_live_smoke.py rebuilt as main's file plus the render-queue smoke test. Focused pass over the resolution diff; 478 fake-tier tests, mypy strict and ruff all green.

Review: clean — merge-resolution diff, focused pass
