### PR TITLE
Probe the Text+ template-append route at both seams (#41)

### DIFF
--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -717,12 +717,21 @@ class FakeMediaPool:
         return placed
 
     def DeleteTimelines(self, timelines: list[FakeTimeline]) -> bool:  # noqa: N802
+        """Delete cuts, refusing the whole call if one of them is the cut now open.
+
+        Resolve will not delete the timeline it is sitting on, and says so only by
+        returning ``False`` — so a caller that deleted a scratch timeline without moving
+        off it first would leave it behind and never hear why.
+        """
         self._check("DeleteTimelines")
         self.deleted_timelines.extend(timelines)
         project = self._owner.current_project if self._owner is not None else None
-        if project is not None:
-            for timeline in timelines:
-                project.remove_timeline(timeline)
+        if project is None:
+            return True
+        if any(timeline is project.GetCurrentTimeline() for timeline in timelines):
+            return False
+        for timeline in timelines:
+            project.remove_timeline(timeline)
         return True
 
     def DeleteFolders(self, folders: list[FakeFolder]) -> bool:  # noqa: N802

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -303,9 +303,21 @@ class FakeTimeline:
         tracks = self._tracks.get(track_type, [])
         return tracks[index - 1] if 1 <= index <= len(tracks) else None
 
+    def first_video_track(self) -> FakeTrack:
+        """The track an append lands on; a timeline Resolve made always has one."""
+        tracks = self._tracks["video"]
+        if not tracks:
+            tracks.append(FakeTrack("Video 1"))
+        return tracks[0]
+
     def GetName(self) -> str:  # noqa: N802 - mirrors the Resolve API
         self._check()
         return self._name
+
+    def GetUniqueId(self) -> str:  # noqa: N802
+        """Resolve's own identity for a cut — the only way to tell two proxies apart."""
+        self._check()
+        return f"fake-timeline-{id(self):x}"
 
     def GetSetting(self, key: str) -> str | None:  # noqa: N802
         self._check()
@@ -507,12 +519,12 @@ class FakeMediaPool:
         self.appends: list[list[Any]] = []
         self.append_result: list[FakeTimelineItem] | None = None
         self.appends_share_one_comp = False
+        self.appends_land_nowhere = False
         self.created_timelines: list[str] = []
-        self.create_timeline_result: FakeTimeline | None = None
         self.refuses_create_timeline = False
+        self.switches_current_timeline = True
         self.deleted_timelines: list[FakeTimeline] = []
         self.deleted_folders: list[FakeFolder] = []
-        self.delete_timelines_result = True
         self.delete_folders_result = True
 
     def _check(self, method: str) -> None:
@@ -614,24 +626,35 @@ class FakeMediaPool:
         return True
 
     def CreateEmptyTimeline(self, name: str) -> FakeTimeline | None:  # noqa: N802
-        """A new empty cut, registered on the open project. ``None`` when Resolve refuses."""
+        """A new empty cut — one video track, no clips. ``None`` when Resolve refuses.
+
+        Whether creating a timeline also *switches* to it is undocumented, so
+        ``switches_current_timeline`` can withhold the switch: a caller that assumed it
+        happened would append onto whatever cut was already open.
+        """
         self._check("CreateEmptyTimeline")
         self.created_timelines.append(name)
         if self.refuses_create_timeline:
             return None
-        timeline = self.create_timeline_result or FakeTimeline(name)
+        timeline = FakeTimeline(name, video=[FakeTrack("Video 1")])
         if self._owner is not None:
             timeline.adopt(self._owner)
             project = self._owner.current_project
             if project is not None:
                 project.add_timeline(timeline)
+                if self.switches_current_timeline:
+                    project.SetCurrentTimeline(timeline)
         return timeline
 
     def AppendToTimeline(  # noqa: N802
         self,
         clips: list[FakeMediaPoolItem | dict[str, Any]],
     ) -> list[FakeTimelineItem]:
-        """Place clips at the end of the current timeline, one timeline item each.
+        """Place clips at the end of the *current* timeline, one timeline item each.
+
+        Which timeline that is matters: the pool appends to whatever cut the project has
+        open, not to the one most recently created, so the placed items land on the
+        current timeline's first video track and nowhere else.
 
         Each placed instance is given its *own copy* of the template's comp, which is what
         makes per-instance text possible at all. ``appends_share_one_comp`` models the
@@ -640,11 +663,12 @@ class FakeMediaPool:
         """
         self._check("AppendToTimeline")
         self.appends.append(list(clips))
+        target = self._current_timeline()
         if self.append_result is not None:
-            return list(self.append_result)
+            return self._land(list(self.append_result), target)
         placed: list[FakeTimelineItem] = []
         shared: FakeFusionComp | None = None
-        record = 0
+        record = _track_end(target)
         for entry in clips:
             asked: dict[str, Any] = (
                 dict(entry) if isinstance(entry, dict) else {"mediaPoolItem": entry}
@@ -672,13 +696,29 @@ class FakeMediaPool:
                 item.adopt(self._owner)
             placed.append(item)
             record += duration
+        return self._land(placed, target)
+
+    def _current_timeline(self) -> FakeTimeline | None:
+        project = self._owner.current_project if self._owner is not None else None
+        return project.GetCurrentTimeline() if project is not None else None
+
+    def _land(
+        self,
+        placed: list[FakeTimelineItem],
+        target: FakeTimeline | None,
+    ) -> list[FakeTimelineItem]:
+        """Put the placed items on the target's first video track, as the append does.
+
+        ``appends_land_nowhere`` models the answer that would fool a caller who trusted the
+        return value: real timeline items handed back, and a timeline that holds none.
+        """
+        if target is not None and not self.appends_land_nowhere:
+            target.first_video_track().items.extend(placed)
         return placed
 
     def DeleteTimelines(self, timelines: list[FakeTimeline]) -> bool:  # noqa: N802
         self._check("DeleteTimelines")
         self.deleted_timelines.extend(timelines)
-        if not self.delete_timelines_result:
-            return False
         project = self._owner.current_project if self._owner is not None else None
         if project is not None:
             for timeline in timelines:
@@ -716,6 +756,14 @@ class FakeMediaPool:
         for sub in folder.subfolders:
             found.extend(self._walk(sub))
         return found
+
+
+def _track_end(timeline: FakeTimeline | None) -> int:
+    """Where the next append starts: after everything already on the first video track."""
+    if timeline is None:
+        return 0
+    placed = timeline.first_video_track().items
+    return max((item.GetStart() + item.GetDuration() for item in placed), default=0)
 
 
 def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
@@ -776,6 +824,7 @@ class FakeProject:
         self._timeline = timeline
         self._fps = fps
         self._media_pool = media_pool
+        self.refuse_set_current = False
         if timelines is not None:
             self._timelines = list(timelines)
         else:
@@ -805,6 +854,13 @@ class FakeProject:
     def add_timeline(self, timeline: FakeTimeline) -> None:
         """What creating a cut does to a project: one more timeline, nothing else touched."""
         self._timelines.append(timeline)
+
+    def SetCurrentTimeline(self, timeline: FakeTimeline) -> bool:  # noqa: N802
+        """Switch the open cut. ``refuse_set_current`` models a Resolve that will not."""
+        if self.refuse_set_current:
+            return False
+        self._timeline = timeline
+        return True
 
     def remove_timeline(self, timeline: FakeTimeline) -> None:
         """Deleting a cut the project never held is a no-op, as in Resolve."""
@@ -948,12 +1004,7 @@ def media_pool(bins: dict[str, list[FakeMediaPoolItem]] | None = None) -> FakeMe
     return pool
 
 
-def text_plus_template(
-    name: str = "Song Title",
-    text: str = "TEMPLATE",
-    tool_id: str = "TextPlus",
-    clip_type: str = "Generator",
-) -> FakeMediaPoolItem:
+def text_plus_template(name: str = "Song Title") -> FakeMediaPoolItem:
     """A GUI-authored Text+ template as it sits in the media pool after a ``.drb`` import.
 
     It has no file path — a title is generated, not read off disk — so anything that
@@ -961,8 +1012,8 @@ def text_plus_template(
     """
     return FakeMediaPoolItem(
         name,
-        properties={"Type": clip_type, "File Path": ""},
-        template_comp=FakeFusionComp([FakeFusionTool(tool_id, inputs={"StyledText": text})]),
+        properties={"Type": "Generator", "File Path": ""},
+        template_comp=FakeFusionComp([FakeFusionTool()]),
     )
 
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -762,7 +762,7 @@ def _track_end(timeline: FakeTimeline | None) -> int:
     """Where the next append starts: after everything already on the first video track."""
     if timeline is None:
         return 0
-    placed = timeline.first_video_track().items
+    placed = timeline.GetItemListInTrack("video", 1) or []
     return max((item.GetStart() + item.GetDuration() for item in placed), default=0)
 
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -20,6 +20,88 @@ class DroppedHandleError(RuntimeError):
     """What a stale Resolve handle raises when the app has gone away."""
 
 
+class FakeFusionTool:
+    """One node inside a Fusion comp; for titling only the Text+ node matters.
+
+    ``SetInput`` returns ``None`` in the real API — it reports nothing, so the only way to
+    know a write landed is to read it back, which is what the probe does.
+    """
+
+    def __init__(
+        self,
+        tool_id: str = "TextPlus",
+        name: str = "Template Text",
+        inputs: dict[str, Any] | None = None,
+        owner: FakeResolve | None = None,
+    ) -> None:
+        self.tool_id = tool_id
+        self.name = name
+        self.inputs: dict[str, Any] = dict(inputs or {"StyledText": "TEMPLATE"})
+        self._owner = owner
+
+    def copy(self) -> FakeFusionTool:
+        return FakeFusionTool(self.tool_id, self.name, dict(self.inputs), self._owner)
+
+    def adopt(self, owner: FakeResolve) -> None:
+        self._owner = owner
+
+    def _check(self) -> None:
+        if self._owner is not None:
+            self._owner._check()
+
+    def GetAttrs(self, key: str | None = None) -> Any:  # noqa: N802
+        """Fusion answers a whole dict, or one key. ``TOOLS_RegID`` is the node's type."""
+        self._check()
+        attrs = {"TOOLS_RegID": self.tool_id, "TOOLS_Name": self.name}
+        return attrs if key is None else attrs.get(key)
+
+    def SetInput(self, key: str, value: Any) -> None:  # noqa: N802
+        self._check()
+        self.inputs[key] = value
+
+    def GetInput(self, key: str) -> Any:  # noqa: N802
+        self._check()
+        return self.inputs.get(key)
+
+
+class FakeFusionComp:
+    """A timeline item's Fusion composition.
+
+    ``GetToolList`` is filtered by node type in the real API and returns a *one-based dict*
+    rather than a list — a comp with no matching node answers an empty dict, not ``None``.
+    """
+
+    def __init__(
+        self,
+        tools: Sequence[FakeFusionTool] | None = None,
+        owner: FakeResolve | None = None,
+    ) -> None:
+        self.tools: list[FakeFusionTool] = list(tools if tools is not None else [FakeFusionTool()])
+        self._owner = owner
+
+    def copy(self) -> FakeFusionComp:
+        """What placing a template instance does: the new instance gets its own comp."""
+        return FakeFusionComp([tool.copy() for tool in self.tools], self._owner)
+
+    def adopt(self, owner: FakeResolve) -> None:
+        self._owner = owner
+        for tool in self.tools:
+            tool.adopt(owner)
+
+    def _check(self) -> None:
+        if self._owner is not None:
+            self._owner._check()
+
+    def GetToolList(  # noqa: N802
+        self,
+        selected_only: bool = False,
+        tool_type: str = "",
+    ) -> dict[int, FakeFusionTool]:
+        self._check()
+        matching = [tool for tool in self.tools if not tool_type or tool.tool_id == tool_type]
+        return {index: tool for index, tool in enumerate(matching, start=1)}
+
+
 class FakeTimelineItem:
     """A clip on a track.
 
@@ -30,6 +112,12 @@ class FakeTimelineItem:
     ``supports_source_frames=False`` models a Resolve older than 18.5, where the source
     getters are *absent* rather than failing — so ``getattr`` misses them, which is the
     branch the wrapper actually takes.
+
+    ``missing`` models the same absence the way the real API expresses it, which is not an
+    ``AttributeError``: fusionscript answers *every* attribute name, handing back ``None``
+    for one it does not know. Verified live on Studio 21.0.3.7, where
+    ``hasattr(item, "GetTakeCount")`` is ``True`` and the attribute is ``None`` — so a
+    ``hasattr`` guard passes and the call then fails with ``NoneType is not callable``.
     """
 
     def __init__(
@@ -46,6 +134,8 @@ class FakeTimelineItem:
         supports_source_frames: bool = True,
         refuses: frozenset[str] | set[str] | None = None,
         end_is_inclusive: bool = False,
+        comps: Sequence[FakeFusionComp] | None = None,
+        missing: frozenset[str] | set[str] | None = None,
         owner: FakeResolve | None = None,
     ) -> None:
         self._name = name
@@ -60,6 +150,8 @@ class FakeTimelineItem:
         self._supports_source_frames = supports_source_frames
         self._refuses = set(refuses or ())
         self._end_is_inclusive = end_is_inclusive
+        self.comps: list[FakeFusionComp] = list(comps or ())
+        self._missing = set(missing or ())
         self._owner = owner
 
     SOURCE_GETTERS = ("GetSourceStartFrame", "GetSourceEndFrame")
@@ -70,10 +162,14 @@ class FakeTimelineItem:
             self, "_supports_source_frames"
         ):
             raise AttributeError(name)
+        if not name.startswith("_") and name in object.__getattribute__(self, "_missing"):
+            return None
         return object.__getattribute__(self, name)
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
+        for comp in self.comps:
+            comp.adopt(owner)
 
     def _check(self, method: str = "") -> None:
         if method and method in self._refuses:
@@ -126,6 +222,18 @@ class FakeTimelineItem:
     def GetTakeCount(self) -> int:  # noqa: N802
         self._check("GetTakeCount")
         return self._takes
+
+    def GetFusionCompCount(self) -> int:  # noqa: N802
+        """Zero for an ordinary clip. A Text+ instance that answers zero has lost its comp."""
+        self._check("GetFusionCompCount")
+        return len(self.comps)
+
+    def GetFusionCompByIndex(self, index: int) -> FakeFusionComp | None:  # noqa: N802
+        """One-based; an index Resolve has no comp for returns ``None`` rather than raising."""
+        self._check("GetFusionCompByIndex")
+        if 1 <= index <= len(self.comps):
+            return self.comps[index - 1]
+        return None
 
 
 class FakeTrack:
@@ -287,7 +395,12 @@ class FakeMediaPoolItem:
         markers: dict[float, dict[str, Any]] | None = None,
         audio_mapping: str | None = None,
         mark_in_out: dict[str, dict[str, int]] | None = None,
+        template_comp: FakeFusionComp | None = None,
     ) -> None:
+        # Deliberately not a getter: a pool item has no Fusion comp in the scripting API.
+        # This is the comp the *placed instance* is given, which is the only way a Text+
+        # template's comp can reach a timeline item at all.
+        self.template_comp = template_comp
         self._name = name
         self._properties = {**DEFAULT_PROPERTIES, "Clip Name": name, "File Path": file_path}
         self._properties.update(properties or {})
@@ -384,6 +497,23 @@ class FakeMediaPool:
         self.relink_result: bool | None = None
         self.move_result = True
         self.calls: list[str] = []
+        # The .drb route. Each knob is one outcome a real import has been seen to take:
+        # a refusal, a success, and the one that costs an afternoon — True with an
+        # untouched pool.
+        self.folder_imports: list[tuple[str, str]] = []
+        self.import_folder_result: bool | None = None
+        self.import_lands_nothing = False
+        self.imported_folder: FakeFolder | None = None
+        self.appends: list[list[Any]] = []
+        self.append_result: list[FakeTimelineItem] | None = None
+        self.appends_share_one_comp = False
+        self.created_timelines: list[str] = []
+        self.create_timeline_result: FakeTimeline | None = None
+        self.refuses_create_timeline = False
+        self.deleted_timelines: list[FakeTimeline] = []
+        self.deleted_folders: list[FakeFolder] = []
+        self.delete_timelines_result = True
+        self.delete_folders_result = True
 
     def _check(self, method: str) -> None:
         self.calls.append(method)
@@ -451,6 +581,118 @@ class FakeMediaPool:
             self._current.clips.append(clip)
             imported.append(clip)
         return imported
+
+    def ImportFolderFromFile(  # noqa: N802
+        self,
+        file_path: str,
+        source_clips_path: str = "",
+    ) -> bool:
+        """Unpack a ``.drb`` bin export under the current folder.
+
+        The bin's *name* comes from the file, not from the caller — Resolve offers no way
+        to name it — so a caller can only find what landed by comparing the current
+        folder's children before and after. ``import_lands_nothing`` models the answer
+        that hides a failure: ``True``, and the pool is untouched.
+        """
+        self._check("ImportFolderFromFile")
+        self.folder_imports.append((file_path, source_clips_path))
+        if self.import_folder_result is not None:
+            landed = self.import_folder_result
+        else:
+            landed = Path(file_path).exists()
+        if not landed:
+            return False
+        if self.import_lands_nothing:
+            return True
+        folder = self.imported_folder
+        if folder is None:
+            folder = FakeFolder(Path(file_path).stem)
+            folder.clips.append(text_plus_template())
+        if self._owner is not None:
+            folder.adopt(self._owner)
+        self._current.subfolders.append(folder)
+        return True
+
+    def CreateEmptyTimeline(self, name: str) -> FakeTimeline | None:  # noqa: N802
+        """A new empty cut, registered on the open project. ``None`` when Resolve refuses."""
+        self._check("CreateEmptyTimeline")
+        self.created_timelines.append(name)
+        if self.refuses_create_timeline:
+            return None
+        timeline = self.create_timeline_result or FakeTimeline(name)
+        if self._owner is not None:
+            timeline.adopt(self._owner)
+            project = self._owner.current_project
+            if project is not None:
+                project.add_timeline(timeline)
+        return timeline
+
+    def AppendToTimeline(  # noqa: N802
+        self,
+        clips: list[FakeMediaPoolItem | dict[str, Any]],
+    ) -> list[FakeTimelineItem]:
+        """Place clips at the end of the current timeline, one timeline item each.
+
+        Each placed instance is given its *own copy* of the template's comp, which is what
+        makes per-instance text possible at all. ``appends_share_one_comp`` models the
+        opposite — every instance handed the same comp, so setting one title's text
+        rewrites every other — and is the reason this probe exists.
+        """
+        self._check("AppendToTimeline")
+        self.appends.append(list(clips))
+        if self.append_result is not None:
+            return list(self.append_result)
+        placed: list[FakeTimelineItem] = []
+        shared: FakeFusionComp | None = None
+        record = 0
+        for entry in clips:
+            asked: dict[str, Any] = (
+                dict(entry) if isinstance(entry, dict) else {"mediaPoolItem": entry}
+            )
+            source: FakeMediaPoolItem = asked["mediaPoolItem"]
+            start = int(asked.get("startFrame", 0))
+            end = int(asked.get("endFrame", start + 119))
+            duration = max(end - start + 1, 1)
+            comps: list[FakeFusionComp] = []
+            if source.template_comp is not None:
+                if self.appends_share_one_comp:
+                    shared = shared or source.template_comp
+                    comps = [shared]
+                else:
+                    comps = [source.template_comp.copy()]
+            item = FakeTimelineItem(
+                source.GetName(),
+                int(asked.get("recordFrame", record)),
+                duration,
+                source_start=start,
+                media_item=source,
+                comps=comps,
+            )
+            if self._owner is not None:
+                item.adopt(self._owner)
+            placed.append(item)
+            record += duration
+        return placed
+
+    def DeleteTimelines(self, timelines: list[FakeTimeline]) -> bool:  # noqa: N802
+        self._check("DeleteTimelines")
+        self.deleted_timelines.extend(timelines)
+        if not self.delete_timelines_result:
+            return False
+        project = self._owner.current_project if self._owner is not None else None
+        if project is not None:
+            for timeline in timelines:
+                project.remove_timeline(timeline)
+        return True
+
+    def DeleteFolders(self, folders: list[FakeFolder]) -> bool:  # noqa: N802
+        self._check("DeleteFolders")
+        self.deleted_folders.extend(folders)
+        if not self.delete_folders_result:
+            return False
+        for parent in self._walk(self._root):
+            parent.subfolders = [sub for sub in parent.subfolders if sub not in folders]
+        return True
 
     def RelinkClips(  # noqa: N802
         self,
@@ -559,6 +801,16 @@ class FakeProject:
 
     def GetMediaPool(self) -> FakeMediaPool | None:  # noqa: N802
         return self._media_pool
+
+    def add_timeline(self, timeline: FakeTimeline) -> None:
+        """What creating a cut does to a project: one more timeline, nothing else touched."""
+        self._timelines.append(timeline)
+
+    def remove_timeline(self, timeline: FakeTimeline) -> None:
+        """Deleting a cut the project never held is a no-op, as in Resolve."""
+        self._timelines = [held for held in self._timelines if held is not timeline]
+        if self._timeline is timeline:
+            self._timeline = None
 
 
 class FakeProjectManager:
@@ -694,6 +946,24 @@ def media_pool(bins: dict[str, list[FakeMediaPoolItem]] | None = None) -> FakeMe
         folder.clips.extend(clips)
     pool.calls.clear()
     return pool
+
+
+def text_plus_template(
+    name: str = "Song Title",
+    text: str = "TEMPLATE",
+    tool_id: str = "TextPlus",
+    clip_type: str = "Generator",
+) -> FakeMediaPoolItem:
+    """A GUI-authored Text+ template as it sits in the media pool after a ``.drb`` import.
+
+    It has no file path — a title is generated, not read off disk — so anything that
+    treats a pathless clip as broken would trip here.
+    """
+    return FakeMediaPoolItem(
+        name,
+        properties={"Type": clip_type, "File Path": ""},
+        template_comp=FakeFusionComp([FakeFusionTool(tool_id, inputs={"StyledText": text})]),
+    )
 
 
 def sync_reference(

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -7,18 +7,27 @@ Resolve upgrade, with Resolve running and a project open:
 
 Everything here goes through the real connection singleton — no fakes — so it is the only
 place the direct-attach path itself is exercised.
+
+Every test here is read-only except the Text+ probe, which creates and then deletes a
+scratch bin and timeline in the open project. It stays skipped until you opt in by
+pointing ``RESOLVE_MCP_TEXTPLUS_TEMPLATE`` at a ``.drb`` you exported from the GUI:
+
+    RESOLVE_MCP_TEXTPLUS_TEMPLATE=C:\\titles\\Titles.drb uv run pytest -m live -s
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
+from resolve_mcp.resolve.connection import get_connection
 from resolve_mcp.tools.escape_hatch import run_python
 from resolve_mcp.tools.media import inspect_clip, list_media
 from resolve_mcp.tools.project import get_status, list_projects, snapshot_project
 from resolve_mcp.tools.timeline import inspect_timeline, list_timelines
+from tests.text_plus_probe import TEMPLATE_ENV, probe_template_append
 
 pytestmark = pytest.mark.live
 
@@ -130,6 +139,29 @@ def test_the_frame_math_holds_on_a_real_timeline() -> None:
                     item["sync_offset"]["frames"]
                     == record["in"]["frames"] - item["source"]["in"]["frames"]
                 )
+
+
+def test_the_text_plus_template_route_survives_a_drb_round_trip() -> None:
+    """#41: the one question no fake can answer — does Resolve give each placed instance
+    of a GUI-authored Text+ template its own text?
+
+    The whole titling design downstream assumes yes. This mutates the open project (a
+    scratch bin and a scratch timeline, both deleted again), so it stays skipped until
+    the template path is set; run it on a throwaway project the first time.
+
+    Paste the printed report onto the ticket — that is the record the ticket asks for.
+    """
+    exported = os.environ.get(TEMPLATE_ENV, "").strip()
+    if not exported:
+        pytest.skip(f"Set {TEMPLATE_ENV} to a .drb holding one GUI-authored Text+ template")
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+
+    report = probe_template_append(get_connection(), Path(exported))
+
+    print("\n" + report.render())
+    assert report.per_instance_text, report.render()
+    assert report.cleaned_up, report.render()
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -10,9 +10,11 @@ place the direct-attach path itself is exercised.
 
 Every test here is read-only except the Text+ probe, which creates and then deletes a
 scratch bin and timeline in the open project. It stays skipped until you opt in by
-pointing ``RESOLVE_MCP_TEXTPLUS_TEMPLATE`` at a ``.drb`` you exported from the GUI:
+pointing ``RESOLVE_MCP_TEXTPLUS_TEMPLATE`` at a ``.drb`` you exported from the GUI —
+in PowerShell, which is the shell on the machine this runs on:
 
-    RESOLVE_MCP_TEXTPLUS_TEMPLATE=C:\\titles\\Titles.drb uv run pytest -m live -s
+    $env:RESOLVE_MCP_TEXTPLUS_TEMPLATE = 'C:\\titles\\Titles.drb'
+    uv run pytest -m live -s
 """
 
 from __future__ import annotations
@@ -27,7 +29,8 @@ from resolve_mcp.tools.escape_hatch import run_python
 from resolve_mcp.tools.media import inspect_clip, list_media
 from resolve_mcp.tools.project import get_status, list_projects, snapshot_project
 from resolve_mcp.tools.timeline import inspect_timeline, list_timelines
-from tests.text_plus_probe import TEMPLATE_ENV, probe_template_append
+
+from .text_plus_probe import TEMPLATE_ENV, probe_template_append
 
 pytestmark = pytest.mark.live
 

--- a/tests/test_text_plus_probe.py
+++ b/tests/test_text_plus_probe.py
@@ -26,6 +26,7 @@ from .fakes import (
     FakeMediaPoolItem,
     FakeProject,
     FakeResolve,
+    FakeTimeline,
     FakeTimelineItem,
     media_pool,
     studio,
@@ -336,6 +337,38 @@ def test_the_scratch_bin_is_removed_when_the_timeline_was_never_created(
     assert [folder.GetName() for folder in pool.deleted_folders] == ["Titles"]
     assert pool.deleted_timelines == []
     assert pool.GetRootFolder().GetSubFolderList() == []
+
+
+def test_a_session_with_no_cut_open_is_moved_off_the_scratch_one_before_it_is_deleted(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Resolve will not delete the timeline it is sitting on, and says so only by returning
+    False. With nothing open to go back to, the scratch cut *is* the one it is sitting on —
+    so any other cut in the project will do."""
+    pool = media_pool()
+    somewhere_else = FakeTimeline("sunset-set v3")
+    attach(studio(pool=pool, timeline=None, timelines=[somewhere_else]))
+
+    report = probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert report.per_instance_text is True
+    assert report.cleaned_up is True
+    assert [timeline.GetName() for timeline in pool.deleted_timelines] == [report.timeline_name]
+
+
+def test_a_project_whose_only_cut_is_the_scratch_one_says_what_it_left_behind(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Nothing to move to, so Resolve refuses the delete. The run still reports its finding
+    — losing the answer over the tidying is the one thing cleanup must not do."""
+    pool = media_pool()
+    attach(studio(pool=pool, timeline=None, timelines=[]))
+
+    report = probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert report.per_instance_text is True
+    assert report.cleaned_up is False
+    assert "left behind" in report.render()
 
 
 def test_a_failed_cleanup_is_recorded_rather_than_raised(attach: Attach, tmp_path: Path) -> None:

--- a/tests/test_text_plus_probe.py
+++ b/tests/test_text_plus_probe.py
@@ -16,27 +16,40 @@ import pytest
 
 from resolve_mcp.errors import NoProjectOpenError
 from resolve_mcp.resolve.connection import get_connection
-from tests.conftest import Attach
-from tests.fakes import (
+
+from .conftest import Attach
+from .fakes import (
     DroppedHandleError,
     FakeFolder,
     FakeFusionComp,
     FakeFusionTool,
     FakeMediaPoolItem,
+    FakeProject,
+    FakeResolve,
     FakeTimelineItem,
     media_pool,
     studio,
     text_plus_template,
 )
-from tests.text_plus_probe import ProbeFailed, probe_template_append
+from .text_plus_probe import ProbeFailed, probe_template_append
 
 
 def a_template_file(tmp_path: Path, name: str = "Titles.drb") -> Path:
-    """The ``.drb`` the human exported from the GUI. Its bytes never matter — only Resolve
-    reads them — but its existence does: an unreadable path is refused, not imported."""
+    """The ``.drb`` the human exported from the GUI.
+
+    Its bytes never matter — only Resolve reads them — but its existence does: an
+    unreadable path is refused, not imported.
+    """
     target = tmp_path / name
     target.write_bytes(b"fake-drb")
     return target
+
+
+def the_open_project(handle: FakeResolve) -> FakeProject:
+    """``studio()`` always opens one; this is only here to say so in the type."""
+    project = handle.current_project
+    assert project is not None
+    return project
 
 
 def test_the_route_runs_end_to_end_and_each_instance_keeps_its_own_text(
@@ -60,6 +73,16 @@ def test_the_route_runs_end_to_end_and_each_instance_keeps_its_own_text(
     assert report.clip_type == "Generator"
     assert report.cleaned_up is True
     assert pool.folder_imports == [(str(a_template_file(tmp_path)), "")]
+    # Each instance is asked for with an inclusive end frame, and lands after the one
+    # before it — two titles stacked on one frame would read back as one title placed twice.
+    sent = [dict(one) for one in pool.appends[0]]
+    assert [{key: one[key] for key in ("startFrame", "endFrame")} for one in sent] == [
+        {"startFrame": 0, "endFrame": 119},
+        {"startFrame": 0, "endFrame": 119},
+    ]
+    assert {one["mediaPoolItem"].GetName() for one in sent} == {"Song Title"}
+    assert [placed.record_in for placed in report.placed] == [0, 120]
+    assert [placed.duration for placed in report.placed] == [120, 120]
 
 
 def test_instances_that_share_one_comp_are_caught_by_reading_every_title_back(
@@ -80,6 +103,65 @@ def test_instances_that_share_one_comp_are_caught_by_reading_every_title_back(
     assert raised.value.step == "read the text back"
     assert "share one comp" in str(raised.value)
     assert "'Two'" in str(raised.value)
+
+
+def test_nothing_is_appended_until_the_scratch_timeline_is_confirmed_current(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The footgun that would have cost the operator their cut.
+
+    ``AppendToTimeline`` appends to the project's *current* timeline, not to the one just
+    created. A probe that assumed ``CreateEmptyTimeline`` switched would, on a Resolve
+    that did not, place two Text+ instances on the open cut — and still pass every
+    assertion after it, because the instances would be perfectly real.
+    """
+    pool = media_pool()
+    pool.switches_current_timeline = False
+    handle = studio(pool=pool)
+    open_cut = the_open_project(handle).GetCurrentTimeline()
+    the_open_project(handle).refuse_set_current = True
+    attach(handle)
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "target the scratch timeline"
+    assert "nothing was appended" in str(raised.value)
+    assert pool.appends == []
+    assert open_cut is not None
+    assert open_cut.first_video_track().items == []
+
+
+def test_an_append_the_timeline_does_not_hold_is_not_taken_on_trust(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """What the append returned proves a call succeeded; what the timeline holds proves a
+    title was placed. Only the second is what titling needs."""
+    pool = media_pool()
+    pool.appends_land_nowhere = True
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "find the placed instances"
+    assert "holds 0" in str(raised.value)
+
+
+def test_the_current_folder_and_timeline_are_put_back(attach: Attach, tmp_path: Path) -> None:
+    """A probe that leaves the GUI somewhere else is a probe that gets blamed for the mess."""
+    pool = media_pool({"Concert/Angles": [FakeMediaPoolItem("C0012.mp4")]})
+    was_in = pool.GetRootFolder().GetSubFolderList()[0]
+    pool.SetCurrentFolder(was_in)
+    handle = studio(pool=pool)
+    was_on = the_open_project(handle).GetCurrentTimeline()
+    attach(handle)
+
+    report = probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert report.per_instance_text is True
+    assert pool.GetCurrentFolder() is was_in
+    assert the_open_project(handle).GetCurrentTimeline() is was_on
 
 
 def test_an_import_that_answers_true_and_lands_nothing_is_not_mistaken_for_success(
@@ -191,7 +273,8 @@ def test_a_build_without_the_fusion_getters_is_named_rather_than_left_to_blow_up
     names neither the method nor the build."""
     pool = media_pool()
     pool.append_result = [
-        FakeTimelineItem("Song Title", 0, 120, missing={"GetFusionCompCount"}) for _ in range(2)
+        FakeTimelineItem("Song Title", record, 120, missing={"GetFusionCompCount"})
+        for record in (0, 120)
     ]
     attach(studio(pool=pool))
 
@@ -202,10 +285,11 @@ def test_a_build_without_the_fusion_getters_is_named_rather_than_left_to_blow_up
     assert "no GetFusionCompCount" in str(raised.value)
 
 
-def test_the_scratch_bin_and_timeline_are_deleted_even_when_a_step_fails(
+def test_the_scratch_bin_is_removed_when_the_timeline_was_never_created(
     attach: Attach, tmp_path: Path
 ) -> None:
-    """A probe that leaves its scratch bin behind is a probe nobody runs twice."""
+    """A probe that leaves its scratch bin behind is a probe nobody runs twice — and the
+    bin is already in the pool by the time a later step fails."""
     pool = media_pool()
     pool.refuses_create_timeline = True
     attach(studio(pool=pool))

--- a/tests/test_text_plus_probe.py
+++ b/tests/test_text_plus_probe.py
@@ -1,0 +1,293 @@
+"""The Text+ template-append probe, run against fakes.
+
+What this tier can prove: that the probe walks the route in the right order, that it
+reads every title back *after* all the writes rather than one at a time, and that each
+way the route can fail comes back named. What it cannot prove is the thing #41 exists to
+answer — whether Resolve really keeps a per-instance comp — because the fake behaves
+however it was told to. That answer only comes from ``uv run pytest -m live``; this suite
+is what stops the live run failing on a typo instead of on a finding.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.errors import NoProjectOpenError
+from resolve_mcp.resolve.connection import get_connection
+from tests.conftest import Attach
+from tests.fakes import (
+    DroppedHandleError,
+    FakeFolder,
+    FakeFusionComp,
+    FakeFusionTool,
+    FakeMediaPoolItem,
+    FakeTimelineItem,
+    media_pool,
+    studio,
+    text_plus_template,
+)
+from tests.text_plus_probe import ProbeFailed, probe_template_append
+
+
+def a_template_file(tmp_path: Path, name: str = "Titles.drb") -> Path:
+    """The ``.drb`` the human exported from the GUI. Its bytes never matter — only Resolve
+    reads them — but its existence does: an unreadable path is refused, not imported."""
+    target = tmp_path / name
+    target.write_bytes(b"fake-drb")
+    return target
+
+
+def test_the_route_runs_end_to_end_and_each_instance_keeps_its_own_text(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = media_pool()
+    attach(studio(pool=pool))
+
+    report = probe_template_append(
+        get_connection(),
+        a_template_file(tmp_path),
+        texts=("Sunset Boulevard", "Bass — Ana Ruiz"),
+    )
+
+    assert [placed.asked for placed in report.placed] == ["Sunset Boulevard", "Bass — Ana Ruiz"]
+    assert [placed.read_back for placed in report.placed] == [
+        "Sunset Boulevard",
+        "Bass — Ana Ruiz",
+    ]
+    assert report.clip_name == "Song Title"
+    assert report.clip_type == "Generator"
+    assert report.cleaned_up is True
+    assert pool.folder_imports == [(str(a_template_file(tmp_path)), "")]
+
+
+def test_instances_that_share_one_comp_are_caught_by_reading_every_title_back(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The finding the whole ticket turns on.
+
+    A probe that set a title and read it straight back would pass here — the second write
+    has not happened yet. Only reading every instance after every write shows the bleed.
+    """
+    pool = media_pool()
+    pool.appends_share_one_comp = True
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path), texts=("One", "Two"))
+
+    assert raised.value.step == "read the text back"
+    assert "share one comp" in str(raised.value)
+    assert "'Two'" in str(raised.value)
+
+
+def test_an_import_that_answers_true_and_lands_nothing_is_not_mistaken_for_success(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = media_pool()
+    pool.import_lands_nothing = True
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "find the imported bin"
+    assert "answered True" in str(raised.value)
+
+
+def test_a_bin_whose_name_was_already_taken_is_reported_rather_than_reused(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """New bins are recognised by name, because Resolve hands out a fresh proxy per call
+    and identity does not survive a second walk. A name collision therefore looks exactly
+    like an import that landed nothing, and must not be answered with the older bin."""
+    pool = media_pool({"Titles": [FakeMediaPoolItem("someone-elses-title")]})
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "find the imported bin"
+    assert "Titles" in str(raised.value)
+
+
+def test_a_refused_import_names_the_template_it_could_not_read(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = media_pool()
+    pool.import_folder_result = False
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "import the template bin"
+    assert "Titles.drb" in str(raised.value)
+
+
+def test_a_template_bin_holding_more_than_one_clip_refuses_to_guess(
+    attach: Attach, tmp_path: Path
+) -> None:
+    crowded = FakeFolder("Titles")
+    crowded.clips.extend([text_plus_template("Song Title"), text_plus_template("Personnel")])
+    pool = media_pool()
+    pool.imported_folder = crowded
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "find the template clip"
+    assert "Song Title" in str(raised.value)
+    assert "Personnel" in str(raised.value)
+
+
+def test_a_placed_instance_with_no_fusion_comp_names_the_drb_round_trip(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A template that survives the export but arrives as a plain clip is the failure
+    mode that would sink the whole Text+ route, so it gets its own sentence."""
+    stripped = FakeFolder("Titles")
+    stripped.clips.append(FakeMediaPoolItem("Song Title", properties={"Type": "Generator"}))
+    pool = media_pool()
+    pool.imported_folder = stripped
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "open the Fusion comp"
+    assert "no Fusion comp" in str(raised.value)
+
+
+def test_a_comp_without_a_text_plus_node_lists_what_the_comp_does_hold(
+    attach: Attach, tmp_path: Path
+) -> None:
+    wrong_node = FakeFolder("Titles")
+    wrong_node.clips.append(
+        FakeMediaPoolItem(
+            "Song Title",
+            properties={"Type": "Generator"},
+            template_comp=FakeFusionComp([FakeFusionTool("Background", name="Backdrop")]),
+        )
+    )
+    pool = media_pool()
+    pool.imported_folder = wrong_node
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "find the Text+ node"
+    assert "Backdrop" in str(raised.value)
+
+
+def test_a_build_without_the_fusion_getters_is_named_rather_than_left_to_blow_up(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Live on 21.0.3.7 a getter Resolve does not have reads back as ``None``, not as a
+    missing attribute — so the naive call dies with ``NoneType is not callable``, which
+    names neither the method nor the build."""
+    pool = media_pool()
+    pool.append_result = [
+        FakeTimelineItem("Song Title", 0, 120, missing={"GetFusionCompCount"}) for _ in range(2)
+    ]
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "open the Fusion comp"
+    assert "no GetFusionCompCount" in str(raised.value)
+
+
+def test_the_scratch_bin_and_timeline_are_deleted_even_when_a_step_fails(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A probe that leaves its scratch bin behind is a probe nobody runs twice."""
+    pool = media_pool()
+    pool.refuses_create_timeline = True
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "create the scratch timeline"
+    assert [folder.GetName() for folder in pool.deleted_folders] == ["Titles"]
+    assert pool.deleted_timelines == []
+    assert pool.GetRootFolder().GetSubFolderList() == []
+
+
+def test_a_failed_cleanup_is_recorded_rather_than_raised(attach: Attach, tmp_path: Path) -> None:
+    """The route worked; only the tidying did not. Losing the result over that would throw
+    away the answer the live run was made for."""
+    pool = media_pool()
+    pool.delete_folders_result = False
+    attach(studio(pool=pool))
+
+    report = probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert report.cleaned_up is False
+    assert "left behind" in report.render()
+
+
+def test_resolve_quitting_mid_probe_surfaces_as_a_dropped_handle(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Not a finding about Text+ — the probe must not dress a departed Resolve up as one."""
+    pool = media_pool()
+    handle = studio(pool=pool)
+    attach(handle)
+    handle.die_after(4)
+
+    with pytest.raises(DroppedHandleError):
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+
+def test_no_project_open_fails_before_anything_is_touched(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(project=None))
+
+    with pytest.raises(NoProjectOpenError):
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+
+def test_two_titles_asked_for_the_same_text_would_prove_nothing(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(pool=media_pool()))
+
+    with pytest.raises(ValueError, match="distinct"):
+        probe_template_append(get_connection(), a_template_file(tmp_path), texts=("Same", "Same"))
+
+
+def test_a_missing_template_is_refused_before_resolve_is_touched(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = media_pool()
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), tmp_path / "never-exported.drb")
+
+    assert raised.value.step == "read the template"
+    assert pool.calls == []
+
+
+def test_the_report_carries_what_the_ticket_has_to_record(attach: Attach, tmp_path: Path) -> None:
+    """The live run happens on a machine nobody is watching; the report is the evidence."""
+    pool = media_pool()
+    attach(studio(pool=pool))
+
+    rendered = probe_template_append(
+        get_connection(), a_template_file(tmp_path), texts=("First", "Second")
+    ).render()
+
+    assert "Titles.drb" in rendered
+    assert "Generator" in rendered
+    # The node's own name, not its RegID: a template with several Text+ nodes is a real
+    # possibility, and which one answered is the part apply_titles cannot guess.
+    assert "Template Text" in rendered
+    assert "Text+ nodes in comp: 1" in rendered
+    assert "First" in rendered and "Second" in rendered
+    assert "per-instance text: yes" in rendered

--- a/tests/test_text_plus_probe.py
+++ b/tests/test_text_plus_probe.py
@@ -132,6 +132,41 @@ def test_nothing_is_appended_until_the_scratch_timeline_is_confirmed_current(
     assert open_cut.first_video_track().items == []
 
 
+def test_a_resolve_that_does_not_switch_on_create_is_switched_by_hand(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The recovery the check above exists for: creating a timeline need not select it, so
+    the probe selects it, and the run proceeds on the scratch cut rather than the open one."""
+    pool = media_pool()
+    pool.switches_current_timeline = False
+    handle = studio(pool=pool)
+    open_cut = the_open_project(handle).GetCurrentTimeline()
+    attach(handle)
+
+    report = probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert report.per_instance_text is True
+    assert open_cut is not None
+    assert open_cut.first_video_track().items == []
+    assert [placed.record_in for placed in report.placed] == [0, 120]
+
+
+def test_two_instances_stacked_on_one_frame_are_not_read_as_two_titles(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """One title placed twice on the same frame would satisfy every later check while
+    proving nothing about per-instance text."""
+    pool = media_pool()
+    pool.append_result = [FakeTimelineItem("Song Title", 0, 120) for _ in range(2)]
+    attach(studio(pool=pool))
+
+    with pytest.raises(ProbeFailed) as raised:
+        probe_template_append(get_connection(), a_template_file(tmp_path))
+
+    assert raised.value.step == "find the placed instances"
+    assert "[0, 0]" in str(raised.value)
+
+
 def test_an_append_the_timeline_does_not_hold_is_not_taken_on_trust(
     attach: Attach, tmp_path: Path
 ) -> None:

--- a/tests/text_plus_probe.py
+++ b/tests/text_plus_probe.py
@@ -1,0 +1,382 @@
+"""The Text+ template-append probe (#41).
+
+One question, asked once, before ``apply_titles`` is designed: does a GUI-authored Text+
+template survive a ``.drb`` round trip, land on a timeline through the API, and give each
+placed instance *its own* text? Everything downstream — a titles track rebuilt per song,
+a typo fixed in one card — assumes yes. Nothing in the API documents it.
+
+So this is a probe, not a wrapper: it lives in ``tests/`` because its output is a finding
+for a ticket, not a tool for an agent. It runs at both seams. Against fakes
+(``test_text_plus_probe.py``) it proves it walks the route in the right order and names
+each failure; against real Resolve (``test_live_smoke.py``) it answers the question.
+
+Three things here are decisions rather than API calls:
+
+* **The imported bin is recognised by name, not by identity.** ``ImportFolderFromFile``
+  returns a bare ``True`` and names the bin after the ``.drb``, and Resolve hands out a
+  fresh proxy object per call — so the only way to find what landed is to diff the root's
+  child *names*. A name already in use is therefore indistinguishable from an import that
+  landed nothing, and is reported as such rather than answered with the older bin.
+* **Every title is read back after every write, never one at a time.** A probe that set a
+  title and immediately read it would pass whether the instances have their own comps or
+  share one; the second write is what exposes the difference.
+* **Cleanup never costs the answer.** The probe creates a scratch bin and a scratch
+  timeline in a real project, and deletes both in a ``finally``; a cleanup that fails is
+  recorded in the report, not raised over the finding the live run was made for.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.logging_config import get_logger
+from resolve_mcp.naming import timestamped_name
+from resolve_mcp.resolve.connection import ResolveConnection
+from resolve_mcp.resolve.media import media_pool
+
+log = get_logger("probe.textplus")
+
+TEMPLATE_ENV = "RESOLVE_MCP_TEXTPLUS_TEMPLATE"
+TEXT_PLUS = "TextPlus"
+STYLED_TEXT = "StyledText"
+DEFAULT_TEXTS = ("Sunset Boulevard", "Bass — Ana Ruiz")
+DEFAULT_DURATION = 120
+
+
+class ProbeFailed(AssertionError):
+    """A step of the route did not do what titling needs it to do.
+
+    Carries the step it failed on and the trail up to it, because the live run happens on
+    a machine nobody is watching and the trail is the whole diagnosis.
+    """
+
+    def __init__(self, step: str, detail: str, trail: Sequence[str]) -> None:
+        self.step = step
+        self.detail = detail
+        self.trail = tuple(trail)
+        walked = "\n".join(f"  {done}" for done in self.trail)
+        super().__init__(f"{step}: {detail}\nwalked:\n{walked}")
+
+
+@dataclass(frozen=True)
+class Placed:
+    """One appended template instance, and what its Text+ node said afterwards."""
+
+    index: int
+    name: str
+    record_in: int
+    duration: int
+    tool_name: str
+    tool_count: int
+    asked: str
+    read_back: str | None
+
+    @property
+    def kept_its_own_text(self) -> bool:
+        return self.read_back == self.asked
+
+
+@dataclass(frozen=True)
+class Report:
+    """What the live run pastes onto the ticket."""
+
+    template: str
+    bin_name: str
+    clip_name: str
+    clip_type: str
+    timeline_name: str
+    placed: tuple[Placed, ...]
+    cleaned_up: bool
+    trail: tuple[str, ...] = field(default=())
+
+    @property
+    def per_instance_text(self) -> bool:
+        return bool(self.placed) and all(one.kept_its_own_text for one in self.placed)
+
+    def render(self) -> str:
+        lines = [
+            f"template:      {self.template}",
+            f"imported bin:  {self.bin_name}",
+            f"template clip: {self.clip_name} (Type={self.clip_type or '<none>'})",
+            f"timeline:      {self.timeline_name}",
+        ]
+        for one in self.placed:
+            lines.append(
+                f"  instance {one.index}: {one.name} @ {one.record_in} for {one.duration}f — "
+                f"{one.tool_name} (Text+ nodes in comp: {one.tool_count}) "
+                f"asked {one.asked!r}, read back {one.read_back!r}"
+            )
+        lines.append(f"per-instance text: {'yes' if self.per_instance_text else 'no'}")
+        lines.append(
+            "scratch bin and timeline: removed"
+            if self.cleaned_up
+            else "scratch bin and timeline: left behind — delete them by hand"
+        )
+        return "\n".join(lines)
+
+
+def probe_template_append(
+    connection: ResolveConnection,
+    template: Path,
+    *,
+    texts: Sequence[str] = DEFAULT_TEXTS,
+    duration: int = DEFAULT_DURATION,
+    label: str = "textplus-probe",
+    now: datetime | None = None,
+) -> Report:
+    """Walk the whole route and report what Resolve did, or raise ``ProbeFailed``.
+
+    Mutates the open project — a scratch bin and a scratch timeline, both removed again.
+    ``texts`` must hold at least two distinct strings: one title proves only that a write
+    landed somewhere, not that it landed on the instance it was aimed at.
+    """
+    asked = list(texts)
+    if len(asked) < 2 or len(set(asked)) != len(asked):
+        raise ValueError("The probe needs at least two distinct texts to prove anything.")
+
+    trail: list[str] = []
+
+    def walked(step: str, detail: str) -> None:
+        trail.append(f"{step}: {detail}")
+        log.info("Text+ probe — %s: %s", step, detail)
+
+    def failed(step: str, detail: str) -> ProbeFailed:
+        return _failure(step, detail, trail)
+
+    step = "read the template"
+    if not template.is_file():
+        raise failed(step, f"No template at {template}. Export one from Resolve first.")
+    walked(step, str(template))
+
+    pool = media_pool(connection)
+    root = pool.GetRootFolder()
+    known = {str(sub.GetName() or "") for sub in root.GetSubFolderList()}
+    pool.SetCurrentFolder(root)
+    walked("reach the media pool", f"root {str(root.GetName() or '')!r}, {len(known)} bins")
+
+    imported: Any = None
+    timeline: Any = None
+    try:
+        step = "import the template bin"
+        if not pool.ImportFolderFromFile(str(template)):
+            raise failed(step, f"Resolve refused {template.name}.")
+        walked(step, f"ImportFolderFromFile({template.name}) answered True")
+
+        step = "find the imported bin"
+        landed = [
+            sub for sub in root.GetSubFolderList() if str(sub.GetName() or "") not in known
+        ]
+        if not landed:
+            raise failed(
+                step,
+                f"ImportFolderFromFile answered True but no new bin appeared under "
+                f"{str(root.GetName() or '')!r}. Either nothing was imported, or the bin's "
+                f"name was already taken by one of: {sorted(known)}. A bin may have been "
+                f"left behind — check the pool by hand.",
+            )
+        if len(landed) > 1:
+            raise failed(step, f"One import produced several bins: {_names(landed)}.")
+        imported = landed[0]
+        bin_name = str(imported.GetName() or "")
+        walked(step, f"bin {bin_name!r}")
+
+        step = "find the template clip"
+        clips = _clips_under(imported)
+        if not clips:
+            raise failed(step, f"The imported bin {bin_name!r} holds no clips.")
+        if len(clips) > 1:
+            raise failed(
+                step,
+                f"The imported bin {bin_name!r} holds more than one clip "
+                f"({_names(clips)}); export a bin holding the one template.",
+            )
+        clip = clips[0]
+        clip_name = str(clip.GetName() or "")
+        clip_type = str(clip.GetClipProperty("Type") or "")
+        walked(step, f"{clip_name!r} (Type={clip_type or '<none>'})")
+
+        step = "create the scratch timeline"
+        timeline_name = timestamped_name(label, "", "textplus-probe", now)
+        timeline = pool.CreateEmptyTimeline(timeline_name)
+        if timeline is None:
+            raise failed(step, f"Resolve created no timeline called {timeline_name!r}.")
+        walked(step, timeline_name)
+
+        step = "append the instances"
+        placements = [
+            {"mediaPoolItem": clip, "startFrame": 0, "endFrame": duration - 1} for _ in asked
+        ]
+        items = list(pool.AppendToTimeline(placements) or [])
+        if len(items) != len(asked):
+            raise failed(
+                step,
+                f"Asked for {len(asked)} instances of {clip_name!r}, got back {len(items)}.",
+            )
+        walked(step, f"{len(items)} instances of {clip_name!r} at {duration}f each")
+
+        step = "open the Fusion comp"
+        tools = [_text_plus_node(item, position, trail) for position, item in enumerate(items, 1)]
+        walked(step, f"a Text+ node in each of {len(tools)} comps")
+
+        step = "write the text"
+        for (_, tool, _), text in zip(tools, asked, strict=True):
+            tool.SetInput(STYLED_TEXT, text)
+        walked(step, ", ".join(repr(text) for text in asked))
+
+        # Every write first, then every read: a shared comp only shows up once a later
+        # write has had the chance to overwrite an earlier instance's title.
+        step = "read the text back"
+        placed: list[Placed] = []
+        for position, (item, (name, _, count), text) in enumerate(
+            zip(items, tools, asked, strict=True), start=1
+        ):
+            _, fresh, _ = _text_plus_node(item, position, trail)
+            read_back = fresh.GetInput(STYLED_TEXT)
+            placed.append(
+                Placed(
+                    index=position,
+                    name=str(item.GetName() or ""),
+                    record_in=int(item.GetStart()),
+                    duration=int(item.GetDuration()),
+                    tool_name=name,
+                    tool_count=count,
+                    asked=text,
+                    read_back=None if read_back is None else str(read_back),
+                )
+            )
+        _check_each_kept_its_own(placed, trail)
+        walked(step, "each instance kept the text it was given")
+
+        report = Report(
+            template=template.name,
+            bin_name=bin_name,
+            clip_name=clip_name,
+            clip_type=clip_type,
+            timeline_name=timeline_name,
+            placed=tuple(placed),
+            cleaned_up=False,
+            trail=tuple(trail),
+        )
+    finally:
+        tidy = _clean_up(pool, imported, timeline)
+
+    return replace(report, cleaned_up=tidy)
+
+
+def _method(obj: Any, name: str, step: str, trail: Sequence[str]) -> Any:
+    """A getter this Resolve build does not have, named rather than left to blow up.
+
+    fusionscript answers *every* attribute name: a method it does not know comes back as
+    ``None``, not as a missing attribute. Verified live on Studio 21.0.3.7, where
+    ``hasattr(item, "GetTakeCount")`` is ``True`` and the attribute is ``None`` — so the
+    usual guard passes and the call dies with ``NoneType is not callable``, which names
+    neither the method nor the build. The Fusion surface is the part of the API most
+    likely to differ between builds, so it is read through here.
+    """
+    getter = getattr(obj, name, None)
+    if getter is None:
+        raise _failure(step, f"This Resolve build has no {name}.", trail)
+    return getter
+
+
+def _failure(step: str, detail: str, trail: Sequence[str]) -> ProbeFailed:
+    log.warning("Text+ probe failed at %s: %s", step, detail)
+    return ProbeFailed(step, detail, trail)
+
+
+def _names(objects: Sequence[Any]) -> str:
+    return ", ".join(sorted(repr(str(one.GetName() or "")) for one in objects))
+
+
+def _clips_under(folder: Any) -> list[Any]:
+    """Every clip in the imported bin, however deeply the GUI nested it."""
+    found = list(folder.GetClipList() or [])
+    for sub in folder.GetSubFolderList() or []:
+        found.extend(_clips_under(sub))
+    return found
+
+
+def _text_plus_node(
+    item: Any,
+    position: int,
+    trail: Sequence[str],
+) -> tuple[str, Any, int]:
+    """The instance's Text+ node, as ``(name, tool, how many the comp holds)``."""
+    step = "open the Fusion comp"
+    if not int(_method(item, "GetFusionCompCount", step, trail)() or 0):
+        raise _failure(
+            step,
+            f"Instance {position} has no Fusion comp — the .drb round trip did not carry "
+            f"the template's comp onto the placed clip.",
+            trail,
+        )
+    comp = _method(item, "GetFusionCompByIndex", step, trail)(1)
+    if comp is None:
+        raise _failure(
+            "open the Fusion comp",
+            f"Instance {position} counts a Fusion comp but hands out none at index 1.",
+            trail,
+        )
+    tool_list = _method(comp, "GetToolList", "find the Text+ node", trail)
+    matching = dict(tool_list(False, TEXT_PLUS) or {})
+    if not matching:
+        held = dict(tool_list(False, "") or {})
+        raise _failure(
+            "find the Text+ node",
+            f"Instance {position}'s comp holds no {TEXT_PLUS} node; it holds "
+            f"{_tool_names(held) or '<nothing>'}.",
+            trail,
+        )
+    first = matching[min(matching)]
+    return str(first.GetAttrs("TOOLS_Name") or ""), first, len(matching)
+
+
+def _tool_names(tools: dict[int, Any]) -> str:
+    return ", ".join(repr(str(tool.GetAttrs("TOOLS_Name") or "")) for tool in tools.values())
+
+
+def _check_each_kept_its_own(placed: Sequence[Placed], trail: Sequence[str]) -> None:
+    strayed = [one for one in placed if not one.kept_its_own_text]
+    if not strayed:
+        return
+    first = strayed[0]
+    others = {one.asked for one in placed if one is not first}
+    bled = first.read_back in others
+    raise _failure(
+        "read the text back",
+        f"Instance {first.index} was given {first.asked!r} and reads back "
+        f"{first.read_back!r}. "
+        + (
+            "That is another instance's text, so the placed instances share one comp and "
+            "per-instance titling is not available on this route."
+            if bled
+            else "The write did not stick."
+        ),
+        trail,
+    )
+
+
+def _clean_up(pool: Any, imported: Any, timeline: Any) -> bool:
+    """Remove the scratch timeline and bin. Never raises — see the module docstring."""
+    tidy = True
+    for what, removed in (("timeline", timeline), ("bin", imported)):
+        if removed is None:
+            continue
+        try:
+            gone = (
+                pool.DeleteTimelines([removed])
+                if what == "timeline"
+                else pool.DeleteFolders([removed])
+            )
+        except Exception:  # noqa: BLE001 - a departed Resolve must not mask the finding
+            log.exception("Text+ probe could not delete its scratch %s", what)
+            tidy = False
+            continue
+        if not gone:
+            log.warning("Text+ probe could not delete its scratch %s", what)
+        tidy = tidy and bool(gone)
+    return tidy

--- a/tests/text_plus_probe.py
+++ b/tests/text_plus_probe.py
@@ -242,7 +242,8 @@ def probe_template_append(
         step = "target the scratch timeline"
         project.SetCurrentTimeline(scratch.timeline)
         current = project.GetCurrentTimeline()
-        if current is None or current.GetUniqueId() != scratch.timeline.GetUniqueId():
+        wanted = _method(scratch.timeline, "GetUniqueId", step, trail)()
+        if current is None or _method(current, "GetUniqueId", step, trail)() != wanted:
             raise failed(
                 step,
                 f"Resolve would not make {timeline_name!r} current — it is still on "
@@ -259,7 +260,9 @@ def probe_template_append(
         if len(returned) != len(asked):
             raise failed(
                 step,
-                f"Asked for {len(asked)} instances of {clip_name!r}, got back {len(returned)}.",
+                f"Asked for {len(asked)} instances of {clip_name!r} at {duration} frames "
+                f"each, got back {len(returned)}. A template shorter than {duration} frames "
+                f"is refused rather than trimmed, so try a shorter duration=.",
             )
         walked(step, f"{len(returned)} instances of {clip_name!r} at {duration}f each")
 
@@ -384,6 +387,13 @@ def _read_each_back(
     asked: Sequence[str],
     trail: Sequence[str],
 ) -> list[Placed]:
+    if len(items) != len(nodes):
+        raise _failure(
+            "read the text back",
+            f"The timeline held {len(nodes)} instances to write to and {len(items)} to read "
+            f"back — something moved them between the two passes.",
+            trail,
+        )
     placed: list[Placed] = []
     for position, (item, node, text) in enumerate(zip(items, nodes, asked, strict=True), start=1):
         fresh = _text_plus_node(item, position, trail)
@@ -435,15 +445,34 @@ def _check_each_kept_its_own(placed: Sequence[Placed], trail: Sequence[str]) -> 
     )
 
 
+def _any_timeline_but(project: Any, scratch: Any) -> Any:
+    """Some cut for Resolve to sit on that is not the one about to be deleted."""
+    try:
+        avoid = scratch.GetUniqueId()
+        for index in range(1, int(project.GetTimelineCount() or 0) + 1):
+            candidate = project.GetTimelineByIndex(index)
+            if candidate is not None and candidate.GetUniqueId() != avoid:
+                return candidate
+    except Exception:  # noqa: BLE001 - a departed Resolve must not mask the finding
+        log.exception("Text+ probe could not look for a timeline to fall back to")
+    log.warning("Text+ probe has no timeline to leave Resolve on; the scratch cut may survive")
+    return None
+
+
 def _clean_up(scratch: _Scratch) -> bool:
     """Put the project back. Never raises — see the module docstring.
 
-    The current timeline is restored before the scratch one is deleted, because Resolve
-    should never be asked to delete the cut it is sitting on.
+    Resolve is moved off the scratch timeline before it is deleted, because it will not
+    delete the cut it is sitting on. A session that had no timeline open when the probe
+    started has nothing to go back to, so any other cut in the project will do; a project
+    whose only timeline is the scratch one leaves it behind, and says so in the report.
     """
     pool, project = scratch.pool, scratch.project
-    was_on, was_in = scratch.previous_timeline, scratch.previous_folder
+    was_in = scratch.previous_folder
     scratch_timeline, scratch_bin = scratch.timeline, scratch.imported
+    was_on = scratch.previous_timeline
+    if was_on is None and scratch_timeline is not None:
+        was_on = _any_timeline_but(project, scratch_timeline)
 
     steps: list[tuple[str, Callable[[], Any]]] = []
     if was_on is not None:
@@ -454,7 +483,8 @@ def _clean_up(scratch: _Scratch) -> bool:
         )
     if scratch_bin is not None:
         steps.append(("delete the scratch bin", lambda: pool.DeleteFolders([scratch_bin])))
-    steps.append(("restore the current folder", lambda: pool.SetCurrentFolder(was_in)))
+    if was_in is not None:
+        steps.append(("restore the current folder", lambda: pool.SetCurrentFolder(was_in)))
 
     tidy = True
     for what, undo in steps:

--- a/tests/text_plus_probe.py
+++ b/tests/text_plus_probe.py
@@ -10,28 +10,37 @@ for a ticket, not a tool for an agent. It runs at both seams. Against fakes
 (``test_text_plus_probe.py``) it proves it walks the route in the right order and names
 each failure; against real Resolve (``test_live_smoke.py``) it answers the question.
 
-Three things here are decisions rather than API calls:
+Five things here are decisions rather than API calls:
 
 * **The imported bin is recognised by name, not by identity.** ``ImportFolderFromFile``
   returns a bare ``True`` and names the bin after the ``.drb``, and Resolve hands out a
   fresh proxy object per call — so the only way to find what landed is to diff the root's
   child *names*. A name already in use is therefore indistinguishable from an import that
   landed nothing, and is reported as such rather than answered with the older bin.
+* **The scratch timeline is made current and checked, before anything is appended.**
+  ``AppendToTimeline`` appends to the project's *current* timeline, not to the one just
+  created. Assuming ``CreateEmptyTimeline`` also switched would, on a build that does not,
+  quietly append two Text+ instances onto the operator's open cut — and every assertion
+  below would still pass, because the instances would be real.
+* **The instances are read back off the timeline, not off the append.** What the append
+  returned proves a call succeeded; what the timeline holds proves a title was placed. The
+  second is what titling needs, so the placed items are re-read from the track.
 * **Every title is read back after every write, never one at a time.** A probe that set a
   title and immediately read it would pass whether the instances have their own comps or
   share one; the second write is what exposes the difference.
-* **Cleanup never costs the answer.** The probe creates a scratch bin and a scratch
-  timeline in a real project, and deletes both in a ``finally``; a cleanup that fails is
-  recorded in the report, not raised over the finding the live run was made for.
+* **Cleanup never costs the answer.** The probe mutates a real project — a scratch bin, a
+  scratch timeline, the current folder and the current timeline — and puts all four back in
+  a ``finally``. A cleanup that fails is recorded in the report, not raised over the
+  finding the live run was made for.
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from dataclasses import dataclass, field, replace
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from resolve_mcp.logging_config import get_logger
 from resolve_mcp.naming import timestamped_name
@@ -43,8 +52,10 @@ log = get_logger("probe.textplus")
 TEMPLATE_ENV = "RESOLVE_MCP_TEXTPLUS_TEMPLATE"
 TEXT_PLUS = "TextPlus"
 STYLED_TEXT = "StyledText"
+SCRATCH_LABEL = "textplus-probe"
 DEFAULT_TEXTS = ("Sunset Boulevard", "Bass — Ana Ruiz")
 DEFAULT_DURATION = 120
+VIDEO = "video"
 
 
 class ProbeFailed(AssertionError):
@@ -60,6 +71,18 @@ class ProbeFailed(AssertionError):
         self.trail = tuple(trail)
         walked = "\n".join(f"  {done}" for done in self.trail)
         super().__init__(f"{step}: {detail}\nwalked:\n{walked}")
+
+
+class TextPlusNode(NamedTuple):
+    """An instance's Text+ node, with how many its comp holds.
+
+    The count travels with the node because a template may hold several Text+ nodes, and
+    which one answered is the part ``apply_titles`` cannot guess later.
+    """
+
+    name: str
+    tool: Any
+    of_how_many: int
 
 
 @dataclass(frozen=True)
@@ -91,7 +114,6 @@ class Report:
     timeline_name: str
     placed: tuple[Placed, ...]
     cleaned_up: bool
-    trail: tuple[str, ...] = field(default=())
 
     @property
     def per_instance_text(self) -> bool:
@@ -119,20 +141,32 @@ class Report:
         return "\n".join(lines)
 
 
+@dataclass
+class _Scratch:
+    """Everything the probe changed in a real project, and what it has to put back."""
+
+    pool: Any
+    project: Any
+    previous_folder: Any
+    previous_timeline: Any
+    imported: Any = None
+    timeline: Any = None
+
+
 def probe_template_append(
     connection: ResolveConnection,
     template: Path,
     *,
     texts: Sequence[str] = DEFAULT_TEXTS,
     duration: int = DEFAULT_DURATION,
-    label: str = "textplus-probe",
     now: datetime | None = None,
 ) -> Report:
     """Walk the whole route and report what Resolve did, or raise ``ProbeFailed``.
 
-    Mutates the open project — a scratch bin and a scratch timeline, both removed again.
-    ``texts`` must hold at least two distinct strings: one title proves only that a write
-    landed somewhere, not that it landed on the instance it was aimed at.
+    Mutates the open project — a scratch bin and a scratch timeline, both removed again,
+    and the current folder and timeline, both restored. ``texts`` must hold at least two
+    distinct strings: one title proves only that a write landed somewhere, not that it
+    landed on the instance it was aimed at.
     """
     asked = list(texts)
     if len(asked) < 2 or len(set(asked)) != len(asked):
@@ -153,13 +187,14 @@ def probe_template_append(
     walked(step, str(template))
 
     pool = media_pool(connection)
+    # Safe only because media_pool() has already refused a session with no project open.
+    project = connection.handle().GetProjectManager().GetCurrentProject()
     root = pool.GetRootFolder()
     known = {str(sub.GetName() or "") for sub in root.GetSubFolderList()}
+    scratch = _Scratch(pool, project, pool.GetCurrentFolder(), project.GetCurrentTimeline())
     pool.SetCurrentFolder(root)
     walked("reach the media pool", f"root {str(root.GetName() or '')!r}, {len(known)} bins")
 
-    imported: Any = None
-    timeline: Any = None
     try:
         step = "import the template bin"
         if not pool.ImportFolderFromFile(str(template)):
@@ -167,9 +202,7 @@ def probe_template_append(
         walked(step, f"ImportFolderFromFile({template.name}) answered True")
 
         step = "find the imported bin"
-        landed = [
-            sub for sub in root.GetSubFolderList() if str(sub.GetName() or "") not in known
-        ]
+        landed = [sub for sub in root.GetSubFolderList() if str(sub.GetName() or "") not in known]
         if not landed:
             raise failed(
                 step,
@@ -180,12 +213,12 @@ def probe_template_append(
             )
         if len(landed) > 1:
             raise failed(step, f"One import produced several bins: {_names(landed)}.")
-        imported = landed[0]
-        bin_name = str(imported.GetName() or "")
+        scratch.imported = landed[0]
+        bin_name = str(scratch.imported.GetName() or "")
         walked(step, f"bin {bin_name!r}")
 
         step = "find the template clip"
-        clips = _clips_under(imported)
+        clips = _clips_under(scratch.imported)
         if not clips:
             raise failed(step, f"The imported bin {bin_name!r} holds no clips.")
         if len(clips) > 1:
@@ -200,54 +233,61 @@ def probe_template_append(
         walked(step, f"{clip_name!r} (Type={clip_type or '<none>'})")
 
         step = "create the scratch timeline"
-        timeline_name = timestamped_name(label, "", "textplus-probe", now)
-        timeline = pool.CreateEmptyTimeline(timeline_name)
-        if timeline is None:
+        timeline_name = timestamped_name(SCRATCH_LABEL, "", SCRATCH_LABEL, now)
+        scratch.timeline = pool.CreateEmptyTimeline(timeline_name)
+        if scratch.timeline is None:
             raise failed(step, f"Resolve created no timeline called {timeline_name!r}.")
         walked(step, timeline_name)
+
+        step = "target the scratch timeline"
+        project.SetCurrentTimeline(scratch.timeline)
+        current = project.GetCurrentTimeline()
+        if current is None or current.GetUniqueId() != scratch.timeline.GetUniqueId():
+            raise failed(
+                step,
+                f"Resolve would not make {timeline_name!r} current — it is still on "
+                f"{'nothing' if current is None else repr(str(current.GetName() or ''))}. "
+                f"Appending now would place titles on the open cut, so nothing was appended.",
+            )
+        walked(step, f"{timeline_name!r} is current")
 
         step = "append the instances"
         placements = [
             {"mediaPoolItem": clip, "startFrame": 0, "endFrame": duration - 1} for _ in asked
         ]
-        items = list(pool.AppendToTimeline(placements) or [])
+        returned = list(pool.AppendToTimeline(placements) or [])
+        if len(returned) != len(asked):
+            raise failed(
+                step,
+                f"Asked for {len(asked)} instances of {clip_name!r}, got back {len(returned)}.",
+            )
+        walked(step, f"{len(returned)} instances of {clip_name!r} at {duration}f each")
+
+        step = "find the placed instances"
+        items = _placed_on(scratch.timeline)
         if len(items) != len(asked):
             raise failed(
                 step,
-                f"Asked for {len(asked)} instances of {clip_name!r}, got back {len(items)}.",
+                f"AppendToTimeline answered {len(returned)} instances but {timeline_name!r} "
+                f"holds {len(items)} on its first video track.",
             )
-        walked(step, f"{len(items)} instances of {clip_name!r} at {duration}f each")
+        _check_each_landed_apart(items, trail)
+        walked(step, f"{len(items)} on the first video track of {timeline_name!r}")
 
         step = "open the Fusion comp"
-        tools = [_text_plus_node(item, position, trail) for position, item in enumerate(items, 1)]
-        walked(step, f"a Text+ node in each of {len(tools)} comps")
+        nodes = [_text_plus_node(item, position, trail) for position, item in enumerate(items, 1)]
+        walked(step, f"a Text+ node in each of {len(nodes)} comps")
 
         step = "write the text"
-        for (_, tool, _), text in zip(tools, asked, strict=True):
-            tool.SetInput(STYLED_TEXT, text)
+        for node, text in zip(nodes, asked, strict=True):
+            node.tool.SetInput(STYLED_TEXT, text)
         walked(step, ", ".join(repr(text) for text in asked))
 
-        # Every write first, then every read: a shared comp only shows up once a later
-        # write has had the chance to overwrite an earlier instance's title.
+        # Every write first, then every read, and every read off the timeline rather than
+        # off the handles written through: a shared comp only shows up once a later write
+        # has had the chance to overwrite an earlier instance's title.
         step = "read the text back"
-        placed: list[Placed] = []
-        for position, (item, (name, _, count), text) in enumerate(
-            zip(items, tools, asked, strict=True), start=1
-        ):
-            _, fresh, _ = _text_plus_node(item, position, trail)
-            read_back = fresh.GetInput(STYLED_TEXT)
-            placed.append(
-                Placed(
-                    index=position,
-                    name=str(item.GetName() or ""),
-                    record_in=int(item.GetStart()),
-                    duration=int(item.GetDuration()),
-                    tool_name=name,
-                    tool_count=count,
-                    asked=text,
-                    read_back=None if read_back is None else str(read_back),
-                )
-            )
+        placed = _read_each_back(_placed_on(scratch.timeline), nodes, asked, trail)
         _check_each_kept_its_own(placed, trail)
         walked(step, "each instance kept the text it was given")
 
@@ -259,10 +299,9 @@ def probe_template_append(
             timeline_name=timeline_name,
             placed=tuple(placed),
             cleaned_up=False,
-            trail=tuple(trail),
         )
     finally:
-        tidy = _clean_up(pool, imported, timeline)
+        tidy = _clean_up(scratch)
 
     return replace(report, cleaned_up=tidy)
 
@@ -300,12 +339,12 @@ def _clips_under(folder: Any) -> list[Any]:
     return found
 
 
-def _text_plus_node(
-    item: Any,
-    position: int,
-    trail: Sequence[str],
-) -> tuple[str, Any, int]:
-    """The instance's Text+ node, as ``(name, tool, how many the comp holds)``."""
+def _placed_on(timeline: Any) -> list[Any]:
+    """What the timeline itself holds — the only witness that a title was placed."""
+    return list(timeline.GetItemListInTrack(VIDEO, 1) or [])
+
+
+def _text_plus_node(item: Any, position: int, trail: Sequence[str]) -> TextPlusNode:
     step = "open the Fusion comp"
     if not int(_method(item, "GetFusionCompCount", step, trail)() or 0):
         raise _failure(
@@ -317,7 +356,7 @@ def _text_plus_node(
     comp = _method(item, "GetFusionCompByIndex", step, trail)(1)
     if comp is None:
         raise _failure(
-            "open the Fusion comp",
+            step,
             f"Instance {position} counts a Fusion comp but hands out none at index 1.",
             trail,
         )
@@ -332,11 +371,47 @@ def _text_plus_node(
             trail,
         )
     first = matching[min(matching)]
-    return str(first.GetAttrs("TOOLS_Name") or ""), first, len(matching)
+    return TextPlusNode(str(first.GetAttrs("TOOLS_Name") or ""), first, len(matching))
 
 
 def _tool_names(tools: dict[int, Any]) -> str:
     return ", ".join(repr(str(tool.GetAttrs("TOOLS_Name") or "")) for tool in tools.values())
+
+
+def _read_each_back(
+    items: Sequence[Any],
+    nodes: Sequence[TextPlusNode],
+    asked: Sequence[str],
+    trail: Sequence[str],
+) -> list[Placed]:
+    placed: list[Placed] = []
+    for position, (item, node, text) in enumerate(zip(items, nodes, asked, strict=True), start=1):
+        fresh = _text_plus_node(item, position, trail)
+        read_back = fresh.tool.GetInput(STYLED_TEXT)
+        placed.append(
+            Placed(
+                index=position,
+                name=str(item.GetName() or ""),
+                record_in=int(item.GetStart()),
+                duration=int(item.GetDuration()),
+                tool_name=node.name,
+                tool_count=node.of_how_many,
+                asked=text,
+                read_back=None if read_back is None else str(read_back),
+            )
+        )
+    return placed
+
+
+def _check_each_landed_apart(items: Sequence[Any], trail: Sequence[str]) -> None:
+    """Two instances stacked on one frame would read back as one title placed twice."""
+    starts = [int(item.GetStart()) for item in items]
+    if len(set(starts)) != len(starts):
+        raise _failure(
+            "find the placed instances",
+            f"The instances did not land apart — record starts {starts}.",
+            trail,
+        )
 
 
 def _check_each_kept_its_own(placed: Sequence[Placed], trail: Sequence[str]) -> None:
@@ -360,23 +435,36 @@ def _check_each_kept_its_own(placed: Sequence[Placed], trail: Sequence[str]) -> 
     )
 
 
-def _clean_up(pool: Any, imported: Any, timeline: Any) -> bool:
-    """Remove the scratch timeline and bin. Never raises — see the module docstring."""
+def _clean_up(scratch: _Scratch) -> bool:
+    """Put the project back. Never raises — see the module docstring.
+
+    The current timeline is restored before the scratch one is deleted, because Resolve
+    should never be asked to delete the cut it is sitting on.
+    """
+    pool, project = scratch.pool, scratch.project
+    was_on, was_in = scratch.previous_timeline, scratch.previous_folder
+    scratch_timeline, scratch_bin = scratch.timeline, scratch.imported
+
+    steps: list[tuple[str, Callable[[], Any]]] = []
+    if was_on is not None:
+        steps.append(("restore the current timeline", lambda: project.SetCurrentTimeline(was_on)))
+    if scratch_timeline is not None:
+        steps.append(
+            ("delete the scratch timeline", lambda: pool.DeleteTimelines([scratch_timeline]))
+        )
+    if scratch_bin is not None:
+        steps.append(("delete the scratch bin", lambda: pool.DeleteFolders([scratch_bin])))
+    steps.append(("restore the current folder", lambda: pool.SetCurrentFolder(was_in)))
+
     tidy = True
-    for what, removed in (("timeline", timeline), ("bin", imported)):
-        if removed is None:
-            continue
+    for what, undo in steps:
         try:
-            gone = (
-                pool.DeleteTimelines([removed])
-                if what == "timeline"
-                else pool.DeleteFolders([removed])
-            )
+            done = undo()
         except Exception:  # noqa: BLE001 - a departed Resolve must not mask the finding
-            log.exception("Text+ probe could not delete its scratch %s", what)
+            log.exception("Text+ probe could not %s", what)
             tidy = False
             continue
-        if not gone:
-            log.warning("Text+ probe could not delete its scratch %s", what)
-        tidy = tidy and bool(gone)
+        if not done:
+            log.warning("Text+ probe could not %s", what)
+            tidy = False
     return tidy

--- a/tests/text_plus_probe.py
+++ b/tests/text_plus_probe.py
@@ -258,11 +258,16 @@ def probe_template_append(
         ]
         returned = list(pool.AppendToTimeline(placements) or [])
         if len(returned) != len(asked):
+            short = (
+                " A template shorter than the span asked for is refused rather than "
+                "trimmed, so try a smaller duration=."
+                if len(returned) < len(asked)
+                else ""
+            )
             raise failed(
                 step,
                 f"Asked for {len(asked)} instances of {clip_name!r} at {duration} frames "
-                f"each, got back {len(returned)}. A template shorter than {duration} frames "
-                f"is refused rather than trimmed, so try a shorter duration=.",
+                f"each, got back {len(returned)}.{short}",
             )
         walked(step, f"{len(returned)} instances of {clip_name!r} at {duration}f each")
 
@@ -387,11 +392,11 @@ def _read_each_back(
     asked: Sequence[str],
     trail: Sequence[str],
 ) -> list[Placed]:
-    if len(items) != len(nodes):
+    if not len(items) == len(nodes) == len(asked):
         raise _failure(
             "read the text back",
-            f"The timeline held {len(nodes)} instances to write to and {len(items)} to read "
-            f"back — something moved them between the two passes.",
+            f"{len(asked)} titles were asked for and {len(nodes)} written, but the timeline "
+            f"holds {len(items)} to read back — something moved them between the passes.",
             trail,
         )
     placed: list[Placed] = []


### PR DESCRIPTION
Closes #41.

## What this is

#41 asks one question that `apply_titles` (#42) cannot be designed without: does a GUI-authored Text+ template survive a `.drb` round trip, land on a timeline through the API, and give each placed instance **its own** text?

The deliverable is a probe, not a wrapper. It lives in `tests/text_plus_probe.py` because its output is a finding for a ticket, not a tool for an agent — nothing is added to `src/`, and the tool catalog is untouched.

## Which seam verifies it

Both, from one implementation.

- **Fake tier** (`tests/test_text_plus_probe.py`, 20 tests) proves the probe walks the route in order, reads every title back *after* all the writes, restores the GUI, and names each way the route can fail. It cannot prove the answer — the fake behaves however it was told to. Its job is to stop the live run failing on a typo instead of on a finding.
- **Live tier** (`tests/test_live_smoke.py::test_the_text_plus_template_route_survives_a_drb_round_trip`) answers the question. It mutates the open project, so it stays skipped until `RESOLVE_MCP_TEXTPLUS_TEMPLATE` points at a `.drb` exported from the GUI. **All three ACs are live and unrun** — see the ticket comment.

## Decisions, recorded in the probe's docstring

- The imported bin is found by diffing the root's child **names**, not by identity — Resolve hands out a fresh proxy per call. A name already taken is therefore indistinguishable from an import that landed nothing, and is reported rather than answered with the older bin.
- The scratch timeline is made current and **checked by unique id before anything is appended**. `AppendToTimeline` appends to the project's *current* timeline, not the one just created.
- The placed instances are read back **off the timeline**, not off what the append returned.
- Every title is written before any is read. A shared comp only shows up once a later write has had its chance.
- Cleanup restores the current folder and timeline and deletes the scratch bin and timeline, and a cleanup that fails is recorded in the report rather than raised over the finding.

## Findings from read-only live introspection of Studio 21.0.3.7

Confirmed present: `ImportFolderFromFile`, `CreateEmptyTimeline`, `AppendToTimeline`, `DeleteTimelines`, `DeleteFolders`, `SetCurrentTimeline`, `GetFusionCompCount`, `GetFusionCompByIndex`, `GetToolList`.

Two footguns worth carrying forward:

1. **`MediaPool` has no `ExportFolder`.** A `.drb` can only be produced from the GUI, which confirms the ticket's premise rather than working around it.
2. **fusionscript answers every attribute name.** A method a build does not have comes back as `None`, not as a missing attribute — `hasattr(item, "GetTakeCount")` is `True` and the attribute is `None`. This is now modelled in the fakes and guarded in the probe. It also uncovered a live bug in shipped code, filed separately: `timeline.py:480` calls `GetTakeCount`, but the getter is `GetTakesCount`, so `takes` is silently always 0.

`TimelineItem` also exposes `ExportFusionComp`/`ImportFusionComp` — a `.comp`-file template route that needs no bin at all, worth weighing in #42.

## Review

Full two-axis review (Standards + Spec sub-agents), then three focused passes over each fix diff.

**Round 1 — Spec.** `AppendToTimeline` appends to the project's *current* timeline, not the one just created; the probe assumed `CreateEmptyTimeline` had switched. On a build that does not, two Text+ instances would have landed on the operator's open cut and every assertion after it would still have passed. **Fixed** — the scratch timeline is made current and verified by unique id, and nothing is appended if Resolve will not switch. The fake was silent on exactly that step (it built timeline items belonging to no timeline), so it now appends onto the current timeline's first video track. Read-back re-reads the placed instances off the track, and distinct record positions are checked.

**Round 1 — Standards.** The probe called `SetCurrentFolder(root)` and never restored the previous folder, against the rule `media.py` already documents. **Fixed** — current folder and current timeline are both restored. Also fixed: absolute `from tests.x` imports where every other test module uses relative; an anonymous `tuple[str, Any, int]` replaced by a `TextPlusNode` NamedTuple; the parameter clump gathered into `_Scratch`; `_clean_up` re-branching on a string it had just bound; unread `Report.trail` and unused fake knobs dropped; a bash env-prefix invocation in the live docstring rewritten for PowerShell, which is the shell on the machine that runs it; a test renamed to stop overclaiming.

**Round 2.** Cleanup could ask Resolve to delete the cut it was sitting on — the restore step was skipped when no timeline had been open, which is exactly when the scratch cut is current. **Fixed**, with a fallback to any other cut in the project. Also: the read-back's `strict=True` zip could raise a bare `ValueError` with no step and no trail; the scratch timeline's `GetUniqueId` now goes through the build-variable-getter guard; the append failure names the duration. Two missing tests added.

**Round 3.** The round-2 cleanup fix had no seam — the fake deleted a timeline whether or not it was current, so the pre-fix code would still have passed. **Fixed**: the fake now refuses the call when one of the timelines is the open cut, with two tests that fail without the fix. The read-back length check covered two of its three sequences; the shorter-template advice was offered in a case where it is wrong.

All findings resolved. Fake tier 219 passed, mypy strict clean, ruff clean.

Review: clean — two-axis review plus three focused fix-diff passes; all findings fixed and re-checked.


---

Merge of origin/main (post-#63/#64/#65/#66) resolved on-branch. Both sides had rewritten the fake pool's append machinery, so the resolution is one implementation carrying both models: main's spike-confirmed routing (mediaType/trackIndex, locked-track swallow, overlap slide, still durations, half-open endFrame) plus this branch's Fusion-comp copy semantics and probe knobs. **One behavioural trade-off to note:** the probe previously sent an inclusive endFrame (duration - 1); main's build wrapper documents endFrame as half-open, confirmed by the #18 spike, so the probe now sends endFrame = duration and its fake-tier expectations moved with it — without this the live probe would have landed 119-frame titles. The probe's grouped append log renamed to append_calls (main owns the flat appends log). Focused pass over the resolution diff; 501 fake-tier tests, mypy strict and ruff all green.

Review: clean — merge-resolution diff, focused pass
