### PR TITLE
Anchored overlays build onto V2 (#30)

### DIFF
--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -482,18 +482,47 @@ def total_frames(doc: dict[str, Any]) -> int:
     return sum(duration_frames(s["in"], s["out"]) for s in _segments(doc))
 
 
+def overlay_positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
+    """Each overlay id to its computed ``(start, duration)`` on V2.
+
+    An overlay names no absolute frame: its position is its anchor segment's computed
+    start plus the offset, which is what makes it ride the content it covers through a
+    tightening pass. E9 judges these numbers and the build places against them, from this
+    one function — a position validated one way and built another is exactly the drift
+    anchoring exists to prevent. An overlay whose anchor does not exist has no position
+    and is absent here; E9 has already refused that document.
+    """
+    return {str(overlay["id"]): at for overlay, at in _anchored(doc) if at is not None}
+
+
+def _anchored(doc: dict[str, Any]) -> Iterator[tuple[dict[str, Any], tuple[int, int] | None]]:
+    """Every overlay with its resolved span, or ``None`` when its anchor is not a segment."""
+    placed = positions(doc)
+    for overlay in _overlays(doc):
+        anchor = placed.get(str(overlay["over"]["segment"]))
+        yield (
+            overlay,
+            None
+            if anchor is None
+            else (
+                anchor[0] + int(overlay["over"]["offset"]),
+                duration_frames(overlay["in"], overlay["out"]),
+            ),
+        )
+
+
 def _overlay_errors(doc: dict[str, Any]) -> list[Finding]:
-    """E9 and E10, both judged on absolute positions resolved from the anchors."""
+    """E9 and E10, both judged on the absolute positions resolved from the anchors."""
     placed = positions(doc)
     total = total_frames(doc)
     findings: list[Finding] = []
     spans: list[tuple[str, int, int]] = []
 
-    for overlay in _overlays(doc):
+    for overlay, resolved in _anchored(doc):
         id = str(overlay["id"])
         anchor = str(overlay["over"]["segment"])
         offset = int(overlay["over"]["offset"])
-        if anchor not in placed:
+        if resolved is None:
             findings.append(
                 _finding(
                     "E9",
@@ -502,7 +531,7 @@ def _overlay_errors(doc: dict[str, Any]) -> list[Finding]:
                 )
             )
             continue
-        start, anchor_duration = placed[anchor]
+        _, anchor_duration = placed[anchor]
         if not 0 <= offset < anchor_duration:
             findings.append(
                 _finding(
@@ -513,8 +542,7 @@ def _overlay_errors(doc: dict[str, Any]) -> list[Finding]:
                 )
             )
             continue
-        duration = duration_frames(overlay["in"], overlay["out"])
-        at = start + offset
+        at, duration = resolved
         if at + duration > total:
             findings.append(
                 _finding(
@@ -759,6 +787,7 @@ __all__ = [
     "ClipFacts",
     "Finding",
     "locked_track_finding",
+    "overlay_positions",
     "parse_failure_finding",
     "positions",
     "resolve_aliases",

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -483,7 +483,8 @@ def total_frames(doc: dict[str, Any]) -> int:
 
 
 def overlay_positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
-    """Each overlay id to its computed ``(start, duration)`` on V2.
+    """Each overlay id to its computed ``(start, duration)`` on V2 — start measured from
+    the cut's first frame, exactly as :func:`positions` measures a segment's.
 
     An overlay names no absolute frame: its position is its anchor segment's computed
     start plus the offset, which is what makes it ride the content it covers through a

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -227,16 +227,6 @@ class CutInvalidError(ResolveMcpError):
     )
 
 
-class UnsupportedCutFeatureError(ResolveMcpError):
-    """The cut is valid but describes something this build cannot place yet.
-
-    Refused rather than partially built: a timeline missing a part of the cut that made it
-    is the half-built outcome the pre-flight exists to prevent.
-    """
-
-    code = "unsupported_cut_feature"
-
-
 class BuildFailedError(ResolveMcpError):
     """Resolve would not build the cut — creation refused, a locked track, a clip astray.
 

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -1,4 +1,4 @@
-"""Materialising a cut file: sequential V1 over one master-audio clip, as a new version.
+"""Materialising a cut file: sequential V1 and anchored V2, over one master-audio clip.
 
 The one write primitive Resolve gives us is append-with-exact-placement, and the #18 spike
 found it full of silent failures. Everything in this file exists to make one guarantee:
@@ -6,9 +6,13 @@ found it full of silent failures. Everything in this file exists to make one gua
 
 * **Nothing starts on a file that will not build.** The same rules ``validate_cut`` runs
   run here first, over the same pool reading, and a single error aborts before a timeline
-  is created. A cut that is valid but describes something this build cannot place is
-  refused for the same reason — a timeline missing part of its own cut is the half-built
-  outcome the pre-flight exists to prevent.
+  is created — a timeline missing part of its own cut is the half-built outcome the
+  pre-flight exists to prevent.
+* **Overlays are placed, never positioned.** An overlay states an anchor segment and an
+  offset, so its V2 record frame is computed from the same layout E9 validated against
+  (``overlay_positions``). Re-timing an earlier segment and rebuilding therefore leaves
+  every overlay over the content it was anchored to, which is the whole point of the
+  anchor: an absolute frame would have to be re-authored on every tightening pass.
 * **A new version every time.** The name is ``<base> v<N+1>`` scanned off the project's
   existing names, so no build ever writes into a timeline someone has already reviewed.
 * **Resolve's answer is never the evidence.** An append onto a locked track returns
@@ -28,8 +32,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Final
 
-from ..cut.validate import locked_track_finding, positions
-from ..errors import BuildFailedError, CutInvalidError, UnsupportedCutFeatureError
+from ..cut.validate import locked_track_finding, overlay_positions, positions
+from ..errors import BuildFailedError, CutInvalidError
 from ..logging_config import get_logger
 from ..naming import next_version_name
 from . import cut, media
@@ -47,9 +51,13 @@ MEDIA_TYPES: Final[dict[str, int]] = {"video": 1, "audio": 2}
 """Resolve's ``mediaType``: 1 appends video only, 2 audio only. Never omitted."""
 
 TRACK_INDEX: Final = 1
-"""Sequential V1 is one video track and one audio track; both are the first of their kind."""
+"""The sequential cut: segments on V1, the master mix on A1, both first of their kind."""
 
-TRACK_LABELS: Final[dict[str, str]] = {"video": "V1", "audio": "A1"}
+OVERLAY_TRACK_INDEX: Final = 2
+"""Overlays ride above the cut on V2, so covering a seam never displaces the segments."""
+
+TRACK_PREFIXES: Final[dict[str, str]] = {"video": "V", "audio": "A"}
+"""Also the order tracks are reported in, so every log and failure detail reads the same."""
 
 AUDIO_TRACK_TYPE: Final = "stereo"
 """What a master mix is. ``AddTrack`` defaults to mono, which would fold a stereo mix."""
@@ -58,12 +66,18 @@ MISPLACED_CAP: Final = 20
 """A drifted build misplaces everything downstream of the blockage; the count says how many."""
 
 
+def _track_label(track_type: str, track_index: int) -> str:
+    """What the timeline header calls a track — the only name an agent or director sees."""
+    return f"{TRACK_PREFIXES[track_type]}{track_index}"
+
+
 @dataclass(frozen=True)
 class Shot:
     """One append: which frames of which clip land where, on which kind of track."""
 
     id: str
     track_type: str
+    track_index: int
     clip: Clip
     name: str
     source_in: int
@@ -75,13 +89,18 @@ class Shot:
         """Half-open, and exactly what Resolve's ``endFrame`` means (#18 spike (a))."""
         return self.source_in + self.duration
 
+    @property
+    def track(self) -> str:
+        """``V1``/``V2``/``A1`` — how a timeline names the track, for logs and failures."""
+        return _track_label(self.track_type, self.track_index)
+
     def clip_info(self) -> dict[str, Any]:
         return {
             "mediaPoolItem": self.clip,
             "startFrame": self.source_in,
             "endFrame": self.source_out,
             "mediaType": MEDIA_TYPES[self.track_type],
-            "trackIndex": TRACK_INDEX,
+            "trackIndex": self.track_index,
             "recordFrame": self.record,
         }
 
@@ -106,7 +125,6 @@ def build_timeline(
     # E1 is an error, so a pre-flight with no errors has a document that parsed and matched
     # the schema — every read of it below is a field the rules have already been over.
     doc: dict[str, Any] = checked.loaded.doc
-    _refuse_what_cannot_be_placed(doc)
 
     project = timeline_read.open_project(connection)
     pool = media.media_pool(connection)
@@ -130,29 +148,17 @@ def build_timeline(
         "content_hash": checked.loaded.content_hash,
         "timeline": timeline_read.summarise(timeline_read.Reader(connection), built, project, name),
         "placed": {
-            "segments": sum(1 for shot in shots if shot.track_type == "video"),
+            "segments": _count(shots, ("video", TRACK_INDEX)),
+            "overlays": _count(shots, ("video", OVERLAY_TRACK_INDEX)),
             "audio": any(shot.track_type == "audio" for shot in shots),
         },
         "warnings": [finding.as_dict() for finding in checked.warnings],
     }
 
 
-# --- what this build will not attempt ------------------------------------------------------
-
-
-def _refuse_what_cannot_be_placed(doc: dict[str, Any]) -> None:
-    """Overlays validate, but only the V1 substrate is built here — say so, build nothing."""
-    overlays = doc.get("overlays") or []
-    if not overlays:
-        return
-    raise UnsupportedCutFeatureError(
-        cause=f"This cut has {len(overlays)} overlay(s); build_timeline places the sequential "
-        f"V1 and the master audio only.",
-        fix="Remove the overlays block to build the V1 cut now — anchored overlays are placed "
-        "by a later tool, and building without them would leave a timeline that does not "
-        "match its own cut file.",
-        detail={"overlays": [str(overlay["id"]) for overlay in overlays]},
-    )
+def _count(shots: list[Shot], track: tuple[str, int]) -> int:
+    """How many of this build's appends one track took — segments and overlays are both V."""
+    return sum(1 for shot in shots if (shot.track_type, shot.track_index) == track)
 
 
 # --- placement ------------------------------------------------------------------------------
@@ -169,8 +175,26 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
             _shot(
                 id=id,
                 track_type="video",
+                track_index=TRACK_INDEX,
                 located=clips[str(segment["source"])],
                 source_in=int(segment["in"]),
+                record=start + offset,
+                duration=duration,
+            )
+        )
+    anchored = overlay_positions(doc)
+    for overlay in doc.get("overlays") or []:
+        # The anchor resolves against the layout above, so an overlay is positioned by the
+        # cut it covers rather than by a frame number anyone had to keep up to date.
+        id = str(overlay["id"])
+        offset, duration = anchored[id]
+        shots.append(
+            _shot(
+                id=id,
+                track_type="video",
+                track_index=OVERLAY_TRACK_INDEX,
+                located=clips[str(overlay["source"])],
+                source_in=int(overlay["in"]),
                 record=start + offset,
                 duration=duration,
             )
@@ -183,6 +207,7 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
             _shot(
                 id="audio",
                 track_type="audio",
+                track_index=TRACK_INDEX,
                 located=clips[str(audio["source"])],
                 source_in=int(audio["in"]),
                 record=start,
@@ -195,6 +220,7 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
 def _shot(
     id: str,
     track_type: str,
+    track_index: int,
     located: media.LocatedClip,
     source_in: int,
     record: int,
@@ -203,6 +229,7 @@ def _shot(
     return Shot(
         id=id,
         track_type=track_type,
+        track_index=track_index,
         clip=located.clip,
         name=str(located.clip.GetName() or ""),
         source_in=source_in,
@@ -252,10 +279,10 @@ def _make_tracks(timeline: Timeline, shots: list[Shot], name: str) -> None:
     came with keeps whatever the project's timeline template gave it — the API cannot
     restyle an existing track, so the layout is logged rather than assumed.
     """
-    for track_type in _track_types(shots):
+    for track_type, track_index in _tracks(shots):
         # Only an audio track takes a sub-type; passing one to video is meaningless.
         extra = (AUDIO_TRACK_TYPE,) if track_type == "audio" else ()
-        while _track_count(timeline, track_type) < TRACK_INDEX:
+        while _track_count(timeline, track_type) < track_index:
             if not timeline.AddTrack(track_type, *extra):
                 # Refused rather than merely unanswered: retrying would spin forever, and
                 # appending to a track that is not there drops the clip silently.
@@ -269,7 +296,7 @@ def _make_tracks(timeline: Timeline, shots: list[Shot], name: str) -> None:
     log.info(
         "%s targets %s (%d video, %d audio tracks)",
         name,
-        ", ".join(TRACK_LABELS[track_type] for track_type in _track_types(shots)),
+        ", ".join(_track_label(*track) for track in _tracks(shots)),
         _track_count(timeline, "video"),
         _track_count(timeline, "audio"),
     )
@@ -283,13 +310,13 @@ def _track_count(timeline: Timeline, track_type: str) -> int:
         return 0
 
 
-def _track_types(shots: list[Shot]) -> list[str]:
-    """The kinds of track this cut needs, in a fixed order so the logs read the same way."""
-    return [
-        track_type
-        for track_type in TRACK_LABELS
-        if any(shot.track_type == track_type for shot in shots)
-    ]
+def _tracks(shots: list[Shot]) -> list[tuple[str, int]]:
+    """The tracks this cut needs, in a fixed order so the logs read the same way each time."""
+    order = list(TRACK_PREFIXES)
+    return sorted(
+        {(shot.track_type, shot.track_index) for shot in shots},
+        key=lambda track: (order.index(track[0]), track[1]),
+    )
 
 
 def _refuse_locked_tracks(timeline: Timeline, shots: list[Shot], name: str) -> None:
@@ -300,9 +327,9 @@ def _refuse_locked_tracks(timeline: Timeline, shots: list[Shot], name: str) -> N
     check costs one call against a failure mode that leaves no trace anywhere else.
     """
     locked = [
-        locked_track_finding(TRACK_LABELS[track_type])
-        for track_type in _track_types(shots)
-        if timeline.GetIsTrackLocked(track_type, TRACK_INDEX)
+        locked_track_finding(_track_label(track_type, track_index))
+        for track_type, track_index in _tracks(shots)
+        if timeline.GetIsTrackLocked(track_type, track_index)
     ]
     if not locked:
         return
@@ -337,11 +364,7 @@ def _append(pool: Pool, shots: list[Shot], name: str) -> None:
 
 def _verify(timeline: Timeline, shots: list[Shot], name: str) -> None:
     """Read the tracks back: the only way to know an append landed where it was told to."""
-    misplaced = [
-        shot
-        for track_type in _track_types(shots)
-        for shot in _adrift(timeline, shots, track_type)
-    ]
+    misplaced = [shot for track in _tracks(shots) for shot in _adrift(timeline, shots, track)]
     if not misplaced:
         return
     raise BuildFailedError(
@@ -358,13 +381,14 @@ def _verify(timeline: Timeline, shots: list[Shot], name: str) -> None:
     )
 
 
-def _adrift(timeline: Timeline, shots: list[Shot], track_type: str) -> list[Shot]:
-    wanted = [shot for shot in shots if shot.track_type == track_type]
+def _adrift(timeline: Timeline, shots: list[Shot], track: tuple[str, int]) -> list[Shot]:
+    track_type, track_index = track
+    wanted = [shot for shot in shots if (shot.track_type, shot.track_index) == track]
     if not wanted:
         return []
     landed = {
         (item.GetStart(), item.GetDuration())
-        for item in timeline.GetItemListInTrack(track_type, TRACK_INDEX) or []
+        for item in timeline.GetItemListInTrack(track_type, track_index) or []
     }
     return [shot for shot in wanted if (shot.record, shot.duration) not in landed]
 
@@ -373,7 +397,7 @@ def _expected(shot: Shot) -> dict[str, Any]:
     return {
         "id": shot.id,
         "clip": shot.name,
-        "track": TRACK_LABELS[shot.track_type],
+        "track": shot.track,
         "record_frame": shot.record,
         "duration": shot.duration,
     }

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -50,12 +50,6 @@ Timeline = Any
 MEDIA_TYPES: Final[dict[str, int]] = {"video": 1, "audio": 2}
 """Resolve's ``mediaType``: 1 appends video only, 2 audio only. Never omitted."""
 
-TRACK_INDEX: Final = 1
-"""The sequential cut: segments on V1, the master mix on A1, both first of their kind."""
-
-OVERLAY_TRACK_INDEX: Final = 2
-"""Overlays ride above the cut on V2, so covering a seam never displaces the segments."""
-
 TRACK_PREFIXES: Final[dict[str, str]] = {"video": "V", "audio": "A"}
 """Also the order tracks are reported in, so every log and failure detail reads the same."""
 
@@ -66,18 +60,39 @@ MISPLACED_CAP: Final = 20
 """A drifted build misplaces everything downstream of the blockage; the count says how many."""
 
 
-def _track_label(track_type: str, track_index: int) -> str:
-    """What the timeline header calls a track — the only name an agent or director sees."""
-    return f"{TRACK_PREFIXES[track_type]}{track_index}"
+@dataclass(frozen=True)
+class Track:
+    """One target track: a media type and a 1-based index, which never travel apart.
+
+    Resolve drops an append naming a ``trackIndex`` without its ``mediaType``, and a lock
+    check or a read-back is meaningless without both — so the pair is one value here.
+    """
+
+    type: str
+    index: int
+
+    @property
+    def label(self) -> str:
+        """What the timeline header calls it — the only name an agent or director sees."""
+        return f"{TRACK_PREFIXES[self.type]}{self.index}"
+
+
+V1: Final = Track("video", 1)
+"""The sequential cut: segments butt-joined in document order."""
+
+V2: Final = Track("video", 2)
+"""Overlays ride above the cut here, so covering a seam never displaces the segments."""
+
+A1: Final = Track("audio", 1)
+"""One continuous master mix under the whole cut."""
 
 
 @dataclass(frozen=True)
 class Shot:
-    """One append: which frames of which clip land where, on which kind of track."""
+    """One append: which frames of which clip land where, on which track."""
 
     id: str
-    track_type: str
-    track_index: int
+    track: Track
     clip: Clip
     name: str
     source_in: int
@@ -89,18 +104,13 @@ class Shot:
         """Half-open, and exactly what Resolve's ``endFrame`` means (#18 spike (a))."""
         return self.source_in + self.duration
 
-    @property
-    def track(self) -> str:
-        """``V1``/``V2``/``A1`` — how a timeline names the track, for logs and failures."""
-        return _track_label(self.track_type, self.track_index)
-
     def clip_info(self) -> dict[str, Any]:
         return {
             "mediaPoolItem": self.clip,
             "startFrame": self.source_in,
             "endFrame": self.source_out,
-            "mediaType": MEDIA_TYPES[self.track_type],
-            "trackIndex": self.track_index,
+            "mediaType": MEDIA_TYPES[self.track.type],
+            "trackIndex": self.track.index,
             "recordFrame": self.record,
         }
 
@@ -148,17 +158,17 @@ def build_timeline(
         "content_hash": checked.loaded.content_hash,
         "timeline": timeline_read.summarise(timeline_read.Reader(connection), built, project, name),
         "placed": {
-            "segments": _count(shots, ("video", TRACK_INDEX)),
-            "overlays": _count(shots, ("video", OVERLAY_TRACK_INDEX)),
-            "audio": any(shot.track_type == "audio" for shot in shots),
+            "segments": _count(shots, V1),
+            "overlays": _count(shots, V2),
+            "audio": bool(_count(shots, A1)),
         },
         "warnings": [finding.as_dict() for finding in checked.warnings],
     }
 
 
-def _count(shots: list[Shot], track: tuple[str, int]) -> int:
+def _count(shots: list[Shot], track: Track) -> int:
     """How many of this build's appends one track took — segments and overlays are both V."""
-    return sum(1 for shot in shots if (shot.track_type, shot.track_index) == track)
+    return sum(1 for shot in shots if shot.track == track)
 
 
 # --- placement ------------------------------------------------------------------------------
@@ -174,8 +184,7 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
         shots.append(
             _shot(
                 id=id,
-                track_type="video",
-                track_index=TRACK_INDEX,
+                track=V1,
                 located=clips[str(segment["source"])],
                 source_in=int(segment["in"]),
                 record=start + offset,
@@ -191,8 +200,7 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
         shots.append(
             _shot(
                 id=id,
-                track_type="video",
-                track_index=OVERLAY_TRACK_INDEX,
+                track=V2,
                 located=clips[str(overlay["source"])],
                 source_in=int(overlay["in"]),
                 record=start + offset,
@@ -206,8 +214,7 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
         shots.append(
             _shot(
                 id="audio",
-                track_type="audio",
-                track_index=TRACK_INDEX,
+                track=A1,
                 located=clips[str(audio["source"])],
                 source_in=int(audio["in"]),
                 record=start,
@@ -219,8 +226,7 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
 
 def _shot(
     id: str,
-    track_type: str,
-    track_index: int,
+    track: Track,
     located: media.LocatedClip,
     source_in: int,
     record: int,
@@ -228,8 +234,7 @@ def _shot(
 ) -> Shot:
     return Shot(
         id=id,
-        track_type=track_type,
-        track_index=track_index,
+        track=track,
         clip=located.clip,
         name=str(located.clip.GetName() or ""),
         source_in=source_in,
@@ -279,24 +284,24 @@ def _make_tracks(timeline: Timeline, shots: list[Shot], name: str) -> None:
     came with keeps whatever the project's timeline template gave it — the API cannot
     restyle an existing track, so the layout is logged rather than assumed.
     """
-    for track_type, track_index in _tracks(shots):
+    for track in _tracks(shots):
         # Only an audio track takes a sub-type; passing one to video is meaningless.
-        extra = (AUDIO_TRACK_TYPE,) if track_type == "audio" else ()
-        while _track_count(timeline, track_type) < track_index:
-            if not timeline.AddTrack(track_type, *extra):
+        extra = (AUDIO_TRACK_TYPE,) if track.type == "audio" else ()
+        while _track_count(timeline, track.type) < track.index:
+            if not timeline.AddTrack(track.type, *extra):
                 # Refused rather than merely unanswered: retrying would spin forever, and
                 # appending to a track that is not there drops the clip silently.
                 raise BuildFailedError(
-                    cause=f"Resolve refused to add a {track_type} track to {name!r}.",
+                    cause=f"Resolve refused to add a {track.type} track to {name!r}.",
                     fix="Close any modal dialog in the Resolve GUI, delete the empty "
                     "timeline, and build again.",
-                    detail={"timeline": name, "track_type": track_type},
+                    detail={"timeline": name, "track": track.label},
                 )
-            log.info("Added a %s track to %s", track_type, name)
+            log.info("Added %s to %s", track.label, name)
     log.info(
         "%s targets %s (%d video, %d audio tracks)",
         name,
-        ", ".join(_track_label(*track) for track in _tracks(shots)),
+        ", ".join(track.label for track in _tracks(shots)),
         _track_count(timeline, "video"),
         _track_count(timeline, "audio"),
     )
@@ -310,12 +315,12 @@ def _track_count(timeline: Timeline, track_type: str) -> int:
         return 0
 
 
-def _tracks(shots: list[Shot]) -> list[tuple[str, int]]:
+def _tracks(shots: list[Shot]) -> list[Track]:
     """The tracks this cut needs, in a fixed order so the logs read the same way each time."""
     order = list(TRACK_PREFIXES)
     return sorted(
-        {(shot.track_type, shot.track_index) for shot in shots},
-        key=lambda track: (order.index(track[0]), track[1]),
+        {shot.track for shot in shots},
+        key=lambda track: (order.index(track.type), track.index),
     )
 
 
@@ -327,9 +332,9 @@ def _refuse_locked_tracks(timeline: Timeline, shots: list[Shot], name: str) -> N
     check costs one call against a failure mode that leaves no trace anywhere else.
     """
     locked = [
-        locked_track_finding(_track_label(track_type, track_index))
-        for track_type, track_index in _tracks(shots)
-        if timeline.GetIsTrackLocked(track_type, track_index)
+        locked_track_finding(track.label)
+        for track in _tracks(shots)
+        if timeline.GetIsTrackLocked(track.type, track.index)
     ]
     if not locked:
         return
@@ -381,14 +386,13 @@ def _verify(timeline: Timeline, shots: list[Shot], name: str) -> None:
     )
 
 
-def _adrift(timeline: Timeline, shots: list[Shot], track: tuple[str, int]) -> list[Shot]:
-    track_type, track_index = track
-    wanted = [shot for shot in shots if (shot.track_type, shot.track_index) == track]
+def _adrift(timeline: Timeline, shots: list[Shot], track: Track) -> list[Shot]:
+    wanted = [shot for shot in shots if shot.track == track]
     if not wanted:
         return []
     landed = {
         (item.GetStart(), item.GetDuration())
-        for item in timeline.GetItemListInTrack(track_type, track_index) or []
+        for item in timeline.GetItemListInTrack(track.type, track.index) or []
     }
     return [shot for shot in wanted if (shot.record, shot.duration) not in landed]
 
@@ -397,10 +401,10 @@ def _expected(shot: Shot) -> dict[str, Any]:
     return {
         "id": shot.id,
         "clip": shot.name,
-        "track": shot.track,
+        "track": shot.track.label,
         "record_frame": shot.record,
         "duration": shot.duration,
     }
 
 
-__all__ = ["Shot", "build_timeline"]
+__all__ = ["Shot", "Track", "build_timeline"]

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -49,7 +49,9 @@ def build_timeline(
 
     Every build makes a new version and never touches an earlier one, so rebuilding after
     an edit is always safe. The segments land butt-joined in document order over one
-    continuous master-audio clip; positions are computed, so gaps cannot happen.
+    continuous master-audio clip; positions are computed, so gaps cannot happen. Overlays
+    land on V2 at their anchor segment's start plus the offset — never a frame you state —
+    so tightening a segment and rebuilding leaves every overlay over the same content.
 
     The validate_cut rules run first: a single error aborts before any timeline is created,
     and comes back with the same per-segment findings. The report echoes the cut file's

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -203,7 +203,7 @@ def test_a_cut_without_audio_builds_video_alone(attach: Attach, tmp_path: Path) 
     result = build_timeline(a_cut(tmp_path, doc))
 
     assert result["ok"] is True
-    assert result["placed"] == {"segments": 3, "audio": False}
+    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": False}
     assert placements(built(resolve, "sunset-set v1"), "audio") == []
 
 
@@ -229,7 +229,7 @@ def test_the_built_timeline_reports_its_own_span(attach: Attach, tmp_path: Path)
 
     assert result["timeline"]["duration"]["frames"] == TOTAL_FRAMES
     assert result["timeline"]["fps"] == 59.94
-    assert result["placed"] == {"segments": 3, "audio": True}
+    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": True}
 
 
 def test_the_build_opens_the_timeline_it_made(attach: Attach, tmp_path: Path) -> None:
@@ -350,30 +350,6 @@ def test_warnings_are_reported_and_do_not_block(attach: Attach, tmp_path: Path) 
     assert [finding["rule"] for finding in result["warnings"]] == ["W1"]
 
 
-def test_overlays_are_refused_rather_than_silently_dropped(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """Anchored overlays are a later tool; building the V1 alone would be a half-built cut."""
-    doc = valid_doc()
-    doc["overlays"] = [
-        {
-            "id": "b01",
-            "source": "keys_wide",
-            "in": 4000,
-            "out": 4020,
-            "over": {"segment": "s001", "offset": 10},
-        }
-    ]
-    pool = a_pool()
-    attach(empty_project(pool))
-
-    result = build_timeline(a_cut(tmp_path, doc))
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "unsupported_cut_feature"
-    assert "CreateEmptyTimeline" not in pool.calls
-
-
 def test_no_project_open_fails_before_anything_else(attach: Attach, tmp_path: Path) -> None:
     attach(studio(project=None))
 
@@ -381,6 +357,169 @@ def test_no_project_open_fails_before_anything_else(attach: Attach, tmp_path: Pa
 
     assert result["ok"] is False
     assert result["error"]["code"] == "no_project_open"
+
+
+# --- anchored overlays --------------------------------------------------------------------
+
+
+def with_overlay(**overrides: Any) -> dict[str, Any]:
+    """:func:`valid_doc` plus one b-roll overlay anchored 10 frames into ``s002``.
+
+    ``s002`` starts at frame 100 of the V1, so the overlay belongs at 110 — a number
+    nothing in the cut file states, which is the point of anchoring.
+    """
+    doc = valid_doc(
+        overlays=[
+            {
+                "id": "b01",
+                "source": "gtr_close",
+                "in": 3000,
+                "out": 3030,
+                "over": {"segment": "s002", "offset": 10},
+            }
+        ]
+    )
+    doc.update(overrides)
+    return doc
+
+
+def test_an_overlay_lands_on_v2_at_its_anchor_plus_offset(
+    attach: Attach, tmp_path: Path
+) -> None:
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, with_overlay()))
+
+    assert result["ok"] is True
+    assert placements(built(resolve, "sunset-set v1"), "video", 2) == [("C0012.mp4", 110, 30)]
+
+
+def test_an_overlay_takes_the_source_frames_the_cut_named(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """``mediaType`` travels with ``trackIndex``, or Resolve drops the clip (#18 (d))."""
+    pool = a_pool()
+    attach(empty_project(pool))
+
+    build_timeline(a_cut(tmp_path, with_overlay()))
+
+    overlay = next(append for append in pool.appends if append["trackIndex"] == 2)
+    assert (overlay["startFrame"], overlay["endFrame"]) == (3000, 3030)
+    assert (overlay["mediaType"], overlay["recordFrame"]) == (1, 110)
+
+
+def test_the_v1_under_an_overlay_is_laid_out_as_if_it_were_not_there(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Overlays ride above the cut; they never displace the segments they cover."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    build_timeline(a_cut(tmp_path, with_overlay()))
+
+    assert placements(built(resolve, "sunset-set v1")) == [
+        ("C0012.mp4", 0, 100),
+        ("C0031.mp4", 100, 80),
+        ("C0012.mp4", 180, 60),
+    ]
+
+
+def test_tightening_an_earlier_segment_keeps_the_overlay_over_the_same_content(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The reason anchors exist: a re-time upstream moves the overlay with its anchor.
+
+    ``s001`` loses 40 frames, so everything after it slides 40 earlier — and the overlay
+    stays exactly 10 frames into ``s002``, covering the same frames of the same clip.
+    """
+    resolve = empty_project(a_pool())
+    attach(resolve)
+    build_timeline(a_cut(tmp_path, with_overlay()))
+
+    tightened = with_overlay()
+    tightened["segments"][0]["out"] = 1060
+    tightened["audio"]["out"] = 200
+    build_timeline(a_cut(tmp_path, tightened))
+
+    before, after = (built(resolve, name) for name in ("sunset-set v1", "sunset-set v2"))
+    assert placements(after, "video", 2) == [("C0012.mp4", 70, 30)]
+    # Same clip, same source frames, same 10-frame offset into the same anchor segment.
+    anchor_before, anchor_after = placements(before)[1], placements(after)[1]
+    assert placements(before, "video", 2)[0][1] - anchor_before[1] == 10
+    assert placements(after, "video", 2)[0][1] - anchor_after[1] == 10
+
+
+def test_the_report_counts_the_overlays_apart_from_the_segments(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(empty_project(a_pool()))
+
+    result = build_timeline(a_cut(tmp_path, with_overlay()))
+
+    assert result["placed"] == {"segments": 3, "overlays": 1, "audio": True}
+
+
+def test_a_cut_without_overlays_builds_no_second_video_track(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """V2 is the overlays' track; a cut that has none must not grow one."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": True}
+    assert built(resolve, "sunset-set v1").GetTrackCount("video") == 1
+
+
+def test_the_overlay_track_is_created_when_the_new_timeline_has_none(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """An append onto a track index past the next free one is dropped silently (#18 (d))."""
+    pool = a_pool()
+    pool.new_timeline_tracks = (0, 0)
+    resolve = empty_project(pool)
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, with_overlay()))
+
+    assert result["ok"] is True
+    assert len(placements(built(resolve, "sunset-set v1"))) == 3
+    assert placements(built(resolve, "sunset-set v1"), "video", 2) == [("C0012.mp4", 110, 30)]
+
+
+def test_a_locked_overlay_track_is_reported_before_anything_is_appended(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """V2 is as lockable as V1, and a locked track swallows the append reporting success."""
+    pool = a_pool()
+    pool.new_timeline_tracks = (2, 1)
+    pool.new_timeline_locked = True
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, with_overlay()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    assert [f["id"] for f in result["error"]["detail"]["errors"]] == ["V1", "V2", "A1"]
+    assert "AppendToTimeline" not in pool.calls
+
+
+def test_an_overlay_that_never_landed_fails_the_build(attach: Attach, tmp_path: Path) -> None:
+    """V2 is read back like every other track: the append's word is not evidence."""
+    pool = a_pool()
+    pool.appends_land_nowhere = True
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, with_overlay()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    reported = result["error"]["detail"]["misplaced"]
+    misplaced = {finding["id"]: finding["track"] for finding in reported}
+    assert misplaced["b01"] == "V2"
+    assert misplaced["s001"] == "V1"
 
 
 # --- the footguns -------------------------------------------------------------------------

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -362,25 +362,24 @@ def test_no_project_open_fails_before_anything_else(attach: Attach, tmp_path: Pa
 # --- anchored overlays --------------------------------------------------------------------
 
 
-def with_overlay(**overrides: Any) -> dict[str, Any]:
+def with_overlay(out: int = 3030) -> dict[str, Any]:
     """:func:`valid_doc` plus one b-roll overlay anchored 10 frames into ``s002``.
 
     ``s002`` starts at frame 100 of the V1, so the overlay belongs at 110 — a number
-    nothing in the cut file states, which is the point of anchoring.
+    nothing in the cut file states, which is the point of anchoring. ``out`` lengthens it
+    past the anchor's end, which is what covering a seam looks like.
     """
-    doc = valid_doc(
+    return valid_doc(
         overlays=[
             {
                 "id": "b01",
                 "source": "gtr_close",
                 "in": 3000,
-                "out": 3030,
+                "out": out,
                 "over": {"segment": "s002", "offset": 10},
             }
         ]
     )
-    doc.update(overrides)
-    return doc
 
 
 def test_an_overlay_lands_on_v2_at_its_anchor_plus_offset(
@@ -448,6 +447,21 @@ def test_tightening_an_earlier_segment_keeps_the_overlay_over_the_same_content(
     anchor_before, anchor_after = placements(before)[1], placements(after)[1]
     assert placements(before, "video", 2)[0][1] - anchor_before[1] == 10
     assert placements(after, "video", 2)[0][1] - anchor_after[1] == 10
+
+
+def test_an_overlay_may_run_past_its_anchor_to_cover_a_seam(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """What b-roll is usually for: the overlay outlives its anchor and covers the cut."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, with_overlay(out=3130)))
+
+    assert result["ok"] is True
+    # 110 to 240: over the last 70 frames of s002, the s002/s003 seam, and all of s003.
+    assert placements(built(resolve, "sunset-set v1"), "video", 2) == [("C0012.mp4", 110, 130)]
+    assert placements(built(resolve, "sunset-set v1"))[2] == ("C0012.mp4", 180, 60)
 
 
 def test_the_report_counts_the_overlays_apart_from_the_segments(

--- a/tests/test_cut_validate.py
+++ b/tests/test_cut_validate.py
@@ -16,6 +16,7 @@ from resolve_mcp.cut.validate import (
     ClipFacts,
     Finding,
     locked_track_finding,
+    overlay_positions,
     validate_project,
     validate_structure,
 )
@@ -442,6 +443,33 @@ def test_e9_catches_an_overlay_running_past_the_end_of_the_cut() -> None:
     findings = validate_structure(doc)
 
     assert "E9" in rules(findings)
+
+
+# --- overlay placement: the numbers E9 judges and the build places against ----------------
+
+
+def test_overlay_positions_resolve_each_anchor_to_an_absolute_span() -> None:
+    """One function answers where an overlay goes, so the rule and the build cannot differ."""
+    doc = valid_doc()
+    doc["overlays"].append(
+        {
+            "id": "b04",
+            "source": "broll_pan",
+            "in": 1400,
+            "out": 1440,
+            "over": {"segment": "s002", "offset": 50},
+        }
+    )
+
+    assert overlay_positions(doc) == {"b03": (24, 100), "b04": (250, 40)}
+
+
+def test_overlay_positions_skip_an_anchor_that_does_not_exist() -> None:
+    """E9 has already refused such a document; there is no position to invent for it."""
+    doc = valid_doc()
+    doc["overlays"][0]["over"]["segment"] = "s999"
+
+    assert overlay_positions(doc) == {}
 
 
 # --- E10: overlays do not overlap each other --------------------------------------------


### PR DESCRIPTION
Closes #30.

An overlay states an anchor segment and an offset, never a timeline frame. `overlay_positions` in `src/resolve_mcp/cut/validate.py` resolves that anchor against the same sequential V1 layout E9 validates against, and the build places from it — one function, so a validated position and a built one cannot drift. Re-timing an earlier segment and rebuilding therefore leaves every overlay over the content it was anchored to.

The build's shots gained a `Track` (media type + index, one value: Resolve drops an append naming a `trackIndex` without its `mediaType`). V1, V2 and A1 are now three named targets rather than "the first of each kind", so track creation, the locked-track pre-flight and the placement read-back all run per track — a locked V2 is reported as `V2`, and an overlay that never landed fails the build exactly like a segment. The refusal that stopped any cut carrying overlays is gone, along with `UnsupportedCutFeatureError`, which it was the only raiser of.

**Acceptance criteria**

- *Overlay builds on V2 at its anchor segment + offset* — `test_an_overlay_lands_on_v2_at_its_anchor_plus_offset`, plus the append's `mediaType`/`trackIndex`/`recordFrame` and the seam case where the overlay outlives its anchor.
- *Shortening an earlier segment and rebuilding leaves the overlay covering the same content* — `test_tightening_an_earlier_segment_keeps_the_overlay_over_the_same_content`: `s001` loses 40 frames, the overlay moves 110 → 70, and it stays exactly 10 frames into `s002` in both versions.
- *Validation enforces anchor exists and offset within segment bounds* — E9/E10 landed with #28 and are unchanged in behaviour here; this PR routes their position math through `overlay_positions` and adds two pure tests for it. No new rules were needed.

**Seam** (CLAUDE.md §Test seams): fake tier — `tests/fakes.py` substituting the Resolve singleton at the connection manager, which is where placement, track creation, locks and read-back are decided; plus the pure-function tier for the anchor arithmetic. **No live ACs on this ticket**, so nothing is left unrun; the one thing no seam covers is whether a real Resolve accepts a V2 append at an exact record frame, which the next live smoke pass on the Windows box will exercise.

**Review record** — `/code-review` (two-axis, Standards + Spec sub-agents) against `origin/main`.

*Standards:* no documented-standard violations. Judgement calls, resolved:
- Data clumps / primitive obsession — `(track_type, track_index)` travelling as two loose primitives, with `_adrift` unpacking a tuple while `_track_label` took two arguments. **Fixed**: one frozen `Track` owning its `label`, with `V1`/`V2`/`A1` as constants.
- Speculative generality — `UnsupportedCutFeatureError` left with no raiser. **Fixed**: deleted.
- Speculative generality — the test helper's unused `**overrides`. **Fixed**: replaced by the single parameter a test varies (`out`, which lengthens the overlay past its anchor).
- Mysterious name — `overlay_positions` documented as returning a start while the build bound it to `offset`. **Fixed in the docstring**: it says the start is measured from the cut's first frame, exactly as `positions` measures a segment's, which is what `start + offset` in `_shots` adds to the timeline start.
- Duplicated code — `positions(doc)` recomputed inside `overlay_positions`, and three similar `shots.append(_shot(...))` blocks. **Held**: the recomputation is pure arithmetic over a validated document, and collapsing the three blocks would hide which fields each kind of shot reads.

*Spec:* all three ACs implemented; no scope creep found (`placed.overlays` is the report evidence for AC1; the track refactor is forced by V2). Findings resolved:
- Seam coverage — an overlay running past its anchor validated but was never *placed* in a test. **Fixed**: `test_an_overlay_may_run_past_its_anchor_to_cover_a_seam`.
- Dead error class. **Fixed** as above.
- `_shots` indexing `overlay_positions` by id could `KeyError` on a missing anchor. **Held**: the pre-flight refuses such a document (E9) before any of `positions`, `clips_by_alias` or `overlay_positions` is read, and guarding one of the three would imply the other two are guaranteed by something else. Noted here rather than silently.

CI: 512 fake-tier tests pass, mypy strict clean, ruff clean.

Review: clean — two-axis review, six findings fixed, two held with reasons above; fix diff re-checked.

Post-open merge of origin/main (takes #29 landed first): resolution keeps both intents — Track refactor with V1/V2/A1 carries the placed report, selectors count restored alongside overlays, `UnsupportedCutFeatureError` import dropped with its only raise site, `_selectors` keyed off V1. Fake tier 544 passed, mypy and ruff clean.
Review: clean — focused pass on the conflict-resolution diff
