### PR TITLE
P1: Render tools — presets, and per-song deliverables off one timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Build contract: [issue #22](https://github.com/danielbaldwin47/resolve-mcp/issue
 
 P1 in progress. Shipped so far: the server skeleton, the session/project tools, the media
 pool tools, the timeline read and interchange tools, the background-job infrastructure
-with audio acquisition, and the `run_python` escape hatch.
+with audio acquisition, the render/deliver tools, and the `run_python` escape hatch.
 
 | Tool | What it does |
 | --- | --- |
@@ -27,6 +27,8 @@ with audio acquisition, and the `run_python` escape hatch.
 | `inspect_timeline` | One timeline at a chosen detail and range, in dual time |
 | `export_timeline` | Writes a timeline out as OTIO, FCPXML or DRT |
 | `import_timeline` | Materialises a **new** timeline from such a file — never overwrites one |
+| `list_render_presets` | The project's render presets, spelled the way `render_timeline` needs |
+| `render_timeline` | Renders a timeline or a range of one as a background job |
 | `get_job` | Polls one background job: progress, result, or a structured failure |
 | `list_jobs` | Lists jobs newest first — how a restarted session finds what it started |
 | `run_python` | Escape hatch: runs scripting-API Python in the server process |
@@ -51,6 +53,15 @@ recover after a restart — a job that was still running when the server went do
 timeline is exported through Resolve's render queue (the only route that captures the
 timeline *mix*, 48 kHz/24-bit WAV), a single source clip is extracted with ffmpeg unless its
 audio mapping says the audio is linked or offset away from the file.
+
+Deliverables come off one timeline the same way: `render_timeline` takes a **preset** by
+name — what a preset renders was decided in the Deliver page and saved there, so the server
+overrides only where the file goes and which frames it covers — plus an optional half-open
+`[start, end)` range in the timeline's own frames, the numbers `inspect_timeline` and
+`list_markers` report. That is a per-song file out of a concert set. Without a `target_dir`
+the file lands in the cache's `renders` folder, which the server replaces freely on a
+re-render; a directory you name is yours, and a file already sitting there is refused until
+you pass `refresh`.
 
 ## Requirements
 

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -30,18 +30,13 @@ from typing import Any
 from ..config import Config, get_config
 from ..errors import AudioExportError, AudioExtractionError, AudioMappingError, RenderQueueError
 from ..jobs import cache
-from ..jobs.runner import JobOutput, Progress, start_job
+from ..jobs.runner import JobOutput, Progress, band, start_job
 from ..logging_config import get_logger
 from ..naming import slug
 from ..resolve import media, render
 from ..resolve.connection import ResolveConnection
 from ..resolve.session import current_project
-from ..resolve.timeline import (
-    Reader,
-    current_timeline,
-    find_timeline,
-)
-from ..resolve.timeline import fingerprint as timeline_fingerprint
+from ..resolve.timeline import Reader, current_timeline, find_timeline, fingerprint
 from . import ffmpeg, wav
 
 log = get_logger("audio")
@@ -57,7 +52,6 @@ CLIP_KIND = "acquire_clip_audio"
 
 RENDER_FORMAT = "wav"
 RENDER_CODEC = "lpcm"
-SINGLE_CLIP = 1
 
 EXPORT_FLOOR = 0.1
 EXPORT_CEILING = 0.9
@@ -87,8 +81,8 @@ def acquire_timeline_audio(
         "sample_rate": sample_rate,
         "bit_depth": bit_depth,
     }
-    fingerprint = timeline_fingerprint(Reader(connection), found)
-    key = cache.cache_key(TIMELINE_KIND, [fingerprint], params)
+    identity = fingerprint(Reader(connection), found)
+    key = cache.cache_key(TIMELINE_KIND, [identity], params)
 
     def work(progress: Progress) -> JobOutput:
         return export_timeline_mix(project, found, key, params, progress, config)
@@ -123,7 +117,7 @@ def export_timeline_mix(
     with current_timeline(project, timeline):
         # One file for the whole timeline. The other mode renders a file per clip on it,
         # which for a concert cut is hundreds of fragments instead of the mix.
-        project.SetCurrentRenderMode(SINGLE_CLIP)
+        project.SetCurrentRenderMode(render.SINGLE_CLIP)
         settings = {
             "SelectAllFrames": True,
             "TargetDir": str(target_dir),
@@ -135,8 +129,13 @@ def export_timeline_mix(
             "AudioSampleRate": int(params["sample_rate"]),
         }
         try:
-            job_id = render.submit(project, settings, RENDER_FORMAT, RENDER_CODEC)
-            render.render(project, job_id, expecting, _scaled(progress))
+            job_id = render.submit(project, settings, (RENDER_FORMAT, RENDER_CODEC))
+            render.render(
+                project,
+                job_id,
+                expecting,
+                band(progress, EXPORT_FLOOR, EXPORT_CEILING),
+            )
         except RenderQueueError as exc:
             raise _as_export_failure(exc) from exc
 
@@ -153,16 +152,6 @@ def _as_export_failure(exc: RenderQueueError) -> AudioExportError:
     """
     specific = exc.fix if exc.fix != RenderQueueError.default_fix else None
     return AudioExportError(cause=exc.cause, fix=specific, detail=exc.detail)
-
-
-def _scaled(progress: Progress) -> Progress:
-    """Map the render's own 0-1 onto the part of the job the render actually is."""
-    span = EXPORT_CEILING - EXPORT_FLOOR
-
-    def scaled(fraction: float, step: str) -> None:
-        progress(EXPORT_FLOOR + span * fraction, step)
-
-    return scaled
 
 
 # --- clip scope: ffmpeg ------------------------------------------------------------------

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -23,8 +23,6 @@ to force the export again when the director changed something no reading can see
 
 from __future__ import annotations
 
-import contextlib
-import hashlib
 from collections.abc import Iterator
 from pathlib import Path, PureWindowsPath
 from typing import Any
@@ -38,7 +36,12 @@ from ..naming import slug
 from ..resolve import media, render
 from ..resolve.connection import ResolveConnection
 from ..resolve.session import current_project
-from ..resolve.timeline import Reader, find_timeline
+from ..resolve.timeline import (
+    Reader,
+    current_timeline,
+    find_timeline,
+)
+from ..resolve.timeline import fingerprint as timeline_fingerprint
 from . import ffmpeg, wav
 
 log = get_logger("audio")
@@ -63,45 +66,6 @@ OFFSET_HINT = ("offset", "delay")
 
 
 # --- timeline scope: the render queue ----------------------------------------------------
-
-
-def timeline_fingerprint(reader: Reader, timeline: Timeline) -> dict[str, Any]:
-    """A timeline's identity, as far as anything outside Resolve can read it.
-
-    Bounds and track counts alone would call a take swap or a reordered cut "unchanged" —
-    same duration, same stack — and hand back yesterday's mix, so the shots themselves are
-    digested too. What no reading can see is a clip's audio level, which the scripting API
-    does not expose at all; that is what ``refresh`` on the starter is for.
-
-    Nothing here smooths a failure into a default: a field that cannot be read while
-    Resolve is dying must not quietly produce a fingerprint, because every dead-handle
-    reading would collide on one key and serve one concert's audio for another.
-    """
-    return {
-        "name": str(timeline.GetName()),
-        "unique_id": reader.optional(timeline, "GetUniqueId", None),
-        "start": timeline.GetStartFrame(),
-        "end": timeline.GetEndFrame(),
-        "audio_tracks": timeline.GetTrackCount("audio"),
-        "video_tracks": timeline.GetTrackCount("video"),
-        "structure": _structure(reader, timeline),
-    }
-
-
-def _structure(reader: Reader, timeline: Timeline) -> str:
-    """A digest of every shot on the cut: what it is, where it starts, how long it runs."""
-    digest = hashlib.sha256()
-    for track_type in ("video", "audio"):
-        count = int(timeline.GetTrackCount(track_type) or 0)
-        for index in range(1, count + 1):
-            items = reader.optional(timeline, "GetItemListInTrack", [], track_type, index) or []
-            digest.update(f"{track_type}{index}:".encode())
-            for item in items:
-                name = reader.optional(item, "GetName", "")
-                start = reader.optional(item, "GetStart", None)
-                duration = reader.optional(item, "GetDuration", None)
-                digest.update(f"{name}@{start}+{duration};".encode())
-    return digest.hexdigest()
 
 
 def acquire_timeline_audio(
@@ -156,7 +120,7 @@ def export_timeline_mix(
     expecting = target_dir / f"{stem}.wav"
 
     progress(0.05, "queuing the audio export")
-    with _current_timeline(project, timeline):
+    with current_timeline(project, timeline):
         # One file for the whole timeline. The other mode renders a file per clip on it,
         # which for a concert cut is hundreds of fragments instead of the mix.
         project.SetCurrentRenderMode(SINGLE_CLIP)
@@ -189,25 +153,6 @@ def _as_export_failure(exc: RenderQueueError) -> AudioExportError:
     """
     specific = exc.fix if exc.fix != RenderQueueError.default_fix else None
     return AudioExportError(cause=exc.cause, fix=specific, detail=exc.detail)
-
-
-@contextlib.contextmanager
-def _current_timeline(project: Project, timeline: Timeline) -> Iterator[None]:
-    """Render what was asked for, and put the director's timeline back afterwards.
-
-    The render queue renders the *current* timeline, so acquiring audio for any other one
-    means switching. Leaving the switch in place would move the GUI out from under whoever
-    is sitting at it.
-    """
-    previous = project.GetCurrentTimeline()
-    switched = previous is not timeline
-    if switched:
-        project.SetCurrentTimeline(timeline)
-    try:
-        yield
-    finally:
-        if switched and previous is not None:
-            project.SetCurrentTimeline(previous)
 
 
 def _scaled(progress: Progress) -> Progress:

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -79,6 +79,17 @@ class Config:
         return self.cache_dir / "audio"
 
     @property
+    def render_dir(self) -> Path:
+        """Deliverables rendered without a target directory of their own.
+
+        Its own folder rather than the audio one because these are files a human opens and
+        hands on, and because everything under it is the server's to replace: a re-render
+        after a review round overwrites in place, which is only safe where nothing the
+        director put there can be sitting.
+        """
+        return self.cache_dir / "renders"
+
+    @property
     def interchange_dir(self) -> Path:
         """Where exported timelines (OTIO, FCPXML, DRT) land when no path is given.
 

--- a/src/resolve_mcp/deliver.py
+++ b/src/resolve_mcp/deliver.py
@@ -33,14 +33,9 @@ from pathlib import Path
 from typing import Any
 
 from .config import Config, get_config
-from .errors import (
-    InvalidRequestError,
-    RenderPresetNotFoundError,
-    RenderQueueError,
-    RenderTargetExistsError,
-)
+from .errors import InvalidRequestError, RenderQueueError, RenderTargetExistsError
 from .jobs import cache
-from .jobs.runner import JobOutput, Progress, start_job
+from .jobs.runner import JobOutput, Progress, band, start_job
 from .logging_config import get_logger
 from .naming import slug
 from .resolve import render
@@ -55,8 +50,6 @@ Timeline = Any
 Project = Any
 
 KIND = "render_timeline"
-SINGLE_CLIP = 1
-"""One file for the span asked for. The other mode writes a file per clip on the timeline."""
 
 DELIVER_TIMEOUT = 6 * 3600.0
 """A concert render legitimately runs for hours; the timeout is for a queue that has stalled.
@@ -107,10 +100,9 @@ def render_timeline(
 
     # Reading the preset list is cheap and does not disturb the queue; loading it is what
     # changes project state, and that waits for the job's turn under the Resolve lock.
-    available = render.presets(project)
-    if preset not in available:
-        raise RenderPresetNotFoundError(preset, available)
+    render.require_preset(project, preset)
 
+    covered = span or (int(found.GetStartFrame()), int(found.GetEndFrame()))
     stem = _stem(name, timeline_name, span)
     directory = Path(target_dir) if target_dir is not None else config.render_dir
     params: dict[str, Any] = {
@@ -118,17 +110,21 @@ def render_timeline(
         "preset": preset,
         "name": stem,
         "target_dir": str(directory),
-        "start": span[0] if span else None,
-        "end": span[1] if span else None,
+        "whole_timeline": span is None,
+        "start": covered[0],
+        "end": covered[1],
         "fps": fps,
     }
     key = cache.cache_key(KIND, [fingerprint(Reader(connection), found)], params)
 
+    # The lookup start_job is about to make, made a moment early: a cache hit renders
+    # nothing, so it is the one case where a file already at the target is this job's own
+    # and not something to refuse over.
     if target_dir is not None and not refresh and cache.lookup(key, config) is None:
-        _refuse_a_file_already_there(directory, stem)
+        _refuse_a_taken_target(directory, stem)
 
     def work(progress: Progress) -> JobOutput:
-        return render_deliverable(project, found, params, progress, config)
+        return render_deliverable(project, found, params, progress)
 
     return start_job(
         KIND,
@@ -146,10 +142,12 @@ def render_deliverable(
     timeline: Timeline,
     params: dict[str, Any],
     progress: Progress,
-    config: Config | None = None,
 ) -> JobOutput:
-    """The worker: load the preset, queue the span, wait for the file it writes."""
-    config = config or get_config()
+    """The worker: load the preset, queue the span, wait for the file it writes.
+
+    Everything it needs is in ``params``, which is also what the job record shows: a render
+    that has to be diagnosed from a job file on disk is one whose inputs are all in it.
+    """
     directory = Path(str(params["target_dir"]))
     directory.mkdir(parents=True, exist_ok=True)
     stem = str(params["name"])
@@ -157,8 +155,8 @@ def render_deliverable(
     progress(0.02, "loading the render preset")
     with current_timeline(project, timeline):
         render.load_preset(project, str(params["preset"]))
-        shape = render.current_format(project)
-        extension = shape.get("format", "")
+        format_and_codec = render.current_format(project)
+        extension = format_and_codec.get("format", "")
         if not extension:
             raise RenderQueueError(
                 cause=f"Resolve would not say what format {params['preset']!r} renders.",
@@ -169,21 +167,21 @@ def render_deliverable(
                 detail={"preset": params["preset"]},
             )
         expecting = directory / f"{stem}.{extension}"
-        _clear(directory, stem)
+        _clear(expecting)
 
-        project.SetCurrentRenderMode(SINGLE_CLIP)
+        project.SetCurrentRenderMode(render.SINGLE_CLIP)
         progress(0.04, "queuing the render")
         job_id = render.submit(project, _settings(directory, stem, params))
         render.render(
             project,
             job_id,
             expecting,
-            _scaled(progress),
+            band(progress, RENDER_FLOOR, RENDER_CEILING),
             timeout=DELIVER_TIMEOUT,
         )
 
     log.info("Rendered %s from %s", expecting, params["timeline"])
-    return JobOutput(_result(expecting, shape, params), (expecting,))
+    return JobOutput(_result(expecting, format_and_codec, params), (expecting,))
 
 
 def _settings(directory: Path, stem: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -193,7 +191,7 @@ def _settings(directory: Path, stem: str, params: dict[str, Any]) -> dict[str, A
     contradict an audio-only or video-only preset the director saved deliberately.
     """
     settings: dict[str, Any] = {"TargetDir": str(directory), "CustomName": stem}
-    if params["start"] is None:
+    if params["whole_timeline"]:
         settings["SelectAllFrames"] = True
         return settings
     settings["SelectAllFrames"] = False
@@ -203,26 +201,33 @@ def _settings(directory: Path, stem: str, params: dict[str, Any]) -> dict[str, A
     return settings
 
 
-def _result(expecting: Path, shape: dict[str, str], params: dict[str, Any]) -> dict[str, Any]:
-    """What the agent reads off a finished render — where the file is, and what it covers."""
+def _result(
+    expecting: Path,
+    format_and_codec: dict[str, str],
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """What the agent reads off a finished render — where the file is, and what it covers.
+
+    The range is reported whether or not one was asked for: a whole-timeline render covers
+    the timeline's own bounds, and a deliverable that will not say what it holds is one the
+    agent has to open Resolve to identify.
+    """
     fps = params["fps"]
-    span = None
-    if params["start"] is not None:
-        start = int(params["start"])
-        end = int(params["end"])
-        span = {
-            "start": dual_time(start, fps),
-            "end": dual_time(end, fps),
-            "duration": dual_time(end - start, fps),
-        }
+    start = int(params["start"])
+    end = int(params["end"])
     return {
         "path": str(expecting),
         "size_bytes": expecting.stat().st_size,
         "timeline": params["timeline"],
         "preset": params["preset"],
-        "format": shape.get("format"),
-        "codec": shape.get("codec"),
-        "range": span,
+        "format": format_and_codec.get("format"),
+        "codec": format_and_codec.get("codec"),
+        "whole_timeline": params["whole_timeline"],
+        "range": {
+            "start": dual_time(start, fps),
+            "end": dual_time(end, fps),
+            "duration": dual_time(end - start, fps),
+        },
     }
 
 
@@ -282,8 +287,13 @@ def _stem(name: str | None, timeline_name: str, span: tuple[int, int] | None) ->
     return base if span is None else f"{base}-{span[0]}-{span[1]}"
 
 
-def _refuse_a_file_already_there(directory: Path, stem: str) -> None:
-    """A caller-named directory is the director's; nothing in it is replaced on a guess."""
+def _refuse_a_taken_target(directory: Path, stem: str) -> None:
+    """A caller-named directory is the director's; nothing in it is replaced on a guess.
+
+    Which suffix the render will take is not known until the preset loads, so the check is
+    on the name: any file called ``<name>.<anything>`` is close enough to be worth asking
+    about, including a sidecar a re-render would leave describing the wrong file.
+    """
     found = sorted(str(path) for path in directory.glob(f"{stem}.*") if path.is_file())
     if found:
         raise RenderTargetExistsError(
@@ -292,23 +302,18 @@ def _refuse_a_file_already_there(directory: Path, stem: str) -> None:
         )
 
 
-def _clear(directory: Path, stem: str) -> None:
+def _clear(expecting: Path) -> None:
     """Take the old file out of the way so Resolve cannot rename around it.
 
-    Only reached once the render is going ahead — either the directory is the server's own,
+    Exactly the one file about to be written, never a glob: a sidecar the director keeps
+    beside a deliverable — a subtitle, a still, an earlier take in another format — is not
+    what this render replaces, even when it carries the same name.
+
+    Only reached once the render is going ahead: either the directory is the server's own,
     or ``refresh`` said to replace what is in the caller's.
     """
-    for path in directory.glob(f"{stem}.*"):
-        if path.is_file():
-            path.unlink()
-            log.info("Replacing %s", path)
+    if expecting.exists():
+        expecting.unlink()
+        log.info("Replacing %s", expecting)
 
 
-def _scaled(progress: Progress) -> Progress:
-    """Map the render's own 0-1 onto the part of the job the render actually is."""
-    span = RENDER_CEILING - RENDER_FLOOR
-
-    def scaled(fraction: float, step: str) -> None:
-        progress(RENDER_FLOOR + span * fraction, step)
-
-    return scaled

--- a/src/resolve_mcp/deliver.py
+++ b/src/resolve_mcp/deliver.py
@@ -1,0 +1,314 @@
+"""Deliverables: a render preset plus a span of one timeline, run as a background job.
+
+A concert set is one timeline and a dozen files. That shape drives every decision here:
+
+* **A preset names the deliverable's shape, and nothing else does.** Format and codec on
+  their own leave resolution, bit rate and colour at whatever the project was last set to.
+  What those should be is the director's call, made once in the Deliver page and saved; this
+  server picks a saved preset by name and overrides only where the file goes and which
+  frames it covers. That is also why the preset catalog was never specified in the spec —
+  it belongs to the project, not to the server.
+
+* **A range is the same half-open ``[in, out)`` as everywhere else, on the timeline's own
+  clock.** The numbers ``inspect_timeline`` and ``list_markers`` report are the numbers to
+  pass, so marking a song's boundaries and rendering it are the same two numbers. Resolve's
+  ``MarkOut`` is inclusive, so the conversion happens here, once — the one frame of
+  difference is invisible in review and wrong in the file.
+
+* **The file is replaced only where the server owns the directory.** Resolve does not
+  reliably overwrite; a name already taken can come back as ``name_0.mp4`` beside the old
+  file, and the job would then report a path holding yesterday's export. So the server's own
+  render directory is cleared before rendering, and a directory the caller named is refused
+  unless ``refresh`` says otherwise. A deliverable the director already sent out is not this
+  server's to overwrite on a guess.
+
+Caching is the timeline fingerprint plus these parameters, so a re-render of an unchanged
+song is instant and a cut that moved renders again — see ``resolve.timeline.fingerprint``
+for what that reading can and cannot see.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .config import Config, get_config
+from .errors import (
+    InvalidRequestError,
+    RenderPresetNotFoundError,
+    RenderQueueError,
+    RenderTargetExistsError,
+)
+from .jobs import cache
+from .jobs.runner import JobOutput, Progress, start_job
+from .logging_config import get_logger
+from .naming import slug
+from .resolve import render
+from .resolve.connection import ResolveConnection
+from .resolve.session import current_project, frame_rate
+from .resolve.timeline import Reader, current_timeline, find_timeline, fingerprint
+from .timing import dual_time, to_frames
+
+log = get_logger("deliver")
+
+Timeline = Any
+Project = Any
+
+KIND = "render_timeline"
+SINGLE_CLIP = 1
+"""One file for the span asked for. The other mode writes a file per clip on the timeline."""
+
+DELIVER_TIMEOUT = 6 * 3600.0
+"""A concert render legitimately runs for hours; the timeout is for a queue that has stalled.
+
+The audio route's hour is right for a mix of one timeline. A 4K master of a two-hour set is
+not a stalled render at ninety minutes, and killing it would waste the whole thing.
+"""
+
+RENDER_FLOOR = 0.05
+RENDER_CEILING = 0.98
+
+
+def list_presets(connection: ResolveConnection) -> dict[str, Any]:
+    """The render presets this project offers, and the format it would render with now."""
+    project = current_project(connection, "No project is open, so there are no render presets.")
+    found = render.presets(project)
+    return {
+        "presets": found,
+        "count": len(found),
+        "current": render.current_format(project) or None,
+    }
+
+
+def render_timeline(
+    connection: ResolveConnection,
+    preset: str,
+    timeline: str | None = None,
+    name: str | None = None,
+    target_dir: str | None = None,
+    start: Any = None,
+    end: Any = None,
+    refresh: bool = False,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Start a job that renders a timeline, or a span of one. Returns the job record.
+
+    Everything that can be checked without touching the render queue is checked here, before
+    a job exists: a preset that is not in the project, a range that runs off the end of the
+    timeline, a file already sitting where this one would land. Those are the caller's
+    mistakes, and a raised error names them a poll earlier than a failed job would.
+    """
+    config = config or get_config()
+    project = current_project(connection, "No project is open, so there is nothing to render.")
+    found = find_timeline(project, timeline)
+    timeline_name = str(found.GetName() or "timeline")
+    fps = frame_rate(project, found)
+    span = _span(start, end, found, fps)
+
+    # Reading the preset list is cheap and does not disturb the queue; loading it is what
+    # changes project state, and that waits for the job's turn under the Resolve lock.
+    available = render.presets(project)
+    if preset not in available:
+        raise RenderPresetNotFoundError(preset, available)
+
+    stem = _stem(name, timeline_name, span)
+    directory = Path(target_dir) if target_dir is not None else config.render_dir
+    params: dict[str, Any] = {
+        "timeline": timeline_name,
+        "preset": preset,
+        "name": stem,
+        "target_dir": str(directory),
+        "start": span[0] if span else None,
+        "end": span[1] if span else None,
+        "fps": fps,
+    }
+    key = cache.cache_key(KIND, [fingerprint(Reader(connection), found)], params)
+
+    if target_dir is not None and not refresh and cache.lookup(key, config) is None:
+        _refuse_a_file_already_there(directory, stem)
+
+    def work(progress: Progress) -> JobOutput:
+        return render_deliverable(project, found, params, progress, config)
+
+    return start_job(
+        KIND,
+        params,
+        work,
+        cache_key=key,
+        touches_resolve=True,
+        refresh=refresh,
+        config=config,
+    )
+
+
+def render_deliverable(
+    project: Project,
+    timeline: Timeline,
+    params: dict[str, Any],
+    progress: Progress,
+    config: Config | None = None,
+) -> JobOutput:
+    """The worker: load the preset, queue the span, wait for the file it writes."""
+    config = config or get_config()
+    directory = Path(str(params["target_dir"]))
+    directory.mkdir(parents=True, exist_ok=True)
+    stem = str(params["name"])
+
+    progress(0.02, "loading the render preset")
+    with current_timeline(project, timeline):
+        render.load_preset(project, str(params["preset"]))
+        shape = render.current_format(project)
+        extension = shape.get("format", "")
+        if not extension:
+            raise RenderQueueError(
+                cause=f"Resolve would not say what format {params['preset']!r} renders.",
+                fix=(
+                    "Open the Deliver page and load the preset by hand to see what it does; "
+                    "a preset that reports no format usually did not load."
+                ),
+                detail={"preset": params["preset"]},
+            )
+        expecting = directory / f"{stem}.{extension}"
+        _clear(directory, stem)
+
+        project.SetCurrentRenderMode(SINGLE_CLIP)
+        progress(0.04, "queuing the render")
+        job_id = render.submit(project, _settings(directory, stem, params))
+        render.render(
+            project,
+            job_id,
+            expecting,
+            _scaled(progress),
+            timeout=DELIVER_TIMEOUT,
+        )
+
+    log.info("Rendered %s from %s", expecting, params["timeline"])
+    return JobOutput(_result(expecting, shape, params), (expecting,))
+
+
+def _settings(directory: Path, stem: str, params: dict[str, Any]) -> dict[str, Any]:
+    """Where the file goes and which frames it covers — the preset decides the rest.
+
+    Nothing else is set: forcing ``ExportVideo``/``ExportAudio`` here would silently
+    contradict an audio-only or video-only preset the director saved deliberately.
+    """
+    settings: dict[str, Any] = {"TargetDir": str(directory), "CustomName": stem}
+    if params["start"] is None:
+        settings["SelectAllFrames"] = True
+        return settings
+    settings["SelectAllFrames"] = False
+    settings["MarkIn"] = int(params["start"])
+    # Half-open in, inclusive out: MarkOut names the last frame Resolve renders.
+    settings["MarkOut"] = int(params["end"]) - 1
+    return settings
+
+
+def _result(expecting: Path, shape: dict[str, str], params: dict[str, Any]) -> dict[str, Any]:
+    """What the agent reads off a finished render — where the file is, and what it covers."""
+    fps = params["fps"]
+    span = None
+    if params["start"] is not None:
+        start = int(params["start"])
+        end = int(params["end"])
+        span = {
+            "start": dual_time(start, fps),
+            "end": dual_time(end, fps),
+            "duration": dual_time(end - start, fps),
+        }
+    return {
+        "path": str(expecting),
+        "size_bytes": expecting.stat().st_size,
+        "timeline": params["timeline"],
+        "preset": params["preset"],
+        "format": shape.get("format"),
+        "codec": shape.get("codec"),
+        "range": span,
+    }
+
+
+def _span(
+    start: Any,
+    end: Any,
+    timeline: Timeline,
+    fps: float | None,
+) -> tuple[int, int] | None:
+    """The half-open frame range to render, or ``None`` for the whole timeline.
+
+    One bound alone runs to the timeline's own edge — a song at the top or the tail of a set
+    is named by the boundary the agent found, not by the one it would have to look up.
+    """
+    if start is None and end is None:
+        return None
+    first = int(timeline.GetStartFrame())
+    last = int(timeline.GetEndFrame())
+    in_frame = to_frames(start, fps, "start")
+    out_frame = to_frames(end, fps, "end")
+    in_frame = first if in_frame is None else in_frame
+    out_frame = last if out_frame is None else out_frame
+
+    bounds = {"timeline_start": first, "timeline_end": last, "start": in_frame, "end": out_frame}
+    if in_frame < first or out_frame > last:
+        raise InvalidRequestError(
+            cause=(
+                f"The range [{in_frame}, {out_frame}) is not inside the timeline, "
+                f"which runs [{first}, {last})."
+            ),
+            fix=(
+                "Timeline frames are numbered from the timeline's own start, not from zero "
+                "— inspect_timeline reports the bounds this range has to sit inside."
+            ),
+            detail=bounds,
+        )
+    if out_frame <= in_frame:
+        raise InvalidRequestError(
+            cause=f"The range [{in_frame}, {out_frame}) covers no frames.",
+            fix="Ranges are half-open [start, end): end must be past start.",
+            detail=bounds,
+        )
+    return in_frame, out_frame
+
+
+def _stem(name: str | None, timeline_name: str, span: tuple[int, int] | None) -> str:
+    """The deliverable's filename, without a suffix.
+
+    A name the caller gave is kept as given (made filename-safe) — this is a file a human
+    opens, so a cache-shaped name would be the wrong thing to hand over. Without one, a
+    range is distinguished by its own frames so that two songs off one timeline do not both
+    claim the timeline's name.
+    """
+    if name is not None:
+        return slug(name, "render")
+    base = slug(timeline_name, "render")
+    return base if span is None else f"{base}-{span[0]}-{span[1]}"
+
+
+def _refuse_a_file_already_there(directory: Path, stem: str) -> None:
+    """A caller-named directory is the director's; nothing in it is replaced on a guess."""
+    found = sorted(str(path) for path in directory.glob(f"{stem}.*") if path.is_file())
+    if found:
+        raise RenderTargetExistsError(
+            cause=f"{found[0]} is already there, and this render would land on it.",
+            detail={"target_dir": str(directory), "name": stem, "found": found},
+        )
+
+
+def _clear(directory: Path, stem: str) -> None:
+    """Take the old file out of the way so Resolve cannot rename around it.
+
+    Only reached once the render is going ahead — either the directory is the server's own,
+    or ``refresh`` said to replace what is in the caller's.
+    """
+    for path in directory.glob(f"{stem}.*"):
+        if path.is_file():
+            path.unlink()
+            log.info("Replacing %s", path)
+
+
+def _scaled(progress: Progress) -> Progress:
+    """Map the render's own 0-1 onto the part of the job the render actually is."""
+    span = RENDER_CEILING - RENDER_FLOOR
+
+    def scaled(fraction: float, step: str) -> None:
+        progress(RENDER_FLOOR + span * fraction, step)
+
+    return scaled

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -293,6 +293,37 @@ class RenderQueueError(ResolveMcpError):
     )
 
 
+class RenderPresetNotFoundError(ResolveMcpError):
+    """The render preset asked for is not one this project offers."""
+
+    code = "render_preset_not_found"
+
+    def __init__(self, name: str, available: list[str]) -> None:
+        super().__init__(
+            cause=f"No render preset named {name!r} in this project.",
+            fix=(
+                "list_render_presets names every preset, exactly as it must be spelled. "
+                "Presets are per project and per user — one made on another machine is not here."
+            ),
+            detail={"requested": name, "available": available},
+        )
+
+
+class RenderTargetExistsError(ResolveMcpError):
+    """A file already sits where the render would land, and the caller named that place.
+
+    Resolve does not reliably overwrite: it may write ``name_0.mp4`` beside the old file
+    instead, and the job would then report a path holding yesterday's export.
+    """
+
+    code = "render_target_exists"
+    default_fix = (
+        "Render under a different name, or pass refresh=true to replace what is there. "
+        "Leaving target_dir out puts the file in the server's own render directory, which "
+        "it replaces without asking."
+    )
+
+
 class AudioExportError(ResolveMcpError):
     """Resolve's render queue would not produce the timeline mix."""
 

--- a/src/resolve_mcp/jobs/runner.py
+++ b/src/resolve_mcp/jobs/runner.py
@@ -65,6 +65,20 @@ Progress = Callable[[float, str], None]
 Work = Callable[[Progress], JobOutput]
 
 
+def band(progress: Progress, floor: float, ceiling: float) -> Progress:
+    """Map a sub-task's own 0-1 onto the part of the job that sub-task actually is.
+
+    A render reports its own percentage and knows nothing about the hashing either side of
+    it; without this the job would jump to 100% and then sit there.
+    """
+    span = ceiling - floor
+
+    def scaled(fraction: float, step: str) -> None:
+        progress(floor + span * fraction, step)
+
+    return scaled
+
+
 def start_job(
     kind: str,
     params: dict[str, Any],

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -38,11 +38,27 @@ RENDER_TIMEOUT = 3600.0
 STATUS = "JobStatus"
 PERCENT = "CompletionPercentage"
 
+SINGLE_CLIP = 1
+"""One file for the span rendered. The other mode writes a file per clip on the timeline."""
+
 
 def presets(project: Project) -> list[str]:
     """Every render preset this project offers, in the order Resolve lists them."""
     listed = project.GetRenderPresetList() or []
     return [str(one) for one in listed]
+
+
+def require_preset(project: Project, name: str) -> list[str]:
+    """Check the project has this preset, and hand back the list it was checked against.
+
+    Resolve answers a bare ``False`` both for a preset it does not have and for one it will
+    not load, so the name is checked against the list to tell the two apart. Reading the
+    list disturbs nothing, which is why a caller can ask this before queuing anything.
+    """
+    available = presets(project)
+    if name not in available:
+        raise RenderPresetNotFoundError(name, available)
+    return available
 
 
 def load_preset(project: Project, name: str) -> None:
@@ -51,13 +67,8 @@ def load_preset(project: Project, name: str) -> None:
     A preset is the only honest way to name a deliverable's shape: format and codec alone
     leave resolution, bit rate and the rest at whatever the project was last set to, and
     what those *should* be is the director's decision, made once in the Deliver page.
-
-    Resolve answers a bare ``False`` both for a preset it does not have and for one it will
-    not load, so the name is checked against the list first to tell the two apart.
     """
-    available = presets(project)
-    if name not in available:
-        raise RenderPresetNotFoundError(name, available)
+    available = require_preset(project, name)
     if not project.LoadRenderPreset(name):
         raise RenderQueueError(
             cause=f"Resolve would not load the render preset {name!r}.",
@@ -83,22 +94,22 @@ def current_format(project: Project) -> dict[str, str]:
 def submit(
     project: Project,
     settings: dict[str, Any],
-    format_: str | None = None,
-    codec: str | None = None,
+    format_and_codec: tuple[str, str] | None = None,
 ) -> str:
     """Push one job onto the queue and return its id.
 
     ``SetRenderSettings`` and the format/codec pair are project-level state; they are set
-    immediately before the job is added so that the job captures them. Format and codec are
-    optional because a loaded preset has already set both, and setting them again would
-    overwrite the rest of what the preset chose.
+    immediately before the job is added so that the job captures them. The pair travels as
+    one because Resolve takes it as one, and it is optional because a loaded preset has
+    already set both — setting them again would overwrite the rest of what the preset chose.
     """
-    named = format_ is not None and codec is not None
-    if named and not project.SetCurrentRenderFormatAndCodec(format_, codec):
-        raise RenderQueueError(
-            cause=f"Resolve would not render {format_}/{codec}.",
-            detail={"format": format_, "codec": codec},
-        )
+    if format_and_codec is not None:
+        format_, codec = format_and_codec
+        if not project.SetCurrentRenderFormatAndCodec(format_, codec):
+            raise RenderQueueError(
+                cause=f"Resolve would not render {format_}/{codec}.",
+                detail={"format": format_, "codec": codec},
+            )
     if not project.SetRenderSettings(settings):
         raise RenderQueueError(
             cause="Resolve refused the render settings.",

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from ..errors import RenderQueueError
+from ..errors import RenderPresetNotFoundError, RenderQueueError
 from ..logging_config import get_logger
 
 log = get_logger("render")
@@ -39,13 +39,62 @@ STATUS = "JobStatus"
 PERCENT = "CompletionPercentage"
 
 
-def submit(project: Project, settings: dict[str, Any], format_: str, codec: str) -> str:
+def presets(project: Project) -> list[str]:
+    """Every render preset this project offers, in the order Resolve lists them."""
+    listed = project.GetRenderPresetList() or []
+    return [str(one) for one in listed]
+
+
+def load_preset(project: Project, name: str) -> None:
+    """Make ``name`` the settings the next job captures — format, codec, resolution and all.
+
+    A preset is the only honest way to name a deliverable's shape: format and codec alone
+    leave resolution, bit rate and the rest at whatever the project was last set to, and
+    what those *should* be is the director's decision, made once in the Deliver page.
+
+    Resolve answers a bare ``False`` both for a preset it does not have and for one it will
+    not load, so the name is checked against the list first to tell the two apart.
+    """
+    available = presets(project)
+    if name not in available:
+        raise RenderPresetNotFoundError(name, available)
+    if not project.LoadRenderPreset(name):
+        raise RenderQueueError(
+            cause=f"Resolve would not load the render preset {name!r}.",
+            fix=(
+                "Open the Deliver page and select the preset by hand — a preset that will "
+                "not load is usually one saved against media or a codec this machine lacks."
+            ),
+            detail={"preset": name, "available": available},
+        )
+    log.info("Loaded render preset %s", name)
+
+
+def current_format(project: Project) -> dict[str, str]:
+    """The format and codec the project would render with now — ``format`` is the extension.
+
+    Empty when Resolve will not say: a deliverable whose suffix cannot be known is a
+    failure the caller has to shape, not a default this layer is allowed to guess.
+    """
+    reading = project.GetCurrentRenderFormatAndCodec() or {}
+    return {str(key): str(value) for key, value in reading.items() if value}
+
+
+def submit(
+    project: Project,
+    settings: dict[str, Any],
+    format_: str | None = None,
+    codec: str | None = None,
+) -> str:
     """Push one job onto the queue and return its id.
 
     ``SetRenderSettings`` and the format/codec pair are project-level state; they are set
-    immediately before the job is added so that the job captures them.
+    immediately before the job is added so that the job captures them. Format and codec are
+    optional because a loaded preset has already set both, and setting them again would
+    overwrite the rest of what the preset chose.
     """
-    if not project.SetCurrentRenderFormatAndCodec(format_, codec):
+    named = format_ is not None and codec is not None
+    if named and not project.SetCurrentRenderFormatAndCodec(format_, codec):
         raise RenderQueueError(
             cause=f"Resolve would not render {format_}/{codec}.",
             detail={"format": format_, "codec": codec},

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -26,7 +26,10 @@ rather than API calls, and are the reason this file exists at all:
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
 import re
+from collections.abc import Iterator
 from typing import Any, NamedTuple
 
 from ..config import Config, get_config
@@ -162,6 +165,68 @@ def next_free_name(requested: str, existing: set[str]) -> str:
     while f"{base} v{number}" in existing:
         number += 1
     return f"{base} v{number}"
+
+
+@contextlib.contextmanager
+def current_timeline(project: Project, timeline: Timeline) -> Iterator[None]:
+    """Work on the timeline that was asked for, and put the director's back afterwards.
+
+    The render queue renders the *current* timeline, so exporting any other one means
+    switching. Leaving the switch in place would move the GUI out from under whoever is
+    sitting at it.
+    """
+    previous = project.GetCurrentTimeline()
+    switched = previous is not timeline
+    if switched:
+        project.SetCurrentTimeline(timeline)
+    try:
+        yield
+    finally:
+        if switched and previous is not None:
+            project.SetCurrentTimeline(previous)
+
+
+def fingerprint(reader: Reader, timeline: Timeline) -> dict[str, Any]:
+    """A timeline's identity, as far as anything outside Resolve can read it.
+
+    Every job that takes a whole timeline as its input — an audio export, a render — keys
+    its cache off this, so it lives with the other timeline reads rather than with either
+    caller.
+
+    Bounds and track counts alone would call a take swap or a reordered cut "unchanged" —
+    same duration, same stack — and hand back yesterday's output, so the shots themselves
+    are digested too. What no reading can see is a clip's audio level, which the scripting
+    API does not expose at all; that is what ``refresh`` on the starters is for.
+
+    Nothing here smooths a failure into a default: a field that cannot be read while
+    Resolve is dying must not quietly produce a fingerprint, because every dead-handle
+    reading would collide on one key and serve one concert's output for another.
+    """
+    return {
+        "name": str(timeline.GetName()),
+        "unique_id": reader.optional(timeline, "GetUniqueId", None),
+        "start": timeline.GetStartFrame(),
+        "end": timeline.GetEndFrame(),
+        "audio_tracks": timeline.GetTrackCount("audio"),
+        "video_tracks": timeline.GetTrackCount("video"),
+        "structure": _structure(reader, timeline),
+    }
+
+
+def _structure(reader: Reader, timeline: Timeline) -> str:
+    """A digest of every shot on the cut: what it is, where it starts, how long it runs."""
+    digest = hashlib.sha256()
+    for track_type in ("video", "audio"):
+        count = int(timeline.GetTrackCount(track_type) or 0)
+        for index in range(1, count + 1):
+            items = reader.optional(timeline, "GetItemListInTrack", [], track_type, index) or []
+            digest.update(f"{track_type}{index}:".encode())
+            for item in items:
+                name = reader.optional(item, "GetName", "")
+                start = reader.optional(item, "GetStart", None)
+                duration = reader.optional(item, "GetDuration", None)
+                digest.update(f"{name}@{start}+{duration};".encode())
+    return digest.hexdigest()
 
 
 # --- shape ---------------------------------------------------------------------------------

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from . import __version__
 from .config import get_config
 from .logging_config import configure_logging, get_logger
-from .tools import cut, escape_hatch, jobs, media, project, timeline
+from .tools import cut, escape_hatch, jobs, media, project, render, timeline
 
 log = get_logger("server")
 
@@ -49,6 +49,7 @@ def build_server() -> FastMCP:
         *media.TOOLS,
         *timeline.TOOLS,
         *cut.TOOLS,
+        *render.TOOLS,
         *jobs.TOOLS,
         *escape_hatch.TOOLS,
     ):

--- a/src/resolve_mcp/tools/render.py
+++ b/src/resolve_mcp/tools/render.py
@@ -1,0 +1,76 @@
+"""Deliver tools — turning a finished cut into files, one preset and one span at a time."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .. import deliver
+from ..resolve.connection import get_connection
+from .envelope import tool
+
+
+@tool
+def list_render_presets() -> dict[str, Any]:
+    """List the render presets this project offers, spelled the way render_timeline needs.
+
+    Presets belong to the project and the machine, not to this server: what a preset renders
+    — format, codec, resolution, bit rate — was decided in the Deliver page and saved there,
+    so pick one by name rather than describing a shape. current is the format and codec the
+    project would render with right now, which is the last preset anything loaded.
+    """
+    connection = get_connection()
+    return deliver.list_presets(connection)
+
+
+@tool
+def render_timeline(
+    preset: str,
+    timeline: str | None = None,
+    name: str | None = None,
+    target_dir: str | None = None,
+    start: Any = None,
+    end: Any = None,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    """Render a timeline, or a span of one, as a background job. Returns a job to poll.
+
+    A render is the longest thing this server does, so it hands back a job straight away and
+    get_job reports it — progress while it runs, the file's path and size when it finishes,
+    a cause and a fix if the queue refused it. preset must be one list_render_presets names;
+    it decides everything about the file except where it goes and which frames it covers.
+
+    start and end cut one deliverable out of a longer timeline — a song off a concert set.
+    They are frames on the timeline's own clock, the numbers inspect_timeline and
+    list_markers report (a timeline starting at 01:00:00:00 starts at frame 86400, not 0),
+    or seconds with an explicit snap. The range is half-open [start, end) like every other
+    range here; one bound alone runs to the timeline's own edge, and neither is the whole
+    timeline.
+
+    Without target_dir the file lands in the server's render directory, which it replaces
+    freely on a re-render — that is the frictionless path after a review round. A target_dir
+    you name is yours: a file already sitting there is refused rather than overwritten,
+    until you pass refresh=true. name is the file's own name (defaulting to the timeline's,
+    plus the range) and is what the director will see, so name it for the song.
+
+    An unchanged cut rendered twice comes back from cache without rendering again; refresh
+    forces the render, which is also how a change no reading can see (a clip's audio level)
+    gets picked up.
+    """
+    connection = get_connection()
+    return {
+        "job": deliver.render_timeline(
+            connection,
+            preset=preset,
+            timeline=timeline,
+            name=name,
+            target_dir=target_dir,
+            start=start,
+            end=end,
+            refresh=refresh,
+        )
+    }
+
+
+TOOLS: tuple[Any, ...] = (list_render_presets, render_timeline)
+
+__all__ = ["TOOLS", "list_render_presets", "render_timeline"]

--- a/src/resolve_mcp/tools/render.py
+++ b/src/resolve_mcp/tools/render.py
@@ -54,7 +54,11 @@ def render_timeline(
 
     An unchanged cut rendered twice comes back from cache without rendering again; refresh
     forces the render, which is also how a change no reading can see (a clip's audio level)
-    gets picked up.
+    gets picked up. The result says what the file covers either way — a whole-timeline
+    render reports the timeline's own bounds, with whole_timeline true.
+
+    A render leaves the Deliver page set to the preset it used, the same way rendering by
+    hand would; the timeline the director had open is the one thing put back.
     """
     connection = get_connection()
     return {

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1067,6 +1067,14 @@ class FakeProject:
         self.render_statuses: list[str] = ["Complete"]
         self.render_seconds = 2.0
         self.render_writes_the_file = True
+        # A preset carries the format and codec with it — loading one is what sets them,
+        # which is why the deliver route never sets a format of its own.
+        self.render_presets: dict[str, tuple[str, str]] = {
+            "H.264 Master": ("mp4", "H.264"),
+            "ProRes 422 HQ": ("mov", "ProRes422HQ"),
+        }
+        self.loaded_presets: list[str] = []
+        self.accepts_preset = True
         self.accepts_format = True
         self.accepts_settings = True
         self.accepts_job = True
@@ -1086,6 +1094,24 @@ class FakeProject:
             return False
         self.render_format = (format_, codec)
         return True
+
+    def GetRenderPresetList(self) -> list[str]:  # noqa: N802
+        return list(self.render_presets)
+
+    def LoadRenderPreset(self, name: str) -> bool:  # noqa: N802
+        """Resolve answers a bare ``False`` for a preset it does not have, and for a refusal."""
+        if not self.accepts_preset or name not in self.render_presets:
+            return False
+        self.loaded_presets.append(name)
+        self.render_format = self.render_presets[name]
+        return True
+
+    def GetCurrentRenderFormatAndCodec(self) -> dict[str, str]:  # noqa: N802
+        """``format`` is the file extension, not the display name — as in the real API."""
+        if self.render_format is None:
+            return {}
+        format_, codec = self.render_format
+        return {"format": format_, "codec": codec}
 
     def SetRenderSettings(self, settings: dict[str, Any]) -> bool:  # noqa: N802
         if not self.accepts_settings:
@@ -1126,14 +1152,20 @@ class FakeProject:
         return False
 
     def _write_the_render(self) -> None:
+        """Whatever the current format says lands: a real WAV, or bytes for a video file."""
         target = Path(str(self.render_settings.get("TargetDir", "")))
         name = str(self.render_settings.get("CustomName", "render"))
-        write_wav(
-            target / f"{name}.wav",
-            seconds=self.render_seconds,
-            sample_rate=int(self.render_settings.get("AudioSampleRate", 48000)),
-            bit_depth=int(self.render_settings.get("AudioBitDepth", 24)),
-        )
+        extension = self.render_format[0] if self.render_format else "wav"
+        if extension == "wav":
+            write_wav(
+                target / f"{name}.wav",
+                seconds=self.render_seconds,
+                sample_rate=int(self.render_settings.get("AudioSampleRate", 48000)),
+                bit_depth=int(self.render_settings.get("AudioBitDepth", 24)),
+            )
+            return
+        target.mkdir(parents=True, exist_ok=True)
+        (target / f"{name}.{extension}").write_bytes(b"\0" * 2048)
 
     def GetName(self) -> str:  # noqa: N802
         return self._name

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -35,6 +35,7 @@ from resolve_mcp.tools.escape_hatch import run_python
 from resolve_mcp.tools.jobs import get_job, list_jobs
 from resolve_mcp.tools.media import inspect_clip, list_media
 from resolve_mcp.tools.project import get_status, list_projects, snapshot_project
+from resolve_mcp.tools.render import list_render_presets, render_timeline
 from resolve_mcp.tools.timeline import (
     export_timeline,
     import_timeline,
@@ -508,6 +509,87 @@ def test_the_render_queue_exports_the_real_timeline_mix() -> None:
 
     again = acquire_timeline_audio(get_connection())
     assert again["cached"] is True, "an unchanged timeline must be a cache hit"
+
+
+def test_the_preset_list_is_the_one_in_the_deliver_page() -> None:
+    """#33: whether ``GetRenderPresetList`` answers at all, and with what spelling.
+
+    Run with ``-s`` and record the names on the ticket — every render_timeline call names
+    one of them, and they are per project and per machine.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+
+    reply = list_render_presets()
+
+    assert reply["ok"] is True, reply.get("error")
+    assert reply["count"] > 0, "a stock Resolve ships presets; an empty list means the getter lied"
+    print(f"\nrender presets: {reply['presets']}")
+
+
+def test_a_range_render_covers_the_frames_it_was_given(tmp_path: Path) -> None:
+    """#33: the AC no fake can answer — that MarkIn/MarkOut are read on the timeline's clock.
+
+    The fakes prove the conversion (half-open in, inclusive out) and that the settings
+    reach ``SetRenderSettings``. What only Resolve can say is whether those frame numbers
+    are absolute timeline frames — a timeline starting at 01:00:00:00 starts at frame 86400,
+    and a Resolve reading them as offsets from zero would render the wrong part of the set
+    while reporting success.
+
+    So two ranges are rendered, one three times the other: if the marks were ignored, both
+    would be the whole timeline and the files would be the same size. Slow — it renders
+    twice. Check the shorter file opens and starts where the range said.
+    """
+    if get_status()["context"]["timeline"] is None:
+        pytest.skip("No timeline open in Resolve")
+    presets = list_render_presets()
+    assert presets["ok"] is True, presets.get("error")
+    if not presets["presets"]:
+        pytest.skip("No render presets in this project")
+    preset = os.environ.get("RESOLVE_MCP_RENDER_PRESET") or presets["presets"][0]
+
+    whole = inspect_timeline(detail="summary")
+    assert whole["ok"] is True
+    first = whole["timeline"]["start"]["frames"]
+    fps = whole["timeline"]["fps"] or 24
+    if whole["timeline"]["duration"]["frames"] < int(fps * 13):
+        pytest.skip("The open timeline is too short to render two ranges out of")
+
+    short = render_timeline(
+        preset=preset,
+        name="resolve-mcp-smoke-short",
+        target_dir=str(tmp_path),
+        start=first + int(fps),
+        end=first + int(fps * 3),
+    )
+    assert short["ok"] is True, short.get("error")
+    short_record = wait_for(short["job"]["job_id"], timeout=1800.0)
+    assert short_record.state == "completed", short_record.error
+
+    long = render_timeline(
+        preset=preset,
+        name="resolve-mcp-smoke-long",
+        target_dir=str(tmp_path),
+        start=first + int(fps),
+        end=first + int(fps * 7),
+    )
+    assert long["ok"] is True, long.get("error")
+    long_record = wait_for(long["job"]["job_id"], timeout=1800.0)
+    assert long_record.state == "completed", long_record.error
+
+    assert short_record.result is not None
+    assert long_record.result is not None
+    shorter = Path(short_record.result["path"])
+    longer = Path(long_record.result["path"])
+    assert shorter.exists() and longer.exists()
+    print(f"\nrendered {shorter} ({shorter.stat().st_size} bytes) with preset {preset!r}")
+    assert longer.stat().st_size > shorter.stat().st_size * 1.5, (
+        "a three-times-longer range rendered the same size — MarkIn/MarkOut were ignored"
+    )
+
+    polled = get_job(short["job"]["job_id"])
+    assert polled["ok"] is True
+    assert polled["job"]["state"] == "completed"
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_render_queue.py
+++ b/tests/test_render_queue.py
@@ -20,7 +20,7 @@ def test_a_completed_render_hands_back_the_file_it_wrote(tmp_path: Path) -> None
     project = FakeProject("sunset-set")
     expecting = tmp_path / "mix.wav"
     write_wav(expecting, seconds=0.1)
-    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
 
     assert render.render(project, job_id, expecting, sleep=_no_sleep) == expecting
     assert project.render_format == ("wav", "lpcm")
@@ -29,7 +29,7 @@ def test_a_completed_render_hands_back_the_file_it_wrote(tmp_path: Path) -> None
 def test_the_queue_is_left_as_it_was_found(tmp_path: Path) -> None:
     project = FakeProject("sunset-set")
     expecting = write_wav(tmp_path / "mix.wav", seconds=0.1)
-    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
 
     render.render(project, job_id, expecting, sleep=_no_sleep)
 
@@ -40,7 +40,7 @@ def test_a_failed_job_is_a_failure_even_though_every_call_returned_true(tmp_path
     project = FakeProject("sunset-set")
     project.render_statuses = ["Rendering", "Failed"]
     expecting = write_wav(tmp_path / "mix.wav", seconds=0.1)
-    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
 
     with pytest.raises(RenderQueueError) as raised:
         render.render(project, job_id, expecting, sleep=_no_sleep)
@@ -53,7 +53,7 @@ def test_a_render_that_writes_nothing_is_not_a_success(tmp_path: Path) -> None:
     """Resolve reports Complete for renders that land nothing — an unwritable target does."""
     project = FakeProject("sunset-set")
     project.render_writes_the_file = False
-    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
 
     with pytest.raises(RenderQueueError) as raised:
         render.render(project, job_id, tmp_path / "mix.wav", sleep=_no_sleep)
@@ -65,7 +65,7 @@ def test_a_queue_that_never_finishes_times_out_pointing_at_the_gui(tmp_path: Pat
     project = FakeProject("sunset-set")
     project.render_statuses = ["Rendering"]
     clock = iter([0.0, 0.0, 10_000.0])
-    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
 
     with pytest.raises(RenderQueueError) as raised:
         render.render(
@@ -87,7 +87,7 @@ def test_progress_comes_from_the_jobs_own_percentage(tmp_path: Path) -> None:
     project.render_statuses = ["Rendering", "Rendering", "Complete"]
     expecting = write_wav(tmp_path / "mix.wav", seconds=0.1)
     seen: list[float] = []
-    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
 
     render.render(
         project,
@@ -117,7 +117,7 @@ def test_every_way_the_queue_can_refuse_a_job_says_which(
     setattr(project, refusal, False)
 
     with pytest.raises(RenderQueueError) as raised:
-        render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+        render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
 
     assert expected in raised.value.cause
 
@@ -125,7 +125,7 @@ def test_every_way_the_queue_can_refuse_a_job_says_which(
 def test_a_queue_that_will_not_start_takes_its_job_back_off(tmp_path: Path) -> None:
     project = FakeProject("sunset-set")
     project.starts_rendering = False
-    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, "wav", "lpcm")
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
 
     with pytest.raises(RenderQueueError) as raised:
         render.render(project, job_id, tmp_path / "mix.wav", sleep=_no_sleep)

--- a/tests/test_render_tools.py
+++ b/tests/test_render_tools.py
@@ -1,0 +1,412 @@
+"""Deliver: listing render presets, and rendering a timeline or a range of one as a job.
+
+The seam is the Resolve scripting boundary — the fake project *is* the render queue, so
+every decision here (which preset was loaded, what MarkIn/MarkOut the range became, whether
+the file was replaced or refused) is read off the calls the tool made. What no fake can
+answer is whether Resolve itself reads MarkIn/MarkOut on the timeline's own clock; that is a
+live AC, and it is the one thing this file cannot prove.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.config import get_config
+from resolve_mcp.jobs.runner import wait_for
+from resolve_mcp.tools.jobs import get_job
+from resolve_mcp.tools.render import list_render_presets, render_timeline
+
+from .conftest import Attach
+from .fakes import FakeProject, FakeResolve, FakeTimeline, studio
+
+PRESET = "H.264 Master"
+
+
+# --- presets -------------------------------------------------------------------------------
+
+
+def test_the_preset_list_names_what_the_deliver_page_offers(attach: Attach) -> None:
+    attach(studio())
+
+    reply = list_render_presets()
+
+    assert reply["ok"] is True
+    assert reply["presets"] == ["H.264 Master", "ProRes 422 HQ"]
+    assert reply["count"] == 2
+
+
+def test_the_preset_list_reports_the_format_currently_loaded(attach: Attach) -> None:
+    resolve = studio()
+    _project(resolve).SetCurrentRenderFormatAndCodec("mov", "ProRes422HQ")
+    attach(resolve)
+
+    reply = list_render_presets()
+
+    assert reply["current"] == {"format": "mov", "codec": "ProRes422HQ"}
+
+
+def test_no_project_open_is_a_failure_not_an_empty_preset_list(attach: Attach) -> None:
+    attach(studio(project=None))
+
+    reply = list_render_presets()
+
+    assert reply["ok"] is False
+    assert reply["error"]["code"] == "no_project_open"
+
+
+# --- the whole timeline --------------------------------------------------------------------
+
+
+def test_a_full_timeline_render_produces_the_file(attach: Attach) -> None:
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "24"))
+    attach(resolve)
+
+    started = render_timeline(preset=PRESET)
+    record = wait_for(started["job"]["job_id"])
+
+    assert record.state == "completed"
+    assert record.result is not None
+    written = Path(record.result["path"])
+    assert written.exists()
+    assert written.suffix == ".mp4"
+    assert record.result["format"] == "mp4"
+    assert record.result["codec"] == "H.264"
+    assert record.result["range"] is None
+    assert record.result["size_bytes"] > 0
+
+    project = _project(resolve)
+    assert project.loaded_presets == [PRESET]
+    assert project.render_settings["SelectAllFrames"] is True
+    assert "MarkIn" not in project.render_settings
+    assert project.render_settings["TargetDir"] == str(get_config().render_dir)
+    assert project.render_mode == 1
+    assert project.render_queue == []
+
+
+def test_the_render_reports_through_get_job_like_any_other_job(attach: Attach) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "24")))
+
+    job_id = render_timeline(preset=PRESET)["job"]["job_id"]
+    wait_for(job_id)
+    polled = get_job(job_id)
+
+    assert polled["ok"] is True
+    assert polled["job"]["kind"] == "render_timeline"
+    assert polled["job"]["state"] == "completed"
+    assert polled["job"]["progress"] == 1.0
+    assert Path(polled["job"]["result"]["path"]).exists()
+
+
+def test_the_deliverable_is_named_for_the_song_not_for_the_cache(attach: Attach) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "24")))
+
+    started = render_timeline(preset=PRESET, name="Blue Monk")
+    record = wait_for(started["job"]["job_id"])
+
+    assert record.result is not None
+    assert Path(record.result["path"]).name == "Blue-Monk.mp4"
+
+
+def test_a_named_target_directory_is_where_the_deliverable_lands(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "24")))
+    deliverables = tmp_path / "deliverables"
+
+    started = render_timeline(preset=PRESET, name="Blue Monk", target_dir=str(deliverables))
+    record = wait_for(started["job"]["job_id"])
+
+    assert record.result is not None
+    assert Path(record.result["path"]) == deliverables / "Blue-Monk.mp4"
+
+
+def test_the_directors_timeline_is_put_back_after_rendering_another_one(
+    attach: Attach,
+) -> None:
+    current = FakeTimeline("sunset-set v3", "24")
+    other = FakeTimeline("sunset-set v2", "24")
+    resolve = studio(timeline=current, timelines=[current, other])
+    attach(resolve)
+
+    wait_for(render_timeline(preset=PRESET, timeline="sunset-set v2")["job"]["job_id"])
+
+    project = _project(resolve)
+    assert project.timeline_switches == ["sunset-set v2", "sunset-set v3"]
+    assert project.GetCurrentTimeline() is current
+
+
+# --- a range off a longer timeline ---------------------------------------------------------
+
+
+def test_a_range_render_marks_in_and_out_on_the_timelines_own_clock(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    started = render_timeline(preset=PRESET, name="Blue Monk", start=86_500, end=86_600)
+    record = wait_for(started["job"]["job_id"])
+
+    assert record.state == "completed"
+    project = _project(resolve)
+    assert project.render_settings["SelectAllFrames"] is False
+    assert project.render_settings["MarkIn"] == 86_500
+    # Half-open in, inclusive out: the last frame rendered is the one before end.
+    assert project.render_settings["MarkOut"] == 86_599
+
+    assert record.result is not None
+    rendered = record.result["range"]
+    assert rendered["start"]["frames"] == 86_500
+    assert rendered["end"]["frames"] == 86_600
+    assert rendered["duration"]["frames"] == 100
+    assert rendered["duration"]["seconds"] == pytest.approx(100 / 24, abs=0.001)
+
+
+def test_a_range_in_seconds_has_to_say_which_way_to_snap(attach: Attach) -> None:
+    attach(studio(timeline=_concert()))
+
+    reply = render_timeline(preset=PRESET, start={"seconds": 3600.0}, end=86_600)
+
+    assert reply["ok"] is False
+    assert reply["error"]["code"] == "invalid_request"
+    assert "snap" in reply["error"]["fix"]
+
+
+def test_a_range_in_seconds_with_a_snap_is_taken(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    started = render_timeline(
+        preset=PRESET,
+        start={"seconds": 3600.0, "snap": "floor"},
+        end={"seconds": 3610.0, "snap": "ceil"},
+    )
+    wait_for(started["job"]["job_id"])
+
+    assert _project(resolve).render_settings["MarkIn"] == 86_400
+    assert _project(resolve).render_settings["MarkOut"] == 86_639
+
+
+def test_one_bound_alone_runs_to_the_timelines_own_edge(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    wait_for(render_timeline(preset=PRESET, start=86_500)["job"]["job_id"])
+
+    assert _project(resolve).render_settings["MarkIn"] == 86_500
+    assert _project(resolve).render_settings["MarkOut"] == 87_399
+
+
+def test_a_range_past_the_end_of_the_timeline_is_refused_before_anything_is_queued(
+    attach: Attach,
+) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    reply = render_timeline(preset=PRESET, start=86_500, end=99_999)
+
+    assert reply["ok"] is False
+    assert reply["error"]["code"] == "invalid_request"
+    assert reply["error"]["detail"]["timeline_end"] == 87_400
+    assert _project(resolve).render_jobs == []
+
+
+def test_a_range_that_covers_no_frames_is_refused(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    reply = render_timeline(preset=PRESET, start=86_600, end=86_600)
+
+    assert reply["ok"] is False
+    assert reply["error"]["code"] == "invalid_request"
+    assert _project(resolve).render_jobs == []
+
+
+def test_two_songs_off_one_timeline_are_two_files(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    first = wait_for(
+        render_timeline(preset=PRESET, name="Blue Monk", start=86_400, end=86_600)["job"]["job_id"]
+    )
+    second = wait_for(
+        render_timeline(preset=PRESET, name="Straight No Chaser", start=86_600, end=86_900)["job"][
+            "job_id"
+        ]
+    )
+
+    assert first.result is not None
+    assert second.result is not None
+    assert first.result["path"] != second.result["path"]
+    assert Path(first.result["path"]).exists()
+    assert Path(second.result["path"]).exists()
+    assert len(_project(resolve).render_jobs) == 2
+
+
+# --- what the queue does wrong -------------------------------------------------------------
+
+
+def test_an_unknown_preset_names_the_ones_that_exist(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    reply = render_timeline(preset="Vimeo 4K")
+
+    assert reply["ok"] is False
+    assert reply["error"]["code"] == "render_preset_not_found"
+    assert reply["error"]["detail"]["available"] == ["H.264 Master", "ProRes 422 HQ"]
+    assert _project(resolve).render_jobs == []
+
+
+def test_a_preset_resolve_refuses_to_load_never_reaches_the_queue(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    _project(resolve).accepts_preset = False
+    attach(resolve)
+
+    record = wait_for(render_timeline(preset=PRESET)["job"]["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "render_queue_failed"
+    assert _project(resolve).render_jobs == []
+
+
+def test_a_queue_that_refuses_the_job_fails_the_job_not_the_server(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    _project(resolve).accepts_job = False
+    attach(resolve)
+
+    record = wait_for(render_timeline(preset=PRESET)["job"]["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "render_queue_failed"
+
+
+def test_a_render_that_reports_success_but_writes_nothing_is_a_failed_job(
+    attach: Attach,
+) -> None:
+    resolve = studio(timeline=_concert())
+    _project(resolve).render_writes_the_file = False
+    attach(resolve)
+
+    record = wait_for(render_timeline(preset=PRESET)["job"]["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert "wrote nothing" in record.error["cause"]
+
+
+# --- caching and replacing -----------------------------------------------------------------
+
+
+def test_the_same_render_twice_does_not_render_twice(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    first = wait_for(render_timeline(preset=PRESET, name="Blue Monk")["job"]["job_id"])
+    again = render_timeline(preset=PRESET, name="Blue Monk")["job"]
+
+    assert again["cached"] is True
+    assert again["state"] == "completed"
+    assert again["result"] == first.result
+    assert len(_project(resolve).render_jobs) == 1
+
+
+def test_refresh_renders_again_and_replaces_the_file(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    first = wait_for(render_timeline(preset=PRESET, name="Blue Monk")["job"]["job_id"])
+    again = wait_for(
+        render_timeline(preset=PRESET, name="Blue Monk", refresh=True)["job"]["job_id"]
+    )
+
+    assert again.cached is False
+    assert again.result is not None
+    assert first.result is not None
+    assert again.result["path"] == first.result["path"]
+    assert Path(again.result["path"]).exists()
+    assert len(_project(resolve).render_jobs) == 2
+
+
+def test_a_file_already_at_the_target_is_never_replaced_silently(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+    deliverables = tmp_path / "deliverables"
+    deliverables.mkdir()
+    theirs = deliverables / "Blue-Monk.mp4"
+    theirs.write_bytes(b"the director's own export")
+
+    reply = render_timeline(preset=PRESET, name="Blue Monk", target_dir=str(deliverables))
+
+    assert reply["ok"] is False
+    assert reply["error"]["code"] == "render_target_exists"
+    assert "refresh" in reply["error"]["fix"]
+    assert theirs.read_bytes() == b"the director's own export"
+    assert _project(resolve).render_jobs == []
+
+
+def test_refresh_is_how_a_file_at_the_target_gets_replaced(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+    deliverables = tmp_path / "deliverables"
+    deliverables.mkdir()
+    (deliverables / "Blue-Monk.mp4").write_bytes(b"an older take")
+
+    record = wait_for(
+        render_timeline(
+            preset=PRESET,
+            name="Blue Monk",
+            target_dir=str(deliverables),
+            refresh=True,
+        )["job"]["job_id"]
+    )
+
+    assert record.state == "completed"
+    assert (deliverables / "Blue-Monk.mp4").read_bytes() != b"an older take"
+
+
+def test_a_cut_that_changed_renders_again_over_the_servers_own_file(attach: Attach) -> None:
+    """A deliverable under the server's own directory is the server's to replace.
+
+    The whole point of the default target is that re-rendering a song after a review round
+    costs nothing but the render — no refresh flag, no name the director has to invent.
+    """
+    timeline = _concert()
+    resolve = studio(timeline=timeline)
+    attach(resolve)
+
+    first = wait_for(render_timeline(preset=PRESET, name="Blue Monk")["job"]["job_id"])
+    timeline._end_frame = 88_000
+    again = render_timeline(preset=PRESET, name="Blue Monk")["job"]
+    finished = wait_for(again["job_id"])
+
+    assert again["cached"] is False
+    assert finished.state == "completed"
+    assert first.result is not None
+    assert finished.result is not None
+    assert finished.result["path"] == first.result["path"]
+    assert len(_project(resolve).render_jobs) == 2
+
+
+# --- helpers -------------------------------------------------------------------------------
+
+
+def _concert() -> FakeTimeline:
+    """An hour-start timeline, as Resolve numbers one: 01:00:00:00 at 24 fps is frame 86400."""
+    return FakeTimeline("sunset-set v3", "24", start_frame=86_400, end_frame=87_400)
+
+
+def _project(resolve: FakeResolve) -> FakeProject:
+    project: Any = resolve.GetProjectManager().GetCurrentProject()
+    assert isinstance(project, FakeProject)
+    return project

--- a/tests/test_render_tools.py
+++ b/tests/test_render_tools.py
@@ -74,7 +74,7 @@ def test_a_full_timeline_render_produces_the_file(attach: Attach) -> None:
     assert written.suffix == ".mp4"
     assert record.result["format"] == "mp4"
     assert record.result["codec"] == "H.264"
-    assert record.result["range"] is None
+    assert record.result["whole_timeline"] is True
     assert record.result["size_bytes"] > 0
 
     project = _project(resolve)
@@ -84,6 +84,20 @@ def test_a_full_timeline_render_produces_the_file(attach: Attach) -> None:
     assert project.render_settings["TargetDir"] == str(get_config().render_dir)
     assert project.render_mode == 1
     assert project.render_queue == []
+
+
+def test_a_whole_timeline_render_still_says_what_it_covers(attach: Attach) -> None:
+    """Dual time everywhere: a file that will not say what it holds has to be opened to know."""
+    attach(studio(timeline=_concert()))
+
+    record = wait_for(render_timeline(preset=PRESET)["job"]["job_id"])
+
+    assert record.result is not None
+    covered = record.result["range"]
+    assert covered["start"]["frames"] == 86_400
+    assert covered["end"]["frames"] == 87_400
+    assert covered["duration"]["frames"] == 1_000
+    assert covered["duration"]["timecode"] == "00:00:41:16"
 
 
 def test_the_render_reports_through_get_job_like_any_other_job(attach: Attach) -> None:
@@ -157,6 +171,7 @@ def test_a_range_render_marks_in_and_out_on_the_timelines_own_clock(attach: Atta
     assert project.render_settings["MarkOut"] == 86_599
 
     assert record.result is not None
+    assert record.result["whole_timeline"] is False
     rendered = record.result["range"]
     assert rendered["start"]["frames"] == 86_500
     assert rendered["end"]["frames"] == 86_600
@@ -373,6 +388,33 @@ def test_refresh_is_how_a_file_at_the_target_gets_replaced(
 
     assert record.state == "completed"
     assert (deliverables / "Blue-Monk.mp4").read_bytes() != b"an older take"
+
+
+def test_replacing_a_deliverable_leaves_its_sidecars_alone(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """refresh replaces the file this render writes — not everything sharing its name."""
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+    deliverables = tmp_path / "deliverables"
+    deliverables.mkdir()
+    (deliverables / "Blue-Monk.mp4").write_bytes(b"an older take")
+    sidecar = deliverables / "Blue-Monk.srt"
+    sidecar.write_text("1\n00:00:00,000 --> 00:00:02,000\nthe subtitles\n", encoding="utf-8")
+
+    record = wait_for(
+        render_timeline(
+            preset=PRESET,
+            name="Blue Monk",
+            target_dir=str(deliverables),
+            refresh=True,
+        )["job"]["job_id"]
+    )
+
+    assert record.state == "completed"
+    assert sidecar.exists()
+    assert "the subtitles" in sidecar.read_text(encoding="utf-8")
 
 
 def test_a_cut_that_changed_renders_again_over_the_servers_own_file(attach: Attach) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,7 +17,7 @@ def descriptions() -> dict[str, str]:
     return {tool.name: tool.description or "" for tool in tools}
 
 
-def test_registers_the_p1_session_media_timeline_cut_and_job_tools() -> None:
+def test_registers_the_p1_session_media_timeline_cut_render_and_job_tools() -> None:
     assert tool_names() == {
         "get_status",
         "list_projects",
@@ -38,6 +38,8 @@ def test_registers_the_p1_session_media_timeline_cut_and_job_tools() -> None:
         "get_cut_schema",
         "validate_cut",
         "build_timeline",
+        "list_render_presets",
+        "render_timeline",
         "get_job",
         "list_jobs",
         "run_python",


### PR DESCRIPTION
Closes #33.

Two tools: `list_render_presets` names what the project's Deliver page offers, and `render_timeline` queues a render of a timeline — or a half-open `[start, end)` range of one — as a background job polled through `get_job`. That is a per-song deliverable off one concert timeline, unattended.

## The three decisions

- **A preset is the deliverable's whole shape.** Format and codec alone leave resolution, bit rate and colour at whatever the project was last set to. The server loads a saved preset by name and overrides only `TargetDir`, `CustomName` and the span. That is also why no preset catalog ships with the server; spec #22 deferred it, and it is now #71.
- **The range is stated in the timeline's own frames** — the numbers `inspect_timeline` and `list_markers` report — half-open, with the conversion to Resolve's inclusive `MarkOut` happening once. One bound alone runs to the timeline's edge.
- **A file is replaced only where the server owns the directory.** Resolve does not reliably overwrite; a taken name can come back as `name_0.mp4` beside the old file and the job would report a stale path. So the server's own `renders` directory is cleared before rendering, and a directory the caller named is refused (`render_target_exists`) until `refresh` says otherwise.

Two shared readings moved down into `resolve/timeline.py` — the timeline fingerprint and the current-timeline restore — because both routes that export a whole timeline need them and neither belongs to the audio package.

## Seam

Fake tier (`tests/test_render_tools.py`, 27 tests): preset resolution and both refusals, range math and the bounds/empty-range refusals, dual time on the result, the target-exists guard and the sidecar it must not delete, caching and refresh, timeline restore, and every queue failure shaped as a failed job rather than a raised one. 527 fake-tier tests pass; mypy strict and ruff clean.

Two ACs are **unrun**, and are in `tests/test_live_smoke.py`: whether `GetRenderPresetList` answers at all, and — the dangerous one — whether Resolve reads `MarkIn`/`MarkOut` as absolute timeline frames. The live test renders two ranges, one three times the other, so marks that were ignored show up as two files of the same size.

## Review

`/code-review` (Standards + Spec, parallel sub-agents) since `origin/main`. Findings and what happened to each:

**Standards**

1. *Duplicated Code* — `_scaled` byte-identical in `deliver` and `audio/acquire`, `SINGLE_CLIP` in both. **Fixed**: `jobs.runner.band(progress, floor, ceiling)`; the render mode moved to `resolve/render.py`.
2. *Duplicated Code* — the preset membership test raised from two places. **Fixed**: `render.require_preset` owns the rule; the pre-flight and the loader both call it.
3. *Speculative Generality* — `render.submit(format_, codec)` made a half-supplied pair a silent no-op. **Fixed**: the pair travels as one tuple, the way Resolve takes it.
4. *Feature Envy* — the starter looks the cache key up a moment before `start_job` does. **Held**: it is what stops a cache hit being refused as a taken target; now commented as such.
5. *Mysterious Name* — `_refuse_a_file_already_there`, `shape`, and an import alias working around a shadowing local. **Fixed**: `_refuse_a_taken_target`, `format_and_codec`, and the local is `identity`.
6. *Data clump* — the `params` dict re-parsed in two places. **Held**: it has to be JSON for the job record, as in `acquire`.

**Spec**

1. The deferred preset catalog never surfaced as a ticket, which spec #22 asked for. **Fixed**: #71.
2. A whole-timeline render reported no range, against "every result echoing frames + seconds + timecode + fps". **Fixed**: it reports the timeline's own bounds, with `whole_timeline` saying which case it was.
3. The overwrite-refusal protocol is not in #33 or #22. **Held**: it is the smallest honest answer to a Resolve that renames rather than overwrites, and it never touches a director's file without being told. Called out here as the largest un-speced surface in the diff.
4. `_clear` globbed `<name>.*` and unlinked every match, so a refresh would have destroyed a sidecar. **Fixed**: it deletes exactly the file about to be written, with a test; the refusal stays broad, because refusing is the safe direction.
5. The Deliver page is left on the preset the render used. **Held**: any render does that, and a half-restore would be worse than none — but the tool docstring now says so instead of leaving it to be discovered.

The fix diff was re-checked as a focused pass, not a second full review.

Review: clean — all fixed except four held with reasons above (cache pre-lookup, params dict, the overwrite protocol, and the Deliver-page state).


Post-open merge of origin/main (takes #29 and overlays #30 landed first): trivial import union in timeline.py and tool-list union in test_server.py; no behavioural overlap. Fake tier, mypy, ruff clean.
Review: clean — focused pass on the conflict-resolution diff
