### PR TITLE
P1: Frame grabs + scene-cut detection (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Build contract: [issue #22](https://github.com/danielbaldwin47/resolve-mcp/issue
 
 P1 in progress. Shipped so far: the server skeleton, the session/project tools, the media
 pool tools, the timeline read and interchange tools, the background-job infrastructure
-with audio acquisition, and the `run_python` escape hatch.
+with audio acquisition, frame grabs and scene-cut detection, and the `run_python` escape
+hatch.
 
 | Tool | What it does |
 | --- | --- |
@@ -27,6 +28,8 @@ with audio acquisition, and the `run_python` escape hatch.
 | `inspect_timeline` | One timeline at a chosen detail and range, in dual time |
 | `export_timeline` | Writes a timeline out as OTIO, FCPXML or DRT |
 | `import_timeline` | Materialises a **new** timeline from such a file — never overwrites one |
+| `grab_frames` | Grabs chosen moments on a clip as JPEGs (≤1568px) the agent reads off disk |
+| `detect_scene_cuts` | Job: catalogs where a clip changes shot, gist inline and the full list on disk |
 | `get_job` | Polls one background job: progress, result, or a structured failure |
 | `list_jobs` | Lists jobs newest first — how a restarted session finds what it started |
 | `run_python` | Escape hatch: runs scripting-API Python in the server process |
@@ -52,6 +55,13 @@ timeline is exported through Resolve's render queue (the only route that capture
 timeline *mix*, 48 kHz/24-bit WAV), a single source clip is extracted with ffmpeg unless its
 audio mapping says the audio is linked or offset away from the file.
 
+Seeing the picture takes two routes, both reading the file on disk rather than rendering
+anything. `grab_frames` is not a job — a seek and one frame is faster than a poll would be,
+so it runs inline and hands back JPEG paths at or under the client's 1568px image cap, cached
+against the media all the same. `detect_scene_cuts` decodes the whole clip, so it is a job:
+the catalog of every cut and shot goes to the cache in dual-time JSON and only a gist (how
+many cuts, the shot lengths, the first few times, the path) comes back inline.
+
 ## Requirements
 
 - Windows 11, DaVinci Resolve **Studio** 21.0.3 (external scripting must be enabled:
@@ -62,8 +72,9 @@ audio mapping says the audio is linked or offset away from the file.
   server refuses to attach on one. [uv](https://docs.astral.sh/uv/) still manages the
   venv and the lockfile.
 - Resolve running, with a project open, before the first Resolve-touching tool call
-- **ffmpeg on PATH** for per-clip audio extraction (`RESOLVE_MCP_FFMPEG` points at it
-  elsewhere). Timeline-scope audio goes through Resolve's own render queue and needs none.
+- **ffmpeg on PATH** for per-clip audio extraction, frame grabs and scene-cut detection
+  (`RESOLVE_MCP_FFMPEG` points at it elsewhere). Timeline-scope audio goes through Resolve's
+  own render queue and needs none.
 
 ## Install
 
@@ -95,8 +106,8 @@ Zero-config by default; every path has an environment override.
 | --- | --- | --- |
 | `RESOLVE_SCRIPT_API` | `%PROGRAMDATA%\Blackmagic Design\DaVinci Resolve\Support\Developer\Scripting` | Scripting API root (holds `Modules/DaVinciResolveScript.py`) |
 | `RESOLVE_SCRIPT_LIB` | `C:\Program Files\Blackmagic Design\DaVinci Resolve\fusionscript.dll` | Scripting library |
-| `RESOLVE_MCP_CACHE` | `%LOCALAPPDATA%\resolve-mcp` | Cache root: snapshots, job records, cached results, acquired audio, model weights |
-| `RESOLVE_MCP_FFMPEG` | `ffmpeg` (found on PATH) | ffmpeg executable used for per-clip audio extraction |
+| `RESOLVE_MCP_CACHE` | `%LOCALAPPDATA%\resolve-mcp` | Cache root: snapshots, job records, cached results, acquired audio, grabbed frames, analysis catalogs, model weights |
+| `RESOLVE_MCP_FFMPEG` | `ffmpeg` (found on PATH) | ffmpeg executable used for per-clip audio extraction, frame grabs and scene-cut detection |
 | `RESOLVE_MCP_LOG_LEVEL` | `INFO` | Log level for the stderr logger |
 | `RESOLVE_MCP_ALLOW_ANY_PYTHON` | unset | Bypass the interpreter check (see ADR 0001) |
 

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -31,6 +31,7 @@ from typing import Any
 
 from ..config import Config, get_config
 from ..errors import AudioExportError, AudioExtractionError, AudioMappingError, RenderQueueError
+from ..ffmpeg import Runner
 from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, start_job
 from ..logging_config import get_logger
@@ -230,7 +231,7 @@ def acquire_clip_audio(
     sample_rate: int = DEFAULT_SAMPLE_RATE,
     bit_depth: int = DEFAULT_BIT_DEPTH,
     refresh: bool = False,
-    runner: ffmpeg.Runner | None = None,
+    runner: Runner | None = None,
     config: Config | None = None,
 ) -> dict[str, Any]:
     """Start a job that extracts one source clip's audio. Returns the job record.
@@ -278,7 +279,7 @@ def extract_clip_audio(
     params: dict[str, Any],
     progress: Progress,
     config: Config | None = None,
-    runner: ffmpeg.Runner | None = None,
+    runner: Runner | None = None,
 ) -> JobOutput:
     """The worker: ffmpeg the clip's audio into the cache as a WAV."""
     config = config or get_config()

--- a/src/resolve_mcp/audio/ffmpeg.py
+++ b/src/resolve_mcp/audio/ffmpeg.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from ..config import Config, get_config
 from ..errors import AudioExtractionError, InvalidRequestError
-from ..ffmpeg import STDERR_TAIL, Runner, invoke
+from ..ffmpeg import Runner, invoke, refused
 from ..logging_config import get_logger
 
 log = get_logger("audio")
@@ -80,14 +80,7 @@ def extract(
     finished = invoke(argv, runner=runner, config=config)
 
     if finished.returncode != 0:
-        raise AudioExtractionError(
-            cause=f"ffmpeg refused {Path(source).name} (exit {finished.returncode}).",
-            detail={
-                "source": str(source),
-                "exit_code": finished.returncode,
-                "stderr": finished.stderr[-STDERR_TAIL:],
-            },
-        )
+        raise refused(source, finished, AudioExtractionError)
     if not destination.exists():
         raise AudioExtractionError(
             cause=f"ffmpeg reported success but wrote nothing to {destination}.",

--- a/src/resolve_mcp/audio/ffmpeg.py
+++ b/src/resolve_mcp/audio/ffmpeg.py
@@ -7,35 +7,22 @@ director is doing in the GUI. What it cannot see is anything Resolve does to tha
 route.
 
 The subprocess call is a parameter (``runner``) so that command construction, failure
-shaping and the missing-binary case are all testable without ffmpeg installed — while the
-real thing stays one plain ``subprocess.run``.
+shaping and the missing-binary case are all testable without ffmpeg installed; the seam
+itself lives in ``resolve_mcp.ffmpeg``, shared with the frame-grab and scene-scan routes.
 """
 
 from __future__ import annotations
 
-import subprocess
-from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import NamedTuple
 
 from ..config import Config, get_config
-from ..errors import AudioExtractionError, FfmpegUnavailableError, InvalidRequestError
+from ..errors import AudioExtractionError, InvalidRequestError
+from ..ffmpeg import STDERR_TAIL, Runner, invoke
 from ..logging_config import get_logger
 
 log = get_logger("audio")
 
 CODECS = {16: "pcm_s16le", 24: "pcm_s24le", 32: "pcm_s32le"}
-STDERR_TAIL = 800
-
-
-class Completed(NamedTuple):
-    """What the runner reports back: ffmpeg says why it refused on stderr."""
-
-    returncode: int
-    stderr: str
-
-
-Runner = Callable[[Sequence[str]], Completed]
 
 
 def command(
@@ -77,11 +64,6 @@ def command(
     ]
 
 
-def _run(argv: Sequence[str]) -> Completed:
-    finished = subprocess.run(argv, capture_output=True, text=True, check=False)
-    return Completed(finished.returncode, finished.stderr or "")
-
-
 def extract(
     source: Path | str,
     target: Path | str,
@@ -95,14 +77,7 @@ def extract(
     destination = Path(target)
     destination.parent.mkdir(parents=True, exist_ok=True)
     argv = command(config.ffmpeg, source, destination, sample_rate, bit_depth)
-
-    try:
-        finished = (runner or _run)(argv)
-    except FileNotFoundError as exc:
-        raise FfmpegUnavailableError(
-            cause=f"No ffmpeg at {config.ffmpeg!r}.",
-            detail={"executable": config.ffmpeg},
-        ) from exc
+    finished = invoke(argv, runner=runner, config=config)
 
     if finished.returncode != 0:
         raise AudioExtractionError(

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -79,6 +79,16 @@ class Config:
         return self.cache_dir / "audio"
 
     @property
+    def frame_dir(self) -> Path:
+        """Grabbed JPEGs. The agent opens these by path, so they outlive the call that made them."""
+        return self.cache_dir / "frames"
+
+    @property
+    def analysis_dir(self) -> Path:
+        """Analysis catalogs — scene cuts today — written whole and returned as a gist."""
+        return self.cache_dir / "analysis"
+
+    @property
     def interchange_dir(self) -> Path:
         """Where exported timelines (OTIO, FCPXML, DRT) land when no path is given.
 

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -333,6 +333,26 @@ class AudioMappingError(ResolveMcpError):
     )
 
 
+class FrameGrabError(ResolveMcpError):
+    """ffmpeg would not give up a frame of this clip."""
+
+    code = "frame_grab_failed"
+    default_fix = (
+        "Check the clip is online and holds video — inspect_clip reports both — and that the "
+        "time asked for is inside its bounds. ffmpeg's own message is in detail.stderr."
+    )
+
+
+class SceneDetectionError(ResolveMcpError):
+    """ffmpeg would not decode this clip looking for scene cuts."""
+
+    code = "scene_detection_failed"
+    default_fix = (
+        "Check the clip is online and holds video — inspect_clip reports both. "
+        "ffmpeg's own message is in detail.stderr."
+    )
+
+
 class InternalError(ResolveMcpError):
     code = "internal_error"
     default_fix = (

--- a/src/resolve_mcp/ffmpeg.py
+++ b/src/resolve_mcp/ffmpeg.py
@@ -7,19 +7,21 @@ failure shaping stay testable on a machine with no ffmpeg on it, while the real 
 one plain ``subprocess.run``.
 
 A missing binary is the one failure that means the same thing to every route, so it is
-shaped here. What a non-zero exit means is the caller's to say: ffmpeg refusing to decode a
-file is an extraction failure to the audio route and a grab failure to the video one, and
-the agent needs the fix that belongs to what it asked for.
+shaped here. So is a refusal — ffmpeg's exit code and its own complaint read the same way
+whatever was asked for — but *what* the refusal means is the caller's to name: the same
+unreadable file is an extraction failure to the audio route and a grab failure to the video
+one, and the agent needs the fix that belongs to what it asked for.
 """
 
 from __future__ import annotations
 
 import subprocess
 from collections.abc import Callable, Sequence
-from typing import NamedTuple
+from pathlib import Path
+from typing import Any, NamedTuple
 
 from .config import Config, get_config
-from .errors import FfmpegUnavailableError
+from .errors import FfmpegUnavailableError, ResolveMcpError
 
 STDERR_TAIL = 800
 """How much of ffmpeg's own complaint travels back in a failure — the end, where it says why."""
@@ -54,3 +56,21 @@ def invoke(
             cause=f"No ffmpeg at {config.ffmpeg!r}.",
             detail={"executable": config.ffmpeg},
         ) from exc
+
+
+def refused(
+    source: Path | str,
+    finished: Completed,
+    failure: type[ResolveMcpError],
+    **detail: Any,
+) -> ResolveMcpError:
+    """A non-zero exit as ``failure``, carrying the end of what ffmpeg said about it."""
+    return failure(
+        cause=f"ffmpeg refused {Path(source).name} (exit {finished.returncode}).",
+        detail={
+            "source": str(source),
+            "exit_code": finished.returncode,
+            "stderr": finished.stderr[-STDERR_TAIL:],
+            **detail,
+        },
+    )

--- a/src/resolve_mcp/ffmpeg.py
+++ b/src/resolve_mcp/ffmpeg.py
@@ -1,0 +1,56 @@
+"""The one place this server shells out to ffmpeg.
+
+Audio extraction, frame grabs and scene scans are three different commands with three
+different failures, but they run the same way: an argv list — never a shell string — handed
+to a ``Runner``. The runner is a parameter everywhere so that command construction and
+failure shaping stay testable on a machine with no ffmpeg on it, while the real path stays
+one plain ``subprocess.run``.
+
+A missing binary is the one failure that means the same thing to every route, so it is
+shaped here. What a non-zero exit means is the caller's to say: ffmpeg refusing to decode a
+file is an extraction failure to the audio route and a grab failure to the video one, and
+the agent needs the fix that belongs to what it asked for.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable, Sequence
+from typing import NamedTuple
+
+from .config import Config, get_config
+from .errors import FfmpegUnavailableError
+
+STDERR_TAIL = 800
+"""How much of ffmpeg's own complaint travels back in a failure — the end, where it says why."""
+
+
+class Completed(NamedTuple):
+    """What the runner reports back: ffmpeg says why it refused on stderr."""
+
+    returncode: int
+    stderr: str
+
+
+Runner = Callable[[Sequence[str]], Completed]
+
+
+def run(argv: Sequence[str]) -> Completed:
+    finished = subprocess.run(argv, capture_output=True, text=True, check=False)
+    return Completed(finished.returncode, finished.stderr or "")
+
+
+def invoke(
+    argv: Sequence[str],
+    runner: Runner | None = None,
+    config: Config | None = None,
+) -> Completed:
+    """Run ffmpeg, turning the missing binary into the error that names the fix."""
+    config = config or get_config()
+    try:
+        return (runner or run)(argv)
+    except FileNotFoundError as exc:
+        raise FfmpegUnavailableError(
+            cause=f"No ffmpeg at {config.ffmpeg!r}.",
+            detail={"executable": config.ffmpeg},
+        ) from exc

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from . import __version__
 from .config import get_config
 from .logging_config import configure_logging, get_logger
-from .tools import cut, escape_hatch, jobs, media, project, timeline
+from .tools import cut, escape_hatch, jobs, media, project, timeline, video
 
 log = get_logger("server")
 
@@ -31,6 +31,9 @@ snap it to a frame ({"seconds": 2.52, "snap": "floor"}).
 Editing is declarative: you author a cut file, the server builds it. Call get_cut_schema
 before writing one and validate_cut after every edit — do not guess the format.
 
+When the audio evidence is ambiguous, look: grab_frames writes JPEGs you can read at any
+moment on any angle, and detect_scene_cuts catalogs where a piece of b-roll changes shot.
+
 Heavy work (renders, analysis) hands back a job_id straight away — carry on working and
 poll it with get_job; list_jobs finds what you started before a restart. Results are cached
 against the media and the parameters, so an unchanged rerun comes back instantly.
@@ -49,6 +52,7 @@ def build_server() -> FastMCP:
         *media.TOOLS,
         *timeline.TOOLS,
         *cut.TOOLS,
+        *video.TOOLS,
         *jobs.TOOLS,
         *escape_hatch.TOOLS,
     ):

--- a/src/resolve_mcp/tools/video.py
+++ b/src/resolve_mcp/tools/video.py
@@ -1,0 +1,78 @@
+"""Video tools — seeing the picture when the audio evidence runs out.
+
+Both routes read the file on disk the media pool points at; neither renders anything in
+Resolve, so both run while the director keeps working in the GUI.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..resolve.connection import get_connection
+from ..video import frames, scenes
+from .envelope import tool
+
+
+@tool
+def grab_frames(
+    clip: str,
+    times: list[Any],
+    bin: str | None = None,  # noqa: A002 - the agent-facing word for a media pool folder
+    max_edge: int = frames.DEFAULT_MAX_EDGE,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    """Grab moments on a clip as JPEGs on disk and return their paths — then read them.
+
+    Times are the clip's own frame numbers, dual time as everywhere: times=[14032] or
+    times=[{"seconds": 234.5, "snap": "floor"}]. inspect_clip reports the bounds they have
+    to sit inside. Up to 12 per call; each frame comes back with its time in frames, seconds
+    and timecode alongside the path and the size it was written at.
+
+    Frames land at or under 1568px on the long edge — the size an image arrives whole at —
+    and are cached against the media, so grabbing the same moment twice costs one decode.
+    Use this to check an angle at a moment the audio left ambiguous; to find where the shots
+    change in b-roll, run detect_scene_cuts instead.
+    """
+    connection = get_connection()
+    return frames.grab_frames(
+        connection,
+        clip,
+        times,
+        bin=bin,
+        max_edge=max_edge,
+        refresh=refresh,
+    )
+
+
+@tool
+def detect_scene_cuts(
+    clip: str,
+    bin: str | None = None,  # noqa: A002
+    threshold: float = scenes.DEFAULT_THRESHOLD,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    """Start a job cataloguing every scene cut in a clip — the b-roll question, answered once.
+
+    Returns a job_id to poll with get_job. The finished result is a gist: how many cuts, how
+    many shots, the shot lengths, the first few cut times — and path, the JSON catalog with
+    every cut and every shot in dual time. Read or grep that file for the span you care
+    about rather than asking for it all inline.
+
+    threshold is how different two frames must be to count as a cut (0.05–1.0, default 0.4):
+    lower it for footage that cuts between similar frames, raise it for handheld that pans.
+    The scan decodes the whole clip, so it is cached against the media — an unchanged clip is
+    never scanned twice.
+    """
+    connection = get_connection()
+    return scenes.detect_scene_cuts(
+        connection,
+        clip,
+        bin=bin,
+        threshold=threshold,
+        refresh=refresh,
+    )
+
+
+TOOLS: tuple[Any, ...] = (grab_frames, detect_scene_cuts)
+
+__all__ = ["TOOLS", "detect_scene_cuts", "grab_frames"]

--- a/src/resolve_mcp/tools/video.py
+++ b/src/resolve_mcp/tools/video.py
@@ -47,7 +47,7 @@ def grab_frames(
 @tool
 def detect_scene_cuts(
     clip: str,
-    bin: str | None = None,  # noqa: A002
+    bin: str | None = None,  # noqa: A002 - the agent-facing word for a media pool folder
     threshold: float = scenes.DEFAULT_THRESHOLD,
     refresh: bool = False,
 ) -> dict[str, Any]:

--- a/src/resolve_mcp/video/__init__.py
+++ b/src/resolve_mcp/video/__init__.py
@@ -1,0 +1,7 @@
+"""Seeing the picture: frame grabs at chosen moments, and where the shots change.
+
+Audio evidence carries most editorial decisions in this server, and video understanding in
+v1 is deliberately small (#22, out of scope): grabs the agent looks at with its own eyes,
+and a scene-cut catalog for b-roll. Neither route asks Resolve to render anything — both
+read the file on disk the media pool points at.
+"""

--- a/src/resolve_mcp/video/ffmpeg.py
+++ b/src/resolve_mcp/video/ffmpeg.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from ..config import Config, get_config
 from ..errors import FrameGrabError, SceneDetectionError
-from ..ffmpeg import STDERR_TAIL, Runner, invoke
+from ..ffmpeg import Runner, invoke, refused
 from ..logging_config import get_logger
 
 log = get_logger("video")
@@ -99,15 +99,7 @@ def grab(
     finished = invoke(argv, runner=runner, config=config)
 
     if finished.returncode != 0:
-        raise FrameGrabError(
-            cause=f"ffmpeg refused {Path(source).name} (exit {finished.returncode}).",
-            detail={
-                "source": str(source),
-                "seconds": seconds,
-                "exit_code": finished.returncode,
-                "stderr": finished.stderr[-STDERR_TAIL:],
-            },
-        )
+        raise refused(source, finished, FrameGrabError, seconds=seconds)
     if not destination.exists():
         raise FrameGrabError(
             cause=f"ffmpeg reported success but wrote nothing to {destination}.",
@@ -133,14 +125,7 @@ def scan(
     finished = invoke(argv, runner=runner, config=config)
 
     if finished.returncode != 0:
-        raise SceneDetectionError(
-            cause=f"ffmpeg refused {Path(source).name} (exit {finished.returncode}).",
-            detail={
-                "source": str(source),
-                "exit_code": finished.returncode,
-                "stderr": finished.stderr[-STDERR_TAIL:],
-            },
-        )
+        raise refused(source, finished, SceneDetectionError, threshold=threshold)
     log.info("Scanned %s for scene cuts at threshold %.2f", source, threshold)
     return finished.stderr
 
@@ -159,10 +144,8 @@ def selected_seconds(log_text: str) -> list[float]:
 
 
 def _leading_number(text: str) -> float | None:
-    digits = text.split()[0] if text.split() else ""
+    fields = text.split()
     try:
-        return float(digits)
+        return float(fields[0]) if fields else None
     except ValueError:
         return None
-
-

--- a/src/resolve_mcp/video/ffmpeg.py
+++ b/src/resolve_mcp/video/ffmpeg.py
@@ -1,0 +1,168 @@
+"""The two ffmpeg commands the video routes run, and what their refusals mean.
+
+Both are argv lists, never shell strings, and both take the same ``runner`` seam the audio
+route takes — the filter expressions below are the part worth testing, and they are testable
+without a decoder. Commas inside a filter expression are escaped, because an unescaped one
+ends the filter and starts the next: ``min(iw,1568)`` would be read as a filter named
+``1568)``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..config import Config, get_config
+from ..errors import FrameGrabError, SceneDetectionError
+from ..ffmpeg import STDERR_TAIL, Runner, invoke
+from ..logging_config import get_logger
+
+log = get_logger("video")
+
+JPEG_QUALITY = "3"
+"""ffmpeg's ``-q:v`` scale, 2 (best) to 31. Three is visually clean at a fraction of 2's size."""
+
+
+def still_command(
+    executable: str,
+    source: Path | str,
+    target: Path | str,
+    seconds: float,
+    max_edge: int,
+) -> list[str]:
+    """Seek, take one frame, scale it to fit inside ``max_edge``, write a JPEG.
+
+    ``-ss`` before ``-i`` seeks the input rather than decoding up to the moment, which is
+    the difference between a grab that is instant on a concert master and one that is not;
+    ffmpeg has decoded to the exact frame from an input seek since 2.1, so it costs nothing
+    in accuracy. ``force_original_aspect_ratio=decrease`` is what keeps a source already
+    inside the cap at its own size instead of blowing it up.
+    """
+    fit = f"min(iw\\,{max_edge})"
+    tall = f"min(ih\\,{max_edge})"
+    return [
+        executable,
+        "-nostdin",
+        "-loglevel",
+        "error",
+        "-y",
+        "-ss",
+        f"{seconds:.6f}",
+        "-i",
+        str(source),
+        "-frames:v",
+        "1",
+        "-vf",
+        f"scale=w={fit}:h={tall}:force_original_aspect_ratio=decrease",
+        "-q:v",
+        JPEG_QUALITY,
+        str(target),
+    ]
+
+
+def scene_command(executable: str, source: Path | str, threshold: float) -> list[str]:
+    """Decode the whole file, keep the frames that differ from the last one, print their times.
+
+    ``showinfo`` writes one line per kept frame to stderr, which is why the log level goes
+    up to info for this command alone. Nothing is encoded — the output is the null muxer, so
+    what this costs is one decode pass.
+    """
+    return [
+        executable,
+        "-nostdin",
+        "-loglevel",
+        "info",
+        "-y",
+        "-i",
+        str(source),
+        "-filter:v",
+        f"select=gt(scene\\,{threshold}),showinfo",
+        "-an",
+        "-f",
+        "null",
+        "-",
+    ]
+
+
+def grab(
+    source: Path | str,
+    target: Path | str,
+    seconds: float,
+    max_edge: int,
+    runner: Runner | None = None,
+    config: Config | None = None,
+) -> Path:
+    """Write one frame of ``source`` to ``target`` as a JPEG, or fail with ffmpeg's message."""
+    config = config or get_config()
+    destination = Path(target)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    argv = still_command(config.ffmpeg, source, destination, seconds, max_edge)
+    finished = invoke(argv, runner=runner, config=config)
+
+    if finished.returncode != 0:
+        raise FrameGrabError(
+            cause=f"ffmpeg refused {Path(source).name} (exit {finished.returncode}).",
+            detail={
+                "source": str(source),
+                "seconds": seconds,
+                "exit_code": finished.returncode,
+                "stderr": finished.stderr[-STDERR_TAIL:],
+            },
+        )
+    if not destination.exists():
+        raise FrameGrabError(
+            cause=f"ffmpeg reported success but wrote nothing to {destination}.",
+            fix=(
+                "A seek past the end of the file exits zero and writes no frame. "
+                "inspect_clip reports the media bounds this grab has to sit inside."
+            ),
+            detail={"source": str(source), "seconds": seconds, "expected": str(destination)},
+        )
+    log.info("Grabbed a frame of %s at %.3fs to %s", source, seconds, destination)
+    return destination
+
+
+def scan(
+    source: Path | str,
+    threshold: float,
+    runner: Runner | None = None,
+    config: Config | None = None,
+) -> str:
+    """Run the scene filter over ``source`` and hand back the log it printed."""
+    config = config or get_config()
+    argv = scene_command(config.ffmpeg, source, threshold)
+    finished = invoke(argv, runner=runner, config=config)
+
+    if finished.returncode != 0:
+        raise SceneDetectionError(
+            cause=f"ffmpeg refused {Path(source).name} (exit {finished.returncode}).",
+            detail={
+                "source": str(source),
+                "exit_code": finished.returncode,
+                "stderr": finished.stderr[-STDERR_TAIL:],
+            },
+        )
+    log.info("Scanned %s for scene cuts at threshold %.2f", source, threshold)
+    return finished.stderr
+
+
+def selected_seconds(log_text: str) -> list[float]:
+    """The ``pts_time`` of every frame ``showinfo`` reported, in the order it reported them."""
+    times: list[float] = []
+    for line in log_text.splitlines():
+        marker = line.find("pts_time:")
+        if marker < 0:
+            continue
+        reading = _leading_number(line[marker + len("pts_time:") :])
+        if reading is not None:
+            times.append(reading)
+    return times
+
+
+def _leading_number(text: str) -> float | None:
+    digits = text.split()[0] if text.split() else ""
+    try:
+        return float(digits)
+    except ValueError:
+        return None
+
+

--- a/src/resolve_mcp/video/frames.py
+++ b/src/resolve_mcp/video/frames.py
@@ -5,8 +5,9 @@ enough that a job record and a poll would cost more than the work — and the wh
 it is that the agent gets a path it can open *now*, while it is reasoning about the moment
 that made it ask. So the route runs inline and returns the files.
 
-It is cached all the same, by the same key every job uses: the same moment on unchanged
-media is the same JPEG, and a session that grabs a frame twice should pay once.
+It is cached all the same, by the same key every job uses, and cached **per frame** rather
+than per call: a session narrows in on a moment, so the second call is usually the first
+call's times plus one more, and a batch key would decode everything again to add it.
 
 The grabs land on disk rather than coming back inline as bytes. The agent reads the path,
 which costs one image in its context instead of one per poll of a job record — and a grab
@@ -16,7 +17,7 @@ rather than downscaled on the way in.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, NamedTuple
 
 from ..config import Config, get_config
 from ..errors import FrameGrabError, InvalidRequestError
@@ -37,9 +38,18 @@ DEFAULT_MAX_EDGE = 1568
 """The client's image cap: a longer edge is downscaled on arrival, so it buys nothing."""
 
 MIN_MAX_EDGE = 64
+"""Below this a frame is a thumbnail — too small to answer the question that asked for it."""
+
 MAX_TIMES = 12
 """Frames per call. Each one is an image in the agent's context; a request for more than a
 dozen is a scene-cut scan or a render, not a grab."""
+
+
+class _Grab(NamedTuple):
+    """One frame and whether it was already in the cache."""
+
+    frame: dict[str, Any]
+    cached: bool
 
 
 def grab_frames(
@@ -64,40 +74,43 @@ def grab_frames(
     config = config or get_config()
     source = locate(connection, clip, bin, FrameGrabError)
     edge = _readable_edge(max_edge)
-    frames = _requested_frames(times, source, clip)
+    frames = _requested_frames(times, source)
 
-    params = {"clip": clip, "bin": source.bin_path, "frames": frames, "max_edge": edge}
-    key = cache.cache_key(KIND, [cache.fingerprint(source.path)], params)
+    fingerprint = cache.fingerprint(source.path)
+    grabs = [
+        _one_frame(source, frame, edge, fingerprint, refresh, runner, config) for frame in frames
+    ]
 
-    if not refresh:
-        hit = cache.lookup(key, config)
-        if hit is not None:
-            log.info("Answered %d frame grab(s) on %s from cache", len(frames), clip)
-            return {**hit, "cached": True}
-
-    grabbed = [_one_frame(source, clip, frame, edge, key, runner, config) for frame in frames]
-    result = {
-        "clip": clip,
+    hits = sum(1 for one in grabs if one.cached)
+    log.info("Returned %d frame(s) of %s, %d of them from cache", len(grabs), clip, hits)
+    return {
+        "clip": source.name,
         "bin": source.bin_path,
         "source": source.path,
         "max_edge": edge,
-        "frames": grabbed,
+        "frames": [one.frame for one in grabs],
+        "cached": hits == len(grabs),
     }
-    cache.remember(key, KIND, result, [one["path"] for one in grabbed], config)
-    return {**result, "cached": False}
 
 
 def _one_frame(
     source: Source,
-    clip: str,
     frame: int,
     max_edge: int,
-    key: str,
+    fingerprint: dict[str, Any],
+    refresh: bool,
     runner: Runner | None,
     config: Config,
-) -> dict[str, Any]:
+) -> _Grab:
     """One grab, described by what was actually written rather than by what was asked for."""
-    target = config.frame_dir / f"{slug(clip, 'frame')}-{key[:12]}-{frame:08d}.jpg"
+    params = {"clip": source.name, "bin": source.bin_path, "frame": frame, "max_edge": max_edge}
+    key = cache.cache_key(KIND, [fingerprint], params)
+    if not refresh:
+        hit = cache.lookup(key, config)
+        if hit is not None:
+            return _Grab(hit, True)
+
+    target = config.frame_dir / f"{slug(source.name, 'frame')}-{key[:12]}.jpg"
     ffmpeg.grab(
         source.path,
         target,
@@ -106,7 +119,9 @@ def _one_frame(
         runner=runner,
         config=config,
     )
-    return {"time": dual_time(frame, source.fps), **jpeg.describe(target)}
+    grabbed = {"time": dual_time(frame, source.fps), **jpeg.describe(target)}
+    cache.remember(key, KIND, grabbed, (target,), config)
+    return _Grab(grabbed, False)
 
 
 def _readable_edge(max_edge: int) -> int:
@@ -123,7 +138,7 @@ def _readable_edge(max_edge: int) -> int:
     return int(max_edge)
 
 
-def _requested_frames(times: list[Any], source: Source, clip: str) -> list[int]:
+def _requested_frames(times: list[Any], source: Source) -> list[int]:
     """The asked-for moments as this clip's frame numbers: whole, in range, each one once."""
     if not times:
         raise InvalidRequestError(
@@ -132,7 +147,7 @@ def _requested_frames(times: list[Any], source: Source, clip: str) -> list[int]:
                 "Pass at least one time: times=[1024] or "
                 'times=[{"seconds": 17.5, "snap": "floor"}].'
             ),
-            detail={"clip": clip},
+            detail={"clip": source.name},
         )
     if len(times) > MAX_TIMES:
         raise InvalidRequestError(
@@ -141,39 +156,31 @@ def _requested_frames(times: list[Any], source: Source, clip: str) -> list[int]:
                 f"Ask for at most {MAX_TIMES} at a time — each grab is an image you have to "
                 "read. To find where the shots change instead, run detect_scene_cuts."
             ),
-            detail={"clip": clip, "requested": len(times), "maximum": MAX_TIMES},
+            detail={"clip": source.name, "requested": len(times), "maximum": MAX_TIMES},
         )
     if not source.fps:
         raise InvalidRequestError(
-            cause=f"Resolve reports no frame rate for {clip!r}, so a time cannot be seeked to.",
+            cause=(
+                f"Resolve reports no frame rate for {source.name!r}, "
+                "so a time cannot be seeked to."
+            ),
             fix="inspect_clip shows what Resolve knows about the clip; a still has no timeline.",
-            detail={"clip": clip, "file_path": source.path},
+            detail={"clip": source.name, "file_path": source.path},
         )
 
     frames: list[int] = []
     for index, value in enumerate(times):
-        frame = to_frames(value, source.fps, field=f"times[{index}]")
+        field = f"times[{index}]"
+        frame = to_frames(value, source.fps, field=field)
         if frame is None:
-            continue
-        _within_media(frame, source, clip)
+            # Dropping it would return fewer frames than were asked for without saying so.
+            raise InvalidRequestError(
+                cause=f"{field} is empty, so there is no moment to grab.",
+                fix="Every entry in times has to name a moment; remove the empty one.",
+                detail={"clip": source.name, "field": field},
+            )
+        if not source.holds(frame):
+            raise source.outside(frame)
         if frame not in frames:
             frames.append(frame)
     return frames
-
-
-def _within_media(frame: int, source: Source, clip: str) -> None:
-    """A seek past the end exits zero and writes nothing, so the range is checked up front."""
-    out = source.out
-    if frame < source.start or (out is not None and frame >= out):
-        raise InvalidRequestError(
-            cause=f"Frame {frame} is outside the media {clip!r} holds.",
-            fix="inspect_clip reports the clip's own bounds; grabs sit inside them, half-open.",
-            detail={
-                "clip": clip,
-                "requested": dual_time(frame, source.fps),
-                "bounds": {
-                    "in": dual_time(source.start, source.fps),
-                    "out": dual_time(out, source.fps),
-                },
-            },
-        )

--- a/src/resolve_mcp/video/frames.py
+++ b/src/resolve_mcp/video/frames.py
@@ -1,0 +1,179 @@
+"""Frame grabs: the moments the agent looks at with its own eyes.
+
+This is the one compute route that is not a job. A grab is a seek and a single frame — fast
+enough that a job record and a poll would cost more than the work — and the whole point of
+it is that the agent gets a path it can open *now*, while it is reasoning about the moment
+that made it ask. So the route runs inline and returns the files.
+
+It is cached all the same, by the same key every job uses: the same moment on unchanged
+media is the same JPEG, and a session that grabs a frame twice should pay once.
+
+The grabs land on disk rather than coming back inline as bytes. The agent reads the path,
+which costs one image in its context instead of one per poll of a job record — and a grab
+sized to the client's image cap (1568px on the long edge) is a frame that arrives whole
+rather than downscaled on the way in.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..config import Config, get_config
+from ..errors import FrameGrabError, InvalidRequestError
+from ..ffmpeg import Runner
+from ..jobs import cache
+from ..logging_config import get_logger
+from ..naming import slug
+from ..resolve.connection import ResolveConnection
+from ..timing import dual_time, to_frames
+from . import ffmpeg, jpeg
+from .source import Source, locate
+
+log = get_logger("video")
+
+KIND = "grab_frames"
+
+DEFAULT_MAX_EDGE = 1568
+"""The client's image cap: a longer edge is downscaled on arrival, so it buys nothing."""
+
+MIN_MAX_EDGE = 64
+MAX_TIMES = 12
+"""Frames per call. Each one is an image in the agent's context; a request for more than a
+dozen is a scene-cut scan or a render, not a grab."""
+
+
+def grab_frames(
+    connection: ResolveConnection,
+    clip: str,
+    times: list[Any],
+    bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
+    max_edge: int = DEFAULT_MAX_EDGE,
+    refresh: bool = False,
+    runner: Runner | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Grab ``times`` on ``clip`` as JPEGs and return where they landed.
+
+    Times are dual time, the same as everywhere else: frames, or seconds with a snap. They
+    are the clip's own frame numbers — the ones ``inspect_clip`` reports — and a moment
+    outside the clip's media is refused here rather than by ffmpeg, which would exit zero
+    and write nothing.
+
+    ``runner`` is the subprocess seam: the default shells out for real.
+    """
+    config = config or get_config()
+    source = locate(connection, clip, bin, FrameGrabError)
+    edge = _readable_edge(max_edge)
+    frames = _requested_frames(times, source, clip)
+
+    params = {"clip": clip, "bin": source.bin_path, "frames": frames, "max_edge": edge}
+    key = cache.cache_key(KIND, [cache.fingerprint(source.path)], params)
+
+    if not refresh:
+        hit = cache.lookup(key, config)
+        if hit is not None:
+            log.info("Answered %d frame grab(s) on %s from cache", len(frames), clip)
+            return {**hit, "cached": True}
+
+    grabbed = [_one_frame(source, clip, frame, edge, key, runner, config) for frame in frames]
+    result = {
+        "clip": clip,
+        "bin": source.bin_path,
+        "source": source.path,
+        "max_edge": edge,
+        "frames": grabbed,
+    }
+    cache.remember(key, KIND, result, [one["path"] for one in grabbed], config)
+    return {**result, "cached": False}
+
+
+def _one_frame(
+    source: Source,
+    clip: str,
+    frame: int,
+    max_edge: int,
+    key: str,
+    runner: Runner | None,
+    config: Config,
+) -> dict[str, Any]:
+    """One grab, described by what was actually written rather than by what was asked for."""
+    target = config.frame_dir / f"{slug(clip, 'frame')}-{key[:12]}-{frame:08d}.jpg"
+    ffmpeg.grab(
+        source.path,
+        target,
+        seconds=source.seek_seconds(frame),
+        max_edge=max_edge,
+        runner=runner,
+        config=config,
+    )
+    return {"time": dual_time(frame, source.fps), **jpeg.describe(target)}
+
+
+def _readable_edge(max_edge: int) -> int:
+    if not MIN_MAX_EDGE <= max_edge <= DEFAULT_MAX_EDGE:
+        raise InvalidRequestError(
+            cause=f"max_edge={max_edge} is outside the range this server grabs at.",
+            fix=(
+                f"Ask for between {MIN_MAX_EDGE} and {DEFAULT_MAX_EDGE} pixels. "
+                f"{DEFAULT_MAX_EDGE} is the client's own image cap — anything larger is "
+                "downscaled on arrival, so it costs decode time and buys no detail."
+            ),
+            detail={"requested": max_edge, "maximum": DEFAULT_MAX_EDGE},
+        )
+    return int(max_edge)
+
+
+def _requested_frames(times: list[Any], source: Source, clip: str) -> list[int]:
+    """The asked-for moments as this clip's frame numbers: whole, in range, each one once."""
+    if not times:
+        raise InvalidRequestError(
+            cause="No time was given to grab.",
+            fix=(
+                "Pass at least one time: times=[1024] or "
+                'times=[{"seconds": 17.5, "snap": "floor"}].'
+            ),
+            detail={"clip": clip},
+        )
+    if len(times) > MAX_TIMES:
+        raise InvalidRequestError(
+            cause=f"{len(times)} frames were asked for in one call.",
+            fix=(
+                f"Ask for at most {MAX_TIMES} at a time — each grab is an image you have to "
+                "read. To find where the shots change instead, run detect_scene_cuts."
+            ),
+            detail={"clip": clip, "requested": len(times), "maximum": MAX_TIMES},
+        )
+    if not source.fps:
+        raise InvalidRequestError(
+            cause=f"Resolve reports no frame rate for {clip!r}, so a time cannot be seeked to.",
+            fix="inspect_clip shows what Resolve knows about the clip; a still has no timeline.",
+            detail={"clip": clip, "file_path": source.path},
+        )
+
+    frames: list[int] = []
+    for index, value in enumerate(times):
+        frame = to_frames(value, source.fps, field=f"times[{index}]")
+        if frame is None:
+            continue
+        _within_media(frame, source, clip)
+        if frame not in frames:
+            frames.append(frame)
+    return frames
+
+
+def _within_media(frame: int, source: Source, clip: str) -> None:
+    """A seek past the end exits zero and writes nothing, so the range is checked up front."""
+    out = source.out
+    if frame < source.start or (out is not None and frame >= out):
+        raise InvalidRequestError(
+            cause=f"Frame {frame} is outside the media {clip!r} holds.",
+            fix="inspect_clip reports the clip's own bounds; grabs sit inside them, half-open.",
+            detail={
+                "clip": clip,
+                "requested": dual_time(frame, source.fps),
+                "bounds": {
+                    "in": dual_time(source.start, source.fps),
+                    "out": dual_time(out, source.fps),
+                },
+            },
+        )

--- a/src/resolve_mcp/video/jpeg.py
+++ b/src/resolve_mcp/video/jpeg.py
@@ -1,0 +1,70 @@
+"""What the agent will actually see, read back off the file ffmpeg wrote.
+
+The dimensions are the point: a grab is only useful if it is inside the client's image cap,
+and the only honest way to report that is to read the header rather than to repeat what was
+asked for — a source smaller than the cap comes back at its own size, and a scale filter
+that silently did nothing else would go unnoticed.
+
+Only the frame header is parsed, with the standard library: a decoder would pull a large
+dependency in to answer a question two integers in the SOF segment already answer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..errors import FrameGrabError
+
+SOI = b"\xff\xd8"
+STANDALONE = frozenset({0x01, *range(0xD0, 0xD9)})
+"""Markers that carry no length field: the restart markers, SOI, and TEM."""
+
+SOF_MARKERS = frozenset(set(range(0xC0, 0xD0)) - {0xC4, 0xC8, 0xCC})
+"""Every start-of-frame flavour — baseline, progressive, lossless — but not DHT/JPG/DAC."""
+
+
+def describe(path: Path | str) -> dict[str, Any]:
+    """``path``, ``width``, ``height`` and ``bytes`` for a JPEG on disk."""
+    resolved = Path(path)
+    data = resolved.read_bytes()
+    width, height = _dimensions(data, resolved)
+    return {
+        "path": str(resolved),
+        "width": width,
+        "height": height,
+        "bytes": len(data),
+    }
+
+
+def _dimensions(data: bytes, path: Path) -> tuple[int, int]:
+    if not data.startswith(SOI):
+        raise _unreadable(path, "it does not start with a JPEG marker")
+
+    at = 2
+    while at + 3 < len(data):
+        if data[at] != 0xFF:
+            raise _unreadable(path, f"a segment at byte {at} does not begin with a marker")
+        marker = data[at + 1]
+        if marker == 0xFF:  # fill bytes are legal padding before the real marker
+            at += 1
+            continue
+        if marker in STANDALONE:
+            at += 2
+            continue
+        length = int.from_bytes(data[at + 2 : at + 4], "big")
+        if marker in SOF_MARKERS:
+            height = int.from_bytes(data[at + 5 : at + 7], "big")
+            width = int.from_bytes(data[at + 7 : at + 9], "big")
+            return width, height
+        at += 2 + length
+
+    raise _unreadable(path, "it carries no start-of-frame segment")
+
+
+def _unreadable(path: Path, why: str) -> FrameGrabError:
+    return FrameGrabError(
+        cause=f"{path.name} is not a JPEG this server can read: {why}.",
+        fix="Grab the frame again with refresh=true; the file in the cache is not a frame.",
+        detail={"path": str(path)},
+    )

--- a/src/resolve_mcp/video/scenes.py
+++ b/src/resolve_mcp/video/scenes.py
@@ -40,6 +40,8 @@ DEFAULT_THRESHOLD = 0.4
 one; lower it for footage that cuts between similar frames, raise it for handheld."""
 
 MIN_THRESHOLD = 0.05
+"""Below this every compressed frame differs from the last one and every frame is a cut."""
+
 INLINE_CUTS = 12
 """How many cuts the gist carries. Enough to see the shape of the clip; the file has the rest."""
 
@@ -65,14 +67,13 @@ def detect_scene_cuts(
     key = cache.cache_key(KIND, [cache.fingerprint(source.path)], params)
 
     def work(progress: Progress) -> JobOutput:
-        return scan_scene_cuts(source, clip, key, params, progress, config, runner)
+        return scan_scene_cuts(source, key, params, progress, config, runner)
 
     return start_job(KIND, params, work, cache_key=key, refresh=refresh, config=config)
 
 
 def scan_scene_cuts(
     source: Source,
-    clip: str,
     key: str,
     params: dict[str, Any],
     progress: Progress,
@@ -89,21 +90,24 @@ def scan_scene_cuts(
     progress(0.9, "cataloguing the cuts")
     cuts = _cut_frames(printed, source)
     shots = _shots(cuts, source)
-    target = config.analysis_dir / f"{slug(clip, 'scenes')}-{key[:12]}.scenes.json"
+    target = config.analysis_dir / f"{slug(source.name, 'scenes')}-{key[:12]}.scenes.json"
     catalog = {
-        "clip": clip,
+        "clip": source.name,
         "bin": source.bin_path,
         "source": source.path,
         "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
         "threshold": threshold,
         "fps": source.fps,
+        # The bounds the shots below are cut against. An out of null is why the last shot is
+        # missing: Resolve reported no End for this clip, so where the tail stops is unknown.
+        "bounds": source.bounds,
         "cuts": [dual_time(frame, source.fps) for frame in cuts],
         "shots": shots,
     }
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(json.dumps(catalog, indent=2), encoding="utf-8")
 
-    log.info("Catalogued %d scene cut(s) in %s to %s", len(cuts), clip, target)
+    log.info("Catalogued %d scene cut(s) in %s to %s", len(cuts), source.name, target)
     return JobOutput(_gist(catalog, target, shots), (target,))
 
 
@@ -138,7 +142,7 @@ def _cut_frames(printed: str, source: Source) -> list[int]:
     frames: list[int] = []
     for seconds in ffmpeg.selected_seconds(printed):
         frame = source.start + frames_from_seconds(seconds, source.fps, IN_POINT)
-        if frame <= source.start or (source.out is not None and frame >= source.out):
+        if frame == source.start or not source.holds(frame):
             continue  # the first frame of the file is not a cut, and neither is one past its end
         if not frames or frame != frames[-1]:
             frames.append(frame)
@@ -146,10 +150,16 @@ def _cut_frames(printed: str, source: Source) -> list[int]:
 
 
 def _shots(cuts: list[int], source: Source) -> list[dict[str, Any]]:
-    """The spans between the cuts, head and tail included — what a cut list is actually for."""
-    if source.out is None or not source.fps:
+    """The spans between the cuts, head and tail included — what a cut list is actually for.
+
+    A clip Resolve reports no ``End`` for still has every shot but the last one: the tail
+    runs to an out point nothing knows, so it is left out rather than guessed at, and what
+    is left is a real catalog instead of an empty one.
+    """
+    if not source.fps:
         return []
-    boundaries = [source.start, *cuts, source.out]
+    tail = [source.out] if source.out is not None else []
+    boundaries = [source.start, *cuts, *tail]
     return [
         {
             "in": dual_time(start, source.fps),

--- a/src/resolve_mcp/video/scenes.py
+++ b/src/resolve_mcp/video/scenes.py
@@ -1,0 +1,180 @@
+"""Scene-cut detection: a catalog of where the picture changes on a piece of b-roll.
+
+Unlike a grab, this decodes the whole file, so it is a job — a job the agent starts and
+polls while it keeps working, and one whose answer is worth caching for as long as the media
+is unchanged.
+
+The catalog goes to disk and only a gist comes back inline, the shape #22 fixes for every
+analysis job: a minute of fast-cut b-roll has hundreds of cuts, and the agent needs the
+count and the shot lengths to decide whether to look at all — then it greps the file for the
+span it cares about. Everything on disk is dual time, so nothing downstream re-derives a
+frame number from a float.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from ..config import Config, get_config
+from ..errors import InvalidRequestError, SceneDetectionError
+from ..ffmpeg import Runner
+from ..jobs import cache
+from ..jobs.runner import JobOutput, Progress, start_job
+from ..logging_config import get_logger
+from ..naming import slug
+from ..resolve.connection import ResolveConnection
+from ..timing import IN_POINT, SECONDS_PRECISION, dual_time, frames_from_seconds
+from . import ffmpeg
+from .source import Source, locate
+
+log = get_logger("video")
+
+KIND = "detect_scene_cuts"
+
+DEFAULT_THRESHOLD = 0.4
+"""ffmpeg's scene score, 0 to 1. Around 0.4 catches a shot change without calling a fast pan
+one; lower it for footage that cuts between similar frames, raise it for handheld."""
+
+MIN_THRESHOLD = 0.05
+INLINE_CUTS = 12
+"""How many cuts the gist carries. Enough to see the shape of the clip; the file has the rest."""
+
+
+def detect_scene_cuts(
+    connection: ResolveConnection,
+    clip: str,
+    bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
+    threshold: float = DEFAULT_THRESHOLD,
+    refresh: bool = False,
+    runner: Runner | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Start a job that catalogs every scene cut in a clip. Returns the job record.
+
+    ``runner`` is the subprocess seam: the default shells out for real.
+    """
+    config = config or get_config()
+    source = locate(connection, clip, bin, SceneDetectionError)
+    sensitivity = _readable_threshold(threshold)
+
+    params = {"clip": clip, "bin": source.bin_path, "threshold": sensitivity}
+    key = cache.cache_key(KIND, [cache.fingerprint(source.path)], params)
+
+    def work(progress: Progress) -> JobOutput:
+        return scan_scene_cuts(source, clip, key, params, progress, config, runner)
+
+    return start_job(KIND, params, work, cache_key=key, refresh=refresh, config=config)
+
+
+def scan_scene_cuts(
+    source: Source,
+    clip: str,
+    key: str,
+    params: dict[str, Any],
+    progress: Progress,
+    config: Config | None = None,
+    runner: Runner | None = None,
+) -> JobOutput:
+    """The worker: one decode pass, then the catalog on disk and the gist for the agent."""
+    config = config or get_config()
+    threshold = float(params["threshold"])
+
+    progress(0.1, "decoding the clip to find scene cuts")
+    printed = ffmpeg.scan(source.path, threshold, runner=runner, config=config)
+
+    progress(0.9, "cataloguing the cuts")
+    cuts = _cut_frames(printed, source)
+    shots = _shots(cuts, source)
+    target = config.analysis_dir / f"{slug(clip, 'scenes')}-{key[:12]}.scenes.json"
+    catalog = {
+        "clip": clip,
+        "bin": source.bin_path,
+        "source": source.path,
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "threshold": threshold,
+        "fps": source.fps,
+        "cuts": [dual_time(frame, source.fps) for frame in cuts],
+        "shots": shots,
+    }
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(catalog, indent=2), encoding="utf-8")
+
+    log.info("Catalogued %d scene cut(s) in %s to %s", len(cuts), clip, target)
+    return JobOutput(_gist(catalog, target, shots), (target,))
+
+
+def _gist(catalog: dict[str, Any], target: Path, shots: list[dict[str, Any]]) -> dict[str, Any]:
+    """What comes back inline: enough to decide whether the file is worth reading."""
+    lengths = [float(one["duration_seconds"]) for one in shots]
+    return {
+        "path": str(target),
+        "clip": catalog["clip"],
+        "threshold": catalog["threshold"],
+        "cuts": len(catalog["cuts"]),
+        "shots": len(shots),
+        "first_cuts": catalog["cuts"][:INLINE_CUTS],
+        "shot_seconds": {
+            "mean": _rounded(statistics.fmean(lengths)) if lengths else None,
+            "median": _rounded(statistics.median(lengths)) if lengths else None,
+            "min": _rounded(min(lengths)) if lengths else None,
+            "max": _rounded(max(lengths)) if lengths else None,
+        },
+    }
+
+
+def _cut_frames(printed: str, source: Source) -> list[int]:
+    """Every reported cut as one of this clip's own frame numbers, in order, deduplicated.
+
+    ``pts_time`` counts from the start of the file; the clip counts from its own ``Start``,
+    so the offset goes back on. A cut lands on the first frame of the new shot — the moment
+    the picture has changed — which is a floor, the same snap an in point takes.
+    """
+    if not source.fps:
+        return []
+    frames: list[int] = []
+    for seconds in ffmpeg.selected_seconds(printed):
+        frame = source.start + frames_from_seconds(seconds, source.fps, IN_POINT)
+        if frame <= source.start or (source.out is not None and frame >= source.out):
+            continue  # the first frame of the file is not a cut, and neither is one past its end
+        if not frames or frame != frames[-1]:
+            frames.append(frame)
+    return frames
+
+
+def _shots(cuts: list[int], source: Source) -> list[dict[str, Any]]:
+    """The spans between the cuts, head and tail included — what a cut list is actually for."""
+    if source.out is None or not source.fps:
+        return []
+    boundaries = [source.start, *cuts, source.out]
+    return [
+        {
+            "in": dual_time(start, source.fps),
+            "out": dual_time(end, source.fps),
+            "duration_frames": end - start,
+            "duration_seconds": _rounded((end - start) / source.fps),
+        }
+        for start, end in zip(boundaries, boundaries[1:], strict=False)
+        if end > start
+    ]
+
+
+def _rounded(seconds: float) -> float:
+    return round(seconds, SECONDS_PRECISION)
+
+
+def _readable_threshold(threshold: float) -> float:
+    if not MIN_THRESHOLD <= threshold <= 1.0:
+        raise InvalidRequestError(
+            cause=f"threshold={threshold} is not a scene score.",
+            fix=(
+                f"Pass a threshold between {MIN_THRESHOLD} and 1.0 — it is how different two "
+                f"frames have to be to count as a cut. {DEFAULT_THRESHOLD} is the default; "
+                "lower finds more, higher finds only hard changes."
+            ),
+            detail={"requested": threshold, "minimum": MIN_THRESHOLD, "maximum": 1.0},
+        )
+    return float(threshold)

--- a/src/resolve_mcp/video/source.py
+++ b/src/resolve_mcp/video/source.py
@@ -1,0 +1,75 @@
+"""From a clip name to the file ffmpeg will open, and the numbers that file is read in.
+
+Both video routes start the same way and fail the same way when the media has moved — and
+both need the clip's own frame numbering, which is not the file's. Resolve numbers a clip
+from its ``Start`` (an hour in, for footage with an hour-based start timecode); ffmpeg
+counts from zero. Getting that wrong grabs the right file at the wrong moment, silently, so
+the offset lives here rather than in each caller.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from ..errors import ResolveMcpError
+from ..resolve import media
+from ..resolve.connection import ResolveConnection
+
+RELINK_FIX = (
+    "relink_media points a clip back at its media; list_media shows what is offline."
+)
+
+
+class Source(NamedTuple):
+    """A clip's media as the video routes need it."""
+
+    path: str
+    bin_path: str
+    fps: float | None
+    start: int
+    out: int | None
+    reported: dict[str, str]
+
+    def seek_seconds(self, frame: int) -> float:
+        """Where ffmpeg has to seek to land on ``frame`` of this clip."""
+        if not self.fps:
+            raise ValueError("seek_seconds needs a frame rate; callers check for one first")
+        return (frame - self.start) / self.fps
+
+    @property
+    def duration_frames(self) -> int | None:
+        return None if self.out is None else self.out - self.start
+
+
+def locate(
+    connection: ResolveConnection,
+    clip: str,
+    bin_path: str | None,
+    failure: type[ResolveMcpError],
+) -> Source:
+    """Find the clip and the file behind it, or raise ``failure`` naming what to do about it.
+
+    The failure type is the caller's because the fix is: a grab that cannot find its media
+    and a scan that cannot find its media are the same problem to the director and different
+    tools to the agent.
+    """
+    pool = media.media_pool(connection)
+    located = media.find_clip(pool, clip, bin_path)
+    reported = media.properties(located.clip)
+    path = reported.get(media.FILE_PATH, "")
+    if not path or media.is_offline(path):
+        raise failure(
+            cause=f"{clip!r} has no readable file on disk.",
+            fix=RELINK_FIX,
+            detail={"clip": clip, "file_path": path},
+        )
+
+    start, out = media.frame_bounds(reported)
+    return Source(
+        path=path,
+        bin_path=located.bin_path,
+        fps=media.frame_rate(reported),
+        start=start or 0,
+        out=out,
+        reported=reported,
+    )

--- a/src/resolve_mcp/video/source.py
+++ b/src/resolve_mcp/video/source.py
@@ -9,26 +9,25 @@ the offset lives here rather than in each caller.
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
-from ..errors import ResolveMcpError
+from ..errors import InvalidRequestError, ResolveMcpError
 from ..resolve import media
 from ..resolve.connection import ResolveConnection
+from ..timing import dual_time
 
-RELINK_FIX = (
-    "relink_media points a clip back at its media; list_media shows what is offline."
-)
+RELINK_FIX = "relink_media points a clip back at its media; list_media shows what is offline."
 
 
 class Source(NamedTuple):
-    """A clip's media as the video routes need it."""
+    """A clip's media as the video routes need it, in the clip's own frame numbering."""
 
+    name: str
     path: str
     bin_path: str
     fps: float | None
     start: int
     out: int | None
-    reported: dict[str, str]
 
     def seek_seconds(self, frame: int) -> float:
         """Where ffmpeg has to seek to land on ``frame`` of this clip."""
@@ -36,9 +35,30 @@ class Source(NamedTuple):
             raise ValueError("seek_seconds needs a frame rate; callers check for one first")
         return (frame - self.start) / self.fps
 
+    def holds(self, frame: int) -> bool:
+        """Whether ``frame`` is inside this clip's media, half-open ``[start, out)``."""
+        return frame >= self.start and (self.out is None or frame < self.out)
+
+    def outside(self, frame: int) -> InvalidRequestError:
+        """Why a frame this clip does not hold cannot be asked for.
+
+        Worth refusing rather than passing on: ffmpeg seeked past the end of a file exits
+        zero and writes nothing, which reads as a server bug rather than as a bad time.
+        """
+        return InvalidRequestError(
+            cause=f"Frame {frame} is outside the media {self.name!r} holds.",
+            fix="inspect_clip reports the clip's own bounds; times sit inside them, half-open.",
+            detail={
+                "clip": self.name,
+                "requested": dual_time(frame, self.fps),
+                "bounds": self.bounds,
+            },
+        )
+
     @property
-    def duration_frames(self) -> int | None:
-        return None if self.out is None else self.out - self.start
+    def bounds(self) -> dict[str, Any]:
+        """The clip's media bounds in dual time, half-open."""
+        return {"in": dual_time(self.start, self.fps), "out": dual_time(self.out, self.fps)}
 
 
 def locate(
@@ -66,10 +86,10 @@ def locate(
 
     start, out = media.frame_bounds(reported)
     return Source(
+        name=clip,
         path=path,
         bin_path=located.bin_path,
         fps=media.frame_rate(reported),
         start=start or 0,
         out=out,
-        reported=reported,
     )

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -7,6 +7,10 @@ is exercised with Resolve closed.
 The fakes mimic the real API's shape, including its quirks: getters return ``None``
 rather than raising, ``LoadProject`` returns ``None`` for an unknown name, and settings
 come back as strings.
+
+It also holds the fixtures and stand-ins that go with them: the media files the worker tier
+reads back (``write_wav``, ``write_jpeg``) and the ffmpeg runners every route that shells
+out is tested against (``ffmpeg_absent``, ``ffmpeg_refusing``).
 """
 
 from __future__ import annotations
@@ -17,6 +21,8 @@ import wave
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
+
+from resolve_mcp.ffmpeg import Completed, Runner
 
 
 class DroppedHandleError(RuntimeError):
@@ -1376,6 +1382,20 @@ def write_jpeg(path: Path, width: int = 1568, height: int = 882) -> Path:
         b"\xff\xd8" + b"\xff\xe0" + (2 + len(jfif)).to_bytes(2, "big") + jfif + frame + b"\xff\xd9"
     )
     return path
+
+
+def ffmpeg_absent(argv: Sequence[str]) -> Completed:
+    """A machine with no ffmpeg on it: the runner raises what ``subprocess`` would raise."""
+    raise FileNotFoundError(argv[0])
+
+
+def ffmpeg_refusing(stderr: str) -> Runner:
+    """An ffmpeg that ran and would not have the file, complaining the way it does."""
+
+    def runner(argv: Sequence[str]) -> Completed:
+        return Completed(1, stderr)
+
+    return runner
 
 
 def media_pool(bins: dict[str, list[FakeMediaPoolItem]] | None = None) -> FakeMediaPool:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1352,6 +1352,32 @@ def write_wav(
     return path
 
 
+def write_jpeg(path: Path, width: int = 1568, height: int = 882) -> Path:
+    """A JPEG header carrying real dimensions, standing in for a frame ffmpeg wrote.
+
+    The grab route reads the width and height back off the file rather than repeating what
+    it asked for, so the fixture has to carry a truthful SOF0 segment. It carries nothing
+    else: no scan data, because no test decodes a pixel, and a file full of them would only
+    make the fixture slower to write.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    jfif = b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    components = b"\x01\x22\x00\x02\x11\x01\x03\x11\x01"  # three components, 8-bit, one table
+    frame = (
+        b"\xff\xc0"
+        + (8 + len(components)).to_bytes(2, "big")
+        + b"\x08"
+        + height.to_bytes(2, "big")
+        + width.to_bytes(2, "big")
+        + b"\x03"
+        + components
+    )
+    path.write_bytes(
+        b"\xff\xd8" + b"\xff\xe0" + (2 + len(jfif)).to_bytes(2, "big") + jfif + frame + b"\xff\xd9"
+    )
+    return path
+
+
 def media_pool(bins: dict[str, list[FakeMediaPoolItem]] | None = None) -> FakeMediaPool:
     """A media pool from ``{"": [root clips], "Angles/Cam A": [clips]}``."""
     pool = FakeMediaPool()

--- a/tests/test_audio_acquisition.py
+++ b/tests/test_audio_acquisition.py
@@ -21,9 +21,9 @@ from resolve_mcp.audio.acquire import (
     acquire_timeline_audio,
     mapping_conflict,
 )
-from resolve_mcp.audio.ffmpeg import Completed, Runner
 from resolve_mcp.config import get_config
 from resolve_mcp.errors import AudioExtractionError, AudioMappingError, RenderQueueError
+from resolve_mcp.ffmpeg import Completed, Runner
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.resolve.connection import get_connection
 

--- a/tests/test_audio_acquisition.py
+++ b/tests/test_audio_acquisition.py
@@ -33,6 +33,8 @@ from .fakes import (
     FakeProject,
     FakeResolve,
     FakeTimeline,
+    ffmpeg_absent,
+    ffmpeg_refusing,
     media_pool,
     studio,
     sync_reference,
@@ -40,6 +42,7 @@ from .fakes import (
 )
 
 FIXTURE_SECONDS = 2.0
+REFUSAL = "Stream map '0:a:0' matches no streams."
 
 
 @pytest.fixture
@@ -229,7 +232,7 @@ def test_no_ffmpeg_on_the_machine_is_a_named_failure(attach: Attach, fixture_aud
     attach(_studio_holding(fixture_audio))
 
     record = wait_for(
-        acquire_clip_audio(get_connection(), "drums.wav", runner=_absent)["job_id"]
+        acquire_clip_audio(get_connection(), "drums.wav", runner=ffmpeg_absent)["job_id"]
     )
 
     assert record.state == "failed"
@@ -245,7 +248,7 @@ def test_ffmpegs_own_complaint_travels_back_with_the_failure(
     attach(_studio_holding(fixture_audio))
 
     record = wait_for(
-        acquire_clip_audio(get_connection(), "drums.wav", runner=_refusing)["job_id"]
+        acquire_clip_audio(get_connection(), "drums.wav", runner=ffmpeg_refusing(REFUSAL))["job_id"]
     )
 
     assert record.state == "failed"
@@ -338,9 +341,3 @@ def _copying(calls: list[Sequence[str]]) -> Runner:
     return runner
 
 
-def _absent(argv: Sequence[str]) -> Completed:
-    raise FileNotFoundError(argv[0])
-
-
-def _refusing(argv: Sequence[str]) -> Completed:
-    return Completed(1, "Stream map '0:a:0' matches no streams.")

--- a/tests/test_frame_grabs.py
+++ b/tests/test_frame_grabs.py
@@ -1,0 +1,448 @@
+"""Frame grabs: seeing a chosen moment on a chosen angle.
+
+The subprocess call is substituted the way the audio route substitutes it, because that is
+where the decisions are: which seconds ffmpeg is seeked to, that the scale filter keeps the
+long edge inside the agent's image cap, what a refusal looks like, and that an unchanged
+clip is never grabbed twice. The stand-in writes a JPEG header carrying real dimensions —
+the worker reads them back off the file, so a stub of zero bytes would prove nothing.
+
+The one thing no stand-in can prove — that ffmpeg accepts this argv and writes a JPEG whose
+long edge really is inside the cap — runs against real ffmpeg when the machine has it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.config import get_config
+from resolve_mcp.errors import FfmpegUnavailableError, FrameGrabError, InvalidRequestError
+from resolve_mcp.ffmpeg import Completed, Runner
+from resolve_mcp.resolve.connection import get_connection
+from resolve_mcp.tools import video as video_tools
+from resolve_mcp.video import jpeg
+from resolve_mcp.video.frames import DEFAULT_MAX_EDGE, MAX_TIMES, grab_frames
+
+from .conftest import Attach
+from .fakes import FakeMediaPoolItem, FakeResolve, media_pool, studio, write_jpeg
+
+CLIP_FPS = 59.94
+
+
+@pytest.fixture
+def fixture_video(tmp_path: Path) -> Path:
+    """Stands in for an angle on disk: the grab route only ever stats it."""
+    target = tmp_path / "media" / "C0012.mp4"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"not really an mp4, but a file with a size and an mtime")
+    return target
+
+
+# --- the grab ------------------------------------------------------------------------------
+
+
+def test_a_chosen_moment_comes_back_as_a_jpeg_the_agent_can_read(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+
+    reading = grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
+
+    grabbed = reading["frames"][0]
+    assert Path(grabbed["path"]).exists()
+    assert Path(grabbed["path"]).parent == get_config().frame_dir
+    assert Path(grabbed["path"]).suffix == ".jpg"
+    assert grabbed["width"] == 1568
+    assert grabbed["height"] == 882
+    assert grabbed["bytes"] > 0
+    assert calls[0][0] == "ffmpeg"
+    assert "-frames:v" in calls[0]
+
+
+def test_every_grabbed_moment_carries_dual_time(attach: Attach, fixture_video: Path) -> None:
+    attach(_studio_holding(fixture_video))
+
+    reading = grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing([]))
+
+    assert reading["frames"][0]["time"] == {
+        "frames": 60,
+        "seconds": pytest.approx(1.001, abs=0.001),
+        "timecode": "00:00:01:00",
+        "fps": CLIP_FPS,
+    }
+
+
+def test_a_time_in_seconds_is_taken_when_it_says_which_way_to_snap(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+
+    reading = grab_frames(
+        get_connection(),
+        "C0012.mp4",
+        [{"seconds": 1.5, "snap": "floor"}],
+        runner=_drawing(calls),
+    )
+
+    assert reading["frames"][0]["time"]["frames"] == 89
+    assert _seek(calls[0]) == pytest.approx(89 / CLIP_FPS, abs=0.001)
+
+
+def test_bare_seconds_are_refused_the_same_way_every_other_time_is(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+
+    with pytest.raises(InvalidRequestError) as raised:
+        grab_frames(get_connection(), "C0012.mp4", [{"seconds": 1.5}], runner=_drawing([]))
+
+    assert "snap" in raised.value.fix
+
+
+def test_the_seek_is_measured_from_the_start_of_the_file_not_the_clips_timecode(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    """Resolve numbers a clip from its own Start; ffmpeg only ever counts from zero."""
+    attach(_studio_holding(fixture_video, {"Start": "3600", "End": "3699", "Frames": "100"}))
+    calls: list[Sequence[str]] = []
+
+    grab_frames(get_connection(), "C0012.mp4", [3660], runner=_drawing(calls))
+
+    assert _seek(calls[0]) == pytest.approx(60 / CLIP_FPS, abs=0.001)
+
+
+def test_the_grab_is_scaled_into_the_agents_image_cap(attach: Attach, fixture_video: Path) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+
+    grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
+
+    scale = calls[0][calls[0].index("-vf") + 1]
+    assert str(DEFAULT_MAX_EDGE) in scale
+    assert "force_original_aspect_ratio=decrease" in scale
+
+
+def test_a_smaller_cap_can_be_asked_for_but_a_bigger_one_cannot(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+
+    grab_frames(get_connection(), "C0012.mp4", [60], max_edge=640, runner=_drawing(calls))
+
+    assert "640" in calls[0][calls[0].index("-vf") + 1]
+    with pytest.raises(InvalidRequestError) as raised:
+        grab_frames(get_connection(), "C0012.mp4", [60], max_edge=4096, runner=_drawing([]))
+    assert str(DEFAULT_MAX_EDGE) in raised.value.fix
+
+
+def test_several_moments_come_back_in_one_call_one_file_each(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+
+    reading = grab_frames(get_connection(), "C0012.mp4", [0, 30, 60], runner=_drawing(calls))
+
+    assert [one["time"]["frames"] for one in reading["frames"]] == [0, 30, 60]
+    assert len({one["path"] for one in reading["frames"]}) == 3
+    assert len(calls) == 3
+
+
+def test_the_same_moment_asked_for_twice_is_grabbed_once(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+
+    reading = grab_frames(get_connection(), "C0012.mp4", [60, 60], runner=_drawing(calls))
+
+    assert len(reading["frames"]) == 1
+    assert len(calls) == 1
+
+
+# --- the cache -----------------------------------------------------------------------------
+
+
+def test_an_unchanged_clip_and_the_same_times_never_run_ffmpeg_twice(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+    first = grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
+
+    again = grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
+
+    assert first["cached"] is False
+    assert again["cached"] is True
+    assert again["frames"] == first["frames"]
+    assert len(calls) == 1
+
+
+def test_different_times_are_a_different_cache_entry(attach: Attach, fixture_video: Path) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+    grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
+
+    again = grab_frames(get_connection(), "C0012.mp4", [90], runner=_drawing(calls))
+
+    assert again["cached"] is False
+    assert len(calls) == 2
+
+
+def test_a_grab_whose_jpeg_was_deleted_is_taken_again(attach: Attach, fixture_video: Path) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+    first = grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
+    Path(first["frames"][0]["path"]).unlink()
+
+    again = grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
+
+    assert again["cached"] is False
+    assert len(calls) == 2
+
+
+def test_refresh_takes_the_grab_again_and_replaces_the_entry(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+    grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
+
+    again = grab_frames(get_connection(), "C0012.mp4", [60], refresh=True, runner=_drawing(calls))
+
+    assert again["cached"] is False
+    assert len(calls) == 2
+
+
+# --- refusals ------------------------------------------------------------------------------
+
+
+def test_a_time_outside_the_clips_own_media_is_refused_before_ffmpeg_runs(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+
+    with pytest.raises(InvalidRequestError) as raised:
+        grab_frames(get_connection(), "C0012.mp4", [100], runner=_drawing(calls))
+
+    assert raised.value.detail["bounds"]["out"]["frames"] == 100
+    assert calls == []
+
+
+def test_asking_for_nothing_or_for_too_much_is_refused(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+
+    with pytest.raises(InvalidRequestError) as empty:
+        grab_frames(get_connection(), "C0012.mp4", [], runner=_drawing([]))
+    with pytest.raises(InvalidRequestError) as flooded:
+        grab_frames(get_connection(), "C0012.mp4", list(range(MAX_TIMES + 1)), runner=_drawing([]))
+
+    assert "at least one" in empty.value.fix
+    assert str(MAX_TIMES) in flooded.value.fix
+
+
+def test_a_clip_whose_media_is_gone_says_so_before_running_ffmpeg(attach: Attach) -> None:
+    attach(_studio_holding(Path("D:/gone/C0012.mp4")))
+
+    with pytest.raises(FrameGrabError) as raised:
+        grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing([]))
+
+    assert "relink_media" in raised.value.fix
+
+
+def test_a_clip_resolve_reports_no_frame_rate_for_cannot_be_seeked(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video, {"FPS": ""}))
+
+    with pytest.raises(InvalidRequestError) as raised:
+        grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing([]))
+
+    assert "frame rate" in raised.value.cause
+
+
+def test_no_ffmpeg_on_the_machine_is_a_named_failure(attach: Attach, fixture_video: Path) -> None:
+    attach(_studio_holding(fixture_video))
+
+    with pytest.raises(FfmpegUnavailableError) as raised:
+        grab_frames(get_connection(), "C0012.mp4", [60], runner=_absent)
+
+    assert "RESOLVE_MCP_FFMPEG" in raised.value.fix
+
+
+def test_ffmpegs_own_complaint_travels_back_with_the_failure(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+
+    with pytest.raises(FrameGrabError) as raised:
+        grab_frames(get_connection(), "C0012.mp4", [60], runner=_refusing)
+
+    assert "Invalid data found" in raised.value.detail["stderr"]
+
+
+def test_a_grab_that_writes_nothing_is_a_failure_not_a_silent_success(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+
+    with pytest.raises(FrameGrabError) as raised:
+        grab_frames(get_connection(), "C0012.mp4", [60], runner=_pretending)
+
+    assert "wrote nothing" in raised.value.cause
+
+
+def test_a_failed_grab_leaves_no_cache_entry_behind(attach: Attach, fixture_video: Path) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+    with pytest.raises(FrameGrabError):
+        grab_frames(get_connection(), "C0012.mp4", [60], runner=_refusing)
+
+    reading = grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
+
+    assert reading["cached"] is False
+    assert len(calls) == 1
+
+
+# --- reading a JPEG back ---------------------------------------------------------------------
+
+
+def test_the_jpeg_header_gives_up_the_dimensions_the_agent_will_see(tmp_path: Path) -> None:
+    written = write_jpeg(tmp_path / "frame.jpg", width=1280, height=720)
+
+    reading = jpeg.describe(written)
+
+    assert reading["width"] == 1280
+    assert reading["height"] == 720
+    assert reading["bytes"] == written.stat().st_size
+    assert reading["path"] == str(written)
+
+
+def test_a_file_that_is_not_a_jpeg_is_refused_rather_than_guessed_at(tmp_path: Path) -> None:
+    impostor = tmp_path / "frame.jpg"
+    impostor.write_bytes(b"\x89PNG\r\n\x1a\n and then some")
+
+    with pytest.raises(FrameGrabError):
+        jpeg.describe(impostor)
+
+
+# --- the tool ---------------------------------------------------------------------------------
+
+
+def test_the_tool_shapes_a_refusal_rather_than_raising(attach: Attach, fixture_video: Path) -> None:
+    """The tool layer takes no subprocess seam — the refusal lands before ffmpeg is reached."""
+    attach(_studio_holding(fixture_video))
+
+    envelope = video_tools.grab_frames("C0012.mp4", [9999])
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["code"] == "invalid_request"
+    assert "context" in envelope
+
+
+# --- against real ffmpeg -----------------------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is not on PATH")
+def test_real_ffmpeg_accepts_the_command_and_writes_a_capped_jpeg(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """The assertions a stand-in cannot make: the argv is one ffmpeg takes, and the cap holds."""
+    source = _render_test_video(tmp_path / "media" / "C0012.mp4", width=1920, height=1080)
+    attach(_studio_holding(source, {"FPS": "10", "Start": "0", "End": "19", "Frames": "20"}))
+
+    envelope = video_tools.grab_frames("C0012.mp4", [10])
+
+    assert envelope["ok"] is True, envelope.get("error")
+    grabbed = envelope["frames"][0]
+    assert Path(grabbed["path"]).exists()
+    assert max(grabbed["width"], grabbed["height"]) <= DEFAULT_MAX_EDGE
+    assert grabbed["width"] / grabbed["height"] == pytest.approx(16 / 9, abs=0.01)
+
+
+# --- helpers -------------------------------------------------------------------------------------
+
+
+def _studio_holding(source: Path, properties: dict[str, str] | None = None) -> FakeResolve:
+    clip = FakeMediaPoolItem(
+        source.name,
+        file_path=str(source),
+        properties={"Type": "Video", "FPS": str(CLIP_FPS), **(properties or {})},
+    )
+    return studio(pool=media_pool({"": [clip]}))
+
+
+def _drawing(calls: list[Sequence[str]], width: int = 1568, height: int = 882) -> Runner:
+    """Stand in for ffmpeg by writing the JPEG header it would have written."""
+
+    def runner(argv: Sequence[str]) -> Completed:
+        calls.append(list(argv))
+        write_jpeg(Path(argv[-1]), width=width, height=height)
+        return Completed(0, "")
+
+    return runner
+
+
+def _absent(argv: Sequence[str]) -> Completed:
+    raise FileNotFoundError(argv[0])
+
+
+def _refusing(argv: Sequence[str]) -> Completed:
+    return Completed(1, "[mp4 @ 0] moov atom not found\nInvalid data found processing input")
+
+
+def _pretending(argv: Sequence[str]) -> Completed:
+    """Exit zero and write nothing — the failure mode that would otherwise cache a lie."""
+    return Completed(0, "")
+
+
+def _seek(argv: Sequence[str]) -> float:
+    return float(argv[argv.index("-ss") + 1])
+
+
+def _render_test_video(target: Path, width: int, height: int) -> Path:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-nostdin",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"testsrc=size={width}x{height}:rate=10:duration=2",
+            "-pix_fmt",
+            "yuv420p",
+            str(target),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return target

--- a/tests/test_frame_grabs.py
+++ b/tests/test_frame_grabs.py
@@ -28,9 +28,18 @@ from resolve_mcp.video import jpeg
 from resolve_mcp.video.frames import DEFAULT_MAX_EDGE, MAX_TIMES, grab_frames
 
 from .conftest import Attach
-from .fakes import FakeMediaPoolItem, FakeResolve, media_pool, studio, write_jpeg
+from .fakes import (
+    FakeMediaPoolItem,
+    FakeResolve,
+    ffmpeg_absent,
+    ffmpeg_refusing,
+    media_pool,
+    studio,
+    write_jpeg,
+)
 
 CLIP_FPS = 59.94
+REFUSAL = "[mp4 @ 0] moov atom not found\nInvalid data found processing input"
 
 
 @pytest.fixture
@@ -204,6 +213,22 @@ def test_different_times_are_a_different_cache_entry(attach: Attach, fixture_vid
     assert len(calls) == 2
 
 
+def test_a_second_call_only_grabs_the_moment_the_first_one_did_not(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    """A session narrows in: the next call is usually the last one's times plus one more."""
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+    first = grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
+
+    again = grab_frames(get_connection(), "C0012.mp4", [60, 90], runner=_drawing(calls))
+
+    assert len(calls) == 2
+    assert again["cached"] is False
+    assert again["frames"][0] == first["frames"][0]
+
+
 def test_a_grab_whose_jpeg_was_deleted_is_taken_again(attach: Attach, fixture_video: Path) -> None:
     attach(_studio_holding(fixture_video))
     calls: list[Sequence[str]] = []
@@ -262,6 +287,21 @@ def test_asking_for_nothing_or_for_too_much_is_refused(
     assert str(MAX_TIMES) in flooded.value.fix
 
 
+def test_an_empty_entry_in_times_is_refused_rather_than_quietly_dropped(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    """Dropping it would return fewer frames than were asked for without saying which."""
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+
+    with pytest.raises(InvalidRequestError) as raised:
+        grab_frames(get_connection(), "C0012.mp4", [60, None], runner=_drawing(calls))
+
+    assert raised.value.detail["field"] == "times[1]"
+    assert calls == []
+
+
 def test_a_clip_whose_media_is_gone_says_so_before_running_ffmpeg(attach: Attach) -> None:
     attach(_studio_holding(Path("D:/gone/C0012.mp4")))
 
@@ -287,7 +327,7 @@ def test_no_ffmpeg_on_the_machine_is_a_named_failure(attach: Attach, fixture_vid
     attach(_studio_holding(fixture_video))
 
     with pytest.raises(FfmpegUnavailableError) as raised:
-        grab_frames(get_connection(), "C0012.mp4", [60], runner=_absent)
+        grab_frames(get_connection(), "C0012.mp4", [60], runner=ffmpeg_absent)
 
     assert "RESOLVE_MCP_FFMPEG" in raised.value.fix
 
@@ -299,7 +339,7 @@ def test_ffmpegs_own_complaint_travels_back_with_the_failure(
     attach(_studio_holding(fixture_video))
 
     with pytest.raises(FrameGrabError) as raised:
-        grab_frames(get_connection(), "C0012.mp4", [60], runner=_refusing)
+        grab_frames(get_connection(), "C0012.mp4", [60], runner=ffmpeg_refusing(REFUSAL))
 
     assert "Invalid data found" in raised.value.detail["stderr"]
 
@@ -320,7 +360,7 @@ def test_a_failed_grab_leaves_no_cache_entry_behind(attach: Attach, fixture_vide
     attach(_studio_holding(fixture_video))
     calls: list[Sequence[str]] = []
     with pytest.raises(FrameGrabError):
-        grab_frames(get_connection(), "C0012.mp4", [60], runner=_refusing)
+        grab_frames(get_connection(), "C0012.mp4", [60], runner=ffmpeg_refusing(REFUSAL))
 
     reading = grab_frames(get_connection(), "C0012.mp4", [60], runner=_drawing(calls))
 
@@ -406,14 +446,6 @@ def _drawing(calls: list[Sequence[str]], width: int = 1568, height: int = 882) -
         return Completed(0, "")
 
     return runner
-
-
-def _absent(argv: Sequence[str]) -> Completed:
-    raise FileNotFoundError(argv[0])
-
-
-def _refusing(argv: Sequence[str]) -> Completed:
-    return Completed(1, "[mp4 @ 0] moov atom not found\nInvalid data found processing input")
 
 
 def _pretending(argv: Sequence[str]) -> Completed:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -42,6 +42,7 @@ from resolve_mcp.tools.timeline import (
     list_markers,
     list_timelines,
 )
+from resolve_mcp.tools.video import grab_frames
 
 from . import otio
 from .text_plus_probe import TEMPLATE_ENV, probe_template_append
@@ -508,6 +509,37 @@ def test_the_render_queue_exports_the_real_timeline_mix() -> None:
 
     again = acquire_timeline_audio(get_connection())
     assert again["cached"] is True, "an unchanged timeline must be a cache hit"
+
+
+def test_a_real_frame_grab_lands_on_the_moment_resolve_numbers_it_at() -> None:
+    """The AC no seam can check: that Start really is the offset between the two clocks.
+
+    The fakes prove the command shape, the cap and the caching against a clip whose Start
+    this test wrote itself. Whether real footage — an hour-based start timecode, a codec
+    ffmpeg has to seek inside — is numbered the way the wrapper assumes only shows up here.
+    """
+    listing = list_media()
+    if not listing["ok"]:
+        pytest.skip("No project open in Resolve")
+    footage = next(
+        (one for one in listing["clips"] if one["fps"] and not one["offline"] and one["frames"]),
+        None,
+    )
+    if footage is None:
+        pytest.skip("No online clip with a frame rate in the media pool")
+    bounds = inspect_clip(footage["name"], bin=footage["bin"] or None)["bounds"]["media"]
+    middle = bounds["in"]["frames"] + bounds["duration"]["frames"] // 2
+
+    result = grab_frames(footage["name"], [middle], bin=footage["bin"] or None)
+
+    assert result["ok"] is True, result.get("error")
+    grabbed = result["frames"][0]
+    assert Path(grabbed["path"]).exists()
+    assert grabbed["time"]["frames"] == middle
+    assert max(grabbed["width"], grabbed["height"]) <= 1568
+
+    again = grab_frames(footage["name"], [middle], bin=footage["bin"] or None)
+    assert again["cached"] is True, "unchanged media must be a cache hit"
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -42,7 +42,7 @@ from resolve_mcp.tools.timeline import (
     list_markers,
     list_timelines,
 )
-from resolve_mcp.tools.video import grab_frames
+from resolve_mcp.tools.video import detect_scene_cuts, grab_frames
 
 from . import otio
 from .text_plus_probe import TEMPLATE_ENV, probe_template_append
@@ -540,6 +540,35 @@ def test_a_real_frame_grab_lands_on_the_moment_resolve_numbers_it_at() -> None:
 
     again = grab_frames(footage["name"], [middle], bin=footage["bin"] or None)
     assert again["cached"] is True, "unchanged media must be a cache hit"
+
+
+def test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock() -> None:
+    """The other half of the clock check: pts_time counts from the file, cuts from the clip.
+
+    Slow — this decodes a whole clip, so it takes the shortest one in the pool. What it is
+    for is the mapping the fakes replay rather than produce: that ffmpeg's reported times
+    become frame numbers inside the bounds ``inspect_clip`` reports for the same clip.
+    """
+    listing = list_media()
+    if not listing["ok"]:
+        pytest.skip("No project open in Resolve")
+    footage = [
+        one for one in listing["clips"] if one["fps"] and not one["offline"] and one["frames"]
+    ]
+    if not footage:
+        pytest.skip("No online clip with a frame rate in the media pool")
+    shortest = min(footage, key=lambda one: one["frames"])
+    bounds = inspect_clip(shortest["name"], bin=shortest["bin"] or None)["bounds"]["media"]
+
+    started = detect_scene_cuts(shortest["name"], bin=shortest["bin"] or None)
+    record = wait_for(started["job_id"], timeout=1800.0)
+
+    assert started["ok"] is True, started.get("error")
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert Path(record.result["path"]).exists()
+    for cut in record.result["first_cuts"]:
+        assert bounds["in"]["frames"] < cut["frames"] < bounds["out"]["frames"]
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_scene_cuts.py
+++ b/tests/test_scene_cuts.py
@@ -29,9 +29,17 @@ from resolve_mcp.tools import video as video_tools
 from resolve_mcp.video.scenes import DEFAULT_THRESHOLD, INLINE_CUTS, detect_scene_cuts
 
 from .conftest import Attach
-from .fakes import FakeMediaPoolItem, FakeResolve, media_pool, studio
+from .fakes import (
+    FakeMediaPoolItem,
+    FakeResolve,
+    ffmpeg_absent,
+    ffmpeg_refusing,
+    media_pool,
+    studio,
+)
 
 CLIP_FPS = 59.94
+REFUSAL = "[mp4 @ 0] moov atom not found\nInvalid data found processing input"
 CLIP_SECONDS = 10.0
 
 
@@ -159,6 +167,29 @@ def test_a_clip_with_no_cut_in_it_is_a_result_not_a_failure(
     assert record.result["shot_seconds"]["max"] == pytest.approx(CLIP_SECONDS, abs=0.02)
 
 
+def test_a_clip_resolve_reports_no_end_for_still_catalogs_the_shots_it_can(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    """The tail runs to an out point nothing knows; every shot before it is still real."""
+    attach(_studio_holding(fixture_video, {"End": "", "Frames": ""}))
+
+    record = wait_for(
+        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_finding([], [1.0, 4.0]))[
+            "job_id"
+        ]
+    )
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert record.result["cuts"] == 2
+    assert record.result["shots"] == 2
+    assert record.result["shot_seconds"]["min"] == pytest.approx(0.984, abs=0.01)
+    catalog = json.loads(Path(record.result["path"]).read_text(encoding="utf-8"))
+    assert catalog["shots"][-1]["out"]["frames"] == 239
+    assert catalog["bounds"]["out"] is None, "the missing tail has to be readable as missing"
+
+
 # --- the cache -----------------------------------------------------------------------------
 
 
@@ -230,7 +261,9 @@ def test_a_refused_scan_fails_the_job_and_carries_ffmpegs_message(
     attach(_studio_holding(fixture_video))
 
     record = wait_for(
-        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_refusing)["job_id"]
+        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=ffmpeg_refusing(REFUSAL))[
+            "job_id"
+        ]
     )
 
     assert record.state == "failed"
@@ -246,7 +279,7 @@ def test_no_ffmpeg_on_the_machine_fails_the_job_by_name(
     attach(_studio_holding(fixture_video))
 
     record = wait_for(
-        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_absent)["job_id"]
+        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=ffmpeg_absent)["job_id"]
     )
 
     assert record.state == "failed"
@@ -318,14 +351,6 @@ def _finding(calls: list[Sequence[str]], seconds: Sequence[float]) -> Runner:
         return Completed(0, "\n".join(["frame= 600 fps=0.0 q=-0.0", *lines]))
 
     return runner
-
-
-def _absent(argv: Sequence[str]) -> Completed:
-    raise FileNotFoundError(argv[0])
-
-
-def _refusing(argv: Sequence[str]) -> Completed:
-    return Completed(1, "[mp4 @ 0] moov atom not found\nInvalid data found processing input")
 
 
 def _render_two_shot_video(target: Path) -> Path:

--- a/tests/test_scene_cuts.py
+++ b/tests/test_scene_cuts.py
@@ -1,0 +1,360 @@
+"""Scene-cut detection: where the shots change on a piece of b-roll.
+
+A full-file decode is a job, so this runs through the job runner and asserts on the record
+the agent polls. The subprocess is substituted with one that replays the ``showinfo`` lines
+ffmpeg prints for selected frames — parsing those, turning them into dual time and keeping
+the inline answer small while the whole catalog goes to disk are the decisions here.
+
+Real ffmpeg runs once, on a two-colour clip with exactly one cut in it, when the machine
+has ffmpeg: only that proves the filter graph is one ffmpeg accepts and that a cut it finds
+lands where the picture actually changed.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.config import get_config
+from resolve_mcp.errors import InvalidRequestError, SceneDetectionError
+from resolve_mcp.ffmpeg import Completed, Runner
+from resolve_mcp.jobs.runner import wait_for
+from resolve_mcp.resolve.connection import get_connection
+from resolve_mcp.tools import video as video_tools
+from resolve_mcp.video.scenes import DEFAULT_THRESHOLD, INLINE_CUTS, detect_scene_cuts
+
+from .conftest import Attach
+from .fakes import FakeMediaPoolItem, FakeResolve, media_pool, studio
+
+CLIP_FPS = 59.94
+CLIP_SECONDS = 10.0
+
+
+@pytest.fixture
+def fixture_video(tmp_path: Path) -> Path:
+    """Stands in for b-roll on disk: the scan route only ever stats it."""
+    target = tmp_path / "media" / "broll_pan.mp4"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"not really an mp4, but a file with a size and an mtime")
+    return target
+
+
+# --- the scan ------------------------------------------------------------------------------
+
+
+def test_a_scan_writes_every_cut_to_disk_and_returns_a_gist(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+
+    record = wait_for(
+        detect_scene_cuts(
+            get_connection(),
+            "broll_pan.mp4",
+            runner=_finding(calls, [1.0, 4.0, 7.5]),
+        )["job_id"]
+    )
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert record.result["cuts"] == 3
+    assert record.result["threshold"] == DEFAULT_THRESHOLD
+    assert Path(record.result["path"]).parent == get_config().analysis_dir
+    assert calls[0][0] == "ffmpeg"
+    assert "showinfo" in calls[0][calls[0].index("-filter:v") + 1]
+
+
+def test_the_catalog_on_disk_carries_dual_time_and_the_run_that_made_it(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    record = wait_for(
+        detect_scene_cuts(
+            get_connection(),
+            "broll_pan.mp4",
+            runner=_finding([], [1.0, 4.0, 7.5]),
+        )["job_id"]
+    )
+    assert record.result is not None
+
+    catalog = json.loads(Path(record.result["path"]).read_text(encoding="utf-8"))
+
+    assert catalog["clip"] == "broll_pan.mp4"
+    assert catalog["generated_at"]
+    assert catalog["threshold"] == DEFAULT_THRESHOLD
+    assert catalog["cuts"][0] == {
+        "frames": 59,
+        "seconds": pytest.approx(0.984, abs=0.002),
+        "timecode": "00:00:00:59",
+        "fps": CLIP_FPS,
+    }
+
+
+def test_shots_are_the_spans_between_the_cuts_head_and_tail_included(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+    record = wait_for(
+        detect_scene_cuts(
+            get_connection(),
+            "broll_pan.mp4",
+            runner=_finding([], [1.0, 4.0, 7.5]),
+        )["job_id"]
+    )
+    assert record.result is not None
+
+    catalog = json.loads(Path(record.result["path"]).read_text(encoding="utf-8"))
+    shots = catalog["shots"]
+
+    assert len(shots) == 4
+    assert shots[0]["in"]["frames"] == 0
+    assert shots[0]["duration_seconds"] == pytest.approx(1.0, abs=0.02)
+    assert shots[-1]["out"]["frames"] == 600
+    assert record.result["shot_seconds"]["min"] == pytest.approx(0.984, abs=0.01)
+    assert record.result["shot_seconds"]["max"] == pytest.approx(3.503, abs=0.01)
+
+
+def test_the_gist_stays_small_however_many_cuts_the_scan_found(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    """A minute of fast b-roll has hundreds of cuts; the agent reads the file for the rest."""
+    many = [round(0.5 + one * 0.02, 3) for one in range(400)]
+    attach(_studio_holding(fixture_video))
+
+    record = wait_for(
+        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_finding([], many))["job_id"]
+    )
+
+    assert record.result is not None
+    assert record.result["cuts"] == len(many)
+    assert len(record.result["first_cuts"]) == INLINE_CUTS
+    catalog = json.loads(Path(record.result["path"]).read_text(encoding="utf-8"))
+    assert len(catalog["cuts"]) == len(many)
+
+
+def test_a_clip_with_no_cut_in_it_is_a_result_not_a_failure(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+
+    record = wait_for(
+        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_finding([], []))["job_id"]
+    )
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert record.result["cuts"] == 0
+    assert record.result["first_cuts"] == []
+    assert record.result["shot_seconds"]["max"] == pytest.approx(CLIP_SECONDS, abs=0.02)
+
+
+# --- the cache -----------------------------------------------------------------------------
+
+
+def test_an_unchanged_clip_is_never_scanned_twice(attach: Attach, fixture_video: Path) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+    wait_for(
+        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_finding(calls, [1.0]))[
+            "job_id"
+        ]
+    )
+
+    again = detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_finding(calls, [1.0]))
+
+    assert again["cached"] is True
+    assert len(calls) == 1
+
+
+def test_a_different_threshold_is_a_different_scan(attach: Attach, fixture_video: Path) -> None:
+    attach(_studio_holding(fixture_video))
+    calls: list[Sequence[str]] = []
+    wait_for(
+        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_finding(calls, [1.0]))[
+            "job_id"
+        ]
+    )
+
+    again = detect_scene_cuts(
+        get_connection(),
+        "broll_pan.mp4",
+        threshold=0.2,
+        runner=_finding(calls, [1.0]),
+    )
+    wait_for(again["job_id"])
+
+    assert again["cached"] is False
+    assert len(calls) == 2
+    assert "0.2" in calls[1][calls[1].index("-filter:v") + 1]
+
+
+# --- refusals ------------------------------------------------------------------------------
+
+
+def test_a_threshold_outside_the_sensitivity_range_is_refused(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+
+    with pytest.raises(InvalidRequestError) as raised:
+        detect_scene_cuts(get_connection(), "broll_pan.mp4", threshold=4.0)
+
+    assert "between" in raised.value.fix
+
+
+def test_a_clip_whose_media_is_gone_says_so_before_starting_a_job(attach: Attach) -> None:
+    attach(_studio_holding(Path("D:/gone/broll_pan.mp4")))
+
+    with pytest.raises(SceneDetectionError) as raised:
+        detect_scene_cuts(get_connection(), "broll_pan.mp4")
+
+    assert "relink_media" in raised.value.fix
+
+
+def test_a_refused_scan_fails_the_job_and_carries_ffmpegs_message(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+
+    record = wait_for(
+        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_refusing)["job_id"]
+    )
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "scene_detection_failed"
+    assert "Invalid data found" in record.error["detail"]["stderr"]
+
+
+def test_no_ffmpeg_on_the_machine_fails_the_job_by_name(
+    attach: Attach,
+    fixture_video: Path,
+) -> None:
+    attach(_studio_holding(fixture_video))
+
+    record = wait_for(
+        detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_absent)["job_id"]
+    )
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "ffmpeg_unavailable"
+
+
+# --- the tool ---------------------------------------------------------------------------------
+
+
+def test_the_tool_shapes_a_refusal_rather_than_raising(attach: Attach, fixture_video: Path) -> None:
+    attach(_studio_holding(fixture_video))
+
+    envelope = video_tools.detect_scene_cuts("broll_pan.mp4", threshold=4.0)
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["code"] == "invalid_request"
+    assert "context" in envelope
+
+
+# --- against real ffmpeg -----------------------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is not on PATH")
+def test_real_ffmpeg_finds_the_one_cut_in_a_two_shot_clip(attach: Attach, tmp_path: Path) -> None:
+    """The assertion a stand-in cannot make: the filter graph runs and the cut is where it is."""
+    source = _render_two_shot_video(tmp_path / "media" / "broll_pan.mp4")
+    attach(_studio_holding(source, {"FPS": "10", "Start": "0", "End": "19", "Frames": "20"}))
+
+    envelope = video_tools.detect_scene_cuts("broll_pan.mp4")
+    record = wait_for(envelope["job_id"])
+
+    assert envelope["ok"] is True, envelope.get("error")
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert record.result["cuts"] == 1
+    assert record.result["first_cuts"][0]["seconds"] == pytest.approx(1.0, abs=0.15)
+
+
+# --- helpers -------------------------------------------------------------------------------------
+
+
+def _studio_holding(source: Path, properties: dict[str, str] | None = None) -> FakeResolve:
+    clip = FakeMediaPoolItem(
+        source.name,
+        file_path=str(source),
+        properties={
+            "Type": "Video",
+            "FPS": str(CLIP_FPS),
+            "Start": "0",
+            "End": "599",
+            "Frames": "600",
+            **(properties or {}),
+        },
+    )
+    return studio(pool=media_pool({"": [clip]}))
+
+
+def _finding(calls: list[Sequence[str]], seconds: Sequence[float]) -> Runner:
+    """Replay the showinfo lines ffmpeg prints for the frames the select filter kept."""
+
+    def runner(argv: Sequence[str]) -> Completed:
+        calls.append(list(argv))
+        lines = [
+            f"[Parsed_showinfo_1 @ 000001] n:{index:4d} pts:{int(one * 1000):8d} "
+            f"pts_time:{one} duration_time:0.016 fmt:yuv420p"
+            for index, one in enumerate(seconds)
+        ]
+        return Completed(0, "\n".join(["frame= 600 fps=0.0 q=-0.0", *lines]))
+
+    return runner
+
+
+def _absent(argv: Sequence[str]) -> Completed:
+    raise FileNotFoundError(argv[0])
+
+
+def _refusing(argv: Sequence[str]) -> Completed:
+    return Completed(1, "[mp4 @ 0] moov atom not found\nInvalid data found processing input")
+
+
+def _render_two_shot_video(target: Path) -> Path:
+    """One second of red, one second of blue: exactly one place the picture changes."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-nostdin",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=red:size=320x240:rate=10:duration=1",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:size=320x240:rate=10:duration=1",
+            "-filter_complex",
+            "[0:v][1:v]concat=n=2:v=1:a=0[v]",
+            "-map",
+            "[v]",
+            "-pix_fmt",
+            "yuv420p",
+            str(target),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return target

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,6 +38,8 @@ def test_registers_the_p1_session_media_timeline_cut_and_job_tools() -> None:
         "get_cut_schema",
         "validate_cut",
         "build_timeline",
+        "grab_frames",
+        "detect_scene_cuts",
         "get_job",
         "list_jobs",
         "run_python",


### PR DESCRIPTION
Closes #34.

Two video routes, both reading the file on disk the media pool points at rather than
rendering anything in Resolve, so both run while the director keeps working in the GUI.

`grab_frames` is deliberately **not** a job: a seek and a single frame is faster than a poll
cycle would be, and the point of a grab is that the agent gets a path it can open *now*,
while it is still reasoning about the moment that made it ask. It is cached by the same key
every job uses, per frame rather than per call. Frames land at or under 1568px on the long
edge — the client's own image cap, above which an image is downscaled on arrival anyway —
and the dimensions come back read off the JPEG header, not repeated from the request.

`detect_scene_cuts` decodes the whole clip, so it is a job. The catalog of every cut and
shot goes to disk in dual time and only a gist comes back inline (counts, shot lengths, the
first twelve cut times, the path), which is the shape #22 fixes for analysis jobs.

Times are dual time throughout, and are the clip's own frame numbers. Resolve numbers a clip
from its `Start` while ffmpeg counts from zero, so the offset lives in `video.source` rather
than in each caller — getting it wrong grabs the right file at the wrong moment, silently.

The ffmpeg subprocess seam moves up to `resolve_mcp.ffmpeg`, shared with the audio route:
three commands, three failure meanings, one place that shells out, one shape for a missing
binary and one for a refusal.

## Test seam

**Fake tier** (`uv run pytest -m 'not live'`), the seam every AC is checked at: the Resolve
singleton substitutes at the connection manager, the ffmpeg subprocess at the `runner`
parameter. Both are where the decisions live — command shape, the 1568px cap, dual-time
parsing, bounds refusals, cache hits and misses, gist size, failure shaping. 542 pass.

Two tests additionally run against **real ffmpeg** when the machine has it (the same
`skipif` precedent as the audio route): a capped JPEG grabbed off a generated 1920×1080
clip, and the single cut in a red-to-blue clip. Both passed on this machine — the only
proof that the argv and the filter graph are ones ffmpeg accepts.

**Live smoke** — two tests, unrun, marked `live`: that `Start` really is the offset between
Resolve's clock and the file's on real footage, and that a real scan's `pts_time` values
land inside the bounds `inspect_clip` reports for the same clip. Neither is answerable at
any seam, and neither runs on the machine this was built on.

## Review

Two-axis `/code-review` (Standards and Spec as parallel sub-agents) against `origin/main`,
run on the branch before this PR existed.

**Spec axis — three defects, all fixed in ba550ca:**

- A grab batch was one cache entry, so `[10]` followed by `[10, 20]` decoded frame 10 twice.
  Each frame is its own entry now.
- An empty entry in `times` was dropped silently — the call returned fewer frames than were
  asked for without saying which vanished. Refused, naming the field.
- A clip Resolve reports no `End` for produced an empty shot list and an all-null gist.
  Every shot before the unknowable tail is catalogued now, and the bounds go into the file
  so an `out` of null says why the last one is missing.

Held, with reasons: `MAX_TIMES = 12` and the `max_edge`/`threshold` knobs are not in the ACs
but guard the agent's own context and are documented at their constants. `video/jpeg.py`'s
header parse stays — a source already inside the cap keeps its own size, so the only honest
way to report what the agent will see is to read the file rather than repeat the request.
The reviewer also flagged that AC4 says "content hash" while both routes fingerprint the
source (path + size + mtime): that is the split `jobs/cache.py` documents from #32 — a
concert master is tens of gigabytes and hashing it per grab would cost minutes — so it is
inherited deliberately rather than silently. Noted on the ticket.

**Standards axis — no documented-standard breach.** Judgement calls taken: the three
identical "ffmpeg exited non-zero" blocks collapse into `ffmpeg.refused`; `Source` gains the
clip name and the range check and drops two members nothing read; the ffmpeg runner
stand-ins move into `fakes` rather than living three times over; two constants gained the
decision line their neighbours carry.

A focused pass over the fix diff found two more — dead local stubs left behind by the test
dedupe, and a catalog that did not say its tail was missing — both fixed in the same commit.

Review: clean — three spec defects and the standards findings fixed in ba550ca; fix diff re-reviewed, its two findings fixed in the same commit.


Post-open merge of origin/main (takes #29, overlays #30, renders #33 landed first): pure unions — tool registration and imports in server.py, frame/analysis/render cache dirs in config.py, README feature rows, and both live-smoke test blocks kept. Fake tier, mypy, ruff clean.
Review: clean — focused pass on the conflict-resolution diff
