### PR TITLE
P1: Alternates + swap_take (#29)

### DIFF
--- a/src/resolve_mcp/cut/schema.py
+++ b/src/resolve_mcp/cut/schema.py
@@ -72,12 +72,17 @@ _TAKES: Final = """\
 
 - Selector = [main, alternates in order]; selected take = main. The main slot
   *is* the current selection, always.
+- `swap_take` counts that order: take 1 = the segment's own `source`, take 2
+  onwards = `alternates` in document order. Indexes, not aliases — the same
+  source can appear twice in one selector (two passes from one camera).
 - Every alternate's duration must equal main's — in-place `swap_take` can't
   ripple a sequential timeline; an unequal-length take choice is a main-segment
   edit + rebuild. Also dodges untested Resolve behavior on mismatched selector
   lengths.
 - Swap sync: after `swap_take`, Claude edits the file — alternate promoted to
-  main, main demoted. The server never writes the cut file."""
+  main, main demoted into its slot, so the selector order survives a rebuild.
+  The swap report hands back those exact fields. The server never writes the
+  cut file."""
 
 _OVERLAYS: Final = """\
 ## 4. Overlays

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -477,6 +477,18 @@ def positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
     return placed
 
 
+def placements(doc: dict[str, Any], start: int) -> dict[str, tuple[int, int]]:
+    """Each segment id to its ``(record frame, duration)`` on a timeline starting at ``start``.
+
+    The one place a cut's own offsets become absolute frames. A build sends these as
+    ``recordFrame`` and a swap finds a shot by them, so a second derivation of the same sum
+    somewhere else is a swap that quietly reads the wrong shot — there is only this one.
+    """
+    return {
+        id: (start + offset, duration) for id, (offset, duration) in positions(doc).items()
+    }
+
+
 def total_frames(doc: dict[str, Any]) -> int:
     """The V1 span: sequential segments, so the sum of their durations."""
     return sum(duration_frames(s["in"], s["out"]) for s in _segments(doc))
@@ -760,6 +772,7 @@ __all__ = [
     "Finding",
     "locked_track_finding",
     "parse_failure_finding",
+    "placements",
     "positions",
     "resolve_aliases",
     "severity_of",

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Final
 
-from ..cut.validate import locked_track_finding, positions
+from ..cut.validate import locked_track_finding, placements
 from ..errors import BuildFailedError, CutInvalidError, UnsupportedCutFeatureError
 from ..logging_config import get_logger
 from ..naming import next_version_name
@@ -46,7 +46,7 @@ Timeline = Any
 MEDIA_TYPES: Final[dict[str, int]] = {"video": 1, "audio": 2}
 """Resolve's ``mediaType``: 1 appends video only, 2 audio only. Never omitted."""
 
-TRACK_INDEX: Final = 1
+TRACK_INDEX: Final = timeline_read.FIRST_TRACK
 """Sequential V1 is one video track and one audio track; both are the first of their kind."""
 
 TRACK_LABELS: Final[dict[str, str]] = {"video": "V1", "audio": "A1"}
@@ -126,7 +126,7 @@ def build_timeline(
     # Takes hang off placed clips, so they are attached only once every placement has been
     # read back — a selector on a shot that slid somewhere else would be alternates for a
     # shot the cut file does not have.
-    selectors = takes.attach_takes(built, _selectors(doc, clips, shots), name)
+    made = takes.attach_takes(built, _selectors(doc, clips, shots), name)
 
     log.info("Built %s: %d clips from %s", name, len(shots), checked.loaded.content_hash)
     return {
@@ -136,7 +136,7 @@ def build_timeline(
         "placed": {
             "segments": sum(1 for shot in shots if shot.track_type == "video"),
             "audio": any(shot.track_type == "audio" for shot in shots),
-            "selectors": selectors,
+            "selectors": made,
         },
         "warnings": [finding.as_dict() for finding in checked.warnings],
     }
@@ -165,18 +165,18 @@ def _refuse_what_cannot_be_placed(doc: dict[str, Any]) -> None:
 
 def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int) -> list[Shot]:
     """Every append the cut asks for, positioned absolutely from the timeline start."""
-    placed = positions(doc)
+    placed = placements(doc, start)
     shots = []
     for segment in doc["segments"]:
         id = str(segment["id"])
-        offset, duration = placed[id]
+        record, duration = placed[id]
         shots.append(
             _shot(
                 id=id,
                 track_type="video",
                 located=clips[str(segment["source"])],
                 source_in=int(segment["in"]),
-                record=start + offset,
+                record=record,
                 duration=duration,
             )
         )
@@ -209,11 +209,16 @@ def _shot(
         id=id,
         track_type=track_type,
         clip=located.clip,
-        name=str(located.clip.GetName() or ""),
+        name=_clip_name(located),
         source_in=source_in,
         record=record,
         duration=duration,
     )
+
+
+def _clip_name(located: media.LocatedClip) -> str:
+    """What to call the clip in a failure — read once, since a dead handle answers nothing."""
+    return str(located.clip.GetName() or "")
 
 
 def _selectors(
@@ -244,7 +249,7 @@ def _take(alternate: dict[str, Any], clips: dict[str, media.LocatedClip]) -> tak
     return takes.Take(
         source=source,
         clip=located.clip,
-        name=str(located.clip.GetName() or ""),
+        name=_clip_name(located),
         source_in=int(alternate["in"]),
         duration=int(alternate["out"]) - int(alternate["in"]),
     )

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -32,7 +32,7 @@ from ..cut.validate import locked_track_finding, positions
 from ..errors import BuildFailedError, CutInvalidError, UnsupportedCutFeatureError
 from ..logging_config import get_logger
 from ..naming import next_version_name
-from . import cut, media
+from . import cut, media, takes
 from . import timeline as timeline_read
 from .connection import ResolveConnection
 
@@ -118,11 +118,15 @@ def build_timeline(
     _unlock_stills(clips)
 
     built = _create(pool, project, name)
-    shots = _shots(doc, clips, _start_frame(built))
+    shots = _shots(doc, clips, timeline_read.start_frame(built))
     _make_tracks(built, shots, name)
     _refuse_locked_tracks(built, shots, name)
     _append(pool, shots, name)
     _verify(built, shots, name)
+    # Takes hang off placed clips, so they are attached only once every placement has been
+    # read back — a selector on a shot that slid somewhere else would be alternates for a
+    # shot the cut file does not have.
+    selectors = takes.attach_takes(built, _selectors(doc, clips, shots), name)
 
     log.info("Built %s: %d clips from %s", name, len(shots), checked.loaded.content_hash)
     return {
@@ -132,6 +136,7 @@ def build_timeline(
         "placed": {
             "segments": sum(1 for shot in shots if shot.track_type == "video"),
             "audio": any(shot.track_type == "audio" for shot in shots),
+            "selectors": selectors,
         },
         "warnings": [finding.as_dict() for finding in checked.warnings],
     }
@@ -211,13 +216,38 @@ def _shot(
     )
 
 
-def _start_frame(timeline: Timeline) -> int:
-    """The timeline's own first frame. A record frame below it is *not* clamped (#18 (d))."""
-    try:
-        return int(float(timeline.GetStartFrame()))
-    except (TypeError, ValueError):
-        log.warning("Resolve gave an unreadable start frame; placing from 0")
-        return 0
+def _selectors(
+    doc: dict[str, Any],
+    clips: dict[str, media.LocatedClip],
+    shots: list[Shot],
+) -> list[takes.Selector]:
+    """The alternates each segment carries, against the record frame its shot landed on."""
+    records = {shot.id: shot.record for shot in shots if shot.track_type == "video"}
+    found = []
+    for segment in doc["segments"]:
+        alternates = segment.get("alternates") or []
+        if not alternates:
+            continue
+        found.append(
+            takes.Selector(
+                segment=str(segment["id"]),
+                record=records[str(segment["id"])],
+                takes=tuple(_take(alternate, clips) for alternate in alternates),
+            )
+        )
+    return found
+
+
+def _take(alternate: dict[str, Any], clips: dict[str, media.LocatedClip]) -> takes.Take:
+    source = str(alternate["source"])
+    located = clips[source]
+    return takes.Take(
+        source=source,
+        clip=located.clip,
+        name=str(located.clip.GetName() or ""),
+        source_in=int(alternate["in"]),
+        duration=int(alternate["out"]) - int(alternate["in"]),
+    )
 
 
 # --- the writes -------------------------------------------------------------------------------

--- a/src/resolve_mcp/resolve/takes.py
+++ b/src/resolve_mcp/resolve/takes.py
@@ -286,7 +286,7 @@ def _shot_at(
     is not this segment's at all, and the swap would land on the wrong angle.
     """
     item = _items_by_record(timeline).get(record)
-    if item is not None and int(item.GetDuration() or 0) == duration:
+    if item is not None and timeline_read.read_frames(item.GetDuration()) == duration:
         return item
     raise InvalidRequestError(
         cause=f"No {duration}-frame shot starts at frame {record} on V1 of {name!r}, where this "

--- a/src/resolve_mcp/resolve/takes.py
+++ b/src/resolve_mcp/resolve/takes.py
@@ -26,8 +26,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Final
 
-from ..cut.document import read_cut_file
-from ..cut.validate import Finding, positions, validate_structure
+from ..cut.document import LoadedCut, read_cut_file
+from ..cut.validate import Finding, placements, validate_structure
 from ..errors import (
     BuildFailedError,
     CutInvalidError,
@@ -49,8 +49,8 @@ TimelineItem = Any
 MAIN_TAKE: Final = 1
 """The main clip's slot. The build ends every selector here; a swap counts from here."""
 
-VIDEO_TRACK: Final = 1
-"""Sequential V1: a segment's selector is always on the first video track."""
+VIDEO_TRACK: Final = timeline_read.FIRST_TRACK
+"""Sequential V1: a segment's selector is always on the video track the build placed it on."""
 
 
 @dataclass(frozen=True)
@@ -99,6 +99,7 @@ def attach_takes(timeline: Timeline, selectors: list[Selector], name: str) -> in
             raise BuildFailedError(
                 cause=f"The shot for segment {selector.segment!r} is no longer on V1 of "
                 f"{name!r}, so its alternates could not be attached.",
+                fix="Delete the version this build made and build again.",
                 detail={"timeline": name, "segment": selector.segment},
             )
         _add_takes(item, selector, name)
@@ -122,7 +123,7 @@ def _add_takes(item: TimelineItem, selector: Selector, name: str) -> None:
                     "clip": take.name,
                 },
             )
-    found = takes_count(item)
+    found = _takes_count(item)
     if found != selector.wanted:
         raise BuildFailedError(
             cause=f"Segment {selector.segment!r} holds {found} take(s) after adding "
@@ -157,7 +158,9 @@ def swap_take(
     timeline: str | None = None,
 ) -> dict[str, Any]:
     """Select take ``take`` on ``segment``'s shot, in place, and report the cut-file edit."""
-    doc = _checked_doc(cut_file)
+    loaded = _checked_cut(cut_file)
+    # E1 is an error, so a cut file that gets here parsed and matched the schema.
+    doc: dict[str, Any] = loaded.doc
     chosen = _segment(doc, segment)
     listed = _selector_of(doc, chosen)
     _refuse_index(segment, take, listed)
@@ -165,18 +168,17 @@ def swap_take(
     project = timeline_read.open_project(connection)
     target = timeline_read.find_timeline(project, timeline)
     name = timeline_read.name_of(target)
-    record = timeline_read.start_frame(target) + positions(doc)[segment][0]
-    item = _shot_at(target, record, segment, name)
+    record, duration = placements(doc, timeline_read.start_frame(target))[segment]
+    item = _shot_at(target, record, duration, segment, name)
     _refuse_drift(item, segment, listed, name)
 
-    previous = selected_take(item)
+    previous = _selected_take(item)
     changed = previous != take
     if changed:
         _select(item, take, _swap_failure(segment, take, name))
         log.info("Swapped segment %s of %s from take %d to take %d", segment, name, previous, take)
 
-    loaded = read_cut_file(cut_file)
-    fps = _fps(doc)
+    fps = float(doc["timeline"]["fps"])
     return {
         "cut_file": str(loaded.path),
         "content_hash": loaded.content_hash,
@@ -187,14 +189,19 @@ def swap_take(
         "changed": changed,
         "selected": listed[take - 1],
         "previous": listed[previous - 1] if 1 <= previous <= len(listed) else None,
-        "duration": dual_time(int(chosen["out"]) - int(chosen["in"]), fps),
+        "duration": dual_time(duration, fps),
         "selector": listed,
         "sync": _sync(chosen, take),
     }
 
 
-def _checked_doc(cut_file: str) -> dict[str, Any]:
-    """The cut file, refused unless it still validates — positions come out of it."""
+def _checked_cut(cut_file: str) -> LoadedCut:
+    """The cut file, refused unless it still validates.
+
+    Read once and carried, so the hash the report echoes is the hash of the very bytes the
+    swap was computed from — a second read could pick up an edit made in between and put a
+    provenance stamp on the report that nothing here ever looked at.
+    """
     loaded = read_cut_file(cut_file)
     findings: list[Finding] = (
         [loaded.parse_error] if loaded.parse_error is not None else validate_structure(loaded.doc)
@@ -209,9 +216,7 @@ def _checked_doc(cut_file: str) -> dict[str, Any]:
                 "errors": [finding.as_dict() for finding in errors],
             },
         )
-    # E1 is an error, so a document that gets here parsed and matched the schema.
-    checked: dict[str, Any] = loaded.doc
-    return checked
+    return loaded
 
 
 def _segment(doc: dict[str, Any], segment: str) -> dict[str, Any]:
@@ -243,30 +248,58 @@ def _selector_of(doc: dict[str, Any], segment: dict[str, Any]) -> list[dict[str,
 
 
 def _refuse_index(segment: str, take: int, listed: list[dict[str, Any]]) -> None:
+    """A segment with no alternates has no selector at all, whatever index is asked for.
+
+    Take 1 on such a segment is not a harmless no-op to wave through: the shot on the
+    timeline is a plain clip, so there is nothing there to select and nothing the swap
+    could confirm. It is refused with the same answer as any other index — add an
+    alternate to the cut file, or you are asking for a rebuild rather than a swap.
+    """
+    if len(listed) == MAIN_TAKE:
+        raise InvalidRequestError(
+            cause=f"Segment {segment!r} has no alternates, so it has no takes to swap between.",
+            fix="Add an equal-duration alternate to this segment in the cut file and build a "
+            "new version — a shot with no alternates is a plain clip, not a take selector.",
+            detail={"segment": segment, "requested": take, "selector": listed},
+        )
     if MAIN_TAKE <= take <= len(listed):
         return
     raise InvalidRequestError(
         cause=f"Segment {segment!r} has {len(listed)} take(s), so take {take} does not exist.",
         fix="Takes are 1-based: 1 is the segment's own source, 2 onwards are its alternates "
-        "in the order the cut file lists them. detail.selector says which is which."
-        if len(listed) > MAIN_TAKE
-        else "This segment has no alternates, so there is nothing to swap to. Add an "
-        "equal-duration alternate to the cut file and build a new version.",
+        "in the order the cut file lists them. detail.selector says which is which.",
         detail={"segment": segment, "requested": take, "selector": listed},
     )
 
 
-def _shot_at(timeline: Timeline, record: int, segment: str, name: str) -> TimelineItem:
+def _shot_at(
+    timeline: Timeline,
+    record: int,
+    duration: int,
+    segment: str,
+    name: str,
+) -> TimelineItem:
+    """The shot this segment built, identified by where it sits and how long it runs.
+
+    Position is identity on a sequential V1, and the length is checked with it: a cut whose
+    earlier segments happen to sum to the same frame would otherwise hand back a shot that
+    is not this segment's at all, and the swap would land on the wrong angle.
+    """
     item = _items_by_record(timeline).get(record)
-    if item is not None:
+    if item is not None and int(item.GetDuration() or 0) == duration:
         return item
     raise InvalidRequestError(
-        cause=f"Nothing starts at frame {record} on V1 of {name!r}, where this cut file puts "
-        f"segment {segment!r}.",
+        cause=f"No {duration}-frame shot starts at frame {record} on V1 of {name!r}, where this "
+        f"cut file puts segment {segment!r}.",
         fix="This timeline was not built from this cut file, or was built from an earlier "
         "state of it. Name the version that was, or build_timeline the file again and swap "
         "on the new version.",
-        detail={"timeline": name, "segment": segment, "record_frame": record},
+        detail={
+            "timeline": name,
+            "segment": segment,
+            "record_frame": record,
+            "duration": duration,
+        },
     )
 
 
@@ -277,7 +310,7 @@ def _refuse_drift(
     name: str,
 ) -> None:
     """A selector that is not the shape the cut file describes means the two have drifted."""
-    found = takes_count(item)
+    found = _takes_count(item)
     if found == len(listed):
         return
     raise InvalidRequestError(
@@ -305,9 +338,10 @@ def _swap_failure(segment: str, take: int, name: str) -> TimelineOperationError:
 def _sync(segment: dict[str, Any], take: int) -> dict[str, Any] | None:
     """The cut-file edit this swap needs: the alternate promoted, the old main demoted.
 
-    They trade slots rather than shuffling the list, so the selector a rebuild produces has
-    the same order as the one on the timeline now — and today's take indexes keep meaning
-    what they meant. Take 1 needs no edit at all: the file already says main is selected.
+    The two trade slots rather than the list shuffling up, so the selector a rebuild produces
+    is the same length and the same shape as the one on the timeline now: only slots 1 and
+    ``take`` change hands, and every other alternate keeps the index it has today. Take 1
+    needs no edit at all — the file already says main is the selection.
     """
     if take == MAIN_TAKE:
         return None
@@ -328,29 +362,22 @@ def _range(entry: dict[str, Any]) -> dict[str, Any]:
     return {"source": str(entry["source"]), "in": int(entry["in"]), "out": int(entry["out"])}
 
 
-def _fps(doc: dict[str, Any]) -> float | None:
-    try:
-        return float(doc["timeline"]["fps"])
-    except (KeyError, TypeError, ValueError):
-        return None
-
-
 # --- the seam itself --------------------------------------------------------------------------
 
 
 def _select(item: TimelineItem, index: int, failure: ResolveMcpError) -> None:
     """Select a take and read the selection back: the return value alone proves nothing."""
-    if not item.SelectTakeByIndex(index) or selected_take(item) != index:
-        failure.detail["selected"] = selected_take(item)
+    if not item.SelectTakeByIndex(index) or _selected_take(item) != index:
+        failure.detail["selected"] = _selected_take(item)
         raise failure
 
 
-def takes_count(item: TimelineItem) -> int:
+def _takes_count(item: TimelineItem) -> int:
     """How many takes the selector holds — zero for a clip that is not a selector at all."""
     return _reading(item, "GetTakesCount")
 
 
-def selected_take(item: TimelineItem) -> int:
+def _selected_take(item: TimelineItem) -> int:
     """The selected take's 1-based index, or zero when the clip is not a take selector."""
     return _reading(item, "GetSelectedTakeIndex")
 

--- a/src/resolve_mcp/resolve/takes.py
+++ b/src/resolve_mcp/resolve/takes.py
@@ -1,0 +1,376 @@
+"""Take selectors: the angle choices a built cut keeps, and the one edit made in place.
+
+Everything else in the cut model is declarative — change the file, build a new version.
+Takes are the exception, and they earn it: a review round is a director saying "try the
+other angle on that shot", and rebuilding a whole concert to answer that would cost
+minutes for a change that alters one frame range.
+
+Two rules make the exception safe, and both are the schema's, not this file's:
+
+* **Equal durations.** An alternate is the same length as the main take, so selecting it
+  cannot ripple the sequential V1. An unequal-length choice is a main-segment edit and a
+  rebuild — there is no in-place answer to it.
+* **Main is the selection.** The selector is ``[main, *alternates]`` and the build leaves
+  it sitting on take 1, so a freshly built timeline always shows what the cut file says.
+  After a swap the two disagree until the agent edits the file, which is why every swap
+  reports the exact edit that puts them back in step. The server never writes the file.
+
+``AddTake`` and ``SelectTakeByIndex`` both answer a bare ``Bool``, so — as everywhere else
+at this seam — the answer is counted and the selector read back, never believed. The one
+call this module deliberately never makes is ``FinalizeTake``: it collapses a selector into
+a plain clip permanently, which would throw away every alternate the cut file describes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from ..cut.document import read_cut_file
+from ..cut.validate import Finding, positions, validate_structure
+from ..errors import (
+    BuildFailedError,
+    CutInvalidError,
+    InvalidRequestError,
+    ResolveMcpError,
+    TimelineOperationError,
+)
+from ..logging_config import get_logger
+from ..timing import dual_time
+from . import timeline as timeline_read
+from .connection import ResolveConnection
+
+log = get_logger("takes")
+
+Clip = Any
+Timeline = Any
+TimelineItem = Any
+
+MAIN_TAKE: Final = 1
+"""The main clip's slot. The build ends every selector here; a swap counts from here."""
+
+VIDEO_TRACK: Final = 1
+"""Sequential V1: a segment's selector is always on the first video track."""
+
+
+@dataclass(frozen=True)
+class Take:
+    """One alternate, resolved to the media it plays and the frames it plays of it."""
+
+    source: str
+    clip: Clip
+    name: str
+    source_in: int
+    duration: int
+
+    @property
+    def source_out(self) -> int:
+        """Half-open, the same as an append's ``endFrame`` — the cut file's only convention."""
+        return self.source_in + self.duration
+
+
+@dataclass(frozen=True)
+class Selector:
+    """One segment's alternates, and the record frame of the shot they hang off."""
+
+    segment: str
+    record: int
+    takes: tuple[Take, ...]
+
+    @property
+    def wanted(self) -> int:
+        """Takes the finished selector must hold: the main clip plus every alternate."""
+        return len(self.takes) + MAIN_TAKE
+
+
+# --- building ---------------------------------------------------------------------------------
+
+
+def attach_takes(timeline: Timeline, selectors: list[Selector], name: str) -> int:
+    """Turn each segment that has alternates into a take selector sitting on its main clip."""
+    if not selectors:
+        return 0
+    placed = _items_by_record(timeline)
+    for selector in selectors:
+        item = placed.get(selector.record)
+        if item is None:
+            # _verify has already matched every placement, so this is unreachable by a
+            # build that got here — and still worth refusing rather than skipping.
+            raise BuildFailedError(
+                cause=f"The shot for segment {selector.segment!r} is no longer on V1 of "
+                f"{name!r}, so its alternates could not be attached.",
+                detail={"timeline": name, "segment": selector.segment},
+            )
+        _add_takes(item, selector, name)
+        _select(item, MAIN_TAKE, _selector_failure(selector, name))
+    log.info("Attached take selectors to %d segment(s) of %s", len(selectors), name)
+    return len(selectors)
+
+
+def _add_takes(item: TimelineItem, selector: Selector, name: str) -> None:
+    for take in selector.takes:
+        if not item.AddTake(take.clip, take.source_in, take.source_out):
+            raise BuildFailedError(
+                cause=f"Resolve refused to add {take.name!r} as an alternate take on segment "
+                f"{selector.segment!r}.",
+                fix="Check the alternate's source clip is online and its range is inside the "
+                "media, then build again — inspect_clip reports both.",
+                detail={
+                    "timeline": name,
+                    "segment": selector.segment,
+                    "source": take.source,
+                    "clip": take.name,
+                },
+            )
+    found = takes_count(item)
+    if found != selector.wanted:
+        raise BuildFailedError(
+            cause=f"Segment {selector.segment!r} holds {found} take(s) after adding "
+            f"{len(selector.takes)}, not the {selector.wanted} the cut file describes.",
+            fix="Delete the version this build made and build again; if it repeats, the "
+            "alternates cannot be attached on this footage and the cut needs them removed.",
+            detail={
+                "timeline": name,
+                "segment": selector.segment,
+                "takes": {"wanted": selector.wanted, "found": found},
+            },
+        )
+
+
+def _selector_failure(selector: Selector, name: str) -> BuildFailedError:
+    return BuildFailedError(
+        cause=f"The take selector on segment {selector.segment!r} would not settle on its "
+        f"main take, so {name!r} may be showing an alternate the cut file does not.",
+        fix="Delete the version this build made and build again.",
+        detail={"timeline": name, "segment": selector.segment},
+    )
+
+
+# --- swapping ---------------------------------------------------------------------------------
+
+
+def swap_take(
+    connection: ResolveConnection,
+    cut_file: str,
+    segment: str,
+    take: int,
+    timeline: str | None = None,
+) -> dict[str, Any]:
+    """Select take ``take`` on ``segment``'s shot, in place, and report the cut-file edit."""
+    doc = _checked_doc(cut_file)
+    chosen = _segment(doc, segment)
+    listed = _selector_of(doc, chosen)
+    _refuse_index(segment, take, listed)
+
+    project = timeline_read.open_project(connection)
+    target = timeline_read.find_timeline(project, timeline)
+    name = timeline_read.name_of(target)
+    record = timeline_read.start_frame(target) + positions(doc)[segment][0]
+    item = _shot_at(target, record, segment, name)
+    _refuse_drift(item, segment, listed, name)
+
+    previous = selected_take(item)
+    changed = previous != take
+    if changed:
+        _select(item, take, _swap_failure(segment, take, name))
+        log.info("Swapped segment %s of %s from take %d to take %d", segment, name, previous, take)
+
+    loaded = read_cut_file(cut_file)
+    fps = _fps(doc)
+    return {
+        "cut_file": str(loaded.path),
+        "content_hash": loaded.content_hash,
+        "timeline": timeline_read.summarise(
+            timeline_read.Reader(connection), target, project, name
+        ),
+        "segment": segment,
+        "changed": changed,
+        "selected": listed[take - 1],
+        "previous": listed[previous - 1] if 1 <= previous <= len(listed) else None,
+        "duration": dual_time(int(chosen["out"]) - int(chosen["in"]), fps),
+        "selector": listed,
+        "sync": _sync(chosen, take),
+    }
+
+
+def _checked_doc(cut_file: str) -> dict[str, Any]:
+    """The cut file, refused unless it still validates — positions come out of it."""
+    loaded = read_cut_file(cut_file)
+    findings: list[Finding] = (
+        [loaded.parse_error] if loaded.parse_error is not None else validate_structure(loaded.doc)
+    )
+    errors = [finding for finding in findings if finding.severity == "error"]
+    if errors:
+        raise CutInvalidError(
+            cause=f"The cut file has {len(errors)} error(s), so no take was swapped.",
+            detail={
+                "cut_file": str(loaded.path),
+                "content_hash": loaded.content_hash,
+                "errors": [finding.as_dict() for finding in errors],
+            },
+        )
+    # E1 is an error, so a document that gets here parsed and matched the schema.
+    checked: dict[str, Any] = loaded.doc
+    return checked
+
+
+def _segment(doc: dict[str, Any], segment: str) -> dict[str, Any]:
+    for candidate in doc["segments"]:
+        if str(candidate["id"]) == segment:
+            found: dict[str, Any] = candidate
+            return found
+    available = [str(candidate["id"]) for candidate in doc["segments"]]
+    raise InvalidRequestError(
+        cause=f"The cut file has no segment {segment!r}.",
+        fix=f"Segment ids come from the cut file and must match exactly: {', '.join(available)}.",
+        detail={"requested": segment, "available": available},
+    )
+
+
+def _selector_of(doc: dict[str, Any], segment: dict[str, Any]) -> list[dict[str, Any]]:
+    """``[main, *alternates]`` as the agent sees it: 1-based, with the clip each take plays."""
+    entries = [segment, *(segment.get("alternates") or [])]
+    return [
+        {
+            "index": index,
+            "source": str(entry["source"]),
+            "clip": str(doc["sources"][str(entry["source"])]["clip"]),
+            "in": int(entry["in"]),
+            "out": int(entry["out"]),
+        }
+        for index, entry in enumerate(entries, start=MAIN_TAKE)
+    ]
+
+
+def _refuse_index(segment: str, take: int, listed: list[dict[str, Any]]) -> None:
+    if MAIN_TAKE <= take <= len(listed):
+        return
+    raise InvalidRequestError(
+        cause=f"Segment {segment!r} has {len(listed)} take(s), so take {take} does not exist.",
+        fix="Takes are 1-based: 1 is the segment's own source, 2 onwards are its alternates "
+        "in the order the cut file lists them. detail.selector says which is which."
+        if len(listed) > MAIN_TAKE
+        else "This segment has no alternates, so there is nothing to swap to. Add an "
+        "equal-duration alternate to the cut file and build a new version.",
+        detail={"segment": segment, "requested": take, "selector": listed},
+    )
+
+
+def _shot_at(timeline: Timeline, record: int, segment: str, name: str) -> TimelineItem:
+    item = _items_by_record(timeline).get(record)
+    if item is not None:
+        return item
+    raise InvalidRequestError(
+        cause=f"Nothing starts at frame {record} on V1 of {name!r}, where this cut file puts "
+        f"segment {segment!r}.",
+        fix="This timeline was not built from this cut file, or was built from an earlier "
+        "state of it. Name the version that was, or build_timeline the file again and swap "
+        "on the new version.",
+        detail={"timeline": name, "segment": segment, "record_frame": record},
+    )
+
+
+def _refuse_drift(
+    item: TimelineItem,
+    segment: str,
+    listed: list[dict[str, Any]],
+    name: str,
+) -> None:
+    """A selector that is not the shape the cut file describes means the two have drifted."""
+    found = takes_count(item)
+    if found == len(listed):
+        return
+    raise InvalidRequestError(
+        cause=f"Segment {segment!r} on {name!r} holds {found} take(s), not the "
+        f"{len(listed)} this cut file describes.",
+        fix="The timeline and the cut file have drifted apart — build_timeline the file "
+        "again and swap on the version that comes out.",
+        detail={
+            "timeline": name,
+            "segment": segment,
+            "takes": {"wanted": len(listed), "found": found},
+        },
+    )
+
+
+def _swap_failure(segment: str, take: int, name: str) -> TimelineOperationError:
+    return TimelineOperationError(
+        cause=f"Resolve would not select take {take} on segment {segment!r} of {name!r}.",
+        fix="Check the timeline is not locked or mid-render in the Resolve GUI, then retry. "
+        "The shot still shows whichever take detail.selected names.",
+        detail={"timeline": name, "segment": segment, "requested": take},
+    )
+
+
+def _sync(segment: dict[str, Any], take: int) -> dict[str, Any] | None:
+    """The cut-file edit this swap needs: the alternate promoted, the old main demoted.
+
+    They trade slots rather than shuffling the list, so the selector a rebuild produces has
+    the same order as the one on the timeline now — and today's take indexes keep meaning
+    what they meant. Take 1 needs no edit at all: the file already says main is selected.
+    """
+    if take == MAIN_TAKE:
+        return None
+    alternates = [_range(entry) for entry in segment.get("alternates") or []]
+    slot = take - MAIN_TAKE - 1
+    promoted = alternates[slot]
+    alternates[slot] = _range(segment)
+    return {
+        "segment": str(segment["id"]),
+        "source": promoted["source"],
+        "in": promoted["in"],
+        "out": promoted["out"],
+        "alternates": alternates,
+    }
+
+
+def _range(entry: dict[str, Any]) -> dict[str, Any]:
+    return {"source": str(entry["source"]), "in": int(entry["in"]), "out": int(entry["out"])}
+
+
+def _fps(doc: dict[str, Any]) -> float | None:
+    try:
+        return float(doc["timeline"]["fps"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+# --- the seam itself --------------------------------------------------------------------------
+
+
+def _select(item: TimelineItem, index: int, failure: ResolveMcpError) -> None:
+    """Select a take and read the selection back: the return value alone proves nothing."""
+    if not item.SelectTakeByIndex(index) or selected_take(item) != index:
+        failure.detail["selected"] = selected_take(item)
+        raise failure
+
+
+def takes_count(item: TimelineItem) -> int:
+    """How many takes the selector holds — zero for a clip that is not a selector at all."""
+    return _reading(item, "GetTakesCount")
+
+
+def selected_take(item: TimelineItem) -> int:
+    """The selected take's 1-based index, or zero when the clip is not a take selector."""
+    return _reading(item, "GetSelectedTakeIndex")
+
+
+def _reading(item: TimelineItem, method: str) -> int:
+    try:
+        return int(getattr(item, method)() or 0)
+    except (AttributeError, TypeError, ValueError):
+        # fusionscript hands back None for a name it does not know, so a build old enough
+        # to lack the method calls None — which is a TypeError, not an AttributeError.
+        log.warning("Resolve gave no answer to %s; reading it as 0", method)
+        return 0
+
+
+def _items_by_record(timeline: Timeline) -> dict[int, TimelineItem]:
+    """V1 keyed by start frame — how a segment's own shot is found, position being identity."""
+    return {
+        int(item.GetStart()): item
+        for item in timeline.GetItemListInTrack("video", VIDEO_TRACK) or []
+    }
+
+
+__all__ = ["MAIN_TAKE", "Selector", "Take", "attach_takes", "swap_take"]

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -147,6 +147,20 @@ def version_of(name: str) -> tuple[str, int | None]:
     return match.group("base"), int(match.group("number"))
 
 
+def start_frame(timeline: Timeline) -> int:
+    """The timeline's own first frame — an hour of timecode on a normal project.
+
+    Every absolute position counts from here, because ``recordFrame`` is *not* clamped to
+    the timeline's span (#18 (d)): a cut frame of 0 sent raw would land before it begins.
+    An unreadable answer counts from 0 rather than stopping, and says so in the log.
+    """
+    frames = read_frames(timeline.GetStartFrame())
+    if frames is None:
+        log.warning("Resolve gave an unreadable start frame; counting from 0")
+        return 0
+    return frames
+
+
 def next_free_name(requested: str, existing: set[str]) -> str:
     """A name no timeline in the project answers to, following ``<base> v<N>``.
 
@@ -523,7 +537,10 @@ def read_item(
         "sync_offset": dual_time(offset, fps),
         "clip": _clip_name(reader, item),
         "enabled": bool(reader.optional(item, "GetClipEnabled", True)),
-        "takes": int(reader.optional(item, "GetTakeCount", 0) or 0),
+        # ``GetTakesCount``, not ``GetTakeCount``: the plural is the method the scripting
+        # README actually declares (line 523), and fusionscript answers an unknown name
+        # with ``None`` rather than raising — so the singular read as zero takes forever.
+        "takes": int(reader.optional(item, "GetTakesCount", 0) or 0),
     }
 
 

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -27,7 +27,7 @@ rather than API calls, and are the reason this file exists at all:
 from __future__ import annotations
 
 import re
-from typing import Any, NamedTuple
+from typing import Any, Final, NamedTuple
 
 from ..config import Config, get_config
 from ..errors import (
@@ -145,6 +145,14 @@ def version_of(name: str) -> tuple[str, int | None]:
     if match is None:
         return name, None
     return match.group("base"), int(match.group("number"))
+
+
+FIRST_TRACK: Final = 1
+"""A sequential V1 cut is one video track and one audio track: both the first of their kind.
+
+Where the build places and where a swap looks have to be the same track, so the index is
+named once rather than written as a literal 1 in each of them.
+"""
 
 
 def start_frame(timeline: Timeline) -> int:

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -29,7 +29,10 @@ together, ranges are half-open [in, out), and a time you give in seconds must sa
 snap it to a frame ({"seconds": 2.52, "snap": "floor"}).
 
 Editing is declarative: you author a cut file, the server builds it. Call get_cut_schema
-before writing one and validate_cut after every edit — do not guess the format.
+before writing one and validate_cut after every edit — do not guess the format. Every
+change is a rebuild into a new version, with one exception: swap_take flips a shot to one
+of its alternates in place. It is yours to keep the cut file in step afterwards — the
+server never writes it, and the swap report says exactly what to change.
 
 Heavy work (renders, analysis) hands back a job_id straight away — carry on working and
 poll it with get_job; list_jobs finds what you started before a restart. Results are cached

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -1,14 +1,15 @@
-"""The cut-file tools: the contract, and the dry run that holds you to it.
+"""The cut-file tools: the contract, the dry run, the build, and the one in-place edit.
 
-A cut file is yours — you author it, the server never writes it. These two tools are how
-you find out what it must contain and whether the one you wrote will build.
+A cut file is yours — you author it, the server never writes it. These tools are how you
+find out what it must contain, whether the one you wrote will build, what happened when it
+did, and how to flip a shot's angle on a built version without starting over.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from ..resolve import build, cut
+from ..resolve import build, cut, takes
 from ..resolve.connection import get_connection
 from .envelope import tool
 
@@ -61,10 +62,35 @@ def build_timeline(
     return build.build_timeline(connection, cut_file, min_segment_frames)
 
 
+@tool
+def swap_take(
+    cut_file: str,
+    segment: str,
+    take: int,
+    timeline: str | None = None,
+) -> dict[str, Any]:
+    """Switch which take a built segment shows, in place, without rebuilding the timeline.
+
+    This is the one edit that does not go through a rebuild, and it only works because
+    alternates are the same length as the take they replace. `take` is the 1-based slot in
+    the selector the cut file describes: 1 is the segment's own `source`, 2 onwards are its
+    `alternates` in order. The report lists the whole selector, so the numbers never have to
+    be guessed, and names the version it touched — `timeline` defaults to the open one.
+
+    Afterwards the timeline and the cut file disagree, and only you can fix that: `sync`
+    holds the exact segment fields to write — the chosen alternate promoted to main, the
+    old main demoted into its slot — so a later rebuild reproduces what is on screen now.
+    A swap on a timeline this cut file did not build is refused rather than guessed at.
+    """
+    connection = get_connection()
+    return takes.swap_take(connection, cut_file, segment, take, timeline)
+
+
 TOOLS: tuple[Any, ...] = (
     get_cut_schema,
     validate_cut,
     build_timeline,
+    swap_take,
 )
 
-__all__ = ["TOOLS", "build_timeline", "get_cut_schema", "validate_cut"]
+__all__ = ["TOOLS", "build_timeline", "get_cut_schema", "swap_take", "validate_cut"]

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -80,7 +80,11 @@ def swap_take(
     Afterwards the timeline and the cut file disagree, and only you can fix that: `sync`
     holds the exact segment fields to write — the chosen alternate promoted to main, the
     old main demoted into its slot — so a later rebuild reproduces what is on screen now.
-    A swap on a timeline this cut file did not build is refused rather than guessed at.
+
+    A shot is found by the position and length this cut file computes for the segment, and
+    its selector must be the size the file describes; anything else is refused as drift with
+    a fix rather than swapped on a guess. That is a shape check, not proof of provenance —
+    if it matters which version you are on, compare `content_hash` against the build report.
     """
     connection = get_connection()
     return takes.swap_take(connection, cut_file, segment, take, timeline)

--- a/tests/cutfile.py
+++ b/tests/cutfile.py
@@ -1,0 +1,148 @@
+"""The cut file and media pool the build tests share.
+
+One miniature concert — three shots over one continuous master mix — used by every test
+that builds a cut and by every test that swaps a take on a built one. They are the same
+fixture on purpose: a swap is only meaningful against a timeline this build made.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .fakes import FakeMediaPoolItem, FakeTimeline, FakeTimelineItem, media_pool, studio
+
+
+def a_cut(tmp_path: Path, doc: Any, name: str = "sunset-set.cut.json") -> str:
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def valid_doc(**overrides: Any) -> dict[str, Any]:
+    """Three shots over one continuous master mix — the concert substrate, in miniature."""
+    doc: dict[str, Any] = {
+        "schema": 1,
+        "timeline": {"name": "sunset-set", "fps": 59.94},
+        "sources": {
+            "gtr_close": {"clip": "C0012.mp4", "bin": "Angles"},
+            "keys_wide": {"clip": "C0031.mp4", "bin": "Angles"},
+            "master_mix": {"clip": "sunset-master.wav"},
+        },
+        "audio": {"source": "master_mix", "in": 0, "out": 240},
+        "segments": [
+            {"id": "s001", "source": "gtr_close", "in": 1000, "out": 1100},
+            {"id": "s002", "source": "keys_wide", "in": 4000, "out": 4080},
+            {"id": "s003", "source": "gtr_close", "in": 2500, "out": 2560},
+        ],
+    }
+    doc.update(overrides)
+    return doc
+
+
+SEGMENT_DURATIONS = (100, 80, 60)
+TOTAL_FRAMES = sum(SEGMENT_DURATIONS)
+
+
+def doc_with_alternates() -> dict[str, Any]:
+    """The same cut with two of its three shots carrying an equal-duration angle choice.
+
+    ``s002`` carries two alternates off *one* source: a second and third pass of the same
+    tune from the same camera is an ordinary retake, so an alias is not a unique key into
+    a selector — which is why swap_take counts indexes rather than naming a source.
+    """
+    doc = valid_doc()
+    doc["segments"][0]["alternates"] = [{"source": "keys_wide", "in": 4500, "out": 4600}]
+    doc["segments"][1]["alternates"] = [
+        {"source": "gtr_close", "in": 5000, "out": 5080},
+        {"source": "gtr_close", "in": 7000, "out": 7080},
+    ]
+    return doc
+
+
+def a_pool(**clips: FakeMediaPoolItem) -> Any:
+    """The pool :func:`valid_doc` builds against; ``clips`` swaps one out by alias."""
+    angle = clips.get(
+        "gtr_close",
+        FakeMediaPoolItem(
+            "C0012.mp4",
+            file_path="D:/media/C0012.mp4",
+            properties={"Frames": "20000", "Start": "0", "End": "19999"},
+        ),
+    )
+    keys = clips.get(
+        "keys_wide",
+        FakeMediaPoolItem(
+            "C0031.mp4",
+            file_path="D:/media/C0031.mp4",
+            properties={"Frames": "20000", "Start": "0", "End": "19999"},
+        ),
+    )
+    master = clips.get(
+        "master_mix",
+        FakeMediaPoolItem(
+            "sunset-master.wav",
+            file_path="D:/media/sunset-master.wav",
+            properties={"Type": "Audio", "FPS": "", "Frames": "600", "Start": "0", "End": "599"},
+        ),
+    )
+    return media_pool({"Angles": [angle, keys], "": [master]})
+
+
+def empty_project(pool: Any, **kwargs: Any) -> Any:
+    """A project with a media pool and no timelines yet."""
+    return studio(timeline=None, timelines=[], pool=pool, **kwargs)
+
+
+def built(resolve: Any, name: str) -> FakeTimeline:
+    """The timeline the build made, read back off the project."""
+    project = resolve.current_project
+    found = [
+        project.GetTimelineByIndex(index)
+        for index in range(1, project.GetTimelineCount() + 1)
+        if project.GetTimelineByIndex(index) is not None
+    ]
+    match: FakeTimeline = next(timeline for timeline in found if timeline.GetName() == name)
+    return match
+
+
+def placements(
+    timeline: FakeTimeline,
+    track_type: str = "video",
+    index: int = 1,
+) -> list[tuple[str, int, int]]:
+    return [
+        (item.GetName(), item.GetStart(), item.GetDuration())
+        for item in timeline.GetItemListInTrack(track_type, index) or []
+    ]
+
+
+def shots(timeline: FakeTimeline) -> list[FakeTimelineItem]:
+    """The video track, item by item — where a segment's take selector lives."""
+    items: list[FakeTimelineItem] = list(timeline.GetItemListInTrack("video", 1) or [])
+    return items
+
+
+def selector(item: FakeTimelineItem) -> list[tuple[str, int, int]]:
+    """Every take in the item's selector, in order: which clip, and which source frames."""
+    return [
+        (take["mediaPoolItem"].GetName(), take["startFrame"], take["endFrame"])
+        for take in (item.GetTakeByIndex(index) for index in range(1, item.GetTakesCount() + 1))
+        if take is not None
+    ]
+
+
+__all__ = [
+    "SEGMENT_DURATIONS",
+    "TOTAL_FRAMES",
+    "a_cut",
+    "a_pool",
+    "built",
+    "doc_with_alternates",
+    "empty_project",
+    "placements",
+    "selector",
+    "shots",
+    "valid_doc",
+]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -121,6 +121,14 @@ class FakeTimelineItem:
     for one it does not know. Verified live on Studio 21.0.3.7, where
     ``hasattr(item, "GetTakeCount")`` is ``True`` and the attribute is ``None`` — so a
     ``hasattr`` guard passes and the call then fails with ``NoneType is not callable``.
+    (``GetTakeCount`` is not an API method at all; the real one is ``GetTakesCount``, which
+    is why that particular name was the one caught being ``None``.)
+
+    The take selector is modelled with the same suspicion as the append: ``AddTake`` and
+    ``SelectTakeByIndex`` both answer ``Bool``, so ``takes_land`` and ``select_take_lands``
+    model the answer that lies — a truthy return over a selector that did not change.
+    ``FinalizeTake`` is deliberately absent: it collapses a selector permanently, so a
+    wrapper that called it should fail loudly here rather than quietly on a real cut.
     """
 
     def __init__(
@@ -140,6 +148,10 @@ class FakeTimelineItem:
         comps: Sequence[FakeFusionComp] | None = None,
         missing: frozenset[str] | set[str] | None = None,
         owner: FakeResolve | None = None,
+        add_take_result: bool = True,
+        takes_land: bool = True,
+        select_take_result: bool = True,
+        select_take_lands: bool = True,
     ) -> None:
         self._name = name
         self._start = start
@@ -149,7 +161,14 @@ class FakeTimelineItem:
         self._source_end = source_end
         self._media_item = media_item
         self._enabled = enabled
-        self._takes = takes
+        self._selector: list[dict[str, Any]] = [self._own_take() for _ in range(takes)]
+        self._selected = 1 if takes else 0
+        # Public so a test can break a selector *after* a build has made one — the item is
+        # created inside the build, so the constructor is not a seam a swap test can reach.
+        self.add_take_result = add_take_result
+        self.takes_land = takes_land
+        self.select_take_result = select_take_result
+        self.select_take_lands = select_take_lands
         self._supports_source_frames = supports_source_frames
         self._refuses = set(refuses or ())
         self._end_is_inclusive = end_is_inclusive
@@ -222,9 +241,67 @@ class FakeTimelineItem:
         self._check("GetClipEnabled")
         return self._enabled
 
-    def GetTakeCount(self) -> int:  # noqa: N802
-        self._check("GetTakeCount")
-        return self._takes
+    def _own_take(self) -> dict[str, Any]:
+        """The clip already on the track, as the take Resolve seeds a new selector with."""
+        start = self._source_start or 0
+        return {
+            "startFrame": start,
+            "endFrame": start + self._duration,
+            "mediaPoolItem": self._media_item,
+        }
+
+    def AddTake(  # noqa: N802
+        self,
+        media_item: FakeMediaPoolItem,
+        start_frame: int | None = None,
+        end_frame: int | None = None,
+    ) -> bool:
+        """Add a take, seeding the selector from the placed clip when there is none yet."""
+        self._check("AddTake")
+        if not self.add_take_result:
+            return False
+        if self.takes_land:
+            if not self._selector:
+                self._selector.append(self._own_take())
+            self._selector.append(
+                {
+                    "startFrame": start_frame,
+                    "endFrame": end_frame,
+                    "mediaPoolItem": media_item,
+                }
+            )
+            # *Unverified*: the README does not say where the selection lands after an add.
+            # The fake takes the worse of the two possibilities — the new take, not the main
+            # one — so a build that leaves the selection to chance shows up here rather than
+            # as the wrong angle on a director's timeline.
+            self._selected = len(self._selector)
+        return True
+
+    def GetTakesCount(self) -> int:  # noqa: N802
+        """Zero for a clip that is not a take selector — not one for its own media."""
+        self._check("GetTakesCount")
+        return len(self._selector)
+
+    def GetTakeByIndex(self, index: int) -> dict[str, Any] | None:  # noqa: N802
+        self._check("GetTakeByIndex")
+        if 1 <= index <= len(self._selector):
+            return dict(self._selector[index - 1])
+        return None
+
+    def GetSelectedTakeIndex(self) -> int:  # noqa: N802
+        """Zero when the clip is not a take selector, else the 1-based selection."""
+        self._check("GetSelectedTakeIndex")
+        return self._selected
+
+    def SelectTakeByIndex(self, index: int) -> bool:  # noqa: N802
+        self._check("SelectTakeByIndex")
+        if not self.select_take_result:
+            return False
+        if not 1 <= index <= len(self._selector):
+            return False
+        if self.select_take_lands:
+            self._selected = index
+        return True
 
     def GetFusionCompCount(self) -> int:  # noqa: N802
         """Zero for an ordinary clip. A Text+ instance that answers zero has lost its comp."""
@@ -613,6 +690,9 @@ class FakeMediaPool:
         self.import_folder_result: bool | None = None
         self.import_lands_nothing = False
         self.imported_folder: FakeFolder | None = None
+        # Take-selector knobs handed to every item this pool appends: an item a build
+        # creates cannot be configured any other way, since the test never holds it.
+        self.take_quirks: dict[str, Any] = {}
         self.append_calls: list[list[dict[str, Any]]] = []
         self.append_result: list[FakeTimelineItem] | None = None
         self.appends_share_one_comp = False
@@ -923,6 +1003,7 @@ class FakeMediaPool:
             media_item=clip,
             comps=comps,
             owner=self._owner,
+            **self.take_quirks,
         )
         # An explicit track index without a media type: Resolve reports success and drops it.
         if media_type is None and "trackIndex" in info:
@@ -949,6 +1030,7 @@ class FakeMediaPool:
                     media_item=clip,
                     comps=comps,
                     owner=self._owner,
+                    **self.take_quirks,
                 )
         if not self.appends_land_nowhere:
             timeline.place(track_type, index, item)

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -13,104 +13,25 @@ wrapper that trusted Resolve's return value fails these tests rather than a real
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Any
 
 from resolve_mcp.cut.document import content_hash
 from resolve_mcp.tools.cut import build_timeline
 
 from .conftest import Attach
-from .fakes import FakeMediaPoolItem, FakeTimeline, FakeTimelineItem, FakeTrack, media_pool, studio
-
-
-def a_cut(tmp_path: Path, doc: Any, name: str = "sunset-set.cut.json") -> str:
-    path = tmp_path / name
-    path.write_text(json.dumps(doc), encoding="utf-8")
-    return str(path)
-
-
-def valid_doc(**overrides: Any) -> dict[str, Any]:
-    """Three shots over one continuous master mix — the concert substrate, in miniature."""
-    doc: dict[str, Any] = {
-        "schema": 1,
-        "timeline": {"name": "sunset-set", "fps": 59.94},
-        "sources": {
-            "gtr_close": {"clip": "C0012.mp4", "bin": "Angles"},
-            "keys_wide": {"clip": "C0031.mp4", "bin": "Angles"},
-            "master_mix": {"clip": "sunset-master.wav"},
-        },
-        "audio": {"source": "master_mix", "in": 0, "out": 240},
-        "segments": [
-            {"id": "s001", "source": "gtr_close", "in": 1000, "out": 1100},
-            {"id": "s002", "source": "keys_wide", "in": 4000, "out": 4080},
-            {"id": "s003", "source": "gtr_close", "in": 2500, "out": 2560},
-        ],
-    }
-    doc.update(overrides)
-    return doc
-
-
-SEGMENT_DURATIONS = (100, 80, 60)
-TOTAL_FRAMES = sum(SEGMENT_DURATIONS)
-
-
-def a_pool(**clips: FakeMediaPoolItem) -> Any:
-    """The pool :func:`valid_doc` builds against; ``clips`` swaps one out by alias."""
-    angle = clips.get(
-        "gtr_close",
-        FakeMediaPoolItem(
-            "C0012.mp4",
-            file_path="D:/media/C0012.mp4",
-            properties={"Frames": "20000", "Start": "0", "End": "19999"},
-        ),
-    )
-    keys = clips.get(
-        "keys_wide",
-        FakeMediaPoolItem(
-            "C0031.mp4",
-            file_path="D:/media/C0031.mp4",
-            properties={"Frames": "20000", "Start": "0", "End": "19999"},
-        ),
-    )
-    master = clips.get(
-        "master_mix",
-        FakeMediaPoolItem(
-            "sunset-master.wav",
-            file_path="D:/media/sunset-master.wav",
-            properties={"Type": "Audio", "FPS": "", "Frames": "600", "Start": "0", "End": "599"},
-        ),
-    )
-    return media_pool({"Angles": [angle, keys], "": [master]})
-
-
-def empty_project(pool: Any, **kwargs: Any) -> Any:
-    """A project with a media pool and no timelines yet."""
-    return studio(timeline=None, timelines=[], pool=pool, **kwargs)
-
-
-def built(resolve: Any, name: str) -> FakeTimeline:
-    """The timeline the build made, read back off the project."""
-    project = resolve.current_project
-    found = [
-        project.GetTimelineByIndex(index)
-        for index in range(1, project.GetTimelineCount() + 1)
-        if project.GetTimelineByIndex(index) is not None
-    ]
-    match: FakeTimeline = next(timeline for timeline in found if timeline.GetName() == name)
-    return match
-
-
-def placements(
-    timeline: FakeTimeline,
-    track_type: str = "video",
-    index: int = 1,
-) -> list[tuple[str, int, int]]:
-    return [
-        (item.GetName(), item.GetStart(), item.GetDuration())
-        for item in timeline.GetItemListInTrack(track_type, index) or []
-    ]
-
+from .cutfile import (
+    TOTAL_FRAMES,
+    a_cut,
+    a_pool,
+    built,
+    doc_with_alternates,
+    empty_project,
+    placements,
+    selector,
+    shots,
+    valid_doc,
+)
+from .fakes import FakeMediaPoolItem, FakeTimeline, FakeTimelineItem, FakeTrack, studio
 
 # --- the clean build ----------------------------------------------------------------------
 
@@ -203,7 +124,7 @@ def test_a_cut_without_audio_builds_video_alone(attach: Attach, tmp_path: Path) 
     result = build_timeline(a_cut(tmp_path, doc))
 
     assert result["ok"] is True
-    assert result["placed"] == {"segments": 3, "audio": False}
+    assert result["placed"] == {"segments": 3, "audio": False, "selectors": 0}
     assert placements(built(resolve, "sunset-set v1"), "audio") == []
 
 
@@ -229,7 +150,7 @@ def test_the_built_timeline_reports_its_own_span(attach: Attach, tmp_path: Path)
 
     assert result["timeline"]["duration"]["frames"] == TOTAL_FRAMES
     assert result["timeline"]["fps"] == 59.94
-    assert result["placed"] == {"segments": 3, "audio": True}
+    assert result["placed"] == {"segments": 3, "audio": True, "selectors": 0}
 
 
 def test_the_build_opens_the_timeline_it_made(attach: Attach, tmp_path: Path) -> None:
@@ -491,6 +412,139 @@ def test_resolve_quitting_mid_build_is_a_structured_failure(
     assert result["error"]["cause"]
     assert result["error"]["fix"]
     assert result["error"]["code"] in {"resolve_unavailable", "build_failed", "internal_error"}
+
+
+# --- alternates as take selectors -----------------------------------------------------------
+
+
+def test_a_segment_with_alternates_becomes_a_take_selector(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Selector = [main, alternates in order] — the order swap_take's indexes count in."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    build_timeline(a_cut(tmp_path, doc_with_alternates()))
+
+    first, second, third = shots(built(resolve, "sunset-set v1"))
+    assert selector(first) == [("C0012.mp4", 1000, 1100), ("C0031.mp4", 4500, 4600)]
+    assert selector(second) == [
+        ("C0031.mp4", 4000, 4080),
+        ("C0012.mp4", 5000, 5080),
+        ("C0012.mp4", 7000, 7080),
+    ]
+    assert third.GetTakesCount() == 0
+
+
+def test_the_main_clip_is_the_selection(attach: Attach, tmp_path: Path) -> None:
+    """What is on the track has to be what the cut file says, or the build is a lie."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    build_timeline(a_cut(tmp_path, doc_with_alternates()))
+
+    first, second, _ = shots(built(resolve, "sunset-set v1"))
+    assert first.GetSelectedTakeIndex() == 1
+    assert second.GetSelectedTakeIndex() == 1
+    assert placements(built(resolve, "sunset-set v1")) == [
+        ("C0012.mp4", 0, 100),
+        ("C0031.mp4", 100, 80),
+        ("C0012.mp4", 180, 60),
+    ]
+
+
+def test_the_report_counts_the_selectors_it_made(attach: Attach, tmp_path: Path) -> None:
+    attach(empty_project(a_pool()))
+
+    result = build_timeline(a_cut(tmp_path, doc_with_alternates()))
+
+    assert result["ok"] is True
+    assert result["placed"] == {"segments": 3, "audio": True, "selectors": 2}
+
+
+def test_a_cut_without_alternates_makes_no_selectors(attach: Attach, tmp_path: Path) -> None:
+    """An ordinary shot stays an ordinary clip: GetTakesCount is 0, not 1."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["placed"]["selectors"] == 0
+    assert [item.GetTakesCount() for item in shots(built(resolve, "sunset-set v1"))] == [0, 0, 0]
+
+
+def test_a_refused_take_fails_the_build_and_names_the_segment(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A shot that lost its alternates is a timeline that no longer matches its cut file."""
+    pool = a_pool()
+    pool.take_quirks = {"add_take_result": False}
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, doc_with_alternates()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    assert result["error"]["detail"]["segment"] == "s001"
+    assert result["error"]["detail"]["timeline"] == "sunset-set v1"
+
+
+def test_a_take_that_reports_success_and_lands_nowhere_fails_the_build(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """``AddTake`` answers Bool, so the selector is read back rather than believed."""
+    pool = a_pool()
+    pool.take_quirks = {"takes_land": False}
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, doc_with_alternates()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    assert result["error"]["detail"]["segment"] == "s001"
+    assert result["error"]["detail"]["takes"] == {"wanted": 2, "found": 0}
+
+
+def test_a_selection_that_does_not_land_fails_the_build(attach: Attach, tmp_path: Path) -> None:
+    """Main *is* the selection; a selector sitting on an alternate is the wrong angle."""
+    pool = a_pool()
+    pool.take_quirks = {"select_take_lands": False}
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, doc_with_alternates()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    assert result["error"]["detail"]["segment"] == "s001"
+
+
+def test_a_refused_selection_fails_the_build(attach: Attach, tmp_path: Path) -> None:
+    pool = a_pool()
+    pool.take_quirks = {"select_take_result": False}
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, doc_with_alternates()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+
+
+def test_unequal_alternates_never_reach_resolve(attach: Attach, tmp_path: Path) -> None:
+    """E8 is what makes an in-place swap possible at all, so it aborts pre-flight."""
+    doc = doc_with_alternates()
+    doc["segments"][0]["alternates"] = [{"source": "keys_wide", "in": 4500, "out": 4599}]
+    pool = a_pool()
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "cut_invalid"
+    errors = result["error"]["detail"]["errors"]
+    assert [finding["rule"] for finding in errors] == ["E8"]
+    assert errors[0]["id"] == "s001"
+    assert errors[0]["fix_hint"]
+    assert "CreateEmptyTimeline" not in pool.calls
 
 
 def test_a_missing_video_track_is_created_before_the_append(

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -30,7 +30,7 @@ import pytest
 from resolve_mcp.audio.acquire import acquire_timeline_audio
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.resolve.connection import get_connection
-from resolve_mcp.tools.cut import build_timeline, validate_cut
+from resolve_mcp.tools.cut import build_timeline, swap_take, validate_cut
 from resolve_mcp.tools.escape_hatch import run_python
 from resolve_mcp.tools.jobs import get_job, list_jobs
 from resolve_mcp.tools.media import inspect_clip, list_media
@@ -334,19 +334,31 @@ def a_source_clip() -> dict[str, Any]:
     pytest.skip("No pool clip long enough to cut a smoke timeline from")
 
 
-def a_smoke_cut(tmp_path: Path, source: dict[str, Any], durations: tuple[int, ...]) -> str:
-    """A rough-cut shaped file (no master audio) built from one real clip."""
+def a_smoke_cut(
+    tmp_path: Path,
+    source: dict[str, Any],
+    durations: tuple[int, ...],
+    alternate_at: int | None = None,
+) -> str:
+    """A rough-cut shaped file (no master audio) built from one real clip.
+
+    ``alternate_at`` gives every segment one equal-duration alternate starting there — the
+    same clip is a legitimate alternate source, and one clip is all a smoke run can count on.
+    """
     at = source["start"]
-    segments = []
+    segments: list[dict[str, Any]] = []
     for index, length in enumerate(durations):
-        segments.append(
-            {
-                "id": f"s{index:03d}",
-                "source": "angle",
-                "in": at,
-                "out": at + length,
-            }
-        )
+        segment: dict[str, Any] = {
+            "id": f"s{index:03d}",
+            "source": "angle",
+            "in": at,
+            "out": at + length,
+        }
+        if alternate_at is not None:
+            segment["alternates"] = [
+                {"source": "angle", "in": alternate_at, "out": alternate_at + length}
+            ]
+        segments.append(segment)
         at += length
     angle = {"clip": source["name"]}
     if source["bin"] is not None:
@@ -379,7 +391,7 @@ def test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it(tmp_path: 
     result = build_timeline(cut_file)
 
     assert result["ok"] is True, result.get("error")
-    assert result["placed"] == {"segments": 3, "audio": False}
+    assert result["placed"] == {"segments": 3, "audio": False, "selectors": 0}
     built = inspect_timeline(result["timeline"]["name"], detail="clips")
     assert built["ok"] is True
     video = [track for track in built["tracks"] if track["type"] == "video"][0]
@@ -387,6 +399,57 @@ def test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it(tmp_path: 
     timeline_start = built["timeline"]["start"]["frames"]
     assert [item["record"]["duration"]["frames"] for item in video["items"]] == list(durations)
     assert starts == [timeline_start, timeline_start + 48, timeline_start + 72]
+
+
+def test_a_real_take_selector_swaps_the_angle_without_moving_the_shot(tmp_path: Path) -> None:
+    """The take path end to end, and the three things no fake can settle about it.
+
+    (a) whether ``AddTake`` reads ``endFrame`` half-open the way ``AppendToTimeline`` does —
+    a selector whose takes are all the same length is the only thing making an in-place swap
+    legal, so an off-by-one here is the whole feature; (b) where Resolve leaves the selection
+    after an add, which the build refuses to assume and sets to the main take explicitly; and
+    (c) whether the swapped shot really plays the alternate's frames while keeping its own
+    position and length.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    source = a_source_clip()
+    durations = (48, 24, 36)
+    alternate_at = source["start"] + sum(durations)
+    cut_file = a_smoke_cut(tmp_path, source, durations, alternate_at=alternate_at)
+    assert validate_cut(cut_file)["valid"] is True
+
+    result = build_timeline(cut_file)
+
+    assert result["ok"] is True, result.get("error")
+    assert result["placed"] == {"segments": 3, "audio": False, "selectors": 3}
+    name = result["timeline"]["name"]
+    before = _video_items(name)
+    assert [item["takes"] for item in before] == [2, 2, 2]
+    assert [item["source"]["in"]["frames"] for item in before][0] == source["start"]
+
+    swapped = swap_take(cut_file, "s000", 2, timeline=name)
+
+    assert swapped["ok"] is True, swapped.get("error")
+    assert swapped["changed"] is True
+    assert swapped["sync"]["in"] == alternate_at
+    after = _video_items(name)
+    assert after[0]["source"]["in"]["frames"] == alternate_at
+    assert [item["record"]["in"]["frames"] for item in after] == [
+        item["record"]["in"]["frames"] for item in before
+    ]
+    assert [item["record"]["duration"]["frames"] for item in after] == list(durations)
+
+    assert swap_take(cut_file, "s000", 1, timeline=name)["ok"] is True
+    assert _video_items(name)[0]["source"]["in"]["frames"] == source["start"]
+
+
+def _video_items(name: str) -> list[dict[str, Any]]:
+    read = inspect_timeline(name, detail="clips")
+    assert read["ok"] is True, read.get("error")
+    video = [track for track in read["tracks"] if track["type"] == "video"][0]
+    items: list[dict[str, Any]] = video["items"]
+    return items
 
 
 def test_a_rebuild_makes_the_next_version_and_leaves_the_last_one_alone(tmp_path: Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,6 +38,7 @@ def test_registers_the_p1_session_media_timeline_cut_and_job_tools() -> None:
         "get_cut_schema",
         "validate_cut",
         "build_timeline",
+        "swap_take",
         "get_job",
         "list_jobs",
         "run_python",

--- a/tests/test_swap_take.py
+++ b/tests/test_swap_take.py
@@ -1,0 +1,324 @@
+"""swap_take: the one in-place edit the cut model allows, and what it refuses to do blind.
+
+Every test here swaps on a timeline this build actually made, because that is the only
+timeline a swap is defined against — the selector's order comes from the cut file, and a
+cut file that no longer describes the timeline is the failure mode worth catching, not a
+detail. The server never writes the cut file, so the report has to hand the agent the edit
+that puts the two back in step.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.tools.cut import build_timeline, swap_take
+
+from .conftest import Attach
+from .cutfile import a_cut, a_pool, built, doc_with_alternates, empty_project, shots, valid_doc
+from .fakes import FakeTimeline, studio
+
+
+def a_built_cut(attach: Attach, tmp_path: Path, doc: Any | None = None) -> tuple[Any, str]:
+    """Build the alternates cut and hand back the fake and the cut file that made it."""
+    pool = a_pool()
+    resolve = empty_project(pool)
+    attach(resolve)
+    cut_file = a_cut(tmp_path, doc_with_alternates() if doc is None else doc)
+    result = build_timeline(cut_file)
+    assert result["ok"] is True
+    return resolve, cut_file
+
+
+def selected(resolve: Any, position: int) -> int:
+    return int(shots(built(resolve, "sunset-set v1"))[position].GetSelectedTakeIndex())
+
+
+# --- the swap -------------------------------------------------------------------------------
+
+
+def test_a_swap_moves_the_selection_in_place(attach: Attach, tmp_path: Path) -> None:
+    resolve, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s001", 2)
+
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert selected(resolve, 0) == 2
+    assert selected(resolve, 1) == 1
+
+
+def test_a_swap_moves_nothing_else_on_the_timeline(attach: Attach, tmp_path: Path) -> None:
+    """In place means in place: the shot keeps its position and its length."""
+    resolve, cut_file = a_built_cut(attach, tmp_path)
+
+    swap_take(cut_file, "s002", 3)
+
+    timeline = built(resolve, "sunset-set v1")
+    assert [(item.GetStart(), item.GetDuration()) for item in shots(timeline)] == [
+        (0, 100),
+        (100, 80),
+        (180, 60),
+    ]
+
+
+def test_the_report_names_the_take_it_took_and_the_one_it_left(
+    attach: Attach, tmp_path: Path
+) -> None:
+    _, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s001", 2)
+
+    assert result["segment"] == "s001"
+    assert result["selected"] == {
+        "index": 2,
+        "source": "keys_wide",
+        "clip": "C0031.mp4",
+        "in": 4500,
+        "out": 4600,
+    }
+    assert result["previous"] == {
+        "index": 1,
+        "source": "gtr_close",
+        "clip": "C0012.mp4",
+        "in": 1000,
+        "out": 1100,
+    }
+    assert result["duration"]["frames"] == 100
+    assert result["timeline"]["name"] == "sunset-set v1"
+    assert result["content_hash"]
+
+
+def test_the_report_lists_the_whole_selector_so_the_indexes_are_never_guessed(
+    attach: Attach, tmp_path: Path
+) -> None:
+    _, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s002", 2)
+
+    assert [(take["index"], take["source"], take["in"]) for take in result["selector"]] == [
+        (1, "keys_wide", 4000),
+        (2, "gtr_close", 5000),
+        (3, "gtr_close", 7000),
+    ]
+
+
+def test_the_report_hands_back_the_cut_file_edit_the_swap_needs(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Promoted to main, old main demoted into its slot — selector order survives a rebuild."""
+    _, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s002", 3)
+
+    assert result["sync"] == {
+        "segment": "s002",
+        "source": "gtr_close",
+        "in": 7000,
+        "out": 7080,
+        "alternates": [
+            {"source": "gtr_close", "in": 5000, "out": 5080},
+            {"source": "keys_wide", "in": 4000, "out": 4080},
+        ],
+    }
+
+
+def test_reverting_to_the_main_take_asks_for_no_cut_file_edit(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The file already says main is the selection, so putting it back needs no edit."""
+    resolve, cut_file = a_built_cut(attach, tmp_path)
+    swap_take(cut_file, "s001", 2)
+
+    result = swap_take(cut_file, "s001", 1)
+
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert result["sync"] is None
+    assert selected(resolve, 0) == 1
+
+
+def test_selecting_the_take_already_selected_changes_nothing(
+    attach: Attach, tmp_path: Path
+) -> None:
+    resolve, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s001", 1)
+
+    assert result["ok"] is True
+    assert result["changed"] is False
+    assert selected(resolve, 0) == 1
+
+
+def test_a_swap_never_touches_the_media_pool(attach: Attach, tmp_path: Path) -> None:
+    """The takes are already on the timeline; re-locating clips would only invent failures."""
+    pool = a_pool()
+    resolve = empty_project(pool)
+    attach(resolve)
+    cut_file = a_cut(tmp_path, doc_with_alternates())
+    build_timeline(cut_file)
+    pool.calls.clear()
+
+    swap_take(cut_file, "s001", 2)
+
+    assert pool.calls == []
+
+
+def test_a_named_timeline_is_swapped_rather_than_the_open_one(
+    attach: Attach, tmp_path: Path
+) -> None:
+    resolve, cut_file = a_built_cut(attach, tmp_path)
+    build_timeline(cut_file)  # v2 is now the open one
+
+    result = swap_take(cut_file, "s001", 2, timeline="sunset-set v1")
+
+    assert result["timeline"]["name"] == "sunset-set v1"
+    assert selected(resolve, 0) == 2
+    assert shots(built(resolve, "sunset-set v2"))[0].GetSelectedTakeIndex() == 1
+
+
+# --- what it refuses ------------------------------------------------------------------------
+
+
+def test_a_take_index_past_the_selector_is_refused_with_the_selector_listed(
+    attach: Attach, tmp_path: Path
+) -> None:
+    _, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s001", 3)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert result["error"]["detail"]["requested"] == 3
+    assert [take["index"] for take in result["error"]["detail"]["selector"]] == [1, 2]
+
+
+def test_a_take_index_below_one_is_refused(attach: Attach, tmp_path: Path) -> None:
+    _, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s001", 0)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+
+
+def test_a_segment_with_no_alternates_has_nothing_to_swap(attach: Attach, tmp_path: Path) -> None:
+    _, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s003", 2)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert [take["source"] for take in result["error"]["detail"]["selector"]] == ["gtr_close"]
+    assert "no alternates" in result["error"]["fix"]
+
+
+def test_an_unknown_segment_is_refused_with_the_ids_that_exist(
+    attach: Attach, tmp_path: Path
+) -> None:
+    _, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s404", 2)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert result["error"]["detail"]["available"] == ["s001", "s002", "s003"]
+
+
+def test_an_invalid_cut_file_stops_before_the_timeline_is_read(
+    attach: Attach, tmp_path: Path
+) -> None:
+    _, _ = a_built_cut(attach, tmp_path)
+    broken = a_cut(tmp_path, {"schema": 1}, name="broken.cut.json")
+
+    result = swap_take(broken, "s001", 2)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "cut_invalid"
+    assert result["error"]["detail"]["errors"]
+
+
+def test_a_timeline_without_the_selector_the_cut_describes_is_refused(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Drift: the open version was built from a cut with no alternates on this shot."""
+    _, _ = a_built_cut(attach, tmp_path, doc=valid_doc())
+    with_takes = a_cut(tmp_path, doc_with_alternates(), name="alternates.cut.json")
+
+    result = swap_take(with_takes, "s001", 2)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert result["error"]["detail"]["takes"] == {"wanted": 2, "found": 0}
+
+
+def test_a_timeline_the_cut_does_not_line_up_with_is_refused(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """No clip starts where the cut says the segment does — a different cut built this."""
+    _, _ = a_built_cut(attach, tmp_path, doc=valid_doc())
+    shifted = doc_with_alternates()
+    shifted["segments"][0]["out"] = 1050
+    shifted["segments"][0]["alternates"] = [{"source": "keys_wide", "in": 4500, "out": 4550}]
+
+    result = swap_take(a_cut(tmp_path, shifted, name="shifted.cut.json"), "s002", 2)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert result["error"]["detail"]["record_frame"] == 50
+
+
+def test_an_unknown_timeline_name_is_refused(attach: Attach, tmp_path: Path) -> None:
+    _, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s001", 2, timeline="sunset-set v9")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_not_found"
+
+
+def test_a_refused_selection_is_a_structured_failure(attach: Attach, tmp_path: Path) -> None:
+    resolve, cut_file = a_built_cut(attach, tmp_path)
+    shots(built(resolve, "sunset-set v1"))[0].select_take_result = False
+
+    result = swap_take(cut_file, "s001", 2)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_operation_failed"
+    assert result["error"]["detail"]["segment"] == "s001"
+
+
+def test_a_selection_that_reports_success_and_does_not_move_is_a_failure(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """``SelectTakeByIndex`` answers Bool; the selection is read back, never believed."""
+    resolve, cut_file = a_built_cut(attach, tmp_path)
+    shots(built(resolve, "sunset-set v1"))[0].select_take_lands = False
+
+    result = swap_take(cut_file, "s001", 2)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_operation_failed"
+    assert result["error"]["detail"]["selected"] == 1
+
+
+def test_no_timeline_open_and_none_named_is_refused(attach: Attach, tmp_path: Path) -> None:
+    resolve = empty_project(a_pool())
+    attach(resolve)
+    cut_file = a_cut(tmp_path, doc_with_alternates())
+
+    result = swap_take(cut_file, "s001", 2)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "no_timeline_open"
+
+
+def test_a_timeline_with_no_video_track_is_refused(attach: Attach, tmp_path: Path) -> None:
+    empty = FakeTimeline("sunset-set v1", "59.94", video=[])
+    attach(studio(timeline=None, timelines=[empty], pool=a_pool()))
+    cut_file = a_cut(tmp_path, doc_with_alternates())
+
+    result = swap_take(cut_file, "s001", 2, timeline="sunset-set v1")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"

--- a/tests/test_swap_take.py
+++ b/tests/test_swap_take.py
@@ -210,7 +210,20 @@ def test_a_segment_with_no_alternates_has_nothing_to_swap(attach: Attach, tmp_pa
     assert result["ok"] is False
     assert result["error"]["code"] == "invalid_request"
     assert [take["source"] for take in result["error"]["detail"]["selector"]] == ["gtr_close"]
-    assert "no alternates" in result["error"]["fix"]
+    assert "no alternates" in result["error"]["cause"]
+
+
+def test_take_one_on_a_segment_with_no_alternates_says_so_rather_than_crying_drift(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The shot is a plain clip, not a selector sitting on take 1 — and nothing has drifted."""
+    _, cut_file = a_built_cut(attach, tmp_path)
+
+    result = swap_take(cut_file, "s003", 1)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert "no alternates" in result["error"]["cause"]
 
 
 def test_an_unknown_segment_is_refused_with_the_ids_that_exist(
@@ -266,6 +279,23 @@ def test_a_timeline_the_cut_does_not_line_up_with_is_refused(
     assert result["ok"] is False
     assert result["error"]["code"] == "invalid_request"
     assert result["error"]["detail"]["record_frame"] == 50
+
+
+def test_a_shot_of_the_wrong_length_at_the_right_frame_is_not_this_segment(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Two cuts can agree on where a segment starts and disagree on what it is."""
+    _, _ = a_built_cut(attach, tmp_path, doc=valid_doc())
+    relengthed = doc_with_alternates()
+    relengthed["segments"][1]["out"] = 4070
+    relengthed["segments"][1]["alternates"] = [{"source": "gtr_close", "in": 5000, "out": 5070}]
+
+    result = swap_take(a_cut(tmp_path, relengthed, name="relengthed.cut.json"), "s002", 2)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert result["error"]["detail"]["record_frame"] == 100
+    assert result["error"]["detail"]["duration"] == 70
 
 
 def test_an_unknown_timeline_name_is_refused(attach: Attach, tmp_path: Path) -> None:

--- a/tests/test_timeline_tools.py
+++ b/tests/test_timeline_tools.py
@@ -280,7 +280,7 @@ def test_one_title_that_refuses_a_getter_costs_a_field_not_the_inspection(
         "Title 01",
         0,
         60,
-        refuses={"GetSourceStartFrame", "GetMediaPoolItem", "GetTakeCount"},
+        refuses={"GetSourceStartFrame", "GetMediaPoolItem", "GetTakesCount"},
     )
     shot = FakeTimelineItem("C0012.mp4", 60, 40, source_start=1000)
     attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", [title, shot])])))


### PR DESCRIPTION
Closes #29.

Segments carrying `alternates` now build as Resolve take selectors, and `swap_take` flips a
shot to another take in place — the one exception to the declarative rebuild model, legal
only because alternates are the same length as the take they replace.

## What changed

- **Build.** After every placement is read back, each segment with alternates gets its
  alternates added as takes and the selection set explicitly to take 1, so a freshly built
  timeline always shows what the cut file says. The report gains `placed.selectors`.
- **`swap_take(cut_file, segment, take, timeline=None)`.** Takes are chosen by 1-based
  selector index (1 = the segment's own `source`, 2+ = `alternates` in order) rather than by
  source alias, because the same alias can legitimately appear twice in one selector — two
  passes from one camera is an ordinary retake. The report lists the whole selector so the
  indexes are never guessed, and returns the exact cut-file edit the swap needs (`sync`):
  alternate promoted to main, old main demoted into its slot, so the selector order survives
  a rebuild. The server never writes the cut file.
- **Drift is refused, not guessed.** A shot is found by the record frame *and* duration this
  cut file computes for the segment, and its selector must be the size the file describes.
  Anything else is a structured `invalid_request` pointing at a rebuild.
- **`AddTake`/`SelectTakeByIndex` answer a bare `Bool`**, so both are counted and the selector
  read back — the same "Resolve's answer is never the evidence" rule the appends follow.
  `FinalizeTake` is never called: it would collapse the selector and destroy every alternate.
- **Bug fix, in scope.** The timeline reader called `GetTakeCount`; the scripting API declares
  `GetTakesCount` (README line 523), and fusionscript answers an unknown name with `None`
  rather than raising — so every read reported zero takes. That is the exact quirk the fake's
  docstring had recorded live without spotting its cause.

## Test seam

**Fake tier** (`tests/test_swap_take.py`, 23 tests; `tests/test_build_timeline.py`, 35). The
take selector is modelled on `FakeTimelineItem` with the two lies that matter: a truthy
`AddTake` that adds nothing, and a truthy `SelectTakeByIndex` that moves nothing. Where the
selection sits after an `AddTake` is undocumented, so the fake deliberately takes the worse
possibility (the new take) — the build cannot depend on the answer and must set it. The shared
cut-file builders moved to `tests/cutfile.py` so build and swap test the same fixture.

AC3 (unequal-duration alternates rejected with a fix hint) was already satisfied on `main` by
rule E8 and its fix hint; this branch adds the build-abort test, not the rule.

**Live smoke** — `test_a_real_take_selector_swaps_the_angle_without_moving_the_shot` is added
and **unrun**. It pins the three things no fake can settle: whether `AddTake` reads `endFrame`
half-open the way `AppendToTimeline` does, where Resolve leaves the selection after an add, and
whether a swapped shot really plays the alternate's frames while keeping its position and
length. `test_a_real_build_places_every_shot...` also changed shape (`placed.selectors`).

## Review

Two-axis `/code-review` against `origin/main`, then a focused pass over the fix diff.

**Standards** — no hard violations; eight judgement calls, seven fixed:
- swap_take read the cut file twice, so the reported `content_hash` came from a different read
  than the document that was validated → one `LoadedCut` carried through.
- The record frame was derived in two places (build and swap) → both now go through
  `cut.validate.placements`, so what the build placed and what the swap looks for cannot drift.
- The first-track index was declared twice → `timeline.FIRST_TRACK` is the single source.
- `_fps` defended against a field E1 had just proved present → deleted.
- Take readers made private; the unreachable build failure gained the `fix` line its peers
  carry; the build's selector *count* no longer shares a name with its list-builder; the
  clip-name read is shared between the two places that made one.
- Not taken: `Take` vs `Shot` as a data clump. They differ in what they carry (`record`,
  `track_type` vs `source` alias) and collapsing them would put build-only fields on a take.

**Spec** — all three ACs implemented; three findings, all fixed:
- `swap_take` on a segment with no alternates with take 1 passed the index check and then
  failed as *drift* — an alarming answer for a timeline that had not drifted. A segment with
  no alternates is now refused as such whatever index is asked for.
- The tool docstring claimed a swap onto a timeline the cut file did not build was refused.
  It is a shape check, not proof of provenance — it now says so and points at `content_hash`.
- `_sync`'s claim that take indexes keep their meaning was wrong; corrected to what the schema
  prose actually describes (slots 1 and *take* trade contents).
- Scope creep noted and kept: the `GetTakesCount` fix (load-bearing for the live assertion),
  the `start_frame` move, and `placed.selectors`.

**Fix-diff pass** — all seven fixes verified to hold, no regressions; one low-severity finding
(`GetDuration` read raw rather than through `timeline.read_frames`, which copes with the string
and `None` answers Resolve gives) fixed in `88c72c8`.

Review: clean — findings above resolved; fake tier, mypy strict and ruff green.
