### PR TITLE
feat: word-level transcription job

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,14 @@ dependencies = [
     "fastmcp>=3.4,<4",
 ]
 
+[project.optional-dependencies]
+# The analysis backends: heavy, GPU-bound, and imported inside the workers that need them.
+# Kept out of the base install so the server (and CI, which runs the fake tier) does not
+# pull a CUDA runtime to answer get_status.
+analysis = [
+    "faster-whisper>=1.0",
+]
+
 [project.scripts]
 resolve-mcp = "resolve_mcp.__main__:main"
 
@@ -48,3 +56,9 @@ python_version = "3.12"
 files = ["src", "tests"]
 strict = true
 warn_unused_ignores = true
+
+# The analysis extra ships no stubs, and is not installed at all in CI or on a machine that
+# only drives Resolve — so the import is unresolvable rather than untyped.
+[[tool.mypy.overrides]]
+module = ["faster_whisper.*"]
+ignore_missing_imports = true

--- a/src/resolve_mcp/analysis/__init__.py
+++ b/src/resolve_mcp/analysis/__init__.py
@@ -1,0 +1,13 @@
+"""Compute jobs that read the audio and write what they read to disk.
+
+Every module here follows the same shape, and the shape is the point: the server measures,
+Claude decides. A transcript is words with confidences and the gaps between them — not a
+"flub detector"; music analysis is beats, energy and boundaries — not a "good cut here"
+signal. A detector's opinion cannot be argued with in a review round, so no detector is
+shipped where a reading will do.
+
+The output is a file, not a return value. A concert's worth of words does not fit in a tool
+result and would eat the client's output cap whole, so the job writes timestamped
+LLM-friendly JSON — one record per line, greppable — and returns the path plus gist stats.
+The agent reads the slices it needs.
+"""

--- a/src/resolve_mcp/analysis/silence.py
+++ b/src/resolve_mcp/analysis/silence.py
@@ -112,15 +112,18 @@ def _span(
 def _window_db(raw: bytes, width: int, channels: int) -> float:
     """One window's RMS in dBFS, from a decimated read of its samples.
 
-    The stride walks *interleaved* samples, so a stride that divides the channel count
-    would land on the same channel every time and call a stereo file silent because its
-    left channel is — hence the step to the next stride that cannot.
+    The stride walks *interleaved* samples, so it has to be coprime with the channel count
+    or it visits a fixed subset of the channels forever — a stride of 64 on a stereo file
+    reads only the left, and one of 150 on a four-channel file reads only channels 0 and 2.
+    Either would call a file silent because the channels it happened to skip are the ones
+    carrying the band. Stepping up to the next coprime stride costs at most a few samples
+    of the 64 and visits every channel in turn.
     """
     count = len(raw) // width
     if count == 0:
         return SILENT_FLOOR_DB
     stride = max(1, count // MAX_SAMPLES_PER_WINDOW)
-    if channels > 1 and stride % channels == 0:
+    while channels > 1 and math.gcd(stride, channels) != 1:
         stride += 1
     total = 0.0
     taken = 0

--- a/src/resolve_mcp/analysis/silence.py
+++ b/src/resolve_mcp/analysis/silence.py
@@ -1,0 +1,158 @@
+"""Where nobody is playing or speaking, read off the waveform.
+
+Silence is derived from RMS rather than from the gaps between transcribed words, because
+the two are different questions. Whisper leaves a gap wherever it heard no *words* — which
+includes a held chord, a drum fill and a room full of applause. Breathing room is where the
+signal itself drops, and only the samples know that.
+
+Two implementation constraints shape this module:
+
+* **A concert is two hours of 48 kHz stereo.** Reading every sample in Python would take
+  longer than the transcription it accompanies, so each window is decimated to at most
+  ``MAX_SAMPLES_PER_WINDOW`` evenly spaced samples. RMS over 64 samples of a 2400-sample
+  window is far more precision than a -40 dB threshold needs.
+
+* **No numpy, no audioop.** numpy is not a dependency of the server, and ``audioop`` — the
+  obvious C-speed answer — is deprecated in 3.12 and removed in 3.13, so anything built on
+  it is scheduled to break on the next interpreter bump.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import math
+import wave
+from pathlib import Path
+
+from ..errors import AudioExtractionError
+
+DEFAULT_WINDOW_SECONDS = 0.05
+DEFAULT_THRESHOLD_DB = -40.0
+DEFAULT_MIN_SECONDS = 0.35
+
+SILENT_FLOOR_DB = -120.0
+MAX_SAMPLES_PER_WINDOW = 64
+BITS_PER_BYTE = 8
+PLACES = 3
+
+
+def silence(
+    path: Path | str,
+    threshold_db: float = DEFAULT_THRESHOLD_DB,
+    min_seconds: float = DEFAULT_MIN_SECONDS,
+    window_seconds: float = DEFAULT_WINDOW_SECONDS,
+) -> list[dict[str, float]]:
+    """The quiet stretches in a WAV, as ``{start, end, duration}`` in seconds."""
+    measured = levels(path, window_seconds=window_seconds)
+    return spans(
+        measured,
+        window_seconds=window_seconds,
+        threshold_db=threshold_db,
+        min_seconds=min_seconds,
+        limit=duration(path),
+    )
+
+
+def levels(path: Path | str, window_seconds: float = DEFAULT_WINDOW_SECONDS) -> list[float]:
+    """RMS per window in dBFS, oldest first — the curve everything else here reads."""
+    target = Path(path)
+    try:
+        with contextlib.closing(wave.open(str(target), "rb")) as handle:
+            width = handle.getsampwidth()
+            rate = handle.getframerate()
+            channels = handle.getnchannels()
+            _refuse_unsigned(target, width)
+            per_window = max(1, round(window_seconds * rate))
+            measured: list[float] = []
+            while True:
+                raw = handle.readframes(per_window)
+                if not raw:
+                    return measured
+                measured.append(_window_db(raw, width))
+                if len(raw) < per_window * width * channels:
+                    return measured
+    except (OSError, wave.Error) as exc:
+        raise AudioExtractionError(
+            cause=f"{target.name} is not a readable WAV file ({exc}).",
+            fix="Delete it from the cache directory and run the job again.",
+            detail={"path": str(target)},
+        ) from exc
+
+
+def duration(path: Path | str) -> float | None:
+    """Seconds of audio, or ``None`` when the header does not say."""
+    with contextlib.closing(wave.open(str(Path(path)), "rb")) as handle:
+        rate = handle.getframerate()
+        return handle.getnframes() / rate if rate else None
+
+
+def spans(
+    measured: list[float],
+    window_seconds: float,
+    threshold_db: float = DEFAULT_THRESHOLD_DB,
+    min_seconds: float = DEFAULT_MIN_SECONDS,
+    limit: float | None = None,
+) -> list[dict[str, float]]:
+    """Runs of windows under the threshold, kept only where they run long enough.
+
+    ``limit`` clamps a run that reaches the end of the file: the last window is a whole
+    window wide even when the audio stopped part way through it, and a span reported past
+    the end of its own audio is a span an agent will try to cut on.
+    """
+    found: list[dict[str, float]] = []
+    start: int | None = None
+    for index, level in enumerate([*measured, threshold_db]):
+        if level < threshold_db:
+            start = index if start is None else start
+            continue
+        if start is not None:
+            found.append(_span(start, index, window_seconds, limit))
+            start = None
+    return [one for one in found if one["duration"] >= min_seconds]
+
+
+def _span(
+    first: int, past: int, window_seconds: float, limit: float | None
+) -> dict[str, float]:
+    start = first * window_seconds
+    end = past * window_seconds
+    if limit is not None:
+        end = min(end, limit)
+    return {
+        "start": round(start, PLACES),
+        "end": round(end, PLACES),
+        "duration": round(end - start, PLACES),
+    }
+
+
+def _window_db(raw: bytes, width: int) -> float:
+    """One window's RMS in dBFS, from a decimated read of its samples."""
+    count = len(raw) // width
+    if count == 0:
+        return SILENT_FLOOR_DB
+    stride = max(1, count // MAX_SAMPLES_PER_WINDOW)
+    total = 0.0
+    taken = 0
+    for index in range(0, count, stride):
+        offset = index * width
+        sample = int.from_bytes(raw[offset : offset + width], "little", signed=True)
+        total += float(sample) * float(sample)
+        taken += 1
+    full_scale = float(1 << (width * BITS_PER_BYTE - 1))
+    rms = math.sqrt(total / taken) / full_scale
+    return SILENT_FLOOR_DB if rms <= 0.0 else max(SILENT_FLOOR_DB, 20.0 * math.log10(rms))
+
+
+def _refuse_unsigned(target: Path, width: int) -> None:
+    """8-bit WAV samples are unsigned, and reading them as signed inverts loud and quiet.
+
+    Nothing this server acquires is 8-bit — both acquisition routes write 16, 24 or 32 —
+    so this is a file someone else put in the cache, and guessing at it would report a loud
+    tone as breathing room.
+    """
+    if width == 1:
+        raise AudioExtractionError(
+            cause=f"{target.name} is 8-bit audio, which this reader does not measure.",
+            fix="Re-acquire the audio (the acquisition jobs write 24-bit WAV) and retry.",
+            detail={"path": str(target), "bit_depth": width * BITS_PER_BYTE},
+        )

--- a/src/resolve_mcp/analysis/silence.py
+++ b/src/resolve_mcp/analysis/silence.py
@@ -19,11 +19,10 @@ Two implementation constraints shape this module:
 
 from __future__ import annotations
 
-import contextlib
 import math
-import wave
 from pathlib import Path
 
+from ..audio import wav
 from ..errors import AudioExtractionError
 
 DEFAULT_WINDOW_SECONDS = 0.05
@@ -32,58 +31,43 @@ DEFAULT_MIN_SECONDS = 0.35
 
 SILENT_FLOOR_DB = -120.0
 MAX_SAMPLES_PER_WINDOW = 64
-BITS_PER_BYTE = 8
 PLACES = 3
 
 
-def silence(
+def measure(
     path: Path | str,
     threshold_db: float = DEFAULT_THRESHOLD_DB,
     min_seconds: float = DEFAULT_MIN_SECONDS,
     window_seconds: float = DEFAULT_WINDOW_SECONDS,
 ) -> list[dict[str, float]]:
     """The quiet stretches in a WAV, as ``{start, end, duration}`` in seconds."""
-    measured = levels(path, window_seconds=window_seconds)
+    reading = wav.describe(path)
     return spans(
-        measured,
+        levels(path, window_seconds=window_seconds),
         window_seconds=window_seconds,
         threshold_db=threshold_db,
         min_seconds=min_seconds,
-        limit=duration(path),
+        limit=reading["duration_seconds"],
     )
 
 
 def levels(path: Path | str, window_seconds: float = DEFAULT_WINDOW_SECONDS) -> list[float]:
     """RMS per window in dBFS, oldest first — the curve everything else here reads."""
     target = Path(path)
-    try:
-        with contextlib.closing(wave.open(str(target), "rb")) as handle:
-            width = handle.getsampwidth()
-            rate = handle.getframerate()
-            channels = handle.getnchannels()
-            _refuse_unsigned(target, width)
-            per_window = max(1, round(window_seconds * rate))
-            measured: list[float] = []
-            while True:
-                raw = handle.readframes(per_window)
-                if not raw:
-                    return measured
-                measured.append(_window_db(raw, width))
-                if len(raw) < per_window * width * channels:
-                    return measured
-    except (OSError, wave.Error) as exc:
-        raise AudioExtractionError(
-            cause=f"{target.name} is not a readable WAV file ({exc}).",
-            fix="Delete it from the cache directory and run the job again.",
-            detail={"path": str(target)},
-        ) from exc
-
-
-def duration(path: Path | str) -> float | None:
-    """Seconds of audio, or ``None`` when the header does not say."""
-    with contextlib.closing(wave.open(str(Path(path)), "rb")) as handle:
+    with wav.opened(target) as handle:
+        width = handle.getsampwidth()
         rate = handle.getframerate()
-        return handle.getnframes() / rate if rate else None
+        channels = handle.getnchannels()
+        _refuse_unsigned(target, width)
+        per_window = max(1, round(window_seconds * rate))
+        measured: list[float] = []
+        while True:
+            raw = handle.readframes(per_window)
+            if not raw:
+                return measured
+            measured.append(_window_db(raw, width, channels))
+            if len(raw) < per_window * width * channels:
+                return measured
 
 
 def spans(
@@ -125,12 +109,19 @@ def _span(
     }
 
 
-def _window_db(raw: bytes, width: int) -> float:
-    """One window's RMS in dBFS, from a decimated read of its samples."""
+def _window_db(raw: bytes, width: int, channels: int) -> float:
+    """One window's RMS in dBFS, from a decimated read of its samples.
+
+    The stride walks *interleaved* samples, so a stride that divides the channel count
+    would land on the same channel every time and call a stereo file silent because its
+    left channel is — hence the step to the next stride that cannot.
+    """
     count = len(raw) // width
     if count == 0:
         return SILENT_FLOOR_DB
     stride = max(1, count // MAX_SAMPLES_PER_WINDOW)
+    if channels > 1 and stride % channels == 0:
+        stride += 1
     total = 0.0
     taken = 0
     for index in range(0, count, stride):
@@ -138,7 +129,7 @@ def _window_db(raw: bytes, width: int) -> float:
         sample = int.from_bytes(raw[offset : offset + width], "little", signed=True)
         total += float(sample) * float(sample)
         taken += 1
-    full_scale = float(1 << (width * BITS_PER_BYTE - 1))
+    full_scale = float(1 << (width * wav.BITS_PER_BYTE - 1))
     rms = math.sqrt(total / taken) / full_scale
     return SILENT_FLOOR_DB if rms <= 0.0 else max(SILENT_FLOOR_DB, 20.0 * math.log10(rms))
 
@@ -154,5 +145,5 @@ def _refuse_unsigned(target: Path, width: int) -> None:
         raise AudioExtractionError(
             cause=f"{target.name} is 8-bit audio, which this reader does not measure.",
             fix="Re-acquire the audio (the acquisition jobs write 24-bit WAV) and retry.",
-            detail={"path": str(target), "bit_depth": width * BITS_PER_BYTE},
+            detail={"path": str(target), "bit_depth": width * wav.BITS_PER_BYTE},
         )

--- a/src/resolve_mcp/analysis/transcribe.py
+++ b/src/resolve_mcp/analysis/transcribe.py
@@ -1,0 +1,204 @@
+"""The transcription job: acquire the audio, read it, write the transcript.
+
+It does not acquire the audio itself. It *chains onto* the acquisition job, and that is the
+load-bearing decision here:
+
+* The agent never sequences two calls. One tool, one job id, one poll — the audio route
+  (render queue for a timeline, ffmpeg for a clip) is an implementation detail of this job,
+  which is what ``tools.jobs`` means by "acquisition is internal to those starters".
+
+* **The cache key is the acquisition's key plus the transcription parameters.** The audio's
+  content hash would be the truer input, but it does not exist until the export has run, and
+  a starter has to return before that. The acquisition key already covers everything that
+  decides those bytes — the clip's fingerprint or the timeline's, sample rate, bit depth —
+  so keying off it says the same thing early enough to be useful. It also means a rerun with
+  a different model pays for the model and not for the export again: that acquisition is
+  itself a cache hit.
+
+* A failure below is reported with the *lower* job's advice. "The audio was not acquired" is
+  not something an agent can act on; "check the render queue for a stuck job" is.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..audio import ffmpeg
+from ..audio.acquire import acquire_clip_audio, acquire_timeline_audio
+from ..config import Config, get_config
+from ..errors import InternalError, InvalidRequestError, TranscriptionError
+from ..jobs import cache, store
+from ..jobs.runner import JobOutput, Progress, start_job, wait_for
+from ..logging_config import get_logger
+from ..naming import slug
+from ..resolve.connection import ResolveConnection
+from . import silence, transcript, whisper
+from .transcript import Transcriber
+
+log = get_logger("analysis")
+
+KIND = "transcribe_audio"
+
+DEFAULT_LOW_CONFIDENCE = 0.5
+ACQUIRE_TIMEOUT = 3600.0
+
+ACQUIRING = 0.05
+READING = 0.2
+MEASURING = 0.85
+WRITING = 0.95
+
+
+def transcribe_audio(
+    connection: ResolveConnection,
+    clip: str | None = None,
+    bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
+    timeline: str | None = None,
+    model: str = whisper.DEFAULT_MODEL,
+    language: str | None = None,
+    low_confidence: float = DEFAULT_LOW_CONFIDENCE,
+    silence_threshold_db: float = silence.DEFAULT_THRESHOLD_DB,
+    min_silence_seconds: float = silence.DEFAULT_MIN_SECONDS,
+    refresh: bool = False,
+    transcriber: Transcriber | None = None,
+    runner: ffmpeg.Runner | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Start a job that transcribes one clip or the timeline mix. Returns the job record.
+
+    ``transcriber`` and ``runner`` are the two seams: the model and the ffmpeg subprocess.
+    The defaults do the real thing; a caller hands in its own to exercise the route.
+    """
+    config = config or get_config()
+    _refuse_an_ambiguous_scope(clip, bin, timeline)
+
+    if clip is not None:
+        acquisition = acquire_clip_audio(
+            connection, clip, bin, refresh=refresh, runner=runner, config=config
+        )
+    else:
+        acquisition = acquire_timeline_audio(connection, timeline, refresh=refresh, config=config)
+
+    acquired = dict(acquisition["params"])
+    params = {
+        "scope": acquired["scope"],
+        "clip": acquired.get("clip"),
+        "bin": acquired.get("bin"),
+        "timeline": acquired.get("timeline"),
+        "model": model,
+        "language": language,
+        "low_confidence": low_confidence,
+        "silence_threshold_db": silence_threshold_db,
+        "min_silence_seconds": min_silence_seconds,
+    }
+    key = cache.cache_key(KIND, [{"audio": _key_of(acquisition)}], params)
+
+    def work(progress: Progress) -> JobOutput:
+        return transcribe_acquired(
+            acquisition["job_id"], key, params, progress, transcriber, config
+        )
+
+    return start_job(KIND, params, work, cache_key=key, refresh=refresh, config=config)
+
+
+def transcribe_acquired(
+    acquisition_job: str,
+    key: str,
+    params: dict[str, Any],
+    progress: Progress,
+    transcriber: Transcriber | None = None,
+    config: Config | None = None,
+) -> JobOutput:
+    """The worker: wait for the audio, transcribe it, measure it, write the document."""
+    config = config or get_config()
+
+    progress(ACQUIRING, "waiting for the audio")
+    audio = _acquired(acquisition_job, config)
+
+    progress(READING, "transcribing")
+    source = Path(str(audio["path"]))
+    heard = (transcriber or whisper.transcribe)(source, params)
+
+    progress(MEASURING, "measuring the silence")
+    spans = silence.silence(
+        source,
+        threshold_db=float(params["silence_threshold_db"]),
+        min_seconds=float(params["min_silence_seconds"]),
+    )
+
+    progress(WRITING, "writing the transcript")
+    document = transcript.document(
+        audio=audio,
+        params=params,
+        words=heard.words,
+        silence=spans,
+        language=heard.language,
+    )
+    target = transcript.write(_target(params, key, config), document)
+
+    log.info(
+        "Transcribed %s: %d words, %d silence spans, %d unsure regions -> %s",
+        _label(params),
+        len(heard.words),
+        len(spans),
+        document["stats"]["low_confidence_regions"],
+        target,
+    )
+    return JobOutput(transcript.gist(document, target), (target,))
+
+
+def _refuse_an_ambiguous_scope(clip: str | None, bin: str | None, timeline: str | None) -> None:  # noqa: A002
+    """One scope per transcript. Guessing which one was meant transcribes the wrong audio."""
+    if clip is not None and timeline is not None:
+        raise InvalidRequestError(
+            cause="A transcript is of one clip or of one timeline, not of both.",
+            fix="Pass clip for a source file, or timeline (or neither, for the open one).",
+            detail={"clip": clip, "timeline": timeline},
+        )
+    if bin is not None and clip is None:
+        raise InvalidRequestError(
+            cause="bin narrows which clip is meant, and no clip was named.",
+            fix="Pass clip as well, or drop bin to transcribe the timeline mix.",
+            detail={"bin": bin},
+        )
+
+
+def _key_of(acquisition: dict[str, Any]) -> str:
+    """The acquisition's cache key, which this job's own key is derived from.
+
+    An acquisition with no key would make every transcript on this machine collide on one
+    entry and serve one concert's words for another, so it is a failure, not a fallback.
+    """
+    key = acquisition.get("cache_key")
+    if not key:
+        raise InternalError(
+            cause="The audio acquisition job was registered without a cache key.",
+            detail={"acquisition_job_id": acquisition.get("job_id")},
+        )
+    return str(key)
+
+
+def _acquired(job_id: str, config: Config) -> dict[str, Any]:
+    """Block until the audio is on disk, or fail carrying the acquisition's own advice."""
+    record = wait_for(job_id, timeout=ACQUIRE_TIMEOUT, config=config)
+    if record.state == store.COMPLETED and record.result is not None:
+        return dict(record.result)
+
+    failure = record.error or {}
+    raise TranscriptionError(
+        cause=(
+            "The audio to transcribe was not acquired: "
+            f"{failure.get('cause') or f'its job is still {record.state}.'}"
+        ),
+        fix=failure.get("fix"),
+        detail={"acquisition": record.payload()},
+    )
+
+
+def _target(params: dict[str, Any], key: str, config: Config) -> Path:
+    """Deterministic from the cache key, so a rerun overwrites instead of accumulating."""
+    return config.analysis_dir / f"{slug(_label(params), 'transcript')}-{key[:12]}.transcript.json"
+
+
+def _label(params: dict[str, Any]) -> str:
+    return str(params.get("clip") or params.get("timeline") or "transcript")

--- a/src/resolve_mcp/analysis/transcribe.py
+++ b/src/resolve_mcp/analysis/transcribe.py
@@ -7,13 +7,17 @@ load-bearing decision here:
   (render queue for a timeline, ffmpeg for a clip) is an implementation detail of this job,
   which is what ``tools.jobs`` means by "acquisition is internal to those starters".
 
-* **The cache key is the acquisition's key plus the transcription parameters.** The audio's
-  content hash would be the truer input, but it does not exist until the export has run, and
-  a starter has to return before that. The acquisition key already covers everything that
-  decides those bytes — the clip's fingerprint or the timeline's, sample rate, bit depth —
-  so keying off it says the same thing early enough to be useful. It also means a rerun with
-  a different model pays for the model and not for the export again: that acquisition is
-  itself a cache hit.
+* **The cache key is the acquired audio's content hash plus the transcription parameters**
+  (#22: "workers key off content hash of cached audio + params hash"). Nothing weaker holds:
+  a timeline's fingerprint is blind to a clip's audio level by its own admission, so a
+  ``refresh`` by any other job can put different bytes behind the same acquisition key, and
+  a transcript keyed off that key would answer with the previous mix's words.
+
+  The hash exists only once the audio does, which splits the job in two. When the
+  acquisition came back already cached — the rerun case, the one the cache is for — the hash
+  is in hand before the starter returns, so the transcript answers from cache with no thread
+  at all. When the audio had to be made, there is nothing to hit anyway, and the worker
+  writes the entry itself once it knows what it transcribed.
 
 * A failure below is reported with the *lower* job's advice. "The audio was not acquired" is
   not something an agent can act on; "check the render queue for a stuck job" is.
@@ -27,11 +31,11 @@ from typing import Any
 from ..audio import ffmpeg
 from ..audio.acquire import acquire_clip_audio, acquire_timeline_audio
 from ..config import Config, get_config
-from ..errors import InternalError, InvalidRequestError, TranscriptionError
+from ..errors import InvalidRequestError, TranscriptionError
 from ..jobs import cache, store
 from ..jobs.runner import JobOutput, Progress, start_job, wait_for
 from ..logging_config import get_logger
-from ..naming import slug
+from ..naming import keyed_name
 from ..resolve.connection import ResolveConnection
 from . import silence, transcript, whisper
 from .transcript import Transcriber
@@ -40,7 +44,6 @@ log = get_logger("analysis")
 
 KIND = "transcribe_audio"
 
-DEFAULT_LOW_CONFIDENCE = 0.5
 ACQUIRE_TIMEOUT = 3600.0
 
 ACQUIRING = 0.05
@@ -56,7 +59,7 @@ def transcribe_audio(
     timeline: str | None = None,
     model: str = whisper.DEFAULT_MODEL,
     language: str | None = None,
-    low_confidence: float = DEFAULT_LOW_CONFIDENCE,
+    low_confidence: float = transcript.DEFAULT_LOW_CONFIDENCE,
     silence_threshold_db: float = silence.DEFAULT_THRESHOLD_DB,
     min_silence_seconds: float = silence.DEFAULT_MIN_SECONDS,
     refresh: bool = False,
@@ -91,36 +94,49 @@ def transcribe_audio(
         "silence_threshold_db": silence_threshold_db,
         "min_silence_seconds": min_silence_seconds,
     }
-    key = cache.cache_key(KIND, [{"audio": _key_of(acquisition)}], params)
+    known = _hash_of(acquisition)
+    key = cache_key(known, params) if known is not None else None
 
     def work(progress: Progress) -> JobOutput:
         return transcribe_acquired(
-            acquisition["job_id"], key, params, progress, transcriber, config
+            acquisition["job_id"], params, progress, key, transcriber, config
         )
 
     return start_job(KIND, params, work, cache_key=key, refresh=refresh, config=config)
 
 
+def cache_key(content_sha256: str, params: dict[str, Any]) -> str:
+    """What one transcript is: these bytes of audio, read with these parameters."""
+    return cache.cache_key(KIND, [{"content_sha256": content_sha256}], params)
+
+
 def transcribe_acquired(
     acquisition_job: str,
-    key: str,
     params: dict[str, Any],
     progress: Progress,
+    known_key: str | None = None,
     transcriber: Transcriber | None = None,
     config: Config | None = None,
 ) -> JobOutput:
-    """The worker: wait for the audio, transcribe it, measure it, write the document."""
+    """The worker: wait for the audio, transcribe it, measure it, write the document.
+
+    ``known_key`` is the key the starter already had, which it only has when the audio was
+    already in the cache. ``None`` means this worker is the first to know what it is
+    transcribing, so writing the cache entry is its job — inside the worker, where a write
+    that fails fails the job rather than leaving a result nothing can find again.
+    """
     config = config or get_config()
 
     progress(ACQUIRING, "waiting for the audio")
     audio = _acquired(acquisition_job, config)
+    key = known_key or cache_key(str(audio["content_sha256"]), params)
 
     progress(READING, "transcribing")
     source = Path(str(audio["path"]))
     heard = (transcriber or whisper.transcribe)(source, params)
 
     progress(MEASURING, "measuring the silence")
-    spans = silence.silence(
+    quiet = silence.measure(
         source,
         threshold_db=float(params["silence_threshold_db"]),
         min_seconds=float(params["min_silence_seconds"]),
@@ -131,7 +147,7 @@ def transcribe_acquired(
         audio=audio,
         params=params,
         words=heard.words,
-        silence=spans,
+        silence=quiet,
         language=heard.language,
     )
     target = transcript.write(_target(params, key, config), document)
@@ -140,11 +156,14 @@ def transcribe_acquired(
         "Transcribed %s: %d words, %d silence spans, %d unsure regions -> %s",
         _label(params),
         len(heard.words),
-        len(spans),
+        len(quiet),
         document["stats"]["low_confidence_regions"],
         target,
     )
-    return JobOutput(transcript.gist(document, target), (target,))
+    output = JobOutput(transcript.gist(document, target), (target,))
+    if known_key is None:
+        cache.remember(key, KIND, output.result, output.artifacts, config)
+    return output
 
 
 def _refuse_an_ambiguous_scope(clip: str | None, bin: str | None, timeline: str | None) -> None:  # noqa: A002
@@ -163,19 +182,17 @@ def _refuse_an_ambiguous_scope(clip: str | None, bin: str | None, timeline: str 
         )
 
 
-def _key_of(acquisition: dict[str, Any]) -> str:
-    """The acquisition's cache key, which this job's own key is derived from.
+def _hash_of(acquisition: dict[str, Any]) -> str | None:
+    """The acquired audio's content hash, when the acquisition already has one.
 
-    An acquisition with no key would make every transcript on this machine collide on one
-    entry and serve one concert's words for another, so it is a failure, not a fallback.
+    It does when that job answered from its own cache, which is exactly the rerun this
+    job's cache exists for. Otherwise the audio is still being made and there is no hash to
+    key on yet — and nothing to hit either, so waiting for one would buy nothing.
     """
-    key = acquisition.get("cache_key")
-    if not key:
-        raise InternalError(
-            cause="The audio acquisition job was registered without a cache key.",
-            detail={"acquisition_job_id": acquisition.get("job_id")},
-        )
-    return str(key)
+    if acquisition.get("state") != store.COMPLETED:
+        return None
+    result = acquisition.get("result") or {}
+    return str(result["content_sha256"]) if result.get("content_sha256") else None
 
 
 def _acquired(job_id: str, config: Config) -> dict[str, Any]:
@@ -190,14 +207,23 @@ def _acquired(job_id: str, config: Config) -> dict[str, Any]:
             "The audio to transcribe was not acquired: "
             f"{failure.get('cause') or f'its job is still {record.state}.'}"
         ),
-        fix=failure.get("fix"),
+        fix=failure.get("fix") or _still_going(record.state),
         detail={"acquisition": record.payload()},
     )
 
 
+def _still_going(state: str) -> str | None:
+    """A running acquisition is not a failure to fix — it is one to wait out and re-ask."""
+    if state != store.RUNNING:
+        return None
+    return (
+        "The audio export is still running after an hour. Poll it with get_job, and start "
+        "the transcript again once it has finished — the audio will be a cache hit by then."
+    )
+
+
 def _target(params: dict[str, Any], key: str, config: Config) -> Path:
-    """Deterministic from the cache key, so a rerun overwrites instead of accumulating."""
-    return config.analysis_dir / f"{slug(_label(params), 'transcript')}-{key[:12]}.transcript.json"
+    return config.analysis_dir / keyed_name(_label(params), key, ".transcript.json", "transcript")
 
 
 def _label(params: dict[str, Any]) -> str:

--- a/src/resolve_mcp/analysis/transcript.py
+++ b/src/resolve_mcp/analysis/transcript.py
@@ -28,6 +28,9 @@ PLACES = 3
 SECONDS_PER_MINUTE = 60.0
 PREVIEW_REGIONS = 20
 
+DEFAULT_LOW_CONFIDENCE = 0.5
+"""Below this a word counts as unsure. Lives here because the document is what applies it."""
+
 
 class Word(NamedTuple):
     """One word as the model heard it. ``confidence`` is 0-1, higher is surer."""
@@ -57,7 +60,7 @@ def document(
     language: str | None = None,
 ) -> dict[str, Any]:
     """The whole transcript, ready to write: header, gist stats, then the records."""
-    below = float(params.get("low_confidence", 0.5))
+    below = float(params.get("low_confidence", DEFAULT_LOW_CONFIDENCE))
     unsure = regions(words, below=below)
     return {
         "schema": SCHEMA,
@@ -79,12 +82,18 @@ def stats(
     unsure: Sequence[Mapping[str, Any]],
     below: float,
 ) -> dict[str, Any]:
-    """The numbers worth having before deciding whether to read the file at all."""
-    duration = float(audio.get("duration_seconds") or 0.0)
+    """The numbers worth having before deciding whether to read the file at all.
+
+    A duration the WAV header did not give up stays ``None`` here and takes every stat
+    derived from it with it. Calling it zero would report a transcript of a two-hour set as
+    nought seconds of speech, which reads as a finding rather than as a missing reading.
+    """
+    reported = audio.get("duration_seconds")
+    duration = float(reported) if reported is not None else None
     quiet = sum(float(one["duration"]) for one in silence)
     confidences = [one.confidence for one in words]
     return {
-        "duration_seconds": round(duration, PLACES),
+        "duration_seconds": round(duration, PLACES) if duration is not None else None,
         "word_count": len(words),
         "words_per_minute": (
             round(len(words) / (duration / SECONDS_PER_MINUTE), 1) if duration else None
@@ -97,7 +106,9 @@ def stats(
         "low_confidence_regions": len(unsure),
         "silence_spans": len(silence),
         "silence_seconds": round(quiet, PLACES),
-        "speech_seconds": round(max(duration - quiet, 0.0), PLACES),
+        "speech_seconds": (
+            round(max(duration - quiet, 0.0), PLACES) if duration is not None else None
+        ),
         "longest_silence_seconds": (
             round(max(float(one["duration"]) for one in silence), PLACES) if silence else 0.0
         ),

--- a/src/resolve_mcp/analysis/transcript.py
+++ b/src/resolve_mcp/analysis/transcript.py
@@ -1,0 +1,190 @@
+"""The transcript document: what gets written, and what comes back inline.
+
+The vocabulary lives here too — ``Word``, ``Transcription``, ``Transcriber`` — so that the
+backend module and the job module share one shape without importing each other.
+
+Two decisions are worth stating, because both are about the agent reading this file rather
+than the server producing it:
+
+* **One record per line.** ``json.dumps(indent=2)`` spreads a word over five lines, so
+  ``grep -n '"word": "bridge"'`` finds a fragment with no timestamp attached to it. Each
+  word, silence span and unsure region is written as one compact object on one line, which
+  greps as a whole record and still parses as ordinary JSON.
+
+* **Nothing is called a flub.** The document reports confidence and gaps; deciding that
+  0.31 on "bridge" plus two seconds of room afterwards is a retake is editorial judgment,
+  and it belongs to whoever is reading, not to this module.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, NamedTuple
+
+SCHEMA = 1
+PLACES = 3
+SECONDS_PER_MINUTE = 60.0
+PREVIEW_REGIONS = 20
+
+
+class Word(NamedTuple):
+    """One word as the model heard it. ``confidence`` is 0-1, higher is surer."""
+
+    text: str
+    start: float
+    end: float
+    confidence: float
+
+
+class Transcription(NamedTuple):
+    """What a backend returns: the words, and the language it decided it was hearing."""
+
+    words: tuple[Word, ...]
+    language: str | None = None
+
+
+Transcriber = Callable[[Path, Mapping[str, Any]], Transcription]
+"""The backend seam. The default shells out to faster-whisper; tests hand in their own."""
+
+
+def document(
+    audio: Mapping[str, Any],
+    params: Mapping[str, Any],
+    words: Sequence[Word],
+    silence: Sequence[Mapping[str, float]],
+    language: str | None = None,
+) -> dict[str, Any]:
+    """The whole transcript, ready to write: header, gist stats, then the records."""
+    below = float(params.get("low_confidence", 0.5))
+    unsure = regions(words, below=below)
+    return {
+        "schema": SCHEMA,
+        "kind": "transcript",
+        "language": language,
+        "audio": dict(audio),
+        "params": dict(params),
+        "stats": stats(audio, words, silence, unsure, below),
+        "words": [_word(one) for one in words],
+        "silence": [dict(one) for one in silence],
+        "low_confidence": unsure,
+    }
+
+
+def stats(
+    audio: Mapping[str, Any],
+    words: Sequence[Word],
+    silence: Sequence[Mapping[str, float]],
+    unsure: Sequence[Mapping[str, Any]],
+    below: float,
+) -> dict[str, Any]:
+    """The numbers worth having before deciding whether to read the file at all."""
+    duration = float(audio.get("duration_seconds") or 0.0)
+    quiet = sum(float(one["duration"]) for one in silence)
+    confidences = [one.confidence for one in words]
+    return {
+        "duration_seconds": round(duration, PLACES),
+        "word_count": len(words),
+        "words_per_minute": (
+            round(len(words) / (duration / SECONDS_PER_MINUTE), 1) if duration else None
+        ),
+        "mean_confidence": (
+            round(sum(confidences) / len(confidences), PLACES) if confidences else None
+        ),
+        "low_confidence_threshold": below,
+        "low_confidence_words": sum(1 for one in confidences if one < below),
+        "low_confidence_regions": len(unsure),
+        "silence_spans": len(silence),
+        "silence_seconds": round(quiet, PLACES),
+        "speech_seconds": round(max(duration - quiet, 0.0), PLACES),
+        "longest_silence_seconds": (
+            round(max(float(one["duration"]) for one in silence), PLACES) if silence else 0.0
+        ),
+    }
+
+
+def regions(words: Sequence[Word], below: float) -> list[dict[str, Any]]:
+    """Neighbouring words the model was unsure of, merged into stretches worth listening to.
+
+    Merged by adjacency in the transcript rather than by a time gap: two unsure words with
+    a confident one between them are two separate doubts, however close together they sit.
+    """
+    found: list[dict[str, Any]] = []
+    run: list[Word] = []
+    stream: list[Word | None] = [*words, None]
+    for word in stream:
+        if word is not None and word.confidence < below:
+            run.append(word)
+            continue
+        if run:
+            found.append(_region(run))
+            run = []
+    return found
+
+
+def write(path: Path, transcript: Mapping[str, Any]) -> Path:
+    """Write the document one record per line, and return where it landed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = ",\n".join(
+        _rows(key, value) if isinstance(value, list) else _field(key, value)
+        for key, value in transcript.items()
+    )
+    path.write_text(f"{{\n{body}\n}}\n", encoding="utf-8")
+    return path
+
+
+def gist(transcript: Mapping[str, Any], path: Path) -> dict[str, Any]:
+    """What the job returns inline: where the file is, and enough to decide about reading it.
+
+    The unsure regions come back capped rather than in full — they are the reason an agent
+    opens a transcript, so a handful inline often answers the question outright, while a
+    take that went badly enough to produce hundreds of them must not blow the output cap.
+    """
+    unsure = list(transcript.get("low_confidence") or [])
+    audio = dict(transcript.get("audio") or {})
+    return {
+        "path": str(path),
+        "language": transcript.get("language"),
+        "stats": transcript.get("stats"),
+        "low_confidence_regions": unsure[:PREVIEW_REGIONS],
+        "low_confidence_truncated": len(unsure) > PREVIEW_REGIONS,
+        "audio": audio,
+    }
+
+
+def _word(word: Word) -> dict[str, Any]:
+    return {
+        "start": round(word.start, PLACES),
+        "end": round(word.end, PLACES),
+        "word": word.text,
+        "confidence": round(word.confidence, PLACES),
+    }
+
+
+def _region(run: Sequence[Word]) -> dict[str, Any]:
+    start = round(run[0].start, PLACES)
+    end = round(run[-1].end, PLACES)
+    return {
+        "start": start,
+        "end": end,
+        "duration": round(end - start, PLACES),
+        "words": len(run),
+        "text": " ".join(one.text.strip() for one in run),
+    }
+
+
+def _rows(key: str, rows: Sequence[Any]) -> str:
+    """A list of records, one per line — the shape that makes the file greppable."""
+    if not rows:
+        return f'  "{key}": []'
+    body = ",\n".join(f"    {json.dumps(row)}" for row in rows)
+    return f'  "{key}": [\n{body}\n  ]'
+
+
+def _field(key: str, value: Any) -> str:
+    return f'  "{key}": {_indented(json.dumps(value, indent=2))}'
+
+
+def _indented(rendered: str) -> str:
+    return rendered.replace("\n", "\n  ")

--- a/src/resolve_mcp/analysis/whisper.py
+++ b/src/resolve_mcp/analysis/whisper.py
@@ -1,0 +1,77 @@
+"""The default backend: faster-whisper, large-v3, word timestamps on.
+
+External to Resolve on purpose (#10). Resolve's own transcription writes end-user subtitles
+— no per-word confidence, no way to get the words out except as a subtitle track — and
+confidence is the whole reason an agent reads a transcript instead of watching the take.
+
+The import is inside the function because the CUDA runtime behind it costs seconds to load
+and the server must start in the time a tool call takes. It is also the reason this is a
+seam: everything above it is tested with the model substituted, and this module is the only
+thing that faster-whisper's absence can break.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ..errors import TranscriberUnavailableError, TranscriptionError
+from ..logging_config import get_logger
+from .transcript import Transcription, Word
+
+log = get_logger("analysis")
+
+DEFAULT_MODEL = "large-v3"
+DEVICE = "auto"
+COMPUTE_TYPE = "default"
+
+
+def transcribe(audio: Path, params: Mapping[str, Any]) -> Transcription:
+    """Word-level transcription of one WAV. Slow, GPU-bound, and always inside a job."""
+    model_name = str(params.get("model") or DEFAULT_MODEL)
+    language = params.get("language") or None
+    model = _model(model_name)
+
+    log.info("Transcribing %s with %s", audio.name, model_name)
+    try:
+        segments, info = model.transcribe(
+            str(audio),
+            word_timestamps=True,
+            language=str(language) if language else None,
+        )
+        words = tuple(_word(one) for segment in segments for one in (segment.words or ()))
+    except Exception as exc:  # noqa: BLE001 - the backend raises its own unrelated types
+        raise TranscriptionError(
+            cause=f"faster-whisper failed on {audio.name}: {type(exc).__name__}: {exc}",
+            fix="Check the WAV plays, and that the GPU is free; then start the job again.",
+            detail={"path": str(audio), "model": model_name},
+        ) from exc
+
+    return Transcription(words=words, language=_language(info))
+
+
+def _model(name: str) -> Any:
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError as exc:
+        raise TranscriberUnavailableError(
+            cause="faster-whisper is not installed in this environment.",
+            detail={"model": name},
+        ) from exc
+    return WhisperModel(name, device=DEVICE, compute_type=COMPUTE_TYPE)
+
+
+def _word(word: Any) -> Word:
+    """One word as faster-whisper reports it: leading space on the text, probability 0-1."""
+    return Word(
+        text=str(word.word).strip(),
+        start=float(word.start),
+        end=float(word.end),
+        confidence=float(word.probability),
+    )
+
+
+def _language(info: Any) -> str | None:
+    detected = getattr(info, "language", None)
+    return str(detected) if detected else None

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -34,7 +34,7 @@ from ..errors import AudioExportError, AudioExtractionError, AudioMappingError, 
 from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, start_job
 from ..logging_config import get_logger
-from ..naming import slug
+from ..naming import keyed_name
 from ..resolve import media, render
 from ..resolve.connection import ResolveConnection
 from ..resolve.session import current_project
@@ -152,7 +152,7 @@ def export_timeline_mix(
     config = config or get_config()
     target_dir = config.audio_dir
     target_dir.mkdir(parents=True, exist_ok=True)
-    stem = _stem(str(params["timeline"]), key)
+    stem = keyed_name(str(params["timeline"]), key, "", "audio")
     expecting = target_dir / f"{stem}.wav"
 
     progress(0.05, "queuing the audio export")
@@ -282,7 +282,7 @@ def extract_clip_audio(
 ) -> JobOutput:
     """The worker: ffmpeg the clip's audio into the cache as a WAV."""
     config = config or get_config()
-    target = config.audio_dir / f"{_stem(str(params['clip']), key)}.wav"
+    target = config.audio_dir / keyed_name(str(params["clip"]), key, ".wav", "audio")
 
     progress(0.1, "extracting audio with ffmpeg")
     ffmpeg.extract(
@@ -365,8 +365,3 @@ def _result(target: Path, params: dict[str, Any]) -> dict[str, Any]:
         target,
     )
     return reading
-
-
-def _stem(label: str, key: str) -> str:
-    """Deterministic from the cache key, so a rerun overwrites instead of accumulating."""
-    return f"{slug(label, 'audio')}-{key[:12]}"

--- a/src/resolve_mcp/audio/wav.py
+++ b/src/resolve_mcp/audio/wav.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import wave
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -18,21 +19,34 @@ from ..errors import AudioExtractionError
 BITS_PER_BYTE = 8
 
 
-def describe(path: Path | str) -> dict[str, Any]:
-    """Duration, sample rate, channels and bit depth of a WAV on disk."""
+@contextlib.contextmanager
+def opened(path: Path | str) -> Iterator[wave.Wave_read]:
+    """An open WAV, or the one failure every reader of one should report.
+
+    Anything that reads a WAV this server wrote reads a file the server can also delete and
+    make again, so the advice is the same wherever the read happens — which is why the
+    reading itself is the only part left to the caller.
+    """
     target = Path(path)
     try:
         with contextlib.closing(wave.open(str(target), "rb")) as handle:
-            frames = handle.getnframes()
-            rate = handle.getframerate()
-            channels = handle.getnchannels()
-            width = handle.getsampwidth()
+            yield handle
     except (OSError, wave.Error) as exc:
         raise AudioExtractionError(
             cause=f"{target.name} is not a readable WAV file ({exc}).",
             fix="Delete it from the cache directory and run the job again.",
             detail={"path": str(target)},
         ) from exc
+
+
+def describe(path: Path | str) -> dict[str, Any]:
+    """Duration, sample rate, channels and bit depth of a WAV on disk."""
+    target = Path(path)
+    with opened(target) as handle:
+        frames = handle.getnframes()
+        rate = handle.getframerate()
+        channels = handle.getnchannels()
+        width = handle.getsampwidth()
     return {
         "path": str(target),
         "duration_seconds": round(frames / rate, 3) if rate else None,

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -79,6 +79,16 @@ class Config:
         return self.cache_dir / "audio"
 
     @property
+    def analysis_dir(self) -> Path:
+        """What the analysis jobs read out of the audio: transcripts, and later beat maps.
+
+        Separate from the WAVs they were read off: the audio is a cache of something Resolve
+        or ffmpeg can make again, while these are the files the agent greps and quotes in a
+        review round, and it should be able to tell the two apart at a glance.
+        """
+        return self.cache_dir / "analysis"
+
+    @property
     def interchange_dir(self) -> Path:
         """Where exported timelines (OTIO, FCPXML, DRT) land when no path is given.
 

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -333,6 +333,27 @@ class AudioMappingError(ResolveMcpError):
     )
 
 
+class TranscriberUnavailableError(ResolveMcpError):
+    """faster-whisper is not installed in this venv, so nothing can be transcribed."""
+
+    code = "transcriber_unavailable"
+    default_fix = (
+        "Install the transcription extra with `uv sync --extra analysis`, which pulls "
+        "faster-whisper and its CUDA runtime. The first run also downloads the model, "
+        "which takes a while and needs the disk space."
+    )
+
+
+class TranscriptionError(ResolveMcpError):
+    """The transcription job could not produce a transcript."""
+
+    code = "transcription_failed"
+    default_fix = (
+        "Check the audio the transcript was to be made from — get_job on the acquisition "
+        "job named in detail reports what happened to it — then start the job again."
+    )
+
+
 class InternalError(ResolveMcpError):
     code = "internal_error"
     default_fix = (

--- a/src/resolve_mcp/naming.py
+++ b/src/resolve_mcp/naming.py
@@ -36,6 +36,20 @@ def timestamped_name(
     return f"{slug(label, fallback)}-{stamp}{suffix}"
 
 
+KEY_IN_NAME = 12
+
+
+def keyed_name(label: str, key: str, suffix: str, fallback: str) -> str:
+    """``<slug>-<key prefix><suffix>`` — the name a cached artifact keeps.
+
+    The opposite rule to ``timestamped_name``: a file whose content is decided entirely by
+    a cache key should be *re*-written by a rerun, not accumulated alongside a dozen dated
+    copies of itself. A stamp here would leave the cache growing with files no lookup will
+    ever name again.
+    """
+    return f"{slug(label, fallback)}-{key[:KEY_IN_NAME]}{suffix}"
+
+
 def write_target(
     path: str | Path | None,
     label: str,

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from . import __version__
 from .config import get_config
 from .logging_config import configure_logging, get_logger
-from .tools import cut, escape_hatch, jobs, media, project, timeline
+from .tools import analysis, cut, escape_hatch, jobs, media, project, timeline
 
 log = get_logger("server")
 
@@ -49,6 +49,7 @@ def build_server() -> FastMCP:
         *media.TOOLS,
         *timeline.TOOLS,
         *cut.TOOLS,
+        *analysis.TOOLS,
         *jobs.TOOLS,
         *escape_hatch.TOOLS,
     ):

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -1,0 +1,65 @@
+"""Analysis starters: heavy reading of the audio, each one a typed job.
+
+The tools here return a job record, never the analysis — the file they write is bigger than
+any tool result should be, and reading it is the agent's job.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..analysis import silence, transcribe, whisper
+from ..resolve.connection import get_connection
+from .envelope import tool
+
+
+@tool
+def transcribe_audio(
+    clip: str | None = None,
+    bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
+    timeline: str | None = None,
+    model: str = whisper.DEFAULT_MODEL,
+    language: str | None = None,
+    low_confidence: float = transcribe.DEFAULT_LOW_CONFIDENCE,
+    silence_threshold_db: float = silence.DEFAULT_THRESHOLD_DB,
+    min_silence_seconds: float = silence.DEFAULT_MIN_SECONDS,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    """Start a word-level transcript of one source clip, or of the timeline mix.
+
+    Name clip (with bin if the name is ambiguous) for a source file; name timeline, or
+    neither, for the open timeline's mix — the audio is acquired for you either way. Poll
+    the returned job with get_job.
+
+    The result is a path to timestamped JSON plus gist stats: duration, word count, mean
+    confidence, how much of it is silence, and the unsure regions (a capped preview of them
+    comes back inline). The file holds one record per line, so grep it and read slices —
+    every word carries start, end and a 0-1 confidence, and the silence spans are measured
+    off the waveform rather than off the gaps between words, so a held chord or a room of
+    applause is not mistaken for room to cut in.
+
+    Nothing here labels a flub, a retake or filler. Low confidence next to a long silence is
+    evidence; what it means is yours to decide. language forces one instead of detecting it;
+    low_confidence moves the threshold a word counts as unsure below; refresh re-transcribes
+    audio the cache would otherwise answer for.
+    """
+    connection = get_connection()
+    return {
+        "job": transcribe.transcribe_audio(
+            connection,
+            clip=clip,
+            bin=bin,
+            timeline=timeline,
+            model=model,
+            language=language,
+            low_confidence=low_confidence,
+            silence_threshold_db=silence_threshold_db,
+            min_silence_seconds=min_silence_seconds,
+            refresh=refresh,
+        )
+    }
+
+
+TOOLS: tuple[Any, ...] = (transcribe_audio,)
+
+__all__ = ["TOOLS", "transcribe_audio"]

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..analysis import silence, transcribe, whisper
+from ..analysis import silence, transcribe, transcript, whisper
 from ..resolve.connection import get_connection
 from .envelope import tool
 
@@ -20,7 +20,7 @@ def transcribe_audio(
     timeline: str | None = None,
     model: str = whisper.DEFAULT_MODEL,
     language: str | None = None,
-    low_confidence: float = transcribe.DEFAULT_LOW_CONFIDENCE,
+    low_confidence: float = transcript.DEFAULT_LOW_CONFIDENCE,
     silence_threshold_db: float = silence.DEFAULT_THRESHOLD_DB,
     min_silence_seconds: float = silence.DEFAULT_MIN_SECONDS,
     refresh: bool = False,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1331,17 +1331,26 @@ def write_wav(
     bit_depth: int = 24,
     channels: int = 2,
     frequency: float = 440.0,
+    silence: Sequence[tuple[float, float]] = (),
 ) -> Path:
     """A real WAV of a sine tone — the fixture audio the worker tier is tested on.
 
     Real audio rather than a stub file, because the workers read the header back: a fake
     that wrote ``b"RIFF"`` would pass a duration assertion that means nothing.
+
+    ``silence`` zeroes the given ``(start, end)`` second-ranges, which is what makes this
+    fixture usable by the analysis tier: a tone that never stops has no breathing room to
+    find, so a silence detector run over it can only ever be asserted to find nothing.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     width = bit_depth // 8
     peak = int(2 ** (bit_depth - 1) * 0.3)
+    quiet = [(start * sample_rate, end * sample_rate) for start, end in silence]
     frames = bytearray()
     for index in range(int(seconds * sample_rate)):
+        if any(start <= index < end for start, end in quiet):
+            frames.extend(b"\x00" * width * channels)
+            continue
         sample = int(peak * math.sin(2 * math.pi * frequency * index / sample_rate))
         frames.extend(sample.to_bytes(width, "little", signed=True) * channels)
     with contextlib.closing(wave.open(str(path), "wb")) as handle:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -515,7 +515,7 @@ def test_the_render_queue_exports_the_real_timeline_mix() -> None:
     importlib.util.find_spec("faster_whisper") is None,
     reason="the analysis extra is not installed (uv sync --extra analysis)",
 )
-def test_faster_whisper_reports_words_in_the_shape_the_worker_reads() -> None:
+def test_faster_whisper_reports_words_in_the_shape_the_worker_reads(tmp_path: Path) -> None:
     """The other AC no seam can check: what a real faster-whisper word object looks like.
 
     The fake tier substitutes the model entirely, so every assertion above it is about
@@ -532,7 +532,7 @@ def test_faster_whisper_reports_words_in_the_shape_the_worker_reads() -> None:
 
     from .fakes import write_wav
 
-    audio = write_wav(Path(os.environ["TEMP"]) / "resolve-mcp-smoke-tone.wav", seconds=2.0)
+    audio = write_wav(tmp_path / "tone.wav", seconds=2.0)
 
     heard = whisper.transcribe(audio, {"model": whisper.DEFAULT_MODEL})
 

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -19,6 +19,7 @@ in PowerShell, which is the shell on the machine this runs on:
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 from datetime import datetime
@@ -508,6 +509,38 @@ def test_the_render_queue_exports_the_real_timeline_mix() -> None:
 
     again = acquire_timeline_audio(get_connection())
     assert again["cached"] is True, "an unchanged timeline must be a cache hit"
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("faster_whisper") is None,
+    reason="the analysis extra is not installed (uv sync --extra analysis)",
+)
+def test_faster_whisper_reports_words_in_the_shape_the_worker_reads() -> None:
+    """The other AC no seam can check: what a real faster-whisper word object looks like.
+
+    The fake tier substitutes the model entirely, so every assertion above it is about
+    ``Word``, a shape this repo made up. That ``segment.words`` is populated at all with
+    ``word_timestamps=True``, and that each one carries ``word``/``start``/``end``/
+    ``probability``, is only answerable with the real model loaded. Slow on first run: it
+    downloads large-v3 and needs a GPU to be quick about it.
+
+    Two seconds of tone is deliberately not speech — the claim under test is the shape of
+    the reply, not what was heard, and a model that hears nothing still has to return
+    cleanly rather than raise.
+    """
+    from resolve_mcp.analysis import whisper
+
+    from .fakes import write_wav
+
+    audio = write_wav(Path(os.environ["TEMP"]) / "resolve-mcp-smoke-tone.wav", seconds=2.0)
+
+    heard = whisper.transcribe(audio, {"model": whisper.DEFAULT_MODEL})
+
+    assert isinstance(heard.words, tuple)
+    for word in heard.words:
+        assert word.text
+        assert 0.0 <= word.start <= word.end
+        assert 0.0 <= word.confidence <= 1.0
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,6 +38,7 @@ def test_registers_the_p1_session_media_timeline_cut_and_job_tools() -> None:
         "get_cut_schema",
         "validate_cut",
         "build_timeline",
+        "transcribe_audio",
         "get_job",
         "list_jobs",
         "run_python",

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import contextlib
 import json
 import wave
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -65,25 +66,45 @@ def test_every_supported_bit_depth_is_read_as_signed_pcm(tmp_path: Path) -> None
         assert min(measured) > silence.DEFAULT_THRESHOLD_DB, depth
 
 
-def test_a_channel_that_is_silent_alone_does_not_make_the_window_silent(
+@pytest.mark.parametrize(
+    ("loud", "window_seconds"),
+    [
+        # 2048 frames of stereo decimate to a stride of 64, which walks the left channel
+        # only; 0.05s of four-channel to a stride of 150, which walks channels 0 and 2.
+        ((False, True), 2048 / 48_000),
+        ((False, True, False, True), WINDOW),
+    ],
+)
+def test_channels_that_are_silent_alone_do_not_make_the_window_silent(
     tmp_path: Path,
+    loud: tuple[bool, ...],
+    window_seconds: float,
 ) -> None:
-    """The windows are decimated, and a stride that lands on one channel only reads it only."""
-    path = tmp_path / "one-sided.wav"
-    peak = int(2 ** 23 * 0.3)
+    """A decimating stride that is not coprime with the channel count reads a fixed subset.
+
+    Both parameter sets are strides that land that way, so this fails on any reader that
+    walks interleaved samples without accounting for how many channels it is walking.
+    """
+    audio = _write_channels(tmp_path / f"{len(loud)}-channel.wav", loud)
+
+    measured = silence.levels(audio, window_seconds=window_seconds)
+
+    assert min(measured) > silence.DEFAULT_THRESHOLD_DB
+
+
+def _write_channels(path: Path, loud: Sequence[bool], seconds: float = 1.0) -> Path:
+    """A WAV whose channels are individually loud or silent, at 24-bit / 48 kHz."""
+    peak = int(2**23 * 0.3)
     frames = bytearray()
-    for _ in range(48_000):
-        frames.extend(b"\x00\x00\x00")
-        frames.extend(peak.to_bytes(3, "little", signed=True))
+    for _ in range(int(seconds * 48_000)):
+        for playing in loud:
+            frames.extend(peak.to_bytes(3, "little", signed=True) if playing else b"\x00\x00\x00")
     with contextlib.closing(wave.open(str(path), "wb")) as handle:
-        handle.setnchannels(2)
+        handle.setnchannels(len(loud))
         handle.setsampwidth(3)
         handle.setframerate(48_000)
         handle.writeframes(bytes(frames))
-
-    measured = silence.levels(path, window_seconds=WINDOW)
-
-    assert min(measured) > silence.DEFAULT_THRESHOLD_DB
+    return path
 
 
 def test_eight_bit_audio_is_refused_rather_than_read_as_if_it_were_signed(

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,0 +1,242 @@
+"""The reading half of transcription: silence off the waveform, and the document on disk.
+
+Both are pure — a WAV in, numbers out — so they are tested without a job, a thread or a
+model anywhere near them. What is under test is the part an agent will act on: that a gap
+in the audio comes back as a span with the right edges, that a run of unsure words is one
+region rather than five, and that the file written is greppable line-by-line while still
+parsing as JSON.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import wave
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.analysis import silence, transcript
+from resolve_mcp.analysis.transcript import Word
+from resolve_mcp.errors import AudioExtractionError
+
+from .fakes import write_wav
+
+WINDOW = 0.05
+TOLERANCE = 2 * WINDOW
+
+
+def _words(*spec: tuple[str, float, float, float]) -> list[Word]:
+    return [Word(text=one[0], start=one[1], end=one[2], confidence=one[3]) for one in spec]
+
+
+# --- levels off the waveform -------------------------------------------------------------
+
+
+def test_a_continuous_tone_has_no_window_anywhere_near_silence(tmp_path: Path) -> None:
+    audio = write_wav(tmp_path / "tone.wav", seconds=1.0)
+
+    measured = silence.levels(audio, window_seconds=WINDOW)
+
+    assert len(measured) == pytest.approx(1.0 / WINDOW, abs=1)
+    assert max(measured) < 0.0
+    assert min(measured) > silence.DEFAULT_THRESHOLD_DB
+
+
+def test_a_zeroed_stretch_reads_at_the_floor_and_the_tone_around_it_does_not(
+    tmp_path: Path,
+) -> None:
+    audio = write_wav(tmp_path / "gap.wav", seconds=1.0, silence=[(0.4, 0.9)])
+
+    measured = silence.levels(audio, window_seconds=WINDOW)
+
+    middle = measured[int(0.5 / WINDOW) : int(0.8 / WINDOW)]
+    assert all(level == silence.SILENT_FLOOR_DB for level in middle)
+    assert measured[0] > silence.DEFAULT_THRESHOLD_DB
+
+
+def test_every_supported_bit_depth_is_read_as_signed_pcm(tmp_path: Path) -> None:
+    """A width read the wrong way round reports a loud tone as silence, or the reverse."""
+    for depth in (16, 24, 32):
+        audio = write_wav(tmp_path / f"tone{depth}.wav", seconds=0.4, bit_depth=depth)
+
+        measured = silence.levels(audio, window_seconds=WINDOW)
+
+        assert min(measured) > silence.DEFAULT_THRESHOLD_DB, depth
+
+
+def test_eight_bit_audio_is_refused_rather_than_read_as_if_it_were_signed(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "eight.wav"
+    with contextlib.closing(wave.open(str(path), "wb")) as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(1)
+        handle.setframerate(48_000)
+        handle.writeframes(b"\x80" * 4800)
+
+    with pytest.raises(AudioExtractionError) as raised:
+        silence.levels(path, window_seconds=WINDOW)
+
+    assert "8-bit" in raised.value.cause
+
+
+# --- spans out of levels -----------------------------------------------------------------
+
+
+def test_neighbouring_quiet_windows_become_one_span(tmp_path: Path) -> None:
+    levels = [-10.0, -80.0, -80.0, -80.0, -80.0, -10.0]
+
+    found = silence.spans(levels, window_seconds=0.1, threshold_db=-40.0, min_seconds=0.2)
+
+    assert found == [{"start": 0.1, "end": 0.5, "duration": 0.4}]
+
+
+def test_a_gap_shorter_than_the_minimum_is_not_breathing_room(tmp_path: Path) -> None:
+    levels = [-10.0, -80.0, -10.0, -80.0, -80.0, -80.0]
+
+    found = silence.spans(levels, window_seconds=0.1, threshold_db=-40.0, min_seconds=0.2)
+
+    assert found == [{"start": 0.3, "end": 0.6, "duration": 0.3}]
+
+
+def test_a_span_running_to_the_end_is_clamped_to_the_audio(tmp_path: Path) -> None:
+    levels = [-10.0, -80.0, -80.0]
+
+    found = silence.spans(
+        levels, window_seconds=0.1, threshold_db=-40.0, min_seconds=0.1, limit=0.25
+    )
+
+    assert found == [{"start": 0.1, "end": 0.25, "duration": 0.15}]
+
+
+def test_the_whole_route_finds_the_gap_that_was_written_into_the_fixture(
+    tmp_path: Path,
+) -> None:
+    audio = write_wav(tmp_path / "gap.wav", seconds=2.0, silence=[(0.6, 1.4)])
+
+    found = silence.silence(audio, window_seconds=WINDOW, min_seconds=0.35)
+
+    assert len(found) == 1
+    assert found[0]["start"] == pytest.approx(0.6, abs=TOLERANCE)
+    assert found[0]["end"] == pytest.approx(1.4, abs=TOLERANCE)
+
+
+# --- low-confidence regions --------------------------------------------------------------
+
+
+def test_a_run_of_unsure_words_is_one_region_carrying_its_text() -> None:
+    words = _words(
+        ("the", 0.0, 0.2, 0.99),
+        ("bridge", 0.2, 0.5, 0.31),
+        ("was", 0.5, 0.7, 0.22),
+        ("fine", 0.7, 1.0, 0.98),
+    )
+
+    found = transcript.regions(words, below=0.5)
+
+    assert found == [
+        {"start": 0.2, "end": 0.7, "duration": 0.5, "words": 2, "text": "bridge was"}
+    ]
+
+
+def test_unsure_words_with_a_confident_one_between_them_stay_separate() -> None:
+    words = _words(
+        ("uh", 0.0, 0.2, 0.10),
+        ("yes", 0.2, 0.4, 0.99),
+        ("mm", 0.4, 0.6, 0.20),
+    )
+
+    found = transcript.regions(words, below=0.5)
+
+    assert [one["text"] for one in found] == ["uh", "mm"]
+
+
+# --- the document ------------------------------------------------------------------------
+
+
+def _document() -> dict[str, object]:
+    return transcript.document(
+        audio={"path": "C:/cache/audio/set.wav", "content_sha256": "abc", "duration_seconds": 4.0},
+        params={"scope": "clip", "clip": "C0012.mp4", "model": "large-v3", "low_confidence": 0.5},
+        words=_words(
+            ("one", 0.0, 0.5, 0.9),
+            ("two", 0.5, 1.0, 0.3),
+            ("three", 3.0, 3.5, 0.7),
+        ),
+        silence=[{"start": 1.0, "end": 3.0, "duration": 2.0}],
+        language="en",
+    )
+
+
+def test_the_gist_stats_answer_what_the_agent_asks_before_reading_the_file() -> None:
+    stats = _document()["stats"]
+    assert isinstance(stats, dict)
+
+    assert stats["duration_seconds"] == 4.0
+    assert stats["word_count"] == 3
+    assert stats["low_confidence_words"] == 1
+    assert stats["low_confidence_regions"] == 1
+    assert stats["silence_spans"] == 1
+    assert stats["silence_seconds"] == 2.0
+    assert stats["speech_seconds"] == 2.0
+    assert stats["mean_confidence"] == pytest.approx(0.633, abs=0.001)
+
+
+def test_every_word_carries_its_own_timestamps_and_confidence() -> None:
+    words = _document()["words"]
+    assert isinstance(words, list)
+
+    assert words[0] == {"start": 0.0, "end": 0.5, "word": "one", "confidence": 0.9}
+    assert [one["start"] for one in words] == [0.0, 0.5, 3.0]
+
+
+def test_the_file_is_valid_json_with_one_word_per_line_so_it_can_be_grepped(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "set.transcript.json"
+
+    transcript.write(target, _document())
+
+    text = target.read_text(encoding="utf-8")
+    assert json.loads(text) == _document()
+    assert len([line for line in text.splitlines() if '"word":' in line]) == 3
+    assert len([line for line in text.splitlines() if '"duration":' in line]) == 2
+
+
+def test_the_inline_result_previews_the_unsure_regions_without_carrying_the_words(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "set.transcript.json"
+    document = _document()
+
+    gist = transcript.gist(document, target)
+
+    assert gist["path"] == str(target)
+    assert gist["stats"] == document["stats"]
+    assert gist["language"] == "en"
+    assert [one["text"] for one in gist["low_confidence_regions"]] == ["two"]
+    assert gist["low_confidence_truncated"] is False
+    assert "words" not in gist
+
+
+def test_a_transcript_full_of_unsure_regions_previews_a_capped_number_of_them(
+    tmp_path: Path,
+) -> None:
+    # Alternating, so each unsure word is its own region rather than one long run.
+    many: list[tuple[str, float, float, float]] = []
+    for index in range(40):
+        many.append(("um", index * 1.0, index * 1.0 + 0.4, 0.1))
+        many.append(("yes", index * 1.0 + 0.4, index * 1.0 + 0.8, 0.99))
+    document = transcript.document(
+        audio={"path": "a.wav", "content_sha256": "abc", "duration_seconds": 40.0},
+        params={"scope": "clip", "clip": "a", "model": "large-v3", "low_confidence": 0.5},
+        words=_words(*many),
+        silence=[],
+        language="en",
+    )
+
+    gist = transcript.gist(document, tmp_path / "a.transcript.json")
+
+    assert len(gist["low_confidence_regions"]) == transcript.PREVIEW_REGIONS
+    assert gist["low_confidence_truncated"] is True

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -65,6 +65,27 @@ def test_every_supported_bit_depth_is_read_as_signed_pcm(tmp_path: Path) -> None
         assert min(measured) > silence.DEFAULT_THRESHOLD_DB, depth
 
 
+def test_a_channel_that_is_silent_alone_does_not_make_the_window_silent(
+    tmp_path: Path,
+) -> None:
+    """The windows are decimated, and a stride that lands on one channel only reads it only."""
+    path = tmp_path / "one-sided.wav"
+    peak = int(2 ** 23 * 0.3)
+    frames = bytearray()
+    for _ in range(48_000):
+        frames.extend(b"\x00\x00\x00")
+        frames.extend(peak.to_bytes(3, "little", signed=True))
+    with contextlib.closing(wave.open(str(path), "wb")) as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(3)
+        handle.setframerate(48_000)
+        handle.writeframes(bytes(frames))
+
+    measured = silence.levels(path, window_seconds=WINDOW)
+
+    assert min(measured) > silence.DEFAULT_THRESHOLD_DB
+
+
 def test_eight_bit_audio_is_refused_rather_than_read_as_if_it_were_signed(
     tmp_path: Path,
 ) -> None:
@@ -84,7 +105,7 @@ def test_eight_bit_audio_is_refused_rather_than_read_as_if_it_were_signed(
 # --- spans out of levels -----------------------------------------------------------------
 
 
-def test_neighbouring_quiet_windows_become_one_span(tmp_path: Path) -> None:
+def test_neighbouring_quiet_windows_become_one_span() -> None:
     levels = [-10.0, -80.0, -80.0, -80.0, -80.0, -10.0]
 
     found = silence.spans(levels, window_seconds=0.1, threshold_db=-40.0, min_seconds=0.2)
@@ -92,7 +113,7 @@ def test_neighbouring_quiet_windows_become_one_span(tmp_path: Path) -> None:
     assert found == [{"start": 0.1, "end": 0.5, "duration": 0.4}]
 
 
-def test_a_gap_shorter_than_the_minimum_is_not_breathing_room(tmp_path: Path) -> None:
+def test_a_gap_shorter_than_the_minimum_is_not_breathing_room() -> None:
     levels = [-10.0, -80.0, -10.0, -80.0, -80.0, -80.0]
 
     found = silence.spans(levels, window_seconds=0.1, threshold_db=-40.0, min_seconds=0.2)
@@ -100,7 +121,7 @@ def test_a_gap_shorter_than_the_minimum_is_not_breathing_room(tmp_path: Path) ->
     assert found == [{"start": 0.3, "end": 0.6, "duration": 0.3}]
 
 
-def test_a_span_running_to_the_end_is_clamped_to_the_audio(tmp_path: Path) -> None:
+def test_a_span_running_to_the_end_is_clamped_to_the_audio() -> None:
     levels = [-10.0, -80.0, -80.0]
 
     found = silence.spans(
@@ -115,7 +136,7 @@ def test_the_whole_route_finds_the_gap_that_was_written_into_the_fixture(
 ) -> None:
     audio = write_wav(tmp_path / "gap.wav", seconds=2.0, silence=[(0.6, 1.4)])
 
-    found = silence.silence(audio, window_seconds=WINDOW, min_seconds=0.35)
+    found = silence.measure(audio, window_seconds=WINDOW, min_seconds=0.35)
 
     assert len(found) == 1
     assert found[0]["start"] == pytest.approx(0.6, abs=TOLERANCE)
@@ -181,6 +202,24 @@ def test_the_gist_stats_answer_what_the_agent_asks_before_reading_the_file() -> 
     assert stats["silence_seconds"] == 2.0
     assert stats["speech_seconds"] == 2.0
     assert stats["mean_confidence"] == pytest.approx(0.633, abs=0.001)
+
+
+def test_a_duration_the_header_did_not_give_up_stays_missing_rather_than_zero() -> None:
+    """Zero seconds of speech reads as a finding; a missing reading has to read as missing."""
+    document = transcript.document(
+        audio={"path": "a.wav", "content_sha256": "abc", "duration_seconds": None},
+        params={"scope": "clip", "clip": "a", "model": "large-v3", "low_confidence": 0.5},
+        words=_words(("one", 0.0, 0.5, 0.9)),
+        silence=[],
+        language="en",
+    )
+
+    stats = document["stats"]
+    assert isinstance(stats, dict)
+    assert stats["duration_seconds"] is None
+    assert stats["speech_seconds"] is None
+    assert stats["words_per_minute"] is None
+    assert stats["word_count"] == 1
 
 
 def test_every_word_carries_its_own_timestamps_and_confidence() -> None:

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import shutil
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -24,6 +25,7 @@ import pytest
 from resolve_mcp.analysis import whisper
 from resolve_mcp.analysis.transcribe import transcribe_audio
 from resolve_mcp.analysis.transcript import Transcriber, Transcription, Word
+from resolve_mcp.audio.acquire import acquire_clip_audio
 from resolve_mcp.audio.ffmpeg import Completed, Runner
 from resolve_mcp.config import get_config
 from resolve_mcp.errors import (
@@ -184,6 +186,34 @@ def test_refresh_transcribes_again_even_when_nothing_moved(
 
     assert again.cached is False
     assert again.state == "completed"
+    assert len(calls) == 2
+
+
+def test_audio_refreshed_by_another_job_is_transcribed_again(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """The reason the key is the audio's content hash and not the acquisition's key.
+
+    An acquisition key is a fingerprint — path, size, mtime for a clip; name, bounds and a
+    digest of the shots for a timeline, which by its own docstring cannot see a clip's audio
+    level. Any job may ``refresh`` that audio and write different bytes under the same key.
+    A transcript keyed off the key would then answer with the previous mix's words.
+    """
+    source = write_wav(tmp_path / "media" / "take-1.wav", seconds=FIXTURE_SECONDS, silence=[GAP])
+    attach(_studio_holding(source))
+    calls: list[Path] = []
+    wait_for(_transcribe(clip="take-1.wav", calls=calls)["job_id"])
+
+    _rerecorded(source)
+    refreshed = acquire_clip_audio(
+        get_connection(), "take-1.wav", refresh=True, runner=_copying()
+    )
+    assert wait_for(refreshed["job_id"]).state == "completed"
+    again = _transcribe(clip="take-1.wav", calls=calls)
+
+    assert again["cached"] is False, "different audio behind the same fingerprint"
+    assert wait_for(again["job_id"]).state == "completed"
     assert len(calls) == 2
 
 
@@ -381,6 +411,18 @@ def _saying(spoken: Sequence[tuple[str, float, float, float]], calls: list[Path]
         return Transcription(words=heard, language="en")
 
     return transcriber
+
+
+def _rerecorded(source: Path) -> None:
+    """Different audio, same size and same mtime — the same fingerprint, other bytes.
+
+    What a director redoing a take does not do, but what an audio level changed in Resolve
+    amounts to: the fingerprint cannot see it, so the acquisition key does not move.
+    """
+    was = source.stat()
+    write_wav(source, seconds=FIXTURE_SECONDS, silence=[GAP], frequency=110.0)
+    assert source.stat().st_size == was.st_size
+    os.utime(source, ns=(was.st_atime_ns, was.st_mtime_ns))
 
 
 def _copying() -> Runner:

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,0 +1,411 @@
+"""The transcription job, both scopes.
+
+The model is substituted the way ffmpeg is substituted in acquisition: a ``Transcriber`` is
+handed in, so what is under test is everything the server decides — which audio gets
+acquired, what the cache key covers, what lands on disk, what comes back inline, and what a
+failure downstream of the starter looks like. Whether faster-whisper hears the words right
+is not a decision this repo makes, and there is no seam at which it could be asserted.
+
+Fixture audio is two seconds of tone with a written-in gap, so the silence spans in the
+document are checked against a gap that is known to be there.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.analysis import whisper
+from resolve_mcp.analysis.transcribe import transcribe_audio
+from resolve_mcp.analysis.transcript import Transcriber, Transcription, Word
+from resolve_mcp.audio.ffmpeg import Completed, Runner
+from resolve_mcp.config import get_config
+from resolve_mcp.errors import (
+    AudioExtractionError,
+    InvalidRequestError,
+    TranscriberUnavailableError,
+)
+from resolve_mcp.jobs.runner import wait_for
+from resolve_mcp.resolve.connection import get_connection
+from resolve_mcp.tools import analysis as analysis_tools
+
+from .conftest import Attach
+from .fakes import (
+    FakeMediaPoolItem,
+    FakeProject,
+    FakeResolve,
+    FakeTimeline,
+    media_pool,
+    studio,
+    write_wav,
+)
+
+FIXTURE_SECONDS = 2.0
+GAP = (0.6, 1.4)
+
+SPOKEN = (
+    ("this", 0.05, 0.25, 0.98),
+    ("one", 0.25, 0.45, 0.94),
+    ("bridge", 1.45, 1.70, 0.31),
+    ("again", 1.70, 1.95, 0.22),
+)
+
+
+@pytest.fixture
+def fixture_audio(tmp_path: Path) -> Path:
+    """Two seconds of tone with a silent stretch in the middle of it."""
+    return write_wav(tmp_path / "media" / "take-1.wav", seconds=FIXTURE_SECONDS, silence=[GAP])
+
+
+# --- the clip route ----------------------------------------------------------------------
+
+
+def test_a_clip_is_transcribed_to_a_file_with_gist_stats_returned_inline(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    attach(_studio_holding(fixture_audio))
+
+    record = wait_for(_transcribe(clip="take-1.wav")["job_id"])
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    result = record.result
+    assert Path(result["path"]).exists()
+    assert result["path"].endswith(".transcript.json")
+    assert Path(result["path"]).parent == get_config().analysis_dir
+    assert result["language"] == "en"
+    assert result["stats"]["word_count"] == len(SPOKEN)
+    assert result["stats"]["duration_seconds"] == pytest.approx(FIXTURE_SECONDS, abs=0.01)
+    assert result["stats"]["low_confidence_regions"] == 1
+    assert result["audio"]["content_sha256"]
+    assert "words" not in result
+
+
+def test_the_document_on_disk_carries_every_word_with_its_timestamps(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    attach(_studio_holding(fixture_audio))
+
+    record = wait_for(_transcribe(clip="take-1.wav")["job_id"])
+
+    assert record.result is not None
+    document = _read(Path(record.result["path"]))
+    assert [one["word"] for one in document["words"]] == [one[0] for one in SPOKEN]
+    assert document["words"][0]["start"] == pytest.approx(0.05)
+    assert document["words"][-1]["end"] == pytest.approx(1.95)
+    assert document["words"][2]["confidence"] == pytest.approx(0.31)
+    assert document["params"]["clip"] == "take-1.wav"
+    assert document["audio"]["content_sha256"] == record.result["audio"]["content_sha256"]
+
+
+def test_the_gap_written_into_the_fixture_comes_back_as_a_silence_span(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    """The spans are RMS-derived, so they find room the words say nothing about."""
+    attach(_studio_holding(fixture_audio))
+
+    record = wait_for(_transcribe(clip="take-1.wav")["job_id"])
+
+    assert record.result is not None
+    document = _read(Path(record.result["path"]))
+    assert len(document["silence"]) == 1
+    assert document["silence"][0]["start"] == pytest.approx(GAP[0], abs=0.15)
+    assert document["silence"][0]["end"] == pytest.approx(GAP[1], abs=0.15)
+    assert record.result["stats"]["silence_seconds"] == pytest.approx(0.8, abs=0.15)
+
+
+def test_the_unsure_run_is_previewed_inline_so_a_flub_is_visible_without_reading(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    attach(_studio_holding(fixture_audio))
+
+    record = wait_for(_transcribe(clip="take-1.wav")["job_id"])
+
+    assert record.result is not None
+    assert record.result["low_confidence_regions"] == [
+        {"start": 1.45, "end": 1.95, "duration": 0.5, "words": 2, "text": "bridge again"}
+    ]
+    assert record.result["low_confidence_truncated"] is False
+
+
+# --- caching -----------------------------------------------------------------------------
+
+
+def test_a_rerun_on_unchanged_media_is_an_instant_cache_hit(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    attach(_studio_holding(fixture_audio))
+    calls: list[Path] = []
+    first = wait_for(_transcribe(clip="take-1.wav", calls=calls)["job_id"])
+
+    again = _transcribe(clip="take-1.wav", calls=calls)
+
+    assert again["state"] == "completed"
+    assert again["cached"] is True
+    assert again["result"] == first.result
+    assert len(calls) == 1
+
+
+def test_a_different_model_is_a_different_transcript(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    attach(_studio_holding(fixture_audio))
+    calls: list[Path] = []
+    wait_for(_transcribe(clip="take-1.wav", calls=calls)["job_id"])
+
+    again = _transcribe(clip="take-1.wav", model="small", calls=calls)
+
+    assert again["cached"] is False
+    assert wait_for(again["job_id"]).state == "completed"
+    assert len(calls) == 2
+
+
+def test_refresh_transcribes_again_even_when_nothing_moved(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    attach(_studio_holding(fixture_audio))
+    calls: list[Path] = []
+    wait_for(_transcribe(clip="take-1.wav", calls=calls)["job_id"])
+
+    again = wait_for(_transcribe(clip="take-1.wav", refresh=True, calls=calls)["job_id"])
+
+    assert again.cached is False
+    assert again.state == "completed"
+    assert len(calls) == 2
+
+
+def test_the_transcript_is_keyed_on_the_audio_rather_than_on_the_clips_name(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """Re-recorded media under the same name must not answer with the old take's words."""
+    source = write_wav(tmp_path / "media" / "take-1.wav", seconds=FIXTURE_SECONDS, silence=[GAP])
+    attach(_studio_holding(source))
+    calls: list[Path] = []
+    first = wait_for(_transcribe(clip="take-1.wav", calls=calls)["job_id"])
+
+    write_wav(source, seconds=FIXTURE_SECONDS + 1.0, silence=[GAP])
+    second = wait_for(_transcribe(clip="take-1.wav", calls=calls)["job_id"])
+
+    assert second.cached is False
+    assert first.result is not None
+    assert second.result is not None
+    assert second.result["path"] != first.result["path"]
+
+
+# --- the timeline route ------------------------------------------------------------------
+
+
+def test_the_timeline_mix_is_transcribed_through_the_render_queue(attach: Attach) -> None:
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    attach(resolve)
+
+    record = wait_for(_transcribe()["job_id"])
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert record.result["stats"]["word_count"] == len(SPOKEN)
+    document = _read(Path(record.result["path"]))
+    assert document["params"]["scope"] == "timeline"
+    assert document["params"]["timeline"] == "sunset-set v3"
+    assert len(_project(resolve).render_jobs) == 1
+
+
+def test_a_second_transcript_of_one_timeline_does_not_export_the_mix_twice(
+    attach: Attach,
+) -> None:
+    """The acquisition it chains onto has its own cache; a reworded run reuses the WAV."""
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    attach(resolve)
+    wait_for(_transcribe()["job_id"])
+
+    again = wait_for(_transcribe(model="small")["job_id"])
+
+    assert again.state == "completed", again.error
+    assert len(_project(resolve).render_jobs) == 1
+
+
+# --- failures ----------------------------------------------------------------------------
+
+
+def test_a_clip_with_no_media_says_so_before_a_job_is_ever_started(attach: Attach) -> None:
+    attach(_studio_holding(Path("D:/gone/missing.wav")))
+
+    with pytest.raises(AudioExtractionError) as raised:
+        _transcribe(clip="missing.wav")
+
+    assert "relink_media" in raised.value.fix
+
+
+def test_an_acquisition_that_fails_in_its_thread_fails_the_transcript_with_its_advice(
+    attach: Attach,
+) -> None:
+    """The agent needs the render queue's fix, not "the audio was not acquired"."""
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    _project(resolve).accepts_job = False
+    attach(resolve)
+
+    record = wait_for(_transcribe()["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "transcription_failed"
+    assert "audio on it" in record.error["fix"]
+    assert record.error["detail"]["acquisition"]
+
+
+def test_a_model_that_raises_fails_the_job_rather_than_the_server(
+    attach: Attach,
+    fixture_audio: Path,
+) -> None:
+    attach(_studio_holding(fixture_audio))
+
+    def refusing(audio: Path, params: Mapping[str, Any]) -> Transcription:
+        raise TranscriberUnavailableError(cause="faster-whisper is not installed.")
+
+    record = wait_for(
+        transcribe_audio(
+            get_connection(),
+            clip="take-1.wav",
+            transcriber=refusing,
+            runner=_copying(),
+        )["job_id"]
+    )
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "transcriber_unavailable"
+
+
+def test_asking_for_a_clip_and_a_timeline_at_once_is_refused(attach: Attach) -> None:
+    attach(None)
+
+    with pytest.raises(InvalidRequestError) as raised:
+        transcribe_audio(get_connection(), clip="take-1.wav", timeline="sunset-set v3")
+
+    assert "clip" in raised.value.fix
+
+
+def test_a_bin_without_a_clip_is_refused_rather_than_quietly_ignored(attach: Attach) -> None:
+    attach(None)
+
+    with pytest.raises(InvalidRequestError):
+        transcribe_audio(get_connection(), bin="Angles")
+
+
+# --- the backend -------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("faster_whisper") is not None,
+    reason="faster-whisper is installed, so the missing-backend path cannot be reached",
+)
+def test_a_machine_without_faster_whisper_says_how_to_get_it(tmp_path: Path) -> None:
+    audio = write_wav(tmp_path / "a.wav", seconds=0.2)
+
+    with pytest.raises(TranscriberUnavailableError) as raised:
+        whisper.transcribe(audio, {"model": whisper.DEFAULT_MODEL})
+
+    assert "analysis" in raised.value.fix
+
+
+# --- the tool ----------------------------------------------------------------------------
+
+
+def test_the_tool_starts_a_job_and_returns_its_record(
+    attach: Attach,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The timeline route, so the only substituted thing is the model itself."""
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    monkeypatch.setattr(whisper, "transcribe", _saying(SPOKEN, []))
+
+    reply = analysis_tools.transcribe_audio()
+
+    assert reply["ok"] is True
+    assert reply["job"]["kind"] == "transcribe_audio"
+    assert reply["job"]["params"]["model"] == whisper.DEFAULT_MODEL
+    assert wait_for(reply["job"]["job_id"]).state == "completed"
+
+
+def test_the_tool_reports_a_bad_request_as_a_failure_envelope(attach: Attach) -> None:
+    attach(None)
+
+    reply = analysis_tools.transcribe_audio(clip="take-1.wav", timeline="sunset-set v3")
+
+    assert reply["ok"] is False
+    assert reply["error"]["code"] == "invalid_request"
+
+
+# --- helpers -----------------------------------------------------------------------------
+
+
+def _transcribe(
+    clip: str | None = None,
+    model: str | None = None,
+    refresh: bool = False,
+    calls: list[Path] | None = None,
+    **rest: Any,
+) -> dict[str, Any]:
+    """Start a transcription with the model and (for the clip route) ffmpeg substituted."""
+    return transcribe_audio(
+        get_connection(),
+        clip=clip,
+        model=model or whisper.DEFAULT_MODEL,
+        refresh=refresh,
+        transcriber=_saying(SPOKEN, calls if calls is not None else []),
+        runner=_copying(),
+        **rest,
+    )
+
+
+def _saying(spoken: Sequence[tuple[str, float, float, float]], calls: list[Path]) -> Transcriber:
+    def transcriber(audio: Path, params: Mapping[str, Any]) -> Transcription:
+        calls.append(audio)
+        heard = tuple(
+            Word(text=one[0], start=one[1], end=one[2], confidence=one[3]) for one in spoken
+        )
+        return Transcription(words=heard, language="en")
+
+    return transcriber
+
+
+def _copying() -> Runner:
+    def runner(argv: Sequence[str]) -> Completed:
+        shutil.copyfile(argv[argv.index("-i") + 1], argv[-1])
+        return Completed(0, "")
+
+    return runner
+
+
+def _read(path: Path) -> dict[str, Any]:
+    parsed: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return parsed
+
+
+def _project(resolve: FakeResolve) -> FakeProject:
+    project = resolve.current_project
+    assert project is not None
+    return project
+
+
+def _studio_holding(source: Path) -> FakeResolve:
+    clip = FakeMediaPoolItem(
+        source.name,
+        file_path=str(source),
+        properties={"Type": "Audio", "Audio Ch": "2"},
+    )
+    return studio(pool=media_pool({"": [clip]}))

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,23 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "18.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a4/570a5a35c8638aba01e739925846c35fdd6b0756a15526766d0a4dd3b7df/av-18.0.0.tar.gz", hash = "sha256:4ef7e72c3d3a872584a1215173b16e0226811037f40dcdbf75992631098df1ba", size = 4340222, upload-time = "2026-07-02T06:37:58.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/4a/9e3463df030e063d757fa12f0f39be6541b45b06b5bad48c2ce361b924bf/av-18.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:149289d40e732a6e49c9530bc245b49d9964cfd1c8c9e06778703b7d5bba6b25", size = 22499354, upload-time = "2026-07-02T06:36:58.751Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b3/2576a44b4f39c7462ced4c17fec04c756f7b0f3c5cb940d124173e417d6a/av-18.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:35274c20d2ad3b4774fe632bcef2e34af79858ddf899352339cc3babbc13a484", size = 18175248, upload-time = "2026-07-02T06:37:01.741Z" },
+    { url = "https://files.pythonhosted.org/packages/84/74/6732f17b96dc23fd23b876b2805435855abdc8a3b397142be4e581165de8/av-18.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4d683b7747a0ba9222b8a5f81e41db5f796e7f64473454ec4fe2548e083c2fa0", size = 33387843, upload-time = "2026-07-02T06:37:05.097Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/7708c43fed7ae28b4a1bad060b4221e3334cd827cec24f7165902a6ac1f4/av-18.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ae56b40b6f8b067a8ad2dac664fbfbabac7f7a55b9a7bb031eb99289252bc017", size = 35536910, upload-time = "2026-07-02T06:37:08.806Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/94/eba99691d184f6a395a242d54dc370e2fd2265e95bbc98e2963a0fdbdd6c/av-18.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:ea2e8ebbce521f21b55df9400e00d721623c9020ef158f5a188a96130be0743f", size = 38984619, upload-time = "2026-07-02T06:37:11.861Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cf/0d7aee07fe16aa9ffdf96043c14bed5485a52c0dea4259de87aa306ecab4/av-18.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef96dabb3e50dac249913145dff5424b302b257fd95dcb64be3c7b7a8aef16d1", size = 34451176, upload-time = "2026-07-02T06:37:15.154Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/810da80b12680d4c4fe235bd1b4003289be9213ac7f114b77b8ecf0e3b3e/av-18.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0f65518a184613e41536f29e8758c8e3d8293e46bf5bef108f04f925bbfa3f44", size = 36619869, upload-time = "2026-07-02T06:37:18.495Z" },
+    { url = "https://files.pythonhosted.org/packages/11/85/0f121ff43dc5a70696676c98a8f1674e2fa787614c2abaacb15fa1a9bc99/av-18.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:aaf4d354d2beaa6651e4f92e54409a578bde64f79c0beef9a30b388d06f7c629", size = 27556236, upload-time = "2026-07-02T06:37:21.388Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f6/2509754d4d2356abc6fc0ea3d57c12ade29bac23a1fb7fc215a53ca518fb/av-18.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:adac2b3833b6cb9bd6cb52664a522b94db453615b3675b1dbb26e13fe1c80da6", size = 20221133, upload-time = "2026-07-02T06:37:23.88Z" },
+]
+
+[[package]]
 name = "beartype"
 version = "0.22.9"
 source = { registry = "https://pypi.org/simple" }
@@ -206,6 +223,23 @@ wheels = [
 ]
 
 [[package]]
+name = "ctranslate2"
+version = "4.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/09/9a50eeab00db68aeac08f6ab7f98b5c36abd26b89cbd707ea39e70656500/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9de0dddd91ae68da0a7323441e90708d14b31d31cd443004dda0e1198b5bf11e", size = 1270522, upload-time = "2026-07-03T12:39:13.368Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/6c41c4d3ae539ec76b1943c362184677befd7c1d5290d2ec361182cdb1e0/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:82e0e6eb7d4301fd79a714495c8faf34242e09542cef04c9e9794c3fe90014a1", size = 11930367, upload-time = "2026-07-03T12:39:14.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d4/03428106134a0a58922461074f8942f92c5ed0bb3a8d018677ad64a9c476/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5ca144b93035b9f53e6d67b7cdf5802c3fffca9aa0247940eecbd4592c68ce2f", size = 16882768, upload-time = "2026-07-03T12:39:17.425Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c9/976a565398a03fb2973cbe5edd5ca03c4332d86b634799e0ee562420d3bc/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dacc408f716ebc73b3b3c6ddd937700e776c4c68b6d9c81862990150ff0f6af6", size = 39529060, upload-time = "2026-07-03T12:39:20.468Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/82/0a5f7f2b03b4e10aacb3146715724e1b96bb993cc7d199be28c9825aa120/ctranslate2-4.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:49f96e861b57301f0b76a082109bde2cac8204a6b4fedc870883008271e82251", size = 19220789, upload-time = "2026-07-03T12:39:23.356Z" },
+]
+
+[[package]]
 name = "cyclopts"
 version = "4.22.5"
 source = { registry = "https://pypi.org/simple" }
@@ -261,6 +295,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "faster-whisper"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av" },
+    { name = "ctranslate2" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
 ]
 
 [[package]]
@@ -327,6 +377,32 @@ server = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.32.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172, upload-time = "2026-07-29T22:46:04.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830, upload-time = "2026-07-29T22:46:03.52Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -342,6 +418,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
 ]
 
 [[package]]
@@ -379,6 +471,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/db/3582597f8be0d34bd6881365a26d390854f12893eabdd62dd36de9df5a47/huggingface_hub-1.26.0.tar.gz", hash = "sha256:c8cd4e2df1ba9402f77fce9b509ec1d52debb502551789473f34016acc14e361", size = 936665, upload-time = "2026-07-30T14:12:04.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/bb/63a644c75b545f3ff394b822e9bd1c4a9586489c618b77a4d8a44a33a23b/huggingface_hub-1.26.0-py3-none-any.whl", hash = "sha256:e8cca670caa5d8dfa7e45bf45e86b466698198cd8150c021bcdb4a86b9252364", size = 780357, upload-time = "2026-07-30T14:12:01.998Z" },
 ]
 
 [[package]]
@@ -630,6 +742,43 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/dcbe7700dca82fa540035abd3c868fe5ad0f86af00b9a3db7c2e27d15c7d/onnxruntime-1.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:26ff0fdd06efb6c155bae95387a09db1a2be89c7a03e4d0bffd5a171cc2826da", size = 19141362, upload-time = "2026-07-25T01:22:36.965Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5b/1d77e62097fdbe07e2dc827f389b1c4c0c275f6fab0369a8f46d2461af27/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e81a23df16e7acb9d51b06d30cc098e49315ef9180f97bc2221d167b4b04d9c", size = 17050628, upload-time = "2026-07-25T01:21:40.481Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/5486ab03e9be288d5268867054c8b04bebcf95bfd12e801c05cc67703dab/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a83bdb70d143cede762b677789bf2a7acca54b3fb82565601d5c30695aa933c", size = 19214257, upload-time = "2026-07-25T01:22:01.695Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3b/986ca67c274932ba9ac5332fb10de56f643dfd433c74e33f8ae8f847cf24/onnxruntime-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:c35064f9b3c43c81c5d5d282091401d0f1ff22796d93ccade4ea2ece5e137ab8", size = 13755036, upload-time = "2026-07-25T01:22:26.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/46/059dba81d46c6ba88e0c2d1c64321ac8098847d678423300a183d42ecbd6/onnxruntime-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:e02feeb0165c5f13b4cc954738078d59b90128516ac12b671ee24a530242bf02", size = 13454462, upload-time = "2026-07-25T01:22:17.38Z" },
+]
+
+[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -696,6 +845,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -920,6 +1084,11 @@ dependencies = [
     { name = "fastmcp" },
 ]
 
+[package.optional-dependencies]
+analysis = [
+    { name = "faster-whisper" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -928,7 +1097,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fastmcp", specifier = ">=3.4,<4" }]
+requires-dist = [
+    { name = "faster-whisper", marker = "extra == 'analysis'", specifier = ">=1.0" },
+    { name = "fastmcp", specifier = ">=3.4,<4" },
+]
+provides-extras = ["analysis"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1025,6 +1198,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1048,6 +1230,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/16/dc49e4b9d348b0f0567a67613a946f4e26b3299408ccf78df318c51a2aec/starlette-1.4.0.tar.gz", hash = "sha256:ecf3a067176d63c6412f98c660dab3355b525584d3725c0c40a4519d33ec2130", size = 2708995, upload-time = "2026-08-05T09:36:43.693Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/f6/7916cd7717e196bba370c0f17abb30466014ce29094665c3581e51a8c24b/starlette-1.4.0-py3-none-any.whl", hash = "sha256:cacd43738e07b834844e2c8e97b898b40089d74f2678234b0a3e93cd3d515813", size = 74021, upload-time = "2026-08-05T09:36:41.944Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #35.

## What this builds

`transcribe_audio` — one typed starter, one job, one poll. It chains onto #32's
acquisition (render queue for a timeline, ffmpeg for a clip), runs faster-whisper for
word-level timing and per-word confidence, measures RMS silence off the same WAV, and
writes an LLM-friendly transcript to disk with gist stats returned inline.

The transcript is the deliverable, not a return value. One record per line so
`grep '"word": "bridge"'` finds a whole record with its timestamps attached; every word
carries `start`, `end` and a 0-1 `confidence`; silence spans are read off the waveform, not
off the gaps between words — a held chord, a drum fill and a room of applause are all gaps
Whisper leaves and none of them are room to cut in.

Nothing here labels a flub, a retake or filler. That is #22's "not by server-side
detectors", and it is why the module reports confidence and gaps and stops.

New: `src/resolve_mcp/analysis/` (`silence`, `transcript`, `whisper`, `transcribe`),
`src/resolve_mcp/tools/analysis.py`, `Config.analysis_dir`, two error codes, and
`faster-whisper` as an optional `analysis` extra (imported inside the worker, so the base
install stays free of a CUDA runtime).

## The seam that verifies it

**Fake tier**, on both levels the repo already has:

- *Pure* (`tests/test_transcript.py`, 18 tests) — RMS levels, span merging and clamping,
  low-confidence region merging, document shape and stats, and that the file greps
  line-by-line while still parsing as JSON.
- *Worker* (`tests/test_transcription.py`, 19 tests) — the whole job on seconds-long
  fixture audio with a silence written into it, through both scopes. The model is
  substituted the way ffmpeg is in acquisition: `Transcriber` and `Runner` are both
  injectable, so everything the server decides is asserted here.

**Live smoke** — one test, skipped unless the `analysis` extra is installed: that a real
faster-whisper word object carries `word`/`start`/`end`/`probability` and that
`segment.words` is populated at all. The fake tier asserts against `Word`, a shape this
repo made up; nothing below that line is checkable at any seam.

## Review

Two-axis `/code-review` against `origin/main` (Standards and Spec as parallel sub-agents),
then a focused re-check of the fix diff. Findings and what happened to them:

**Spec axis**

1. *Cache key unsound* — the key was derived from the acquisition job's key, but #22 says
   workers key off the content hash of the cached audio. Reachable, not theoretical: a
   timeline fingerprint is blind to a clip's audio level by its own admission, so any job's
   `refresh` can put different bytes behind the same acquisition key and the transcript
   would answer with the previous mix's words. **Fixed** — keyed on `content_sha256` +
   params. The hash exists only once the audio does, which splits the job: an acquisition
   that came back already cached (the rerun the cache is for) hands the hash over before the
   starter returns and the transcript answers with no thread at all; otherwise there was
   nothing to hit anyway and the worker writes the entry once it knows what it transcribed.
2. *The keying test overclaimed* — it rewrote the media, which moves size and mtime, so it
   passed under either scheme. **Fixed** — the new test rewrites the media to the same size
   and restores its mtime, refreshes the audio through the acquisition job, and asserts the
   rerun is not a hit. It passes under the old scheme, which is the point of it.
3. *Timeline export exceeding the one-hour wait fails the transcript while the render
   continues.* **Fixed** the advice, kept the timeout: a running acquisition now gets "poll
   it with get_job and start the transcript again" rather than the fix for a broken one.
4. *Scope creep: gist stats beyond the three the ticket names* (`words_per_minute`,
   `mean_confidence`, `speech_seconds`, `longest_silence_seconds`), three tuning parameters,
   and the 8-bit refusal. **Kept, deliberately** — the stats are what story 51 reads a
   transcript for, the parameters are how an agent adapts to a room, and guessing at 8-bit
   audio reports a loud tone as breathing room.

**Standards axis**

5. *`silence.levels` reimplemented `wav.py`* — same wave-open, same `BITS_PER_BYTE`,
   verbatim error text, and a `duration()` that recomputed `describe()`. **Fixed** —
   extracted `wav.opened`; `duration()` is gone. This also stops an unreadable header
   escaping as `internal_error` instead of an audio failure.
6. *The decimating stride walked interleaved samples* and could read one channel forever.
   **Fixed** (see the second round below).
7. *`transcribe._target` and `acquire._stem` were the same function twice*, identical
   docstring included. **Fixed** — both use `naming.keyed_name`; filenames are byte-identical
   to before, so no cached WAV is orphaned.
8. *`stats()` smoothed a missing duration to 0.0*, reporting a two-hour set as nought
   seconds of speech — against this repo's "nothing smooths a failure into a default".
   **Fixed** — it stays `None` and takes its derived stats with it.
9. *`DEFAULT_LOW_CONFIDENCE` once as a constant and once as a bare literal*; *`silence.silence`*
   as a name; *a local shadowing `silence.spans`*; *unused `tmp_path` fixtures*; *the live
   test writing into `%TEMP%` and leaving the file*. **All fixed.**

**Second round, on the fix diff**

10. *The stride guard was half right* — `stride % channels == 0` is not the property; coprime
    is. A four-channel file at the default window strides 150, `150 % 4 == 2`, and the walk
    visits channels 0 and 2 forever. **Fixed** — steps up until `gcd(stride, channels) == 1`.
11. *The test written for that fix was inert* — 0.05s of stereo strides 75, which is odd, so
    the guard never fired either way. **Fixed** — parameterised over two strides that do land
    on a subset (stereo at 2048 frames, four-channel at the default window), and both were
    confirmed to fail with the guard disabled before it was restored.
12. *Declined, with reason*: when the audio has to be re-made, the worker computes the key
    but does not look the transcript up, so a transcript whose WAV was evicted while it
    survived is re-transcribed. A worker-side lookup would save that run, but the job would
    then report `cached: false` having done no work, and what that flag means is a promise
    `get_job` makes system-wide. Paying for the rare re-run is the cheaper of the two.

`uv run pytest -m 'not live'`: 538 passed. `uv run mypy` (strict): clean. `uv run ruff check`:
clean.

Review: clean


Post-open merge of origin/main (takes #29, overlays #30, renders #33, frame grabs #34 landed first): #34 moved Runner/Completed into the shared resolve_mcp.ffmpeg module, so transcription imports were repointed there; the two analysis_dir docstrings folded into one property; remaining conflicts were unions (server registration, errors, live smoke, tool list). Also fixes a README conflict marker the #34 merge left behind. Fake tier, mypy, ruff clean.
Review: clean — focused pass on the conflict-resolution diff
