### PR TITLE
P2: apply_titles — declarative Text+ titling on an owned Titles track

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Build contract: [issue #22](https://github.com/danielbaldwin47/resolve-mcp/issue
 
 ## Status
 
-P1 in progress. Shipped so far: the server skeleton, the session/project tools, the media
-pool tools, the timeline read and interchange tools, the background-job infrastructure
-with audio acquisition, and the `run_python` escape hatch.
+P1 in progress, P2 titling started. Shipped so far: the server skeleton, the
+session/project tools, the media pool tools, the timeline read, marker and interchange
+tools, the declarative cut file and `build_timeline`, the Text+ titling tools, the
+background-job infrastructure with audio acquisition, and the `run_python` escape hatch.
 
 | Tool | What it does |
 | --- | --- |
@@ -25,8 +26,16 @@ with audio acquisition, and the `run_python` escape hatch.
 | `relink_media` | Points offline clips at media that moved (folder relink or file replace) |
 | `list_timelines` | Timelines with version, duration, fps and track stack; names the newest cut |
 | `inspect_timeline` | One timeline at a chosen detail and range, in dual time |
+| `list_markers` | Markers in record time, narrowed by colour and range |
+| `set_markers` | Batch marker writes; an existing marker is never overwritten unless asked |
 | `export_timeline` | Writes a timeline out as OTIO, FCPXML or DRT |
 | `import_timeline` | Materialises a **new** timeline from such a file — never overwrites one |
+| `get_cut_schema` | The cut-file contract, its annotated example and the validation rules |
+| `validate_cut` | Dry-runs a cut file: every error and warning at once, with fix hints |
+| `build_timeline` | Builds a cut file into a fresh `<name> v<N>` timeline and verifies what landed |
+| `get_titles_schema` | The titles-file contract, its annotated example and the validation rules |
+| `validate_titles` | Dry-runs a titles file before the Titles track is touched |
+| `apply_titles` | Places Text+ titles from `titles.json` onto an owned Titles track, fades and all |
 | `get_job` | Polls one background job: progress, result, or a structured failure |
 | `list_jobs` | Lists jobs newest first — how a restarted session finds what it started |
 | `run_python` | Escape hatch: runs scripting-API Python in the server process |
@@ -42,6 +51,15 @@ in the project answers to — colliding names walk the `<base> v<N>` convention.
 Resolve's own document and accepts no import options at all, so it names its own timeline;
 what holds there is the check on the way out. Either way the cut already in the project is
 never the thing that gets written over.
+
+Editing is declarative and split across two files that never mention each other. The
+**cut file** owns the cut and materialises as a new `<name> v<N>` timeline every build.
+**`titles.json`** owns the titles, and `apply_titles` owns the topmost video track named
+`Titles` — every apply clears that track whole and re-places from the file, so the same
+file always produces the same track. Title positions are offsets from the *blue marker*
+naming their song rather than timeline frames, which is what lets one titles file be
+re-applied unchanged to every rebuild. Fades are Fusion opacity keyframes inside each
+placed instance, because Resolve exposes no clip-level fade to the scripting API at all.
 
 Heavy work runs as a background job: the starter returns a `job_id` immediately, `get_job`
 polls it, and results are cached under the cache root against the media and the parameters,

--- a/src/resolve_mcp/cut/document.py
+++ b/src/resolve_mcp/cut/document.py
@@ -1,63 +1,24 @@
-"""Reading a cut file off disk — the one place JSON becomes a document.
+"""Reading a cut file off disk.
 
-The server never writes cut files: authorship stays with Claude and the director. It
-reads one, hashes exactly the bytes it read, and reports what it found. The hash is what
-ties a built timeline back to the cut state that produced it, so it is taken here, on the
-same bytes that were parsed, and never recomputed from the parsed object.
+The mechanics — read the bytes, hash exactly those bytes, parse or report why not — are
+shared with the titles file and live in :mod:`resolve_mcp.document`. What is cut-specific
+is which rule a parse failure belongs to: E1 is "JSON parses", so an unparseable file is
+an E1 finding rather than an exception, while a path that cannot be read at all raises,
+because the call itself was wrong and there is nothing to report findings about.
 """
 
 from __future__ import annotations
 
-import hashlib
-import json
-from pathlib import Path
-from typing import Any, NamedTuple
+from ..document import HASH_DIGEST_BYTES, LoadedDocument, content_hash, read_document
+from .validate import parse_failure_finding
 
-from ..errors import InvalidRequestError
-from .validate import Finding, parse_failure_finding
-
-HASH_DIGEST_BYTES = 16
-"""BLAKE2b digest length: 32 hex characters, short enough to read in a build report."""
-
-
-class LoadedCut(NamedTuple):
-    """A cut file as read: always a path and a hash, a document only if it parsed."""
-
-    path: Path
-    content_hash: str
-    doc: Any  # the parsed document, or None when parse_error says why there is none
-    parse_error: Finding | None
-
-
-def content_hash(data: bytes) -> str:
-    """The BLAKE2b hash a build report echoes for provenance."""
-    return hashlib.blake2b(data, digest_size=HASH_DIGEST_BYTES).hexdigest()
+LoadedCut = LoadedDocument
+"""A cut file as read. The shape is shared; the name is what the build reports on."""
 
 
 def read_cut_file(cut_file: str) -> LoadedCut:
-    """Read and parse ``cut_file``.
-
-    A file that is missing or unreadable raises: the call itself was wrong, and there is
-    nothing to report findings about. A file that is there but is not JSON comes back as
-    an E1 finding, because that *is* a validation result — rule E1 is "JSON parses".
-    """
-    path = Path(cut_file).expanduser()
-    try:
-        data = path.read_bytes()
-    except OSError as exc:
-        raise InvalidRequestError(
-            cause=f"Could not read the cut file {str(path)!r}: {exc.strerror or exc}.",
-            fix="Check the path. Cut files are authored by you, on disk; the server "
-            "never writes them.",
-            detail={"cut_file": str(path)},
-        ) from exc
-
-    digest = content_hash(data)
-    try:
-        doc = json.loads(data.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        return LoadedCut(path, digest, None, parse_failure_finding(str(exc)))
-    return LoadedCut(path, digest, doc, None)
+    """Read and parse ``cut_file``, reporting an unparseable one as E1."""
+    return read_document(cut_file, what="cut file", parse_failure=parse_failure_finding)
 
 
 __all__ = ["HASH_DIGEST_BYTES", "LoadedCut", "content_hash", "read_cut_file"]

--- a/src/resolve_mcp/cut/document.py
+++ b/src/resolve_mcp/cut/document.py
@@ -9,16 +9,13 @@ because the call itself was wrong and there is nothing to report findings about.
 
 from __future__ import annotations
 
-from ..document import HASH_DIGEST_BYTES, LoadedDocument, content_hash, read_document
+from ..document import LoadedDocument, read_document
 from .validate import parse_failure_finding
 
-LoadedCut = LoadedDocument
-"""A cut file as read. The shape is shared; the name is what the build reports on."""
 
-
-def read_cut_file(cut_file: str) -> LoadedCut:
+def read_cut_file(cut_file: str) -> LoadedDocument:
     """Read and parse ``cut_file``, reporting an unparseable one as E1."""
     return read_document(cut_file, what="cut file", parse_failure=parse_failure_finding)
 
 
-__all__ = ["HASH_DIGEST_BYTES", "LoadedCut", "content_hash", "read_cut_file"]
+__all__ = ["read_cut_file"]

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -26,7 +26,7 @@ from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from typing import Any, Final, TypeGuard
 
-from ..findings import Finding, ordered, severity_of
+from ..findings import Finding, ordered
 from ..logging_config import get_logger
 from ..timing import duration_frames, ranges_overlap
 from .schema import SCHEMA_VERSION
@@ -92,10 +92,6 @@ class ClipFacts:
 
 def _finding(rule: str, id: str | None, message: str, fix_hint: str | None = None) -> Finding:
     return Finding(rule=rule, id=id, message=message, fix_hint=fix_hint or _FIX_HINTS[rule])
-
-
-_order = ordered
-"""The shared ordering: errors before warnings, rule number ascending, document order."""
 
 
 def parse_failure_finding(detail: str) -> Finding:
@@ -303,7 +299,7 @@ def validate_structure(
     """
     shape = list(_shape_errors(doc))
     if shape:
-        return _order(shape)
+        return ordered(shape)
 
     findings: list[Finding] = []
     findings += _id_errors(doc)
@@ -313,7 +309,7 @@ def validate_structure(
     findings += _overlay_errors(doc)
     findings += _segment_length_warnings(doc, min_segment_frames)
     findings += _audio_span_warnings(doc)
-    return _order(findings)
+    return ordered(findings)
 
 
 def _segments(doc: dict[str, Any]) -> list[dict[str, Any]]:
@@ -574,7 +570,7 @@ def validate_project(doc: Any, clips: Sequence[ClipFacts]) -> list[Finding]:
     findings += _bounds_errors(doc, resolved)
     findings += _rate_errors(doc, resolved)
     findings += _audio_errors(doc, resolved)
-    return _order(findings)
+    return ordered(findings)
 
 
 def _shape_is_unreadable(doc: Any) -> bool:
@@ -724,12 +720,10 @@ __all__ = [
     "DEFAULT_MIN_SEGMENT_FRAMES",
     "RULE_DESCRIPTIONS",
     "ClipFacts",
-    "Finding",
     "locked_track_finding",
     "parse_failure_finding",
     "positions",
     "resolve_aliases",
-    "severity_of",
     "total_frames",
     "validate_project",
     "validate_structure",

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -26,6 +26,7 @@ from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from typing import Any, Final, TypeGuard
 
+from ..findings import Finding, ordered, severity_of
 from ..logging_config import get_logger
 from ..timing import duration_frames, ranges_overlap
 from .schema import SCHEMA_VERSION
@@ -71,34 +72,6 @@ _FIX_HINTS: Final[dict[str, str]] = {
 }
 
 
-def severity_of(rule: str) -> str:
-    """``error`` blocks the build; ``warning`` is reported and never blocks."""
-    return "warning" if rule.startswith("W") else "error"
-
-
-@dataclass(frozen=True)
-class Finding:
-    """One rule firing on one thing, in the shape the agent reads."""
-
-    rule: str
-    id: str | None
-    message: str
-    fix_hint: str
-
-    @property
-    def severity(self) -> str:
-        """``error`` blocks the build; ``warning`` is reported and never blocks."""
-        return severity_of(self.rule)
-
-    def as_dict(self) -> dict[str, str | None]:
-        return {
-            "rule": self.rule,
-            "id": self.id,
-            "message": self.message,
-            "fix_hint": self.fix_hint,
-        }
-
-
 @dataclass(frozen=True)
 class ClipFacts:
     """What the rules need to know about one media-pool clip.
@@ -121,14 +94,8 @@ def _finding(rule: str, id: str | None, message: str, fix_hint: str | None = Non
     return Finding(rule=rule, id=id, message=message, fix_hint=fix_hint or _FIX_HINTS[rule])
 
 
-def _order(findings: list[Finding]) -> list[Finding]:
-    """Errors before warnings, rule number ascending, document order within a rule."""
-
-    def key(numbered: tuple[int, Finding]) -> tuple[int, int, int]:
-        position, finding = numbered
-        return (0 if finding.severity == "error" else 1, int(finding.rule[1:]), position)
-
-    return [finding for _, finding in sorted(enumerate(findings), key=key)]
+_order = ordered
+"""The shared ordering: errors before warnings, rule number ascending, document order."""
 
 
 def parse_failure_finding(detail: str) -> Finding:

--- a/src/resolve_mcp/document.py
+++ b/src/resolve_mcp/document.py
@@ -1,0 +1,69 @@
+"""Reading an agent-authored JSON file off disk — the one place JSON becomes a document.
+
+The server never writes these files: authorship of both the cut and the titles stays with
+Claude and the director. It reads one, hashes exactly the bytes it read, and reports what
+it found. The hash is what ties a built or titled timeline back to the file state that
+produced it, so it is taken here, on the same bytes that were parsed, and never
+recomputed from the parsed object.
+
+The split between raising and reporting is the same for every such file: a path that
+cannot be read is a wrong *call* and raises, while a file that is there and is not JSON
+is a validation *result* and comes back as the caller's own first rule.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from .errors import InvalidRequestError
+from .findings import Finding
+
+HASH_DIGEST_BYTES = 16
+"""BLAKE2b digest length: 32 hex characters, short enough to read in a report."""
+
+
+class LoadedDocument(NamedTuple):
+    """A file as read: always a path and a hash, a document only if it parsed."""
+
+    path: Path
+    content_hash: str
+    doc: Any  # the parsed document, or None when parse_error says why there is none
+    parse_error: Finding | None
+
+
+def content_hash(data: bytes) -> str:
+    """The BLAKE2b hash a report echoes for provenance."""
+    return hashlib.blake2b(data, digest_size=HASH_DIGEST_BYTES).hexdigest()
+
+
+def read_document(
+    file: str,
+    *,
+    what: str,
+    parse_failure: Callable[[str], Finding],
+) -> LoadedDocument:
+    """Read and parse ``file``. ``what`` names it in the message the agent reads."""
+    path = Path(file).expanduser()
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise InvalidRequestError(
+            cause=f"Could not read the {what} {str(path)!r}: {exc.strerror or exc}.",
+            fix=f"Check the path. {what.capitalize()}s are authored by you, on disk; the "
+            f"server never writes them.",
+            detail={"file": str(path)},
+        ) from exc
+
+    digest = content_hash(data)
+    try:
+        doc = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return LoadedDocument(path, digest, None, parse_failure(str(exc)))
+    return LoadedDocument(path, digest, doc, None)
+
+
+__all__ = ["HASH_DIGEST_BYTES", "LoadedDocument", "content_hash", "read_document"]

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -237,6 +237,49 @@ class UnsupportedCutFeatureError(ResolveMcpError):
     code = "unsupported_cut_feature"
 
 
+class TitlesInvalidError(ResolveMcpError):
+    """The titles file did not pass the rules, so nothing was applied. ``detail`` holds them.
+
+    Nothing was applied means nothing was *cleared* either: the Titles track still holds
+    whatever the last good apply put there.
+    """
+
+    code = "titles_invalid"
+    default_fix = (
+        "Fix every error in detail.errors and apply again — validate_titles runs the "
+        "identical checks without touching the timeline."
+    )
+
+
+class TitlesApplyFailedError(ResolveMcpError):
+    """Resolve would not place the titles — a locked track, a refused clear, a clip astray.
+
+    ``detail`` names the timeline and the track it was working on, because the Titles
+    track may have been cleared before the failure: re-applying is always the right next
+    move, and it is safe, because the apply is declarative.
+    """
+
+    code = "titles_apply_failed"
+    default_fix = (
+        "Fix what detail names in the Resolve GUI (unlock the Titles track, close any modal "
+        "dialog) and apply again — the apply is idempotent, so a retry is always safe."
+    )
+
+
+class TitleTemplateError(ResolveMcpError):
+    """A placed template instance is not one this route can title.
+
+    The clip landed on the timeline but carries no Fusion comp, or a comp with no Text+
+    node in it — which means the media-pool clip is not a Text+ title template at all.
+    """
+
+    code = "title_template_unusable"
+    default_fix = (
+        "Point the template at a Text+ title clip: author it in the Resolve GUI, export "
+        "its bin as a .drb, and import that bin into the project's media pool."
+    )
+
+
 class BuildFailedError(ResolveMcpError):
     """Resolve would not build the cut — creation refused, a locked track, a clip astray.
 

--- a/src/resolve_mcp/findings.py
+++ b/src/resolve_mcp/findings.py
@@ -1,0 +1,55 @@
+"""One finding shape, shared by every file the server validates.
+
+A cut file and a titles file have entirely different rules, but the agent reads the
+result of both the same way — ``{rule, id, message, fix_hint}``, errors before warnings,
+all of them at once rather than the first. That agreement lives here so the two rule sets
+cannot drift apart in shape while they evolve apart in content.
+
+The rule code carries the severity: ``W`` for a warning that never blocks, anything else
+for an error that does. Nothing outside a rule set needs to know which letters it uses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def severity_of(rule: str) -> str:
+    """``error`` blocks the operation; ``warning`` is reported and never blocks."""
+    return "warning" if rule.startswith("W") else "error"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One rule firing on one thing, in the shape the agent reads."""
+
+    rule: str
+    id: str | None
+    message: str
+    fix_hint: str
+
+    @property
+    def severity(self) -> str:
+        """``error`` blocks the operation; ``warning`` is reported and never blocks."""
+        return severity_of(self.rule)
+
+    def as_dict(self) -> dict[str, str | None]:
+        return {
+            "rule": self.rule,
+            "id": self.id,
+            "message": self.message,
+            "fix_hint": self.fix_hint,
+        }
+
+
+def ordered(findings: list[Finding]) -> list[Finding]:
+    """Errors before warnings, rule number ascending, document order within a rule."""
+
+    def key(numbered: tuple[int, Finding]) -> tuple[int, int, int]:
+        position, finding = numbered
+        return (0 if finding.severity == "error" else 1, int(finding.rule[1:]), position)
+
+    return [finding for _, finding in sorted(enumerate(findings), key=key)]
+
+
+__all__ = ["Finding", "ordered", "severity_of"]

--- a/src/resolve_mcp/resolve/apply.py
+++ b/src/resolve_mcp/resolve/apply.py
@@ -1,0 +1,373 @@
+"""Applying a titles file: one owned track, cleared and re-placed from the file every time.
+
+This is to ``titles.py`` what ``build.py`` is to ``cut.py`` — the rules have already run,
+and everything here writes. But it works on a timeline someone else built, so the safety
+it needs is different from a build's: a build makes a *new* version and can afford to
+fail half-done, while an apply edits the version under review and must never destroy the
+good state it is replacing.
+
+That gives the order everything here follows:
+
+* **Validate everything, then touch nothing until it all passes.** The rules run over the
+  file, the timeline's markers and the media pool before the Titles track is looked at, so
+  a refused apply leaves the previous titles exactly where they were.
+* **Own one track, completely.** The topmost video track named ``Titles`` belongs to this
+  tool: it is created if absent, cleared whole, and re-placed from the file. The name is
+  not the caller's to choose — a tool that could be pointed at any track could clear one
+  it does not own. Nothing else on the timeline is read or written, which is what makes
+  "rebuild the cut, re-apply the titles" safe.
+* **Songs are found by marker, not by frame.** Every event's position is an offset from
+  the blue marker naming its song, so the same file lands correctly on every rebuild.
+* **Resolve's answer is never the evidence.** ``AppendToTimeline`` writes to the *current*
+  timeline (so the switch is made and verified first), reports success on a locked track,
+  and slides an append that overlaps. Every placement is read back off the track, and
+  every title is read back after *all* the writes — an instance that shares its comp with
+  another only shows up once a later write has had the chance to overwrite it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from ..errors import TitlesApplyFailedError, TitlesInvalidError
+from ..logging_config import get_logger
+from ..timing import dual_time
+from ..titles.schema import TRACK_NAME
+from ..titles.validate import Event
+from . import fusion, media
+from . import timeline as timeline_read
+from . import titles as titles_read
+from .connection import ResolveConnection
+
+log = get_logger("titles")
+
+Item = Any
+Pool = Any
+Project = Any
+Timeline = Any
+
+VIDEO: Final = "video"
+MEDIA_TYPE_VIDEO: Final = 1
+"""Resolve's ``mediaType`` for a video-only append. Never omitted: it drops the clip."""
+
+TEMPLATE_SOURCE_IN: Final = 0
+"""A title template is placed from its own first frame; it has no other content."""
+
+
+@dataclass(frozen=True)
+class OwnedTrack:
+    """The one track this tool writes to, and the timeline it is on.
+
+    The three of them travel together through every step and into every failure's
+    ``detail``, because a titling failure the agent can act on is always "which track of
+    which timeline" — and the name is a constant rather than a field so that no caller
+    can widen what "owned" means.
+    """
+
+    index: int
+    timeline: str
+    created: bool
+
+    @property
+    def name(self) -> str:
+        return TRACK_NAME
+
+    def detail(self, **extra: Any) -> dict[str, Any]:
+        return {
+            "timeline": self.timeline,
+            "track": self.name,
+            "track_index": self.index,
+            **extra,
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"index": self.index, "name": self.name, "created": self.created}
+
+
+def apply_titles(connection: ResolveConnection, titles_file: str) -> dict[str, Any]:
+    """Clear the Titles track and re-place every event in ``titles_file`` onto it."""
+    checked = titles_read.preflight(connection, titles_file)
+    if checked.errors:
+        raise TitlesInvalidError(
+            cause=f"The titles file has {len(checked.errors)} error(s), so nothing was "
+            f"applied and the Titles track was not touched.",
+            detail={
+                "titles_file": str(checked.loaded.path),
+                "content_hash": checked.loaded.content_hash,
+                "errors": [finding.as_dict() for finding in checked.errors],
+                "warnings": [finding.as_dict() for finding in checked.warnings],
+            },
+        )
+    # No error means the document parsed, matched the schema and resolved against the
+    # project — every reading below is one the rules have already been over.
+    project, timeline = checked.project, checked.timeline
+    pool = media.media_pool(connection)
+
+    track = _own_track(timeline, timeline_read.name_of(timeline))
+    _refuse_locked(timeline, track)
+    _target(project, timeline, track.timeline)
+    cleared = _clear(timeline, track)
+    _place(pool, checked.events, checked.templates, track)
+    items = _verify(timeline, checked.events, track)
+    titled = _write_titles(checked.events, items)
+
+    log.info("Applied %d title(s) to %s of %r", len(titled), track.name, track.timeline)
+    return {
+        "titles_file": str(checked.loaded.path),
+        "content_hash": checked.loaded.content_hash,
+        "timeline": timeline_read.summarise(
+            timeline_read.Reader(connection),
+            timeline,
+            project,
+            timeline_read.current_name(project),
+        ),
+        "track": track.as_dict(),
+        "cleared": cleared,
+        "placed": [_placed(event, node, fade, checked.fps) for event, node, fade in titled],
+        "warnings": [finding.as_dict() for finding in checked.warnings],
+    }
+
+
+def _placed(
+    event: Event,
+    node: fusion.TitleNode,
+    fade: fusion.Fade,
+    fps: float | None,
+) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "song": event.song,
+        "kind": event.kind,
+        "template": event.template,
+        "text": event.text,
+        "record": dual_time(event.record_in, fps),
+        "duration": dual_time(event.duration, fps),
+        "node": {"name": node.name, "text_plus_in_comp": node.of_how_many},
+        "fade": fade.as_dict(),
+        "note": event.note,
+    }
+
+
+def _own_track(timeline: Timeline, name: str) -> OwnedTrack:
+    """The topmost video track called ``Titles``, created and named if there is none.
+
+    Topmost rather than first: a title belongs over the cut, and a project template that
+    already carries a ``Titles`` track lower down is the operator's business. A track that
+    is added but cannot be *named* is refused, because the next apply would not recognise
+    it and would stack a second one on top.
+    """
+    matching = [
+        index
+        for index in range(1, _track_count(timeline) + 1)
+        if str(timeline.GetTrackName(VIDEO, index) or "") == TRACK_NAME
+    ]
+    if matching:
+        return OwnedTrack(max(matching), name, created=False)
+
+    if not timeline.AddTrack(VIDEO):
+        raise TitlesApplyFailedError(
+            cause=f"Resolve refused to add a {TRACK_NAME!r} track to {name!r}, so nothing "
+            f"was applied.",
+            detail={"timeline": name, "track": TRACK_NAME},
+        )
+    added = OwnedTrack(_track_count(timeline), name, created=True)
+    rename = getattr(timeline, "SetTrackName", None)
+    if not (callable(rename) and rename(VIDEO, added.index, TRACK_NAME)):
+        raise TitlesApplyFailedError(
+            cause=f"Resolve added video track {added.index} to {name!r} but would not name "
+            f"it {TRACK_NAME!r}, so nothing was applied.",
+            fix=f"Delete the empty video track {added.index}, or rename it {TRACK_NAME!r} by "
+            f"hand, and apply again — an unnamed track would be left behind on the next apply.",
+            detail=added.detail(),
+        )
+    log.info("Added the %s track to %r as video %d", TRACK_NAME, name, added.index)
+    return added
+
+
+def _track_count(timeline: Timeline) -> int:
+    try:
+        return int(timeline.GetTrackCount(VIDEO) or 0)
+    except (TypeError, ValueError):
+        log.warning("Resolve gave an unreadable video track count")
+        return 0
+
+
+def _refuse_locked(timeline: Timeline, track: OwnedTrack) -> None:
+    """A locked track takes the append, reports items and places nothing — and clearing it
+    would not work either, so this is checked before anything is deleted."""
+    if not timeline.GetIsTrackLocked(VIDEO, track.index):
+        return
+    raise TitlesApplyFailedError(
+        cause=f"The {track.name!r} track of {track.timeline!r} is locked; Resolve would "
+        f"report the titles as placed and place none, so nothing was applied.",
+        fix="Unlock the track in the timeline header and apply again.",
+        detail=track.detail(),
+    )
+
+
+def _target(project: Project, timeline: Timeline, name: str) -> None:
+    """Make the target current, and check it — appends go to whatever is current (#41).
+
+    A build that does not honour the switch would otherwise take every title of this file
+    and place it on the cut the operator has open, reporting success the whole way.
+    """
+    project.SetCurrentTimeline(timeline)
+    current = project.GetCurrentTimeline()
+    if current is None or not _same(current, timeline):
+        raise TitlesApplyFailedError(
+            cause=f"Resolve would not open {name!r}, and an append lands on whatever "
+            f"timeline is current — so nothing was applied.",
+            fix="Close any modal dialog in the Resolve GUI, open the timeline, and apply again.",
+            detail={
+                "timeline": name,
+                "current": None if current is None else timeline_read.name_of(current),
+            },
+        )
+
+
+def _same(one: Timeline, other: Timeline) -> bool:
+    """Identity by Resolve's own id: two proxies for one timeline are not the same object."""
+    first, second = getattr(one, "GetUniqueId", None), getattr(other, "GetUniqueId", None)
+    if callable(first) and callable(second):
+        return bool(first() == second())
+    return bool(timeline_read.name_of(one) == timeline_read.name_of(other))
+
+
+def _clear(timeline: Timeline, track: OwnedTrack) -> int:
+    """Empty the owned track, and read it back — a stale title left there would double up."""
+    standing = list(timeline.GetItemListInTrack(VIDEO, track.index) or [])
+    if not standing:
+        return 0
+    delete = getattr(timeline, "DeleteClips", None)
+    if not callable(delete):
+        raise TitlesApplyFailedError(
+            cause=f"This Resolve build has no DeleteClips, so the {len(standing)} title(s) "
+            f"already on {track.name!r} cannot be cleared and nothing was applied.",
+            fix="Delete the clips on the Titles track by hand and apply again.",
+            detail=track.detail(standing=len(standing)),
+        )
+    # Never a ripple delete: the Titles track is the only one this tool owns, and a ripple
+    # would pull the cut on V1 along with it.
+    delete(standing, False)
+    left = list(timeline.GetItemListInTrack(VIDEO, track.index) or [])
+    if left:
+        raise TitlesApplyFailedError(
+            cause=f"{len(left)} of {len(standing)} title(s) are still on {track.name!r} "
+            f"after the clear, so nothing new was placed.",
+            detail=track.detail(remaining=len(left)),
+        )
+    log.info("Cleared %d title(s) off %s of %r", len(standing), track.name, track.timeline)
+    return len(standing)
+
+
+def _place(
+    pool: Pool,
+    events: list[Event],
+    templates: dict[str, media.LocatedClip],
+    track: OwnedTrack,
+) -> None:
+    """One call for the whole file. Its return value is counted, never believed."""
+    if not events:
+        return
+    placements = [
+        {
+            "mediaPoolItem": templates[event.template].clip,
+            "startFrame": TEMPLATE_SOURCE_IN,
+            "endFrame": event.duration,
+            "mediaType": MEDIA_TYPE_VIDEO,
+            "trackIndex": track.index,
+            "recordFrame": event.record_in,
+        }
+        for event in events
+    ]
+    returned = list(pool.AppendToTimeline(placements) or [])
+    if len(returned) != len(events):
+        raise TitlesApplyFailedError(
+            cause=f"Asked Resolve for {len(events)} title(s) on {track.timeline!r} and got "
+            f"back {len(returned)}.",
+            fix="A template shorter than the span asked for is refused rather than trimmed "
+            "— shorten the longest event, or lengthen the template in the Resolve GUI and "
+            "export its bin again.",
+            detail=track.detail(asked=len(events), returned=len(returned)),
+        )
+    log.info("Appended %d title(s) to %r", len(events), track.timeline)
+
+
+def _verify(timeline: Timeline, events: list[Event], track: OwnedTrack) -> list[Item]:
+    """Read the track back and pair each event with the clip that landed for it.
+
+    Position is the pairing key because the events cannot overlap (T8), so a record frame
+    identifies exactly one of them — and a title that did not land on its own frame is
+    the failure this read exists to catch.
+    """
+    landed = {
+        int(item.GetStart()): item
+        for item in timeline.GetItemListInTrack(VIDEO, track.index) or []
+    }
+    adrift = [
+        event
+        for event in events
+        if event.record_in not in landed
+        or int(landed[event.record_in].GetDuration()) != event.duration
+    ]
+    if adrift:
+        raise TitlesApplyFailedError(
+            cause=f"{len(adrift)} of {len(events)} title(s) did not land where the file puts "
+            f"them on {track.name!r} of {track.timeline!r}.",
+            fix="Resolve slides an append that overlaps existing media and drops one onto a "
+            "track it cannot reach, both while reporting success. Check the Titles track is "
+            "empty of anything this tool did not place, and apply again.",
+            detail=track.detail(
+                adrift=[
+                    {"id": event.id, "record_frame": event.record_in, "duration": event.duration}
+                    for event in adrift
+                ]
+            ),
+        )
+    return [landed[event.record_in] for event in events]
+
+
+def _write_titles(
+    events: list[Event],
+    items: list[Item],
+) -> list[tuple[Event, fusion.TitleNode, fusion.Fade]]:
+    """Set every title's text and fade, then read every text back off the placed clips.
+
+    Every write happens before any read on purpose (#41): reading a title straight after
+    writing it would pass whether or not the instances share one Fusion comp, because the
+    write that overwrites an earlier title has not happened yet. For the same reason the
+    read-back walks to the node again from the timeline item rather than reusing the node
+    it wrote through — a handle can go on answering for a comp the timeline has replaced.
+    """
+    written: list[tuple[Event, fusion.TitleNode, fusion.Fade]] = []
+    for event, item in zip(events, items, strict=True):
+        node = fusion.title_node(item, f"title {event.id!r}")
+        fusion.set_text(node, event.text)
+        fade = fusion.write_fade(
+            node,
+            duration=event.duration,
+            fade_in=event.fade_in,
+            fade_out=event.fade_out,
+        )
+        written.append((event, node, fade))
+
+    strayed: list[tuple[Event, str | None]] = []
+    for (event, _, _), item in zip(written, items, strict=True):
+        read = fusion.read_text(fusion.title_node(item, f"title {event.id!r}"))
+        if read != event.text:
+            strayed.append((event, read))
+    if strayed:
+        first, read = strayed[0]
+        raise TitlesApplyFailedError(
+            cause=f"{len(strayed)} title(s) do not read back as written: {first.id!r} was "
+            f"given {first.text!r} and reads {read!r}.",
+            fix="If a title reads back as another title's text, the placed instances share "
+            "one Fusion comp and this template cannot carry per-instance titles — author a "
+            "fresh Text+ template in the GUI and export its bin again.",
+            detail={"strayed": [{"id": event.id, "read_back": text} for event, text in strayed]},
+        )
+    return written
+
+
+__all__ = ["OwnedTrack", "apply_titles"]

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -16,19 +16,19 @@ from __future__ import annotations
 
 from typing import Any, NamedTuple
 
-from ..cut.document import LoadedCut, read_cut_file
+from ..cut.document import read_cut_file
 from ..cut.schema import ANNOTATED_EXAMPLE, SCHEMA_DOC, SCHEMA_VERSION
 from ..cut.validate import (
     DEFAULT_MIN_SEGMENT_FRAMES,
     RULE_DESCRIPTIONS,
     ClipFacts,
-    Finding,
     resolve_aliases,
-    severity_of,
     total_frames,
     validate_project,
     validate_structure,
 )
+from ..document import LoadedDocument
+from ..findings import Finding, severity_of
 from ..logging_config import get_logger
 from ..timing import dual_time
 from . import media
@@ -75,7 +75,7 @@ class Source(NamedTuple):
 class Preflight(NamedTuple):
     """One pass of the rules, and the pool reading they were judged against."""
 
-    loaded: LoadedCut
+    loaded: LoadedDocument
     findings: list[Finding]
     sources: list[Source]
 

--- a/src/resolve_mcp/resolve/fusion.py
+++ b/src/resolve_mcp/resolve/fusion.py
@@ -237,8 +237,14 @@ def _keyframes(start: int, end: int, fade_in: int, fade_out: int) -> tuple[tuple
 
     When the two ramps meet — the file asked for a fade the whole length of the title —
     the held section collapses to one frame at full rather than inverting the keyframes.
+    A title that fades both ways always keeps both of its clear ends: an in-ramp long
+    enough to reach the last frame is pulled back one, because a ramp that landed *on*
+    the last frame would take the frame the out-ramp has to end clear on, and the title
+    would finish at full opacity while the report still said it faded out.
     """
     up_at = start + fade_in
+    if fade_in and fade_out:
+        up_at = min(up_at, end - 1)
     down_at = max(end - fade_out, up_at)
     # Keyed by frame, because the ramps can collapse onto one another and a repeated
     # frame written twice is a keyframe whose value depends on write order.

--- a/src/resolve_mcp/resolve/fusion.py
+++ b/src/resolve_mcp/resolve/fusion.py
@@ -133,6 +133,13 @@ def title_node(item: Item, where: str) -> TitleNode:
         raise TitleTemplateError(
             cause=f"The comp placed for {where} holds no {TEXT_PLUS} node; it holds "
             f"{_names(held) or '<nothing>'}.",
+            # A Fusion *macro* is the other thing a title template can be, and its editable
+            # text is an exported input on the macro rather than a Text+ node — reachable
+            # by a different route than this one, so it is named rather than guessed at.
+            fix=f"This route titles a plain {TEXT_PLUS} template. If the clip is a Fusion "
+            f"macro, its text is an exported input rather than a {TEXT_PLUS} node and this "
+            f"tool cannot reach it — author a plain {TEXT_PLUS} title in the GUI and export "
+            f"its bin as a .drb instead.",
             detail={"where": where, "tools": sorted(_names_of(held))},
         )
     first = tools[min(tools)]
@@ -222,20 +229,25 @@ def _as_frame(value: Any) -> int | None:
 def _keyframes(start: int, end: int, fade_in: int, fade_out: int) -> tuple[tuple[int, float], ...]:
     """Up from nothing over ``fade_in``, held, down to nothing over ``fade_out``.
 
-    ``end`` is the comp's last frame, so the ramps are inclusive of both ends. When the
-    two ramps meet — the file asked for a fade the whole length of the title — the held
-    section collapses to a single frame at full rather than inverting the keyframe order.
+    ``end`` is the comp's last frame, so the ramps are inclusive of both ends. Both ends
+    always carry a keyframe, even the end that is not fading: what a spline does *outside*
+    its keyframes is an extrapolation setting nobody here has set, so a title asked to
+    fade out only would otherwise rely on Fusion holding full opacity backwards from the
+    first keyframe. Anchoring both ends says it instead of assuming it.
+
+    When the two ramps meet — the file asked for a fade the whole length of the title —
+    the held section collapses to one frame at full rather than inverting the keyframes.
     """
-    keys: list[tuple[int, float]] = []
     up_at = start + fade_in
     down_at = max(end - fade_out, up_at)
+    # Keyed by frame, because the ramps can collapse onto one another and a repeated
+    # frame written twice is a keyframe whose value depends on write order.
+    keys = {start: CLEAR if fade_in else FULL, end: CLEAR if fade_out else FULL}
     if fade_in:
-        keys.append((start, CLEAR))
-        keys.append((up_at, FULL))
+        keys[up_at] = FULL
     if fade_out:
-        keys.append((down_at, FULL))
-        keys.append((end, CLEAR))
-    return tuple(keys)
+        keys[down_at] = FULL
+    return tuple(sorted(keys.items()))
 
 
 def _read_back(tool: Tool, keyframes: tuple[tuple[int, float], ...]) -> tuple[bool, str]:

--- a/src/resolve_mcp/resolve/fusion.py
+++ b/src/resolve_mcp/resolve/fusion.py
@@ -1,0 +1,275 @@
+"""Inside a placed title: the Text+ node, its text, and the opacity spline that fades it.
+
+This is the only part of the server that reaches into a Fusion comp, and it is the part
+the scripting API documents least. Four things here are decisions rather than API calls:
+
+* **Every attribute is checked for being callable, never for existing.** fusionscript
+  answers *every* attribute name — a method a build does not have comes back as ``None``,
+  not as a missing attribute (#41, verified live on Studio 21.0.3.7). ``hasattr`` is no
+  guard at all, so each Fusion-side method is fetched and checked before it is used, and
+  a build that lacks one is named rather than left to die on ``NoneType is not callable``.
+* **The fade is written where the API allows one at all.** Resolve exposes no clip-level
+  fade handles and no keyframe API (#5): ``TimelineItem.SetProperty`` reaches a *static*
+  opacity and nothing else. The only scriptable fade is inside the comp — a BezierSpline
+  on the Text+ node's ``Opacity1``, keyframed by index assignment, which is the pattern
+  shipping Text+ automation uses.
+* **A fade that cannot be written does not sink the title.** The text is the title; the
+  fade is how it arrives. So a comp with no Text+ node raises — the title would be blank
+  and wrong — while an opacity input that will not animate comes back as a fade marked
+  unverified, with the reason, and the placed title stays. The report says which per
+  event, because on a machine nobody is watching that distinction is the whole diagnosis.
+* **The keyframes are read back at their own times.** Writing them proves the calls were
+  accepted; reading ``GetInput`` at each keyframe time is the only evidence the spline is
+  connected and animating. A build whose ``GetInput`` takes no time argument cannot answer
+  that, which is reported as unverified rather than treated as a failure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from ..errors import TitleTemplateError
+from ..logging_config import get_logger
+
+log = get_logger("fusion")
+
+Comp = Any
+Item = Any
+Tool = Any
+
+TEXT_PLUS: Final = "TextPlus"
+"""The node type a Text+ title is built on — what ``GetToolList`` filters by."""
+
+STYLED_TEXT: Final = "StyledText"
+"""The Text+ input holding the words. Multi-line via ``\\n``."""
+
+OPACITY: Final = "Opacity1"
+"""Shading element 1's opacity: the Text+ input a fade is written on (#5)."""
+
+CLEAR: Final = 0.0
+FULL: Final = 1.0
+
+RENDER_START: Final = "COMPN_RenderStart"
+RENDER_END: Final = "COMPN_RenderEnd"
+
+_TOLERANCE: Final = 1e-6
+"""Opacity crosses a C bridge as a float; only a real difference should read as one."""
+
+
+@dataclass(frozen=True)
+class TitleNode:
+    """The Text+ node of one placed instance, with the comp it lives in.
+
+    ``of_how_many`` travels with it because a template may hold several Text+ nodes and
+    which one answered is exactly what an apply report cannot reconstruct afterwards.
+    """
+
+    comp: Comp
+    tool: Tool
+    name: str
+    of_how_many: int
+
+
+@dataclass(frozen=True)
+class Fade:
+    """What was asked of the opacity spline, and what came back when it was read."""
+
+    frames_in: int
+    frames_out: int
+    keyframes: tuple[tuple[int, float], ...]
+    verified: bool
+    detail: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "in": self.frames_in,
+            "out": self.frames_out,
+            "keyframes": [{"frame": frame, "opacity": value} for frame, value in self.keyframes],
+            "verified": self.verified,
+            "detail": self.detail,
+        }
+
+
+NO_FADE = Fade(0, 0, (), True, "no fade asked for")
+"""A hard cut on and off — the file said nothing about a fade, so nothing was written."""
+
+
+def _callable(obj: Any, name: str) -> Any | None:
+    """The named method, or ``None`` when this build does not really have it."""
+    found = getattr(obj, name, None)
+    return found if callable(found) else None
+
+
+def _required(obj: Any, name: str, where: str) -> Any:
+    found = _callable(obj, name)
+    if found is None:
+        raise TitleTemplateError(
+            cause=f"This Resolve build has no {name}, so {where} cannot be titled.",
+            fix="Check the Resolve version — the Fusion comp getters are the part of the "
+            "scripting API that differs most between builds.",
+            detail={"method": name, "where": where},
+        )
+    return found
+
+
+def title_node(item: Item, where: str) -> TitleNode:
+    """The Text+ node of a placed template instance. Raises if there is not exactly one."""
+    if not int(_required(item, "GetFusionCompCount", where)() or 0):
+        raise TitleTemplateError(
+            cause=f"The clip placed for {where} carries no Fusion comp, so it is not a "
+            f"Text+ title template.",
+            detail={"where": where},
+        )
+    comp = _required(item, "GetFusionCompByIndex", where)(1)
+    if comp is None:
+        raise TitleTemplateError(
+            cause=f"The clip placed for {where} counts a Fusion comp but hands out none.",
+            detail={"where": where},
+        )
+    tools = dict(_required(comp, "GetToolList", where)(False, TEXT_PLUS) or {})
+    if not tools:
+        held = dict(_required(comp, "GetToolList", where)(False, "") or {})
+        raise TitleTemplateError(
+            cause=f"The comp placed for {where} holds no {TEXT_PLUS} node; it holds "
+            f"{_names(held) or '<nothing>'}.",
+            detail={"where": where, "tools": sorted(_names_of(held))},
+        )
+    first = tools[min(tools)]
+    return TitleNode(comp, first, str(first.GetAttrs("TOOLS_Name") or ""), len(tools))
+
+
+def _names_of(tools: dict[int, Tool]) -> list[str]:
+    return [str(tool.GetAttrs("TOOLS_Name") or "") for tool in tools.values()]
+
+
+def _names(tools: dict[int, Tool]) -> str:
+    return ", ".join(repr(name) for name in _names_of(tools))
+
+
+def set_text(node: TitleNode, text: str) -> None:
+    """Write one instance's words. ``SetInput`` reports nothing — read it back to know."""
+    node.tool.SetInput(STYLED_TEXT, text)
+
+
+def read_text(node: TitleNode) -> str | None:
+    """What the node says its text is now — the only evidence a write landed."""
+    value = node.tool.GetInput(STYLED_TEXT)
+    return None if value is None else str(value)
+
+
+def write_fade(node: TitleNode, *, duration: int, fade_in: int, fade_out: int) -> Fade:
+    """Keyframe ``Opacity1`` up over ``fade_in`` and down over ``fade_out``.
+
+    Never raises: a fade this build will not write is reported, and the title it belongs
+    to stays placed and correctly worded. ``duration`` is the placed instance's length in
+    frames, used only when the comp will not say what its own render range is.
+    """
+    if not fade_in and not fade_out:
+        return NO_FADE
+
+    spline = _callable(node.comp, "BezierSpline")
+    if spline is None:
+        return _unwritten(fade_in, fade_out, "this Resolve build has no comp.BezierSpline")
+
+    start, end = _render_range(node.comp, duration)
+    keyframes = _keyframes(start, end, fade_in, fade_out)
+    setattr(node.tool, OPACITY, spline())
+    animated = getattr(node.tool, OPACITY, None)
+    if animated is None:
+        return _unwritten(fade_in, fade_out, f"the {TEXT_PLUS} node has no {OPACITY} input")
+    try:
+        for frame, value in keyframes:
+            animated[frame] = value
+    except TypeError as exc:
+        # An Input that will not take a keyframe by index assignment: the write is refused
+        # by the bridge itself, which is a build difference rather than a bug here.
+        return _unwritten(fade_in, fade_out, f"{OPACITY} would not take a keyframe: {exc}")
+
+    verified, detail = _read_back(node.tool, keyframes)
+    return Fade(fade_in, fade_out, keyframes, verified, detail)
+
+
+def _unwritten(fade_in: int, fade_out: int, why: str) -> Fade:
+    log.warning("No opacity fade written: %s", why)
+    return Fade(fade_in, fade_out, (), False, why)
+
+
+def _render_range(comp: Comp, duration: int) -> tuple[int, int]:
+    """The comp's own first and last frame, or the instance's own length as a fallback.
+
+    A Fusion comp on a timeline clip is rendered over its own range, which is what a
+    keyframe time is counted in. The fallback is what an edit-page comp normally holds
+    anyway, and it is logged, because a wrong range puts a fade outside the title.
+    """
+    attrs = _callable(comp, "GetAttrs")
+    reported = attrs() if attrs is not None else None
+    if isinstance(reported, dict):
+        start, end = _as_frame(reported.get(RENDER_START)), _as_frame(reported.get(RENDER_END))
+        if start is not None and end is not None and end > start:
+            return (start, end)
+    log.info("Comp reported no usable render range; fading over the instance's %d frames", duration)
+    return (0, max(duration - 1, 0))
+
+
+def _as_frame(value: Any) -> int | None:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _keyframes(start: int, end: int, fade_in: int, fade_out: int) -> tuple[tuple[int, float], ...]:
+    """Up from nothing over ``fade_in``, held, down to nothing over ``fade_out``.
+
+    ``end`` is the comp's last frame, so the ramps are inclusive of both ends. When the
+    two ramps meet — the file asked for a fade the whole length of the title — the held
+    section collapses to a single frame at full rather than inverting the keyframe order.
+    """
+    keys: list[tuple[int, float]] = []
+    up_at = start + fade_in
+    down_at = max(end - fade_out, up_at)
+    if fade_in:
+        keys.append((start, CLEAR))
+        keys.append((up_at, FULL))
+    if fade_out:
+        keys.append((down_at, FULL))
+        keys.append((end, CLEAR))
+    return tuple(keys)
+
+
+def _read_back(tool: Tool, keyframes: tuple[tuple[int, float], ...]) -> tuple[bool, str]:
+    """Read the animated input at each keyframe time; say plainly if it will not answer."""
+    for frame, value in keyframes:
+        try:
+            reported = tool.GetInput(OPACITY, frame)
+        except TypeError:
+            return (False, f"this build's GetInput does not read {OPACITY} at a time")
+        read = _as_opacity(reported)
+        if read is None:
+            return (False, f"{OPACITY} read back as {reported!r} at frame {frame}")
+        if abs(read - value) > _TOLERANCE:
+            return (False, f"{OPACITY} reads {read} at frame {frame}, not {value}")
+    return (True, "read back at every keyframe")
+
+
+def _as_opacity(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "CLEAR",
+    "FULL",
+    "OPACITY",
+    "STYLED_TEXT",
+    "TEXT_PLUS",
+    "Fade",
+    "TitleNode",
+    "read_text",
+    "set_text",
+    "title_node",
+    "write_fade",
+]

--- a/src/resolve_mcp/resolve/markers.py
+++ b/src/resolve_mcp/resolve/markers.py
@@ -220,6 +220,29 @@ def _colors(markers: list[dict[str, Any]]) -> dict[str, int]:
     return counts
 
 
+def markers_by_name(
+    connection: ResolveConnection,
+    timeline: Timeline,
+    fps: float | None,
+    color: str | None = None,
+) -> dict[str, list[int]]:
+    """Marker name -> every record frame carrying it, for one colour or all of them.
+
+    A name is not unique on a timeline — nothing stops the GUI carrying two markers with
+    the same note — so every frame is kept and the caller decides what a repeat means. A
+    caller joining data to markers by name (titling does) has to be able to say "that
+    song is marked twice" rather than silently take the first.
+    """
+    clock = MarkerClock(connection, timeline, fps)
+    found: dict[str, list[int]] = {}
+    for relative, detail in sorted(_reported(clock).items()):
+        marker = _marker(relative, detail, clock)
+        if not _matches(marker, color):
+            continue
+        found.setdefault(marker["name"], []).append(marker["record"]["frames"])
+    return found
+
+
 # --- write ------------------------------------------------------------------------------
 
 

--- a/src/resolve_mcp/resolve/takes.py
+++ b/src/resolve_mcp/resolve/takes.py
@@ -29,7 +29,6 @@ from typing import Any, Final
 from ..cut.document import read_cut_file
 from ..cut.validate import placements, validate_structure
 from ..document import LoadedDocument
-from ..findings import Finding
 from ..errors import (
     BuildFailedError,
     CutInvalidError,
@@ -37,6 +36,7 @@ from ..errors import (
     ResolveMcpError,
     TimelineOperationError,
 )
+from ..findings import Finding
 from ..logging_config import get_logger
 from ..timing import dual_time
 from . import timeline as timeline_read

--- a/src/resolve_mcp/resolve/titles.py
+++ b/src/resolve_mcp/resolve/titles.py
@@ -1,0 +1,514 @@
+"""Applying a titles file: one owned track, cleared and re-placed from the file every time.
+
+``apply_titles`` is declarative in the same way ``build_timeline`` is, but it works on a
+timeline someone else built, so the safety it needs is different: a build makes a *new*
+version and can afford to fail half-done, while an apply edits the version under review
+and must never destroy the good state it is replacing.
+
+That gives the order everything here follows:
+
+* **Validate everything, then touch nothing until it all passes.** The rules run over the
+  file, the timeline's markers and the media pool before the Titles track is looked at, so
+  a refused apply leaves the previous titles exactly where they were.
+* **Own one track, completely.** The topmost video track named ``Titles`` belongs to this
+  tool: it is created if absent, cleared whole, and re-placed from the file. Nothing else
+  on the timeline is read or written — the cut on V1 is untouched, which is what makes
+  "rebuild the cut, re-apply the titles" safe.
+* **Songs are found by marker, not by frame.** Every event's position is an offset from
+  the blue marker naming its song, so the same file lands correctly on every rebuild.
+* **Resolve's answer is never the evidence.** ``AppendToTimeline`` writes to the *current*
+  timeline (so the switch is made and verified first), reports success on a locked track,
+  and slides an append that overlaps. Every placement is read back off the track, and
+  every title is read back after *all* the writes — an instance that shares its comp with
+  another only shows up once a later write has had the chance to overwrite it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Final
+
+from ..errors import TitlesApplyFailedError, TitlesInvalidError
+from ..findings import Finding, severity_of
+from ..logging_config import get_logger
+from ..timing import dual_time
+from ..titles.document import LoadedTitles, read_titles_file
+from ..titles.schema import (
+    ANNOTATED_EXAMPLE,
+    SCHEMA_DOC,
+    SCHEMA_VERSION,
+    TRACK_NAME,
+)
+from ..titles.validate import (
+    ANCHOR_COLOR,
+    RULE_DESCRIPTIONS,
+    Event,
+    TemplateFacts,
+    plan,
+    template_of,
+    validate_project,
+    validate_structure,
+)
+from . import fusion, markers, media
+from . import timeline as timeline_read
+from .connection import ResolveConnection
+from .session import frame_rate
+
+log = get_logger("titles")
+
+Item = Any
+Pool = Any
+Project = Any
+Timeline = Any
+
+VIDEO: Final = "video"
+MEDIA_TYPE_VIDEO: Final = 1
+"""Resolve's ``mediaType`` for a video-only append. Never omitted: it drops the clip."""
+
+TEMPLATE_SOURCE_IN: Final = 0
+"""A title template is placed from its own first frame; it has no other content."""
+
+
+def get_titles_schema() -> dict[str, Any]:
+    """The titles-file contract: the schema document, its annotated example, the rules."""
+    return {
+        "schema": SCHEMA_VERSION,
+        "document": SCHEMA_DOC,
+        "annotated_example": ANNOTATED_EXAMPLE,
+        "rules": [
+            {"rule": rule, "severity": severity_of(rule), "description": description}
+            for rule, description in RULE_DESCRIPTIONS.items()
+        ],
+    }
+
+
+@dataclass(frozen=True)
+class Preflight:
+    """One pass of the rules, and everything the apply would need if they pass.
+
+    The timeline, the templates and the events travel with the findings so the apply
+    never looks anything up twice — a file validated against one clip and applied with
+    another is the failure this pairing makes impossible.
+    """
+
+    loaded: LoadedTitles
+    findings: list[Finding]
+    project: Project | None = None
+    timeline: Timeline | None = None
+    fps: float | None = None
+    templates: dict[str, media.LocatedClip] = field(default_factory=dict)
+    events: list[Event] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[Finding]:
+        return [finding for finding in self.findings if finding.severity == "error"]
+
+    @property
+    def warnings(self) -> list[Finding]:
+        return [finding for finding in self.findings if finding.severity == "warning"]
+
+
+def preflight(connection: ResolveConnection, titles_file: str) -> Preflight:
+    """Read ``titles_file`` and run every rule on it. The dry run and the apply share this."""
+    loaded = read_titles_file(titles_file)
+    if loaded.parse_error is not None:
+        return Preflight(loaded, [loaded.parse_error])
+
+    findings = validate_structure(loaded.doc)
+    if any(finding.rule == "T1" for finding in findings):
+        log.info("Titles file %s is not schema-valid; Resolve was not read", loaded.path)
+        return Preflight(loaded, findings)
+
+    doc: dict[str, Any] = loaded.doc
+    project = timeline_read.open_project(connection)
+    timeline = timeline_read.find_timeline(project, doc.get("timeline"))
+    fps = frame_rate(project, timeline)
+    pool = media.media_pool(connection)
+
+    facts, located = _templates(pool, doc)
+    anchors = markers.markers_by_name(connection, timeline, fps, ANCHOR_COLOR)
+    log.info(
+        "Titling %r: %d %s marker(s), %d template(s) declared",
+        timeline_read.name_of(timeline),
+        len(anchors),
+        ANCHOR_COLOR.lower(),
+        len(facts),
+    )
+    findings = [
+        *findings,
+        *validate_project(doc, anchors=anchors, templates=facts, span=_span(timeline)),
+    ]
+    return Preflight(loaded, findings, project, timeline, fps, located, plan(doc, anchors))
+
+
+def _span(timeline: Timeline) -> tuple[int, int]:
+    """The timeline's own ``[start, end)`` in record frames, as T9 judges against it."""
+    start = timeline_read.read_frames(timeline.GetStartFrame())
+    end = timeline_read.read_frames(timeline.GetEndFrame())
+    if start is None or end is None:
+        log.warning("Timeline reported an unreadable span; T9 cannot check placement bounds")
+        return (0, 0) if start is None and end is None else (start or 0, end or 0)
+    return (start, end)
+
+
+def _templates(
+    pool: Pool,
+    doc: dict[str, Any],
+) -> tuple[list[TemplateFacts], dict[str, media.LocatedClip]]:
+    """Every declared template the file actually uses, resolved against the pool.
+
+    Reported as facts rather than raised on, because T5 has to name every unusable
+    template at once — and the resolved handles come back beside them so the apply places
+    the very clips the rules were judged against.
+    """
+    used = {template_of(event) for song in doc["songs"] for event in song["events"]}
+    declared = {
+        name: template for name, template in doc["templates"].items() if name in used
+    }
+    found = media.clips_named(pool, {str(one["clip"]) for one in declared.values()})
+
+    facts: list[TemplateFacts] = []
+    located: dict[str, media.LocatedClip] = {}
+    for name, template in declared.items():
+        clip = str(template["clip"])
+        bin_path = template.get("bin")
+        matches = [one for one in found if str(one.clip.GetName() or "") == clip]
+        if bin_path is not None:
+            matches = [one for one in matches if _under(one.bin_path, str(bin_path))]
+        facts.append(
+            TemplateFacts(
+                name=name,
+                clip=clip,
+                bin_path=None if bin_path is None else str(bin_path),
+                matches=len(matches),
+                found_in=tuple(one.bin_path or "<root>" for one in matches),
+            )
+        )
+        if len(matches) == 1:
+            located[name] = matches[0]
+    return facts, located
+
+
+def _under(bin_path: str | None, declared: str) -> bool:
+    """Whether a clip's bin is the declared one or nested inside it, as find_clip searches."""
+    where = bin_path or ""
+    return where == declared or where.startswith(f"{declared}{media.BIN_SEPARATOR}")
+
+
+def validate_titles(connection: ResolveConnection, titles_file: str) -> dict[str, Any]:
+    """Dry-run ``titles_file``: every rule, every failure, before anything is applied."""
+    return _report(preflight(connection, titles_file))
+
+
+def _report(checked: Preflight) -> dict[str, Any]:
+    return {
+        "titles_file": str(checked.loaded.path),
+        "content_hash": checked.loaded.content_hash,
+        "valid": not checked.errors,
+        "errors": [finding.as_dict() for finding in checked.errors],
+        "warnings": [finding.as_dict() for finding in checked.warnings],
+        "timeline": (
+            None if checked.timeline is None else timeline_read.name_of(checked.timeline)
+        ),
+        "events": len(checked.events),
+    }
+
+
+# --- the apply ------------------------------------------------------------------------------
+
+
+def apply_titles(connection: ResolveConnection, titles_file: str) -> dict[str, Any]:
+    """Clear the Titles track and re-place every event in ``titles_file`` onto it."""
+    checked = preflight(connection, titles_file)
+    if checked.errors:
+        raise TitlesInvalidError(
+            cause=f"The titles file has {len(checked.errors)} error(s), so nothing was "
+            f"applied and the Titles track was not touched.",
+            detail={
+                "titles_file": str(checked.loaded.path),
+                "content_hash": checked.loaded.content_hash,
+                "errors": [finding.as_dict() for finding in checked.errors],
+                "warnings": [finding.as_dict() for finding in checked.warnings],
+            },
+        )
+    # No error means the document parsed, matched the schema and resolved against the
+    # project — every reading below is one the rules have already been over.
+    doc: dict[str, Any] = checked.loaded.doc
+    project, timeline = checked.project, checked.timeline
+    name = timeline_read.name_of(timeline)
+    track_name = str(doc.get("track", TRACK_NAME))
+    pool = media.media_pool(connection)
+
+    track, created = _own_track(timeline, track_name, name)
+    _refuse_locked(timeline, track, track_name, name)
+    _target(project, timeline, name)
+    cleared = _clear(timeline, track, track_name, name)
+    _place(pool, checked.events, checked.templates, track, name)
+    items = _verify(timeline, checked.events, track, track_name, name)
+    titled = _write_titles(checked.events, items)
+
+    log.info("Applied %d title(s) to %s of %r", len(titled), track_name, name)
+    return {
+        "titles_file": str(checked.loaded.path),
+        "content_hash": checked.loaded.content_hash,
+        "timeline": timeline_read.summarise(
+            timeline_read.Reader(connection),
+            timeline,
+            project,
+            timeline_read.current_name(project),
+        ),
+        "track": {"index": track, "name": track_name, "created": created},
+        "cleared": cleared,
+        "placed": [_placed(event, node, fade, checked.fps) for event, node, fade in titled],
+        "warnings": [finding.as_dict() for finding in checked.warnings],
+    }
+
+
+def _placed(
+    event: Event,
+    node: fusion.TitleNode,
+    fade: fusion.Fade,
+    fps: float | None,
+) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "song": event.song,
+        "kind": event.kind,
+        "template": event.template,
+        "text": event.text,
+        "record": dual_time(event.record_in, fps),
+        "duration": dual_time(event.duration, fps),
+        "node": {"name": node.name, "text_plus_in_comp": node.of_how_many},
+        "fade": fade.as_dict(),
+        "note": event.note,
+    }
+
+
+def _own_track(timeline: Timeline, track_name: str, name: str) -> tuple[int, bool]:
+    """The topmost video track called ``track_name``, created and named if there is none.
+
+    Topmost rather than first: a title belongs over the cut, and a project template that
+    already carries a ``Titles`` track lower down is the operator's business. A track that
+    is added but cannot be *named* is refused, because the next apply would not recognise
+    it and would stack a second one on top.
+    """
+    matching = [
+        index
+        for index in range(1, _track_count(timeline) + 1)
+        if str(timeline.GetTrackName(VIDEO, index) or "") == track_name
+    ]
+    if matching:
+        return (max(matching), False)
+
+    if not timeline.AddTrack(VIDEO):
+        raise TitlesApplyFailedError(
+            cause=f"Resolve refused to add a {track_name!r} track to {name!r}, so nothing "
+            f"was applied.",
+            detail={"timeline": name, "track": track_name},
+        )
+    index = _track_count(timeline)
+    rename = getattr(timeline, "SetTrackName", None)
+    if not (callable(rename) and rename(VIDEO, index, track_name)):
+        raise TitlesApplyFailedError(
+            cause=f"Resolve added video track {index} to {name!r} but would not name it "
+            f"{track_name!r}, so nothing was applied.",
+            fix=f"Delete the empty video track {index}, or rename it {track_name!r} by hand, "
+            f"and apply again — an unnamed track would be left behind on the next apply.",
+            detail={"timeline": name, "track": track_name, "track_index": index},
+        )
+    log.info("Added the %s track to %r as video %d", track_name, name, index)
+    return (index, True)
+
+
+def _track_count(timeline: Timeline) -> int:
+    try:
+        return int(timeline.GetTrackCount(VIDEO) or 0)
+    except (TypeError, ValueError):
+        log.warning("Resolve gave an unreadable video track count")
+        return 0
+
+
+def _refuse_locked(timeline: Timeline, track: int, track_name: str, name: str) -> None:
+    """A locked track takes the append, reports items and places nothing — and clearing
+    it would not work either, so this is checked before anything is deleted."""
+    if not timeline.GetIsTrackLocked(VIDEO, track):
+        return
+    raise TitlesApplyFailedError(
+        cause=f"The {track_name!r} track of {name!r} is locked; Resolve would report the "
+        f"titles as placed and place none, so nothing was applied.",
+        fix="Unlock the track in the timeline header and apply again.",
+        detail={"timeline": name, "track": track_name, "track_index": track},
+    )
+
+
+def _target(project: Project, timeline: Timeline, name: str) -> None:
+    """Make the target current, and check it — appends go to whatever is current (#41).
+
+    A build that does not honour the switch would otherwise take every title of this file
+    and place it on the cut the operator has open, reporting success the whole way.
+    """
+    project.SetCurrentTimeline(timeline)
+    current = project.GetCurrentTimeline()
+    if current is None or not _same(current, timeline):
+        raise TitlesApplyFailedError(
+            cause=f"Resolve would not open {name!r}, and an append lands on whatever "
+            f"timeline is current — so nothing was applied.",
+            fix="Close any modal dialog in the Resolve GUI, open the timeline, and apply again.",
+            detail={
+                "timeline": name,
+                "current": None if current is None else timeline_read.name_of(current),
+            },
+        )
+
+
+def _same(one: Timeline, other: Timeline) -> bool:
+    """Identity by Resolve's own id: two proxies for one timeline are not the same object."""
+    first, second = getattr(one, "GetUniqueId", None), getattr(other, "GetUniqueId", None)
+    if callable(first) and callable(second):
+        return bool(first() == second())
+    return bool(timeline_read.name_of(one) == timeline_read.name_of(other))
+
+
+def _clear(timeline: Timeline, track: int, track_name: str, name: str) -> int:
+    """Empty the owned track, and read it back — a stale title left there would double up."""
+    standing = list(timeline.GetItemListInTrack(VIDEO, track) or [])
+    if not standing:
+        return 0
+    delete = getattr(timeline, "DeleteClips", None)
+    if not callable(delete):
+        raise TitlesApplyFailedError(
+            cause=f"This Resolve build has no DeleteClips, so the {len(standing)} title(s) "
+            f"already on {track_name!r} cannot be cleared and nothing was applied.",
+            fix="Delete the clips on the Titles track by hand and apply again.",
+            detail={"timeline": name, "track": track_name, "standing": len(standing)},
+        )
+    # Never a ripple delete: the Titles track is the only one this tool owns, and a ripple
+    # would pull the cut on V1 along with it.
+    delete(standing, False)
+    left = list(timeline.GetItemListInTrack(VIDEO, track) or [])
+    if left:
+        raise TitlesApplyFailedError(
+            cause=f"{len(left)} of {len(standing)} title(s) are still on {track_name!r} "
+            f"after the clear, so nothing new was placed.",
+            detail={"timeline": name, "track": track_name, "remaining": len(left)},
+        )
+    log.info("Cleared %d title(s) off %s of %r", len(standing), track_name, name)
+    return len(standing)
+
+
+def _place(
+    pool: Pool,
+    events: list[Event],
+    templates: dict[str, media.LocatedClip],
+    track: int,
+    name: str,
+) -> None:
+    """One call for the whole file. Its return value is counted, never believed."""
+    if not events:
+        return
+    placements = [
+        {
+            "mediaPoolItem": templates[event.template].clip,
+            "startFrame": TEMPLATE_SOURCE_IN,
+            "endFrame": event.duration,
+            "mediaType": MEDIA_TYPE_VIDEO,
+            "trackIndex": track,
+            "recordFrame": event.record_in,
+        }
+        for event in events
+    ]
+    returned = list(pool.AppendToTimeline(placements) or [])
+    if len(returned) != len(events):
+        raise TitlesApplyFailedError(
+            cause=f"Asked Resolve for {len(events)} title(s) on {name!r} and got back "
+            f"{len(returned)}.",
+            fix="A template shorter than the span asked for is refused rather than trimmed "
+            "— shorten the longest event, or lengthen the template in the Resolve GUI and "
+            "export its bin again.",
+            detail={"timeline": name, "asked": len(events), "returned": len(returned)},
+        )
+    log.info("Appended %d title(s) to %r", len(events), name)
+
+
+def _verify(
+    timeline: Timeline,
+    events: list[Event],
+    track: int,
+    track_name: str,
+    name: str,
+) -> list[Item]:
+    """Read the track back and pair each event with the clip that landed for it.
+
+    Position is the pairing key because the events cannot overlap (T8), so a record frame
+    identifies exactly one of them — and a title that did not land on its own frame is
+    the failure this read exists to catch.
+    """
+    landed = {
+        int(item.GetStart()): item for item in timeline.GetItemListInTrack(VIDEO, track) or []
+    }
+    adrift = [
+        event
+        for event in events
+        if event.record_in not in landed
+        or int(landed[event.record_in].GetDuration()) != event.duration
+    ]
+    if adrift:
+        raise TitlesApplyFailedError(
+            cause=f"{len(adrift)} of {len(events)} title(s) did not land where the file puts "
+            f"them on {track_name!r} of {name!r}.",
+            fix="Resolve slides an append that overlaps existing media and drops one onto a "
+            "track it cannot reach, both while reporting success. Check the Titles track is "
+            "empty of anything this tool did not place, and apply again.",
+            detail={
+                "timeline": name,
+                "track": track_name,
+                "adrift": [
+                    {"id": event.id, "record_frame": event.record_in, "duration": event.duration}
+                    for event in adrift
+                ],
+            },
+        )
+    return [landed[event.record_in] for event in events]
+
+
+def _write_titles(
+    events: list[Event],
+    items: list[Item],
+) -> list[tuple[Event, fusion.TitleNode, fusion.Fade]]:
+    """Set every title's text and fade, then read every text back off the placed clips.
+
+    Every write happens before any read on purpose (#41): reading a title straight after
+    writing it would pass whether or not the instances share one Fusion comp, because the
+    write that overwrites an earlier title has not happened yet.
+    """
+    written: list[tuple[Event, fusion.TitleNode, fusion.Fade]] = []
+    for event, item in zip(events, items, strict=True):
+        node = fusion.title_node(item, f"title {event.id!r}")
+        fusion.set_text(node, event.text)
+        fade = fusion.write_fade(
+            node,
+            duration=event.duration,
+            fade_in=event.fade_in,
+            fade_out=event.fade_out,
+        )
+        written.append((event, node, fade))
+
+    strayed: list[tuple[Event, str | None]] = []
+    for (event, _, _), item in zip(written, items, strict=True):
+        read = fusion.read_text(fusion.title_node(item, f"title {event.id!r}"))
+        if read != event.text:
+            strayed.append((event, read))
+    if strayed:
+        first, read = strayed[0]
+        raise TitlesApplyFailedError(
+            cause=f"{len(strayed)} title(s) do not read back as written: {first.id!r} was "
+            f"given {first.text!r} and reads {read!r}.",
+            fix="If a title reads back as another title's text, the placed instances share "
+            "one Fusion comp and this template cannot carry per-instance titles — author a "
+            "fresh Text+ template in the GUI and export its bin again.",
+            detail={"strayed": [{"id": event.id, "read_back": text} for event, text in strayed]},
+        )
+    return written
+
+
+__all__ = ["apply_titles", "get_titles_schema", "preflight", "validate_titles"]

--- a/src/resolve_mcp/resolve/titles.py
+++ b/src/resolve_mcp/resolve/titles.py
@@ -1,44 +1,27 @@
-"""Applying a titles file: one owned track, cleared and re-placed from the file every time.
+"""Reading a titles file against a project: the contract, and the dry run that holds it.
 
-``apply_titles`` is declarative in the same way ``build_timeline`` is, but it works on a
-timeline someone else built, so the safety it needs is different: a build makes a *new*
-version and can afford to fail half-done, while an apply edits the version under review
-and must never destroy the good state it is replacing.
+The rules that judge a titles file need three readings Resolve alone can give — the
+timeline it names, the blue markers that anchor its songs, and the media-pool clips its
+templates resolve to. Gathering those and running the rules over them happens here, once,
+so :func:`validate_titles` and :mod:`resolve_mcp.resolve.apply` cannot drift apart: the
+dry run and the apply are the same pass, and only one of them goes on to write.
 
-That gives the order everything here follows:
-
-* **Validate everything, then touch nothing until it all passes.** The rules run over the
-  file, the timeline's markers and the media pool before the Titles track is looked at, so
-  a refused apply leaves the previous titles exactly where they were.
-* **Own one track, completely.** The topmost video track named ``Titles`` belongs to this
-  tool: it is created if absent, cleared whole, and re-placed from the file. Nothing else
-  on the timeline is read or written — the cut on V1 is untouched, which is what makes
-  "rebuild the cut, re-apply the titles" safe.
-* **Songs are found by marker, not by frame.** Every event's position is an offset from
-  the blue marker naming its song, so the same file lands correctly on every rebuild.
-* **Resolve's answer is never the evidence.** ``AppendToTimeline`` writes to the *current*
-  timeline (so the switch is made and verified first), reports success on a locked track,
-  and slides an append that overlaps. Every placement is read back off the track, and
-  every title is read back after *all* the writes — an instance that shares its comp with
-  another only shows up once a later write has had the chance to overwrite it.
+Everything Resolve reports is gathered as *facts* rather than handles wherever a rule
+touches it, so the rules stay pure and unit-testable — while the handles the apply will
+need travel alongside them, which is what stops a file being validated against one clip
+and applied with another.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Final
+from typing import Any
 
-from ..errors import TitlesApplyFailedError, TitlesInvalidError
+from ..document import LoadedDocument
 from ..findings import Finding, severity_of
 from ..logging_config import get_logger
-from ..timing import dual_time
-from ..titles.document import LoadedTitles, read_titles_file
-from ..titles.schema import (
-    ANNOTATED_EXAMPLE,
-    SCHEMA_DOC,
-    SCHEMA_VERSION,
-    TRACK_NAME,
-)
+from ..titles.document import read_titles_file
+from ..titles.schema import ANNOTATED_EXAMPLE, SCHEMA_DOC, SCHEMA_VERSION
 from ..titles.validate import (
     ANCHOR_COLOR,
     RULE_DESCRIPTIONS,
@@ -49,24 +32,16 @@ from ..titles.validate import (
     validate_project,
     validate_structure,
 )
-from . import fusion, markers, media
+from . import markers, media
 from . import timeline as timeline_read
 from .connection import ResolveConnection
 from .session import frame_rate
 
 log = get_logger("titles")
 
-Item = Any
 Pool = Any
 Project = Any
 Timeline = Any
-
-VIDEO: Final = "video"
-MEDIA_TYPE_VIDEO: Final = 1
-"""Resolve's ``mediaType`` for a video-only append. Never omitted: it drops the clip."""
-
-TEMPLATE_SOURCE_IN: Final = 0
-"""A title template is placed from its own first frame; it has no other content."""
 
 
 def get_titles_schema() -> dict[str, Any]:
@@ -91,7 +66,7 @@ class Preflight:
     another is the failure this pairing makes impossible.
     """
 
-    loaded: LoadedTitles
+    loaded: LoadedDocument
     findings: list[Finding]
     project: Project | None = None
     timeline: Timeline | None = None
@@ -147,7 +122,7 @@ def _span(timeline: Timeline) -> tuple[int, int]:
     end = timeline_read.read_frames(timeline.GetEndFrame())
     if start is None or end is None:
         log.warning("Timeline reported an unreadable span; T9 cannot check placement bounds")
-        return (0, 0) if start is None and end is None else (start or 0, end or 0)
+        return (start or 0, end or 0)
     return (start, end)
 
 
@@ -162,9 +137,7 @@ def _templates(
     the very clips the rules were judged against.
     """
     used = {template_of(event) for song in doc["songs"] for event in song["events"]}
-    declared = {
-        name: template for name, template in doc["templates"].items() if name in used
-    }
+    declared = {name: one for name, one in doc["templates"].items() if name in used}
     found = media.clips_named(pool, {str(one["clip"]) for one in declared.values()})
 
     facts: list[TemplateFacts] = []
@@ -214,301 +187,4 @@ def _report(checked: Preflight) -> dict[str, Any]:
     }
 
 
-# --- the apply ------------------------------------------------------------------------------
-
-
-def apply_titles(connection: ResolveConnection, titles_file: str) -> dict[str, Any]:
-    """Clear the Titles track and re-place every event in ``titles_file`` onto it."""
-    checked = preflight(connection, titles_file)
-    if checked.errors:
-        raise TitlesInvalidError(
-            cause=f"The titles file has {len(checked.errors)} error(s), so nothing was "
-            f"applied and the Titles track was not touched.",
-            detail={
-                "titles_file": str(checked.loaded.path),
-                "content_hash": checked.loaded.content_hash,
-                "errors": [finding.as_dict() for finding in checked.errors],
-                "warnings": [finding.as_dict() for finding in checked.warnings],
-            },
-        )
-    # No error means the document parsed, matched the schema and resolved against the
-    # project — every reading below is one the rules have already been over.
-    doc: dict[str, Any] = checked.loaded.doc
-    project, timeline = checked.project, checked.timeline
-    name = timeline_read.name_of(timeline)
-    track_name = str(doc.get("track", TRACK_NAME))
-    pool = media.media_pool(connection)
-
-    track, created = _own_track(timeline, track_name, name)
-    _refuse_locked(timeline, track, track_name, name)
-    _target(project, timeline, name)
-    cleared = _clear(timeline, track, track_name, name)
-    _place(pool, checked.events, checked.templates, track, name)
-    items = _verify(timeline, checked.events, track, track_name, name)
-    titled = _write_titles(checked.events, items)
-
-    log.info("Applied %d title(s) to %s of %r", len(titled), track_name, name)
-    return {
-        "titles_file": str(checked.loaded.path),
-        "content_hash": checked.loaded.content_hash,
-        "timeline": timeline_read.summarise(
-            timeline_read.Reader(connection),
-            timeline,
-            project,
-            timeline_read.current_name(project),
-        ),
-        "track": {"index": track, "name": track_name, "created": created},
-        "cleared": cleared,
-        "placed": [_placed(event, node, fade, checked.fps) for event, node, fade in titled],
-        "warnings": [finding.as_dict() for finding in checked.warnings],
-    }
-
-
-def _placed(
-    event: Event,
-    node: fusion.TitleNode,
-    fade: fusion.Fade,
-    fps: float | None,
-) -> dict[str, Any]:
-    return {
-        "id": event.id,
-        "song": event.song,
-        "kind": event.kind,
-        "template": event.template,
-        "text": event.text,
-        "record": dual_time(event.record_in, fps),
-        "duration": dual_time(event.duration, fps),
-        "node": {"name": node.name, "text_plus_in_comp": node.of_how_many},
-        "fade": fade.as_dict(),
-        "note": event.note,
-    }
-
-
-def _own_track(timeline: Timeline, track_name: str, name: str) -> tuple[int, bool]:
-    """The topmost video track called ``track_name``, created and named if there is none.
-
-    Topmost rather than first: a title belongs over the cut, and a project template that
-    already carries a ``Titles`` track lower down is the operator's business. A track that
-    is added but cannot be *named* is refused, because the next apply would not recognise
-    it and would stack a second one on top.
-    """
-    matching = [
-        index
-        for index in range(1, _track_count(timeline) + 1)
-        if str(timeline.GetTrackName(VIDEO, index) or "") == track_name
-    ]
-    if matching:
-        return (max(matching), False)
-
-    if not timeline.AddTrack(VIDEO):
-        raise TitlesApplyFailedError(
-            cause=f"Resolve refused to add a {track_name!r} track to {name!r}, so nothing "
-            f"was applied.",
-            detail={"timeline": name, "track": track_name},
-        )
-    index = _track_count(timeline)
-    rename = getattr(timeline, "SetTrackName", None)
-    if not (callable(rename) and rename(VIDEO, index, track_name)):
-        raise TitlesApplyFailedError(
-            cause=f"Resolve added video track {index} to {name!r} but would not name it "
-            f"{track_name!r}, so nothing was applied.",
-            fix=f"Delete the empty video track {index}, or rename it {track_name!r} by hand, "
-            f"and apply again — an unnamed track would be left behind on the next apply.",
-            detail={"timeline": name, "track": track_name, "track_index": index},
-        )
-    log.info("Added the %s track to %r as video %d", track_name, name, index)
-    return (index, True)
-
-
-def _track_count(timeline: Timeline) -> int:
-    try:
-        return int(timeline.GetTrackCount(VIDEO) or 0)
-    except (TypeError, ValueError):
-        log.warning("Resolve gave an unreadable video track count")
-        return 0
-
-
-def _refuse_locked(timeline: Timeline, track: int, track_name: str, name: str) -> None:
-    """A locked track takes the append, reports items and places nothing — and clearing
-    it would not work either, so this is checked before anything is deleted."""
-    if not timeline.GetIsTrackLocked(VIDEO, track):
-        return
-    raise TitlesApplyFailedError(
-        cause=f"The {track_name!r} track of {name!r} is locked; Resolve would report the "
-        f"titles as placed and place none, so nothing was applied.",
-        fix="Unlock the track in the timeline header and apply again.",
-        detail={"timeline": name, "track": track_name, "track_index": track},
-    )
-
-
-def _target(project: Project, timeline: Timeline, name: str) -> None:
-    """Make the target current, and check it — appends go to whatever is current (#41).
-
-    A build that does not honour the switch would otherwise take every title of this file
-    and place it on the cut the operator has open, reporting success the whole way.
-    """
-    project.SetCurrentTimeline(timeline)
-    current = project.GetCurrentTimeline()
-    if current is None or not _same(current, timeline):
-        raise TitlesApplyFailedError(
-            cause=f"Resolve would not open {name!r}, and an append lands on whatever "
-            f"timeline is current — so nothing was applied.",
-            fix="Close any modal dialog in the Resolve GUI, open the timeline, and apply again.",
-            detail={
-                "timeline": name,
-                "current": None if current is None else timeline_read.name_of(current),
-            },
-        )
-
-
-def _same(one: Timeline, other: Timeline) -> bool:
-    """Identity by Resolve's own id: two proxies for one timeline are not the same object."""
-    first, second = getattr(one, "GetUniqueId", None), getattr(other, "GetUniqueId", None)
-    if callable(first) and callable(second):
-        return bool(first() == second())
-    return bool(timeline_read.name_of(one) == timeline_read.name_of(other))
-
-
-def _clear(timeline: Timeline, track: int, track_name: str, name: str) -> int:
-    """Empty the owned track, and read it back — a stale title left there would double up."""
-    standing = list(timeline.GetItemListInTrack(VIDEO, track) or [])
-    if not standing:
-        return 0
-    delete = getattr(timeline, "DeleteClips", None)
-    if not callable(delete):
-        raise TitlesApplyFailedError(
-            cause=f"This Resolve build has no DeleteClips, so the {len(standing)} title(s) "
-            f"already on {track_name!r} cannot be cleared and nothing was applied.",
-            fix="Delete the clips on the Titles track by hand and apply again.",
-            detail={"timeline": name, "track": track_name, "standing": len(standing)},
-        )
-    # Never a ripple delete: the Titles track is the only one this tool owns, and a ripple
-    # would pull the cut on V1 along with it.
-    delete(standing, False)
-    left = list(timeline.GetItemListInTrack(VIDEO, track) or [])
-    if left:
-        raise TitlesApplyFailedError(
-            cause=f"{len(left)} of {len(standing)} title(s) are still on {track_name!r} "
-            f"after the clear, so nothing new was placed.",
-            detail={"timeline": name, "track": track_name, "remaining": len(left)},
-        )
-    log.info("Cleared %d title(s) off %s of %r", len(standing), track_name, name)
-    return len(standing)
-
-
-def _place(
-    pool: Pool,
-    events: list[Event],
-    templates: dict[str, media.LocatedClip],
-    track: int,
-    name: str,
-) -> None:
-    """One call for the whole file. Its return value is counted, never believed."""
-    if not events:
-        return
-    placements = [
-        {
-            "mediaPoolItem": templates[event.template].clip,
-            "startFrame": TEMPLATE_SOURCE_IN,
-            "endFrame": event.duration,
-            "mediaType": MEDIA_TYPE_VIDEO,
-            "trackIndex": track,
-            "recordFrame": event.record_in,
-        }
-        for event in events
-    ]
-    returned = list(pool.AppendToTimeline(placements) or [])
-    if len(returned) != len(events):
-        raise TitlesApplyFailedError(
-            cause=f"Asked Resolve for {len(events)} title(s) on {name!r} and got back "
-            f"{len(returned)}.",
-            fix="A template shorter than the span asked for is refused rather than trimmed "
-            "— shorten the longest event, or lengthen the template in the Resolve GUI and "
-            "export its bin again.",
-            detail={"timeline": name, "asked": len(events), "returned": len(returned)},
-        )
-    log.info("Appended %d title(s) to %r", len(events), name)
-
-
-def _verify(
-    timeline: Timeline,
-    events: list[Event],
-    track: int,
-    track_name: str,
-    name: str,
-) -> list[Item]:
-    """Read the track back and pair each event with the clip that landed for it.
-
-    Position is the pairing key because the events cannot overlap (T8), so a record frame
-    identifies exactly one of them — and a title that did not land on its own frame is
-    the failure this read exists to catch.
-    """
-    landed = {
-        int(item.GetStart()): item for item in timeline.GetItemListInTrack(VIDEO, track) or []
-    }
-    adrift = [
-        event
-        for event in events
-        if event.record_in not in landed
-        or int(landed[event.record_in].GetDuration()) != event.duration
-    ]
-    if adrift:
-        raise TitlesApplyFailedError(
-            cause=f"{len(adrift)} of {len(events)} title(s) did not land where the file puts "
-            f"them on {track_name!r} of {name!r}.",
-            fix="Resolve slides an append that overlaps existing media and drops one onto a "
-            "track it cannot reach, both while reporting success. Check the Titles track is "
-            "empty of anything this tool did not place, and apply again.",
-            detail={
-                "timeline": name,
-                "track": track_name,
-                "adrift": [
-                    {"id": event.id, "record_frame": event.record_in, "duration": event.duration}
-                    for event in adrift
-                ],
-            },
-        )
-    return [landed[event.record_in] for event in events]
-
-
-def _write_titles(
-    events: list[Event],
-    items: list[Item],
-) -> list[tuple[Event, fusion.TitleNode, fusion.Fade]]:
-    """Set every title's text and fade, then read every text back off the placed clips.
-
-    Every write happens before any read on purpose (#41): reading a title straight after
-    writing it would pass whether or not the instances share one Fusion comp, because the
-    write that overwrites an earlier title has not happened yet.
-    """
-    written: list[tuple[Event, fusion.TitleNode, fusion.Fade]] = []
-    for event, item in zip(events, items, strict=True):
-        node = fusion.title_node(item, f"title {event.id!r}")
-        fusion.set_text(node, event.text)
-        fade = fusion.write_fade(
-            node,
-            duration=event.duration,
-            fade_in=event.fade_in,
-            fade_out=event.fade_out,
-        )
-        written.append((event, node, fade))
-
-    strayed: list[tuple[Event, str | None]] = []
-    for (event, _, _), item in zip(written, items, strict=True):
-        read = fusion.read_text(fusion.title_node(item, f"title {event.id!r}"))
-        if read != event.text:
-            strayed.append((event, read))
-    if strayed:
-        first, read = strayed[0]
-        raise TitlesApplyFailedError(
-            cause=f"{len(strayed)} title(s) do not read back as written: {first.id!r} was "
-            f"given {first.text!r} and reads {read!r}.",
-            fix="If a title reads back as another title's text, the placed instances share "
-            "one Fusion comp and this template cannot carry per-instance titles — author a "
-            "fresh Text+ template in the GUI and export its bin again.",
-            detail={"strayed": [{"id": event.id, "read_back": text} for event, text in strayed]},
-        )
-    return written
-
-
-__all__ = ["apply_titles", "get_titles_schema", "preflight", "validate_titles"]
+__all__ = ["Preflight", "get_titles_schema", "preflight", "validate_titles"]

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from . import __version__
 from .config import get_config
 from .logging_config import configure_logging, get_logger
-from .tools import cut, escape_hatch, jobs, media, project, timeline
+from .tools import cut, escape_hatch, jobs, media, project, timeline, titles
 
 log = get_logger("server")
 
@@ -29,7 +29,9 @@ together, ranges are half-open [in, out), and a time you give in seconds must sa
 snap it to a frame ({"seconds": 2.52, "snap": "floor"}).
 
 Editing is declarative: you author a cut file, the server builds it. Call get_cut_schema
-before writing one and validate_cut after every edit — do not guess the format.
+before writing one and validate_cut after every edit — do not guess the format. Titles are
+declarative too and live outside the cut file: get_titles_schema, then apply_titles, which
+owns a Titles track and can be re-applied to every rebuild.
 
 Heavy work (renders, analysis) hands back a job_id straight away — carry on working and
 poll it with get_job; list_jobs finds what you started before a restart. Results are cached
@@ -49,6 +51,7 @@ def build_server() -> FastMCP:
         *media.TOOLS,
         *timeline.TOOLS,
         *cut.TOOLS,
+        *titles.TOOLS,
         *jobs.TOOLS,
         *escape_hatch.TOOLS,
     ):

--- a/src/resolve_mcp/titles/__init__.py
+++ b/src/resolve_mcp/titles/__init__.py
@@ -1,0 +1,1 @@
+"""The titles file: its contract, and the rules that hold a file to it."""

--- a/src/resolve_mcp/titles/document.py
+++ b/src/resolve_mcp/titles/document.py
@@ -10,13 +10,10 @@ from __future__ import annotations
 from ..document import LoadedDocument, read_document
 from .validate import parse_failure_finding
 
-LoadedTitles = LoadedDocument
-"""A titles file as read. The shape is shared; the name is what the apply reports on."""
 
-
-def read_titles_file(titles_file: str) -> LoadedTitles:
+def read_titles_file(titles_file: str) -> LoadedDocument:
     """Read and parse ``titles_file``, reporting an unparseable one as T1."""
     return read_document(titles_file, what="titles file", parse_failure=parse_failure_finding)
 
 
-__all__ = ["LoadedTitles", "read_titles_file"]
+__all__ = ["read_titles_file"]

--- a/src/resolve_mcp/titles/document.py
+++ b/src/resolve_mcp/titles/document.py
@@ -1,0 +1,22 @@
+"""Reading a titles file off disk.
+
+The mechanics are shared with the cut file (:mod:`resolve_mcp.document`). What is
+titles-specific is which rule a parse failure belongs to: T1 is "JSON parses", so an
+unparseable file is a T1 finding rather than an exception.
+"""
+
+from __future__ import annotations
+
+from ..document import LoadedDocument, read_document
+from .validate import parse_failure_finding
+
+LoadedTitles = LoadedDocument
+"""A titles file as read. The shape is shared; the name is what the apply reports on."""
+
+
+def read_titles_file(titles_file: str) -> LoadedTitles:
+    """Read and parse ``titles_file``, reporting an unparseable one as T1."""
+    return read_document(titles_file, what="titles file", parse_failure=parse_failure_finding)
+
+
+__all__ = ["LoadedTitles", "read_titles_file"]

--- a/src/resolve_mcp/titles/schema.py
+++ b/src/resolve_mcp/titles/schema.py
@@ -40,7 +40,6 @@ ANNOTATED_EXAMPLE: Final = """\
 {
   "schema": 1,                       // supported-version check
   "timeline": "sunset-set v4",       // optional; default = the current timeline
-  "track": "Titles",                 // optional; default "Titles" (§1)
 
   // GUI-authored Text+ templates, already in the media pool. Identity = clip name
   // + optional bin, resolved to exactly one media-pool clip at apply.
@@ -73,11 +72,13 @@ _TRACK: Final = """\
 ## 1. One track, owned outright
 
 `apply_titles` owns the topmost video track named `Titles`, and creates it if the
-timeline has none. Every re-run clears that track completely and re-places from
-the file, so the track always holds exactly what the file says and nothing else.
-Put nothing there by hand that you want to keep. No other track is read or
-written — the cut on V1 is never touched, which is what makes "rebuild the cut,
-re-apply the titles" safe in either order."""
+timeline has none. The name is not configurable: one track is owned outright, and
+a tool that could be pointed at any track could clear one it does not own. Every
+re-run clears that track completely and re-places from the file, so it always
+holds exactly what the file says and nothing else. Put nothing there by hand that
+you want to keep. No other track is read or written — the cut on V1 is never
+touched, which is what makes "rebuild the cut, re-apply the titles" safe in
+either order."""
 
 _ANCHORS: Final = """\
 ## 2. Songs are anchored to blue markers, not to frames
@@ -119,8 +120,8 @@ _RERUN: Final = """\
 `apply_titles` is declarative and idempotent: same file, same timeline, same
 result. Nothing is validated against the previous run, and no state is kept
 between runs — the timeline *is* the state. Edit the file and re-apply to move,
-retime or re-word titles; a one-word typo fix has a cheaper route in
-`set_title_text`, which edits a placed instance without clearing the track."""
+retime or re-word titles, including a one-word typo fix: re-applying costs one
+clear and one append, and it is the only route this server offers today."""
 
 _RULES: Final = """\
 ## 5. Validation

--- a/src/resolve_mcp/titles/schema.py
+++ b/src/resolve_mcp/titles/schema.py
@@ -1,0 +1,145 @@
+"""The titles-file schema v1, served verbatim by ``get_titles_schema``.
+
+The text below is the contract settled by the titling workflow spec (issue #14) and the
+title-control research (issue #5). It is data, not documentation: Claude authors
+``titles.json`` against exactly this, so the example stays annotated and is served
+character-for-character as written here. Editing it changes the contract — do it in a
+ticket, not in passing.
+
+Two decisions in it are worth naming here, because they are what make titling
+re-runnable rather than merely automatic:
+
+* **Event times are offsets from the song's blue marker, never absolute frames.** The
+  marker name is the song key, which is the explicit join between the file and the
+  timeline (#14 §1). A rebuild makes a new timeline version; re-marking the songs on it
+  is all that is needed for the same titles file to land correctly again. Absolute
+  frames would silently point at the wrong music the moment a segment's length changed.
+* **Titles are not in the cut file, and the cut file is not read here.** The two files
+  together describe a deliverable, and each owns its own tracks — ``build_timeline``
+  never touches the Titles track, and ``apply_titles`` never touches V1.
+"""
+
+from typing import Final
+
+SCHEMA_VERSION: Final = 1
+"""The only titles-file ``schema`` value this server accepts."""
+
+TRACK_NAME: Final = "Titles"
+"""The track ``apply_titles`` owns. Everything on it is the server's to clear and re-place."""
+
+KINDS: Final = ("title", "personnel", "custom")
+"""What an event is for. ``kind`` picks the template unless ``template`` overrides it."""
+
+ROUTES: Final = ("textplus", "png")
+"""How an event is rendered. Only ``textplus`` is placed today; ``png`` is the PNG route."""
+
+SUPPORTED_ROUTES: Final = ("textplus",)
+"""The routes this build can place. A declared-but-unsupported route is a T6 error."""
+
+ANNOTATED_EXAMPLE: Final = """\
+{
+  "schema": 1,                       // supported-version check
+  "timeline": "sunset-set v4",       // optional; default = the current timeline
+  "track": "Titles",                 // optional; default "Titles" (§1)
+
+  // GUI-authored Text+ templates, already in the media pool. Identity = clip name
+  // + optional bin, resolved to exactly one media-pool clip at apply.
+  "templates": {
+    "title":     { "clip": "Song Title", "bin": "Titles/Templates" },
+    "personnel": { "clip": "Personnel" }
+  },
+
+  "songs": [
+    {
+      "key": "sunset-boulevard",     // the name of a blue marker on the timeline (§2)
+      "events": [
+        {
+          "id": "t01",               // required, unique across the whole file
+          "kind": "title",           // title | personnel | custom
+          "route": "textplus",       // textplus (png = the PNG route, not this one)
+          "template": "title",       // optional; default = kind
+          "text": "Sunset Boulevard",     // the final string, verbatim; \\n for a line break
+          "in": 240, "out": 720,     // frames from the song's marker, half-open [in, out)
+          "fade": { "in": 24, "out": 36 },  // optional; frames of opacity ramp (§3)
+          "note": "let four bars play"      // free text; server ignores; feeds the report
+        }
+      ]
+    }
+  ]
+}"""
+"""The annotated schema example, verbatim. Comments are ``//`` — strip before parsing."""
+
+_TRACK: Final = """\
+## 1. One track, owned outright
+
+`apply_titles` owns the topmost video track named `Titles`, and creates it if the
+timeline has none. Every re-run clears that track completely and re-places from
+the file, so the track always holds exactly what the file says and nothing else.
+Put nothing there by hand that you want to keep. No other track is read or
+written — the cut on V1 is never touched, which is what makes "rebuild the cut,
+re-apply the titles" safe in either order."""
+
+_ANCHORS: Final = """\
+## 2. Songs are anchored to blue markers, not to frames
+
+A song's `key` is the *name* of a blue marker on the target timeline; every
+event's `in`/`out` counts frames forward from that marker. So the join between
+this file and the timeline is explicit and survives a rebuild: build the new
+version, mark the songs on it, re-apply this file unchanged.
+
+Exactly one blue marker must carry each key (T7). A blue marker with no matching
+song is reported as a warning, never an error — a set list is often titled a song
+at a time."""
+
+_FADES: Final = """\
+## 3. Fades are Fusion opacity keyframes
+
+Resolve's clip-level fade handles are not reachable from the scripting API at
+all, so a fade is written *inside* the placed instance's Fusion comp: a
+BezierSpline on the Text+ node's `Opacity1`, keyframed 0 -> 1 over `fade.in` at
+the head and 1 -> 0 over `fade.out` at the tail. Omit `fade` for a hard cut on
+and off. `fade.in + fade.out` must fit inside the event's duration (T4).
+
+Fade timing is a judgement call, not a default: fast tune roughly 0.5-1 s,
+ballad roughly 2-4 s. The report says per event whether the written spline read
+back, because a Resolve build that will not answer for an animated input is the
+one thing here no test can check."""
+
+_TIME: Final = """\
+## Time
+
+Frames authoritative, half-open `[in, out)` — duration = out - in. Offsets are
+from the song's marker, so `in: 0` is the marker frame itself. Seconds are not
+accepted here: the fps that would convert them belongs to the timeline, and a
+titles file outlives any one version of it."""
+
+_RERUN: Final = """\
+## 4. Re-running
+
+`apply_titles` is declarative and idempotent: same file, same timeline, same
+result. Nothing is validated against the previous run, and no state is kept
+between runs — the timeline *is* the state. Edit the file and re-apply to move,
+retime or re-word titles; a one-word typo fix has a cheaper route in
+`set_title_text`, which edits a placed instance without clearing the track."""
+
+_RULES: Final = """\
+## 5. Validation
+
+9 hard errors (T1-T9) block an apply; 2 warnings (W1-W2) never do. A single
+error aborts before the Titles track is touched, so a refused apply always
+leaves the timeline exactly as it was. Every finding is
+`{rule, id, message, fix_hint}` — see the `rules` field of this result."""
+
+SCHEMA_DOC: Final = "\n\n".join(
+    [
+        "# Titles-file schema v1",
+        _TRACK,
+        _ANCHORS,
+        "## Schema\n\n```jsonc\n" + ANNOTATED_EXAMPLE + "\n```",
+        _TIME,
+        _FADES,
+        _RERUN,
+        _RULES,
+    ]
+)
+"""The full schema document: prose contract with the annotated example embedded."""

--- a/src/resolve_mcp/titles/validate.py
+++ b/src/resolve_mcp/titles/validate.py
@@ -26,7 +26,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Final, TypeGuard
 
-from ..findings import Finding, ordered, severity_of
+from ..findings import Finding, ordered
 from ..logging_config import get_logger
 from ..timing import ranges_overlap
 from .schema import KINDS, ROUTES, SCHEMA_VERSION, SUPPORTED_ROUTES
@@ -157,9 +157,8 @@ def _schema_version_errors(doc: dict[str, Any]) -> Iterator[Finding]:
 
 
 def _target_errors(doc: dict[str, Any]) -> Iterator[Finding]:
-    for field in ("timeline", "track"):
-        if field in doc and not (isinstance(doc[field], str) and doc[field].strip()):
-            yield _finding("T1", None, f"'{field}' must be a non-empty string when present.")
+    if "timeline" in doc and not (isinstance(doc["timeline"], str) and doc["timeline"].strip()):
+        yield _finding("T1", None, "'timeline' must be a non-empty timeline name when present.")
 
 
 def _templates_errors(doc: dict[str, Any]) -> Iterator[Finding]:
@@ -543,13 +542,11 @@ __all__ = [
     "ANCHOR_COLOR",
     "RULE_DESCRIPTIONS",
     "Event",
-    "Finding",
     "TemplateFacts",
     "fades",
     "parse_failure_finding",
     "plan",
     "route_of",
-    "severity_of",
     "template_of",
     "validate_project",
     "validate_structure",

--- a/src/resolve_mcp/titles/validate.py
+++ b/src/resolve_mcp/titles/validate.py
@@ -1,0 +1,556 @@
+"""The titles-file validation rules: 9 hard errors, 2 warnings, one implementation.
+
+The list is identical in the ``validate_titles`` dry run and in ``apply_titles``'
+pre-flight, so it lives here once and both call it. A failing file must abort before the
+Titles track is cleared — a track emptied for titles that were never placed is the
+outcome this file exists to prevent, and it is worse than the cut's equivalent because
+the thing destroyed is the *previous* good state.
+
+Two passes, because they need different things:
+
+* :func:`validate_structure` reads the document alone — no project, no connection. Shape,
+  ids, ranges, fades and routes (T1-T4, T6, W1).
+* :func:`validate_project` takes the song anchors and template facts already read off the
+  timeline and the media pool, and answers everything that depends on them (T5, T7-T9,
+  W2). It is a pure function over those facts, so every rule here is unit-testable
+  without Resolve.
+
+:func:`plan` is the bridge to the apply: the same offsets the rules judged, turned into
+the absolute record frames Resolve needs. Positions are computed once, in one place, so
+a title can never be validated at one frame and placed at another.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Final, TypeGuard
+
+from ..findings import Finding, ordered, severity_of
+from ..logging_config import get_logger
+from ..timing import ranges_overlap
+from .schema import KINDS, ROUTES, SCHEMA_VERSION, SUPPORTED_ROUTES
+
+log = get_logger("titles")
+
+RULE_DESCRIPTIONS: Final[dict[str, str]] = {
+    "T1": "JSON parses; schema-valid; schema version supported",
+    "T2": "event ids unique across the file; song keys unique",
+    "T3": "in < out on every event",
+    "T4": "fade in + fade out fit inside the event's duration",
+    "T5": "every template resolves to exactly one media-pool clip",
+    "T6": "event route supported by this build (textplus)",
+    "T7": "every song key names exactly one blue marker on the timeline",
+    "T8": "events do not overlap — one Titles track shows one title at a time",
+    "T9": "every event lands inside the timeline",
+    "W1": "a song with no events",
+    "W2": "a blue marker with no song in the file",
+}
+
+_FIX_HINTS: Final[dict[str, str]] = {
+    "T1": "Call get_titles_schema and match the annotated example exactly.",
+    "T2": "Give every event its own id and every song its own key.",
+    "T3": "Ranges are half-open [in, out); make out strictly greater than in.",
+    "T4": "Shorten the fades or lengthen the event — a fade cannot run past the title.",
+    "T5": "Import the template bin into the media pool, or fix templates.<name>.clip/.bin.",
+    "T6": "Only textplus titles are placed today; png titles land with the PNG route.",
+    "T7": "Name a blue marker exactly this key with set_markers, or fix the key.",
+    "T8": "Stagger the events — one Titles track can only show one title at a time.",
+    "T9": "Pull the event inside the timeline, or re-mark the song on the version you title.",
+    "W1": "Add events to the song, or drop it from the file.",
+    "W2": "Expected while titling a set a song at a time; otherwise add the song.",
+}
+
+ANCHOR_COLOR: Final = "Blue"
+"""The reserved song-start colour (#14 §1). Every other marker colour is the director's."""
+
+
+@dataclass(frozen=True)
+class TemplateFacts:
+    """What the rules need to know about one declared template.
+
+    Gathered once from the media pool and then handed to a pure function, so the rules
+    never hold a Resolve handle. ``matches`` is a count rather than a handle because a
+    name that resolves to two clips is as unplaceable as one that resolves to none, and
+    both have to be said in the same sentence.
+    """
+
+    name: str
+    clip: str
+    bin_path: str | None
+    matches: int
+    found_in: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Event:
+    """One title, positioned absolutely and ready to place.
+
+    ``record_in`` is an absolute record frame — the timeline's own clock, the same one
+    ``recordFrame`` counts in — because the song anchor it came from was read in that
+    clock too. Nothing downstream re-derives it.
+    """
+
+    id: str
+    song: str
+    kind: str
+    route: str
+    template: str
+    text: str
+    record_in: int
+    duration: int
+    fade_in: int
+    fade_out: int
+    note: str
+
+    @property
+    def record_out(self) -> int:
+        """Half-open, and exactly what Resolve's ``endFrame`` measures against."""
+        return self.record_in + self.duration
+
+
+def _finding(rule: str, id: str | None, message: str, fix_hint: str | None = None) -> Finding:
+    return Finding(rule=rule, id=id, message=message, fix_hint=fix_hint or _FIX_HINTS[rule])
+
+
+def parse_failure_finding(detail: str) -> Finding:
+    """T1: the file is on disk but is not JSON, so no other rule can be answered."""
+    return _finding("T1", None, f"The titles file is not valid JSON: {detail}.")
+
+
+# --- shape (T1) ---------------------------------------------------------------------------
+
+
+def _is_int(value: Any) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _kind(value: Any) -> str:
+    return type(value).__name__
+
+
+def _shape_errors(doc: Any) -> Iterator[Finding]:
+    """Everything that makes the document unreadable, reported as T1."""
+    if not isinstance(doc, dict):
+        yield _finding("T1", None, f"The titles file must be a JSON object, got {_kind(doc)}.")
+        return
+
+    yield from _schema_version_errors(doc)
+    yield from _target_errors(doc)
+    yield from _templates_errors(doc)
+    yield from _songs_errors(doc)
+
+
+def _schema_version_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    version = doc.get("schema")
+    if version is None:
+        yield _finding("T1", None, "The titles file has no 'schema' version field.")
+    elif not _is_int(version):
+        yield _finding("T1", None, f"'schema' must be an integer, got {_kind(version)}.")
+    elif version != SCHEMA_VERSION:
+        yield _finding(
+            "T1",
+            None,
+            f"Titles-file schema {version} is not supported; this server serves "
+            f"schema {SCHEMA_VERSION}.",
+        )
+
+
+def _target_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    for field in ("timeline", "track"):
+        if field in doc and not (isinstance(doc[field], str) and doc[field].strip()):
+            yield _finding("T1", None, f"'{field}' must be a non-empty string when present.")
+
+
+def _templates_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    templates = doc.get("templates")
+    if not isinstance(templates, dict) or not templates:
+        yield _finding(
+            "T1",
+            None,
+            "'templates' must be a non-empty object of name -> {clip, bin}; a Text+ title "
+            "is placed from a template clip and there is no default one.",
+        )
+        return
+    for name, template in templates.items():
+        where = f"templates.{name}"
+        if not isinstance(template, dict):
+            yield _finding("T1", name, f"'{where}' must be an object with a 'clip' name.")
+            continue
+        if not isinstance(template.get("clip"), str) or not template["clip"]:
+            yield _finding("T1", name, f"'{where}.clip' must be a non-empty clip name.")
+        if "bin" in template and not isinstance(template["bin"], str):
+            yield _finding("T1", name, f"'{where}.bin' must be a string when present.")
+
+
+def _songs_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    songs = doc.get("songs")
+    if not isinstance(songs, list) or not songs:
+        yield _finding("T1", None, "'songs' must be a non-empty array; a titles file needs one.")
+        return
+    for index, song in enumerate(songs):
+        where = f"songs[{index}]"
+        if not isinstance(song, dict):
+            yield _finding("T1", None, f"'{where}' must be an object.")
+            continue
+        key = song.get("key") if isinstance(song.get("key"), str) else None
+        if not key:
+            yield _finding("T1", None, f"'{where}.key' must be a non-empty marker name.")
+        events = song.get("events")
+        if not isinstance(events, list):
+            yield _finding("T1", key, f"'{where}.events' must be an array.")
+            continue
+        for position, event in enumerate(events):
+            yield from _event_errors(event, f"{where}.events[{position}]", key)
+
+
+def _event_errors(event: Any, where: str, song: str | None) -> Iterator[Finding]:
+    if not isinstance(event, dict):
+        yield _finding("T1", song, f"'{where}' must be an object.")
+        return
+    id = event.get("id") if isinstance(event.get("id"), str) else None
+    if not id:
+        yield _finding("T1", song, f"'{where}.id' must be a non-empty string.")
+    if event.get("kind") not in KINDS:
+        yield _finding("T1", id, f"'{where}.kind' must be one of: {', '.join(KINDS)}.")
+    if "route" in event and event["route"] not in ROUTES:
+        yield _finding("T1", id, f"'{where}.route' must be one of: {', '.join(ROUTES)}.")
+    if "template" in event and not isinstance(event["template"], str):
+        yield _finding("T1", id, f"'{where}.template' must be a template name.")
+    if not isinstance(event.get("text"), str) or not event["text"].strip():
+        yield _finding(
+            "T1",
+            id,
+            f"'{where}.text' must be the non-empty string to show; the server never "
+            f"formats prose, so pass the final text.",
+        )
+    for edge in ("in", "out"):
+        if not _is_int(event.get(edge)):
+            yield _finding(
+                "T1",
+                id,
+                f"'{where}.{edge}' must be an integer frame offset from the song's marker, "
+                f"got {event.get(edge)!r}.",
+            )
+    if "note" in event and not isinstance(event["note"], str):
+        yield _finding("T1", id, f"'{where}.note' must be a string.")
+    yield from _fade_errors(event, where, id)
+
+
+def _fade_errors(event: dict[str, Any], where: str, id: str | None) -> Iterator[Finding]:
+    if "fade" not in event:
+        return
+    fade = event["fade"]
+    if not isinstance(fade, dict):
+        yield _finding("T1", id, f"'{where}.fade' must be an object: {{\"in\": 24, \"out\": 24}}.")
+        return
+    for edge in ("in", "out"):
+        if edge in fade and not (_is_int(fade[edge]) and fade[edge] >= 0):
+            yield _finding(
+                "T1",
+                id,
+                f"'{where}.fade.{edge}' must be a frame count of zero or more, "
+                f"got {fade[edge]!r}.",
+            )
+
+
+# --- the structural pass ------------------------------------------------------------------
+
+
+def validate_structure(doc: Any) -> list[Finding]:
+    """Every rule answerable from the document alone. Never mutates it.
+
+    A document that fails T1 is returned with T1 findings only: the later rules read
+    fields whose types they can no longer trust, so running them would report noise.
+    """
+    shape = list(_shape_errors(doc))
+    if shape:
+        return ordered(shape)
+
+    findings: list[Finding] = []
+    findings += _duplicate_errors(doc)
+    findings += _range_errors(doc)
+    findings += _fade_fit_errors(doc)
+    findings += _route_errors(doc)
+    findings += _declared_template_errors(doc)
+    findings += _empty_song_warnings(doc)
+    return ordered(findings)
+
+
+def _songs(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    songs: list[dict[str, Any]] = doc["songs"]
+    return songs
+
+
+def _events(doc: dict[str, Any]) -> Iterator[tuple[dict[str, Any], dict[str, Any]]]:
+    """Every event with the song it belongs to — the pair almost every rule needs."""
+    for song in _songs(doc):
+        for event in song["events"]:
+            yield song, event
+
+
+def _duplicate_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    """T2: two events with one id, or two songs with one key.
+
+    Both are reported rather than merged. A duplicate id makes the apply report
+    ambiguous, and a duplicate key would silently place one song's titles twice.
+    """
+    yield from _repeats([str(song["key"]) for song in _songs(doc)], "song key")
+    yield from _repeats([str(event["id"]) for _, event in _events(doc)], "event id")
+
+
+def _repeats(values: Sequence[str], what: str) -> Iterator[Finding]:
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            yield _finding("T2", value, f"Duplicate {what} {value!r}.")
+        seen.add(value)
+
+
+def _range_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    """T3: half-open ranges, so an event with no frames in it is an error, not a no-op."""
+    for _, event in _events(doc):
+        if int(event["out"]) <= int(event["in"]):
+            yield _finding(
+                "T3",
+                str(event["id"]),
+                f"in {event['in']} is not before out {event['out']}, so the title would "
+                f"have no frames.",
+            )
+
+
+def _fade_fit_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    """T4: a fade longer than the title it rides on never reaches full opacity."""
+    for _, event in _events(doc):
+        duration = int(event["out"]) - int(event["in"])
+        if duration <= 0:
+            continue  # T3 already said so; a second finding on the same event is noise
+        fade_in, fade_out = fades(event)
+        if fade_in + fade_out > duration:
+            yield _finding(
+                "T4",
+                str(event["id"]),
+                f"Fades of {fade_in} in and {fade_out} out do not fit in {duration} frames.",
+            )
+
+
+def fades(event: Mapping[str, Any]) -> tuple[int, int]:
+    """An event's fade lengths in frames; a missing ``fade`` block means a hard cut."""
+    fade = event.get("fade")
+    if not isinstance(fade, Mapping):
+        return (0, 0)
+    return (int(fade.get("in", 0)), int(fade.get("out", 0)))
+
+
+def _route_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    """T6: a route this build cannot place, named now rather than half-applied later."""
+    for _, event in _events(doc):
+        route = route_of(event)
+        if route not in SUPPORTED_ROUTES:
+            yield _finding(
+                "T6",
+                str(event["id"]),
+                f"Route {route!r} is not placed by this tool; it places "
+                f"{', '.join(SUPPORTED_ROUTES)}.",
+            )
+
+
+def route_of(event: Mapping[str, Any]) -> str:
+    return str(event.get("route", SUPPORTED_ROUTES[0]))
+
+
+def template_of(event: Mapping[str, Any]) -> str:
+    """The template an event is placed from: its own, or the one its kind implies."""
+    return str(event.get("template", event["kind"]))
+
+
+def _declared_template_errors(doc: dict[str, Any]) -> Iterator[Finding]:
+    """T5's first leg: a template the file never declared cannot be looked up at all."""
+    declared = set(doc["templates"])
+    for _, event in _events(doc):
+        wanted = template_of(event)
+        if wanted not in declared:
+            yield _finding(
+                "T5",
+                str(event["id"]),
+                f"No template called {wanted!r} is declared; the file declares "
+                f"{', '.join(sorted(declared))}.",
+            )
+
+
+def _empty_song_warnings(doc: dict[str, Any]) -> Iterator[Finding]:
+    for song in _songs(doc):
+        if not song["events"]:
+            yield _finding("W1", str(song["key"]), "This song has no title events.")
+
+
+# --- the project pass ---------------------------------------------------------------------
+
+
+def validate_project(
+    doc: dict[str, Any],
+    *,
+    anchors: Mapping[str, Sequence[int]],
+    templates: Sequence[TemplateFacts],
+    span: tuple[int, int],
+) -> list[Finding]:
+    """Every rule that needs the timeline and the pool, over facts already read from them.
+
+    ``anchors`` maps a marker name to every blue-marker record frame carrying it, so
+    "no such song" and "that song is marked twice" are one rule with two messages.
+    ``span`` is the timeline's own ``[start, end)`` in record frames.
+    """
+    findings: list[Finding] = []
+    findings += _template_resolution_errors(doc, templates)
+    findings += _anchor_errors(doc, anchors)
+    placed = plan(doc, anchors)
+    findings += _bounds_errors(placed, span)
+    findings += _overlap_errors(placed)
+    findings += _unused_anchor_warnings(doc, anchors)
+    return ordered(findings)
+
+
+def _template_resolution_errors(
+    doc: dict[str, Any],
+    templates: Sequence[TemplateFacts],
+) -> Iterator[Finding]:
+    """T5's second leg: the declared template must be exactly one clip in the pool."""
+    used = {template_of(event) for _, event in _events(doc)}
+    for facts in templates:
+        if facts.name not in used or facts.matches == 1:
+            continue
+        where = f" in {facts.bin_path!r}" if facts.bin_path else ""
+        if facts.matches == 0:
+            yield _finding(
+                "T5",
+                facts.name,
+                f"No clip called {facts.clip!r}{where} is in the media pool.",
+            )
+        else:
+            yield _finding(
+                "T5",
+                facts.name,
+                f"{facts.matches} clips are called {facts.clip!r}{where} "
+                f"(in {', '.join(facts.found_in)}); name the bin to pick one.",
+            )
+
+
+def _anchor_errors(
+    doc: dict[str, Any],
+    anchors: Mapping[str, Sequence[int]],
+) -> Iterator[Finding]:
+    """T7: the join to the timeline. Both failure modes place titles on the wrong music."""
+    for song in _songs(doc):
+        key = str(song["key"])
+        found = anchors.get(key, ())
+        if len(found) == 1:
+            continue
+        if not found:
+            known = ", ".join(sorted(anchors)) or "<none>"
+            yield _finding(
+                "T7",
+                key,
+                f"No {ANCHOR_COLOR.lower()} marker on the timeline is named {key!r}. "
+                f"It carries: {known}.",
+            )
+        else:
+            yield _finding(
+                "T7",
+                key,
+                f"{len(found)} {ANCHOR_COLOR.lower()} markers are named {key!r} "
+                f"(at record {', '.join(str(frame) for frame in sorted(found))}); "
+                f"a song key must name exactly one.",
+            )
+
+
+def plan(doc: dict[str, Any], anchors: Mapping[str, Sequence[int]]) -> list[Event]:
+    """Every event the file asks for, positioned absolutely, in document order.
+
+    Songs whose key does not resolve to exactly one marker are left out: T7 has already
+    said so, and a made-up anchor would produce findings about a position no one asked
+    for. The rules that follow therefore judge only what could actually be placed.
+    """
+    planned: list[Event] = []
+    for song in _songs(doc):
+        found = anchors.get(str(song["key"]), ())
+        if len(found) != 1:
+            continue
+        anchor = found[0]
+        for event in song["events"]:
+            fade_in, fade_out = fades(event)
+            planned.append(
+                Event(
+                    id=str(event["id"]),
+                    song=str(song["key"]),
+                    kind=str(event["kind"]),
+                    route=route_of(event),
+                    template=template_of(event),
+                    text=str(event["text"]),
+                    record_in=anchor + int(event["in"]),
+                    duration=int(event["out"]) - int(event["in"]),
+                    fade_in=fade_in,
+                    fade_out=fade_out,
+                    note=str(event.get("note", "")),
+                )
+            )
+    return planned
+
+
+def _bounds_errors(planned: Sequence[Event], span: tuple[int, int]) -> Iterator[Finding]:
+    """T9: a record frame outside the timeline is not clamped — it is placed nowhere."""
+    start, end = span
+    for event in planned:
+        if event.record_in < start or event.record_out > end:
+            yield _finding(
+                "T9",
+                event.id,
+                f"Record {event.record_in}-{event.record_out} falls outside the timeline's "
+                f"{start}-{end}.",
+            )
+
+
+def _overlap_errors(planned: Sequence[Event]) -> Iterator[Finding]:
+    """T8: one track, so two titles over one frame cannot both be placed.
+
+    Resolve would not refuse it — it slides the second append clear of the first and
+    reports success, which puts a title somewhere nobody chose. Reported against the
+    later event, since that is the one that would move.
+    """
+    for position, event in enumerate(planned):
+        for earlier in planned[:position]:
+            if ranges_overlap(
+                earlier.record_in, earlier.record_out, event.record_in, event.record_out
+            ):
+                yield _finding(
+                    "T8",
+                    event.id,
+                    f"Overlaps {earlier.id!r} — {event.record_in}-{event.record_out} against "
+                    f"{earlier.record_in}-{earlier.record_out} in record frames.",
+                )
+
+
+def _unused_anchor_warnings(
+    doc: dict[str, Any],
+    anchors: Mapping[str, Sequence[int]],
+) -> Iterator[Finding]:
+    titled = {str(song["key"]) for song in _songs(doc)}
+    for key in sorted(anchors):
+        if key not in titled:
+            yield _finding("W2", key, f"The song marked {key!r} has no entry in the titles file.")
+
+
+__all__ = [
+    "ANCHOR_COLOR",
+    "RULE_DESCRIPTIONS",
+    "Event",
+    "Finding",
+    "TemplateFacts",
+    "fades",
+    "parse_failure_finding",
+    "plan",
+    "route_of",
+    "severity_of",
+    "template_of",
+    "validate_project",
+    "validate_structure",
+]

--- a/src/resolve_mcp/tools/titles.py
+++ b/src/resolve_mcp/tools/titles.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..resolve import titles
+from ..resolve import apply, titles
 from ..resolve.connection import get_connection
 from .envelope import tool
 
@@ -60,7 +60,7 @@ def apply_titles(titles_file: str) -> dict[str, Any]:
     is current. The report says per title whether its fade read back — a fade that did
     not is the one thing here worth checking by eye in the GUI.
     """
-    return titles.apply_titles(get_connection(), titles_file)
+    return apply.apply_titles(get_connection(), titles_file)
 
 
 TOOLS: tuple[Any, ...] = (

--- a/src/resolve_mcp/tools/titles.py
+++ b/src/resolve_mcp/tools/titles.py
@@ -1,0 +1,72 @@
+"""The titling tools: the contract, the dry run, and the apply.
+
+Titles are declarative in the same way the cut is — you author `titles.json`, the server
+places it — but they never enter the cut file. The two files own different tracks, so a
+cut can be rebuilt and the same titles re-applied to the new version unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..resolve import titles
+from ..resolve.connection import get_connection
+from .envelope import tool
+
+
+@tool
+def get_titles_schema() -> dict[str, Any]:
+    """Return the titles-file schema v1, its annotated example, and the validation rules.
+
+    Read this before authoring or editing a titles file — the format is not guessable and
+    the example is the contract. In particular, event times are offsets from the song's
+    blue marker rather than timeline frames, which is what lets one titles file survive a
+    rebuild. `rules` lists every error that blocks an apply and every warning that does
+    not. Needs no project open.
+    """
+    return titles.get_titles_schema()
+
+
+@tool
+def validate_titles(titles_file: str) -> dict[str, Any]:
+    """Dry-run a titles file and return every error and warning it has, with fix hints.
+
+    Worth running after every edit: apply_titles runs the identical checks first, and
+    unlike a build it works on a timeline you already have — so knowing the file is good
+    before the Titles track is cleared is the cheap way round. Each finding names the
+    rule, the event or song it is about, what is wrong and how to fix it — all of them at
+    once, not the first.
+    """
+    return titles.validate_titles(get_connection(), titles_file)
+
+
+@tool
+def apply_titles(titles_file: str) -> dict[str, Any]:
+    """Place every event in a titles file onto the timeline's own Titles track.
+
+    Declarative and re-runnable: the topmost video track named `Titles` belongs to this
+    tool, and every apply clears it whole and re-places from the file, so the same file
+    always produces the same track. Nothing else on the timeline is touched — rebuild the
+    cut, mark the songs on the new version, re-apply this file unchanged.
+
+    Each song's events are positioned from the blue marker whose name is the song key, so
+    the file needs no timeline frames in it. Text comes from the file verbatim, and fades
+    are written as Fusion opacity keyframes inside each placed instance, because Resolve
+    exposes no clip-level fade to the API at all.
+
+    The validate_titles rules run first: a single error aborts before the track is
+    cleared, so a refused apply leaves the previous titles in place. The target timeline
+    is opened in Resolve as part of the apply, since an append lands on whatever timeline
+    is current. The report says per title whether its fade read back — a fade that did
+    not is the one thing here worth checking by eye in the GUI.
+    """
+    return titles.apply_titles(get_connection(), titles_file)
+
+
+TOOLS: tuple[Any, ...] = (
+    get_titles_schema,
+    validate_titles,
+    apply_titles,
+)
+
+__all__ = ["TOOLS", "apply_titles", "get_titles_schema", "validate_titles"]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -23,6 +23,24 @@ class DroppedHandleError(RuntimeError):
     """What a stale Resolve handle raises when the app has gone away."""
 
 
+class AnswersNone:
+    """A Resolve object whose ``missing`` methods answer ``None`` instead of raising.
+
+    That is how the real API expresses "this build does not have that method": fusionscript
+    answers *every* attribute name, so ``hasattr`` passes and the call then dies with
+    ``NoneType is not callable``. Verified live on Studio 21.0.3.7 (#41). A wrapper that
+    guarded with ``hasattr`` would pass against a fake that raised ``AttributeError``, so
+    no fake here does.
+    """
+
+    _missing: set[str]
+
+    def __getattribute__(self, name: str) -> Any:
+        if not name.startswith("_") and name in object.__getattribute__(self, "_missing"):
+            return None
+        return object.__getattribute__(self, name)
+
+
 class FakeSpline:
     """An animation modifier on one input: keyframes written by index assignment.
 
@@ -66,10 +84,6 @@ class FakeFusionTool:
     an animated value cannot be read back at a keyframe.
     """
 
-    _OWN = frozenset(
-        {"tool_id", "name", "inputs", "animated", "animatable", "reads_at_a_time"}
-    )
-
     def __init__(
         self,
         tool_id: str = "TextPlus",
@@ -79,6 +93,10 @@ class FakeFusionTool:
         animatable: bool = True,
         reads_at_a_time: bool = True,
     ) -> None:
+        # Every field is set while the node is still being built, so nothing here can be
+        # mistaken for an input connection — and no list of field names has to be kept in
+        # step with this signature for that to hold.
+        object.__setattr__(self, "_built", False)
         self.tool_id = tool_id
         self.name = name
         self.inputs: dict[str, Any] = dict(inputs or {"StyledText": "TEMPLATE"})
@@ -86,9 +104,10 @@ class FakeFusionTool:
         self.animatable = animatable
         self.reads_at_a_time = reads_at_a_time
         self._owner = owner
+        object.__setattr__(self, "_built", True)
 
     def __setattr__(self, key: str, value: Any) -> None:
-        if key.startswith("_") or key in FakeFusionTool._OWN:
+        if key.startswith("_") or not self._built:
             object.__setattr__(self, key, value)
             return
         self._check()
@@ -104,7 +123,8 @@ class FakeFusionTool:
         return self.__dict__.get("animated", {}).get(key)
 
     def copy(self) -> FakeFusionTool:
-        twin = FakeFusionTool(
+        """A fresh instance's node: the template's inputs, none of its animation."""
+        return FakeFusionTool(
             self.tool_id,
             self.name,
             dict(self.inputs),
@@ -112,7 +132,6 @@ class FakeFusionTool:
             self.animatable,
             self.reads_at_a_time,
         )
-        return twin
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
@@ -142,7 +161,7 @@ class FakeFusionTool:
         return spline.at(time) if spline is not None else self.inputs.get(key)
 
 
-class FakeFusionComp:
+class FakeFusionComp(AnswersNone):
     """A timeline item's Fusion composition.
 
     ``GetToolList`` is filtered by node type in the real API and returns a *one-based dict*
@@ -167,11 +186,6 @@ class FakeFusionComp:
         self.takes_keyframes = takes_keyframes
         self._missing = set(missing or ())
         self._owner = owner
-
-    def __getattribute__(self, name: str) -> Any:
-        if not name.startswith("_") and name in object.__getattribute__(self, "_missing"):
-            return None
-        return object.__getattribute__(self, name)
 
     def copy(self) -> FakeFusionComp:
         """What placing a template instance does: the new instance gets its own comp."""
@@ -216,7 +230,7 @@ class FakeFusionComp:
         return {index: tool for index, tool in enumerate(matching, start=1)}
 
 
-class FakeTimelineItem:
+class FakeTimelineItem(AnswersNone):
     """A clip on a track.
 
     ``GetEnd`` is deliberately configurable: the scripting docs do not say whether it is
@@ -271,14 +285,17 @@ class FakeTimelineItem:
     SOURCE_GETTERS = ("GetSourceStartFrame", "GetSourceEndFrame")
 
     def __getattribute__(self, name: str) -> Any:
-        """Hide the source getters entirely on a build that predates them."""
+        """Hide the source getters entirely on a build that predates them.
+
+        Absent is not the same as ``missing``: a Resolve older than 18.5 does not have
+        these at all, so ``getattr`` misses them — which is the branch the wrapper takes.
+        Everything else answers ``None`` the way :class:`AnswersNone` describes.
+        """
         if name in FakeTimelineItem.SOURCE_GETTERS and not object.__getattribute__(
             self, "_supports_source_frames"
         ):
             raise AttributeError(name)
-        if not name.startswith("_") and name in object.__getattribute__(self, "_missing"):
-            return None
-        return object.__getattribute__(self, name)
+        return super().__getattribute__(name)
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
@@ -378,7 +395,7 @@ def _as_tracks(spec: TrackSpec | None, label: str) -> list[FakeTrack]:
     return tracks
 
 
-class FakeTimeline:
+class FakeTimeline(AnswersNone):
     def __init__(
         self,
         name: str,
@@ -420,12 +437,6 @@ class FakeTimeline:
         # can only find by re-reading the track — the same shape as a locked-track append.
         self.delete_clips_leaves_them = False
         self.deleted_clips: list[tuple[list[FakeTimelineItem], bool]] = []
-
-    def __getattribute__(self, name: str) -> Any:
-        """A method this build does not have answers ``None``, as fusionscript does."""
-        if not name.startswith("_") and name in object.__getattribute__(self, "_missing"):
-            return None
-        return object.__getattribute__(self, name)
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -23,12 +23,52 @@ class DroppedHandleError(RuntimeError):
     """What a stale Resolve handle raises when the app has gone away."""
 
 
+class FakeSpline:
+    """An animation modifier on one input: keyframes written by index assignment.
+
+    That is the whole Fusion keyframe API from Python — ``tool.Opacity1[frame] = value``
+    once a spline is connected. ``takes_keyframes=False`` models the bridge refusing the
+    assignment, which is a ``TypeError`` rather than a return value.
+    """
+
+    def __init__(self, takes_keyframes: bool = True) -> None:
+        self.keyframes: dict[float, float] = {}
+        self.takes_keyframes = takes_keyframes
+
+    def __setitem__(self, frame: Any, value: Any) -> None:
+        if not self.takes_keyframes:
+            raise TypeError("'FakeSpline' object does not support item assignment")
+        self.keyframes[float(frame)] = float(value)
+
+    def __getitem__(self, frame: Any) -> float | None:
+        return self.keyframes.get(float(frame))
+
+    def at(self, frame: Any) -> float | None:
+        """What the animated input reads at a time — a keyframe or nothing between them."""
+        return self.keyframes.get(float(frame))
+
+
 class FakeFusionTool:
     """One node inside a Fusion comp; for titling only the Text+ node matters.
 
     ``SetInput`` returns ``None`` in the real API — it reports nothing, so the only way to
     know a write landed is to read it back, which is what the probe does.
+
+    Attribute access is the other half of the Fusion API and behaves nothing like Python's:
+    an input is *connected* to a modifier by assigning to an attribute named after it
+    (``tool.Opacity1 = comp.BezierSpline()``), and every attribute name answers — an input
+    this node does not have reads back as ``None`` rather than raising. Both are modelled,
+    because a wrapper that guarded with ``hasattr`` would pass here and fail live.
+
+    ``animatable=False`` models a node that has no such input at all: the assignment is
+    accepted, nothing is connected, and the attribute still reads back as ``None``.
+    ``reads_at_a_time=False`` models a build whose ``GetInput`` takes no time argument, so
+    an animated value cannot be read back at a keyframe.
     """
+
+    _OWN = frozenset(
+        {"tool_id", "name", "inputs", "animated", "animatable", "reads_at_a_time"}
+    )
 
     def __init__(
         self,
@@ -36,14 +76,43 @@ class FakeFusionTool:
         name: str = "Template Text",
         inputs: dict[str, Any] | None = None,
         owner: FakeResolve | None = None,
+        animatable: bool = True,
+        reads_at_a_time: bool = True,
     ) -> None:
         self.tool_id = tool_id
         self.name = name
         self.inputs: dict[str, Any] = dict(inputs or {"StyledText": "TEMPLATE"})
+        self.animated: dict[str, FakeSpline] = {}
+        self.animatable = animatable
+        self.reads_at_a_time = reads_at_a_time
         self._owner = owner
 
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key.startswith("_") or key in FakeFusionTool._OWN:
+            object.__setattr__(self, key, value)
+            return
+        self._check()
+        if not self.animatable:
+            return  # accepted and dropped, exactly as a node without the input answers
+        self.animated[key] = value
+
+    def __getattr__(self, key: str) -> Any:
+        # Only reached when normal lookup failed, which for fusionscript means "an input
+        # or a method this build does not have" — and that answers None, never raises.
+        if key.startswith("_"):
+            raise AttributeError(key)
+        return self.__dict__.get("animated", {}).get(key)
+
     def copy(self) -> FakeFusionTool:
-        return FakeFusionTool(self.tool_id, self.name, dict(self.inputs), self._owner)
+        twin = FakeFusionTool(
+            self.tool_id,
+            self.name,
+            dict(self.inputs),
+            self._owner,
+            self.animatable,
+            self.reads_at_a_time,
+        )
+        return twin
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
@@ -62,9 +131,15 @@ class FakeFusionTool:
         self._check()
         self.inputs[key] = value
 
-    def GetInput(self, key: str) -> Any:  # noqa: N802
+    def GetInput(self, key: str, time: Any = None) -> Any:  # noqa: N802
+        """The input's value, at a time when one is asked for and the build answers for it."""
         self._check()
-        return self.inputs.get(key)
+        if time is None:
+            return self.inputs.get(key)
+        if not self.reads_at_a_time:
+            raise TypeError("GetInput() takes 2 positional arguments but 3 were given")
+        spline = self.animated.get(key)
+        return spline.at(time) if spline is not None else self.inputs.get(key)
 
 
 class FakeFusionComp:
@@ -72,19 +147,41 @@ class FakeFusionComp:
 
     ``GetToolList`` is filtered by node type in the real API and returns a *one-based dict*
     rather than a list — a comp with no matching node answers an empty dict, not ``None``.
+
+    ``render_range`` is what ``GetAttrs`` reports as the comp's own frame range, which is
+    the clock a keyframe time is counted in; ``None`` models a comp that will not say, so
+    the caller has to fall back to the placed instance's length. ``missing`` hides a method
+    the way fusionscript does — answering ``None`` rather than raising.
     """
 
     def __init__(
         self,
         tools: Sequence[FakeFusionTool] | None = None,
         owner: FakeResolve | None = None,
+        render_range: tuple[int, int] | None = (0, 119),
+        takes_keyframes: bool = True,
+        missing: frozenset[str] | set[str] | None = None,
     ) -> None:
         self.tools: list[FakeFusionTool] = list(tools if tools is not None else [FakeFusionTool()])
+        self.render_range = render_range
+        self.takes_keyframes = takes_keyframes
+        self._missing = set(missing or ())
         self._owner = owner
+
+    def __getattribute__(self, name: str) -> Any:
+        if not name.startswith("_") and name in object.__getattribute__(self, "_missing"):
+            return None
+        return object.__getattribute__(self, name)
 
     def copy(self) -> FakeFusionComp:
         """What placing a template instance does: the new instance gets its own comp."""
-        return FakeFusionComp([tool.copy() for tool in self.tools], self._owner)
+        return FakeFusionComp(
+            [tool.copy() for tool in self.tools],
+            self._owner,
+            self.render_range,
+            self.takes_keyframes,
+            set(self._missing),
+        )
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
@@ -94,6 +191,20 @@ class FakeFusionComp:
     def _check(self) -> None:
         if self._owner is not None:
             self._owner._check()
+
+    def GetAttrs(self, key: str | None = None) -> Any:  # noqa: N802
+        """The comp's own attributes; the render range is the one titling reads."""
+        self._check()
+        if self.render_range is None:
+            return {}
+        start, end = self.render_range
+        attrs = {"COMPN_RenderStart": start, "COMPN_RenderEnd": end}
+        return attrs if key is None else attrs.get(key)
+
+    def BezierSpline(self) -> FakeSpline:  # noqa: N802
+        """Fusion's constructor-style tool creation: ``comp.BezierSpline()`` makes one."""
+        self._check()
+        return FakeSpline(self.takes_keyframes)
 
     def GetToolList(  # noqa: N802
         self,
@@ -279,8 +390,10 @@ class FakeTimeline:
         # normally, but the type is not the fake's to promise, and the wrapper parses them.
         markers: dict[Any, dict[str, Any]] | None = None,
         end_frame: int | None = None,
+        missing: frozenset[str] | set[str] | None = None,
         owner: FakeResolve | None = None,
     ) -> None:
+        self._missing = set(missing or ())
         self._name = name
         self._fps = fps
         self._start_frame = start_frame
@@ -302,6 +415,17 @@ class FakeTimeline:
         self.export_result = True
         self.export_writes_the_file = True
         self.add_track_result = True
+        self.set_track_name_result = True
+        # A clear that answers True and leaves the clips standing is the failure a caller
+        # can only find by re-reading the track — the same shape as a locked-track append.
+        self.delete_clips_leaves_them = False
+        self.deleted_clips: list[tuple[list[FakeTimelineItem], bool]] = []
+
+    def __getattribute__(self, name: str) -> Any:
+        """A method this build does not have answers ``None``, as fusionscript does."""
+        if not name.startswith("_") and name in object.__getattribute__(self, "_missing"):
+            return None
+        return object.__getattribute__(self, name)
 
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
@@ -453,6 +577,36 @@ class FakeTimeline:
             return False
         tracks = self._tracks.setdefault(track_type, [])
         tracks.append(FakeTrack(f"{track_type.capitalize()} {len(tracks) + 1}"))
+        return True
+
+    def SetTrackName(self, track_type: str, index: int, name: str) -> bool:  # noqa: N802
+        """Rename a track. Resolve refuses with a bare ``False`` and never says why."""
+        self._check()
+        track = self._track(track_type, index)
+        if track is None or not self.set_track_name_result:
+            return False
+        track.name = name
+        return True
+
+    def DeleteClips(  # noqa: N802
+        self,
+        items: list[FakeTimelineItem],
+        ripple: bool = False,
+    ) -> bool:
+        """Remove items from whichever track holds them, recording the ripple flag.
+
+        The flag is recorded rather than acted on: what matters to a caller that owns one
+        track is that it never asks for a ripple, because that would drag the cut on the
+        tracks below along with the titles it deleted.
+        """
+        self._check()
+        self.deleted_clips.append((list(items), bool(ripple)))
+        if self.delete_clips_leaves_them:
+            return True
+        wanted = {id(item) for item in items}
+        for tracks in self._tracks.values():
+            for track in tracks:
+                track.items = [held for held in track.items if id(held) not in wanted]
         return True
 
     def place(self, track_type: str, index: int, item: FakeTimelineItem) -> None:
@@ -914,6 +1068,12 @@ class FakeMediaPool:
         track_type = "audio" if media_type == AUDIO_TYPE else "video"
         index = int(info.get("trackIndex", 1))
         record = int(info.get("recordFrame", _track_end(timeline, track_type, index)))
+
+        # A placed instance's comp is rendered over the instance, so its render range is
+        # the clip's own length — which is the clock a keyframe on it is counted in.
+        for comp in comps:
+            if comp.render_range is not None:
+                comp.render_range = (0, duration - 1)
 
         item = FakeTimelineItem(
             clip.GetName(),

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -17,7 +17,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from resolve_mcp.cut.document import content_hash
+from resolve_mcp.document import content_hash
 from resolve_mcp.tools.cut import build_timeline
 
 from .conftest import Attach

--- a/tests/test_cut_validate.py
+++ b/tests/test_cut_validate.py
@@ -14,11 +14,11 @@ import pytest
 
 from resolve_mcp.cut.validate import (
     ClipFacts,
-    Finding,
     locked_track_finding,
     validate_project,
     validate_structure,
 )
+from resolve_mcp.findings import Finding
 
 
 def valid_doc() -> dict[str, Any]:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -29,7 +29,9 @@ import pytest
 
 from resolve_mcp.audio.acquire import acquire_timeline_audio
 from resolve_mcp.jobs.runner import wait_for
+from resolve_mcp.naming import timestamped_name
 from resolve_mcp.resolve.connection import get_connection
+from resolve_mcp.resolve.media import find_clip, media_pool
 from resolve_mcp.tools.cut import build_timeline, validate_cut
 from resolve_mcp.tools.escape_hatch import run_python
 from resolve_mcp.tools.jobs import get_job, list_jobs
@@ -42,6 +44,7 @@ from resolve_mcp.tools.timeline import (
     list_markers,
     list_timelines,
 )
+from resolve_mcp.tools.titles import apply_titles
 
 from . import otio
 from .text_plus_probe import TEMPLATE_ENV, probe_template_append
@@ -543,3 +546,126 @@ def test_the_text_plus_template_route_survives_a_drb_round_trip() -> None:
     print("\n" + report.render())
     assert report.per_instance_text, report.render()
     assert report.cleaned_up, report.render()
+
+
+TITLES_TEMPLATE_ENV = "RESOLVE_MCP_TITLES_TEMPLATE"
+"""The media-pool clip *name* of an imported Text+ template — not a path; #41 imports it."""
+
+SMOKE_SONGS = ("smoke-song-one", "smoke-song-two")
+FILLER_FRAMES = 120
+"""Long enough to hold two short titles, short enough for a stock five-second template."""
+
+TITLE_FRAMES = 50
+FADE_FRAMES = 12
+
+
+def test_apply_titles_places_text_plus_instances_with_their_own_text_and_fades(
+    tmp_path: Path,
+) -> None:
+    """#42 ACs 1, 2 and 4: the titles land at the right frames with the right words, the
+    opacity spline reads back, and a second apply replaces rather than stacks.
+
+    Runs on a scratch timeline it creates, marks, titles and deletes again — the same
+    shape as the #41 probe, so it never touches the cut anyone is reviewing. The template
+    must already be in the media pool (import its `.drb` once); pass its clip name.
+
+    Paste the printed report onto the ticket — that is the record the ticket asks for.
+    """
+    wanted = os.environ.get(TITLES_TEMPLATE_ENV, "").strip()
+    if not wanted:
+        pytest.skip(f"Set {TITLES_TEMPLATE_ENV} to the pool clip name of a Text+ template")
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+
+    connection = get_connection()
+    pool = media_pool(connection)
+    project = connection.handle().GetProjectManager().GetCurrentProject()
+    template = find_clip(pool, wanted)
+    was_on = project.GetCurrentTimeline()
+
+    name = timestamped_name("apply-titles-smoke", "", "apply-titles-smoke")
+    scratch = pool.CreateEmptyTimeline(name)
+    assert scratch is not None, f"Resolve created no timeline called {name!r}"
+    try:
+        assert project.SetCurrentTimeline(scratch), f"Resolve would not open {name!r}"
+        start = int(scratch.GetStartFrame())
+        # Something on V1 so the timeline has a span for the titles to land inside.
+        placed = pool.AppendToTimeline(
+            [
+                {
+                    "mediaPoolItem": template.clip,
+                    "startFrame": 0,
+                    "endFrame": FILLER_FRAMES,
+                    "mediaType": 1,
+                    "trackIndex": 1,
+                    "recordFrame": start,
+                }
+            ]
+        )
+        assert placed, f"{wanted!r} would not append at {FILLER_FRAMES} frames — too short?"
+        for offset, key in zip((0, 60), SMOKE_SONGS, strict=True):
+            assert scratch.AddMarker(offset, "Blue", key, "apply_titles smoke", 1), (
+                f"Resolve refused a blue marker at {offset}"
+            )
+
+        file = tmp_path / "titles.json"
+        file.write_text(json.dumps(_smoke_titles(name, wanted)), encoding="utf-8")
+
+        result = apply_titles(str(file))
+        again = apply_titles(str(file))
+
+        print("\n" + _render_titles(result, again))
+        assert result["ok"] is True, result.get("error")
+        assert [one["id"] for one in result["placed"]] == ["smoke-01", "smoke-02"]
+        assert [one["record"]["frames"] for one in result["placed"]] == [start, start + 60]
+        assert again["ok"] is True, again.get("error")
+        assert again["cleared"] == 2, "a second apply must replace the titles, not stack them"
+    finally:
+        if was_on is not None:
+            project.SetCurrentTimeline(was_on)
+        pool.DeleteTimelines([scratch])
+
+
+def _smoke_titles(timeline: str, template: str) -> dict[str, Any]:
+    return {
+        "schema": 1,
+        "timeline": timeline,
+        "templates": {"title": {"clip": template}},
+        "songs": [
+            {
+                "key": key,
+                "events": [
+                    {
+                        "id": f"smoke-0{position}",
+                        "kind": "title",
+                        "text": f"Live smoke {position}",
+                        "in": 0,
+                        "out": TITLE_FRAMES,
+                        "fade": {"in": FADE_FRAMES, "out": FADE_FRAMES},
+                    }
+                ],
+            }
+            for position, key in enumerate(SMOKE_SONGS, start=1)
+        ],
+    }
+
+
+def _render_titles(first: dict[str, Any], second: dict[str, Any]) -> str:
+    """The report the ticket asks for: what landed, and what the fades said."""
+    if not first["ok"]:
+        return f"apply failed: {first['error']['cause']}\nfix: {first['error']['fix']}"
+    lines = [
+        f"timeline:      {first['timeline']['name']}",
+        f"track:         {first['track']['name']} "
+        f"(video {first['track']['index']}, created={first['track']['created']})",
+        f"second apply:  cleared {second.get('cleared')}, ok={second['ok']}",
+    ]
+    for one in first["placed"]:
+        lines.append(
+            f"  {one['id']}: {one['text']!r} @ {one['record']['frames']} for "
+            f"{one['duration']['frames']}f — node {one['node']['name']!r} "
+            f"({one['node']['text_plus_in_comp']} Text+ in comp), fade "
+            f"{one['fade']['in']}/{one['fade']['out']} verified={one['fade']['verified']} "
+            f"({one['fade']['detail']})"
+        )
+    return "\n".join(lines)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,7 +17,7 @@ def descriptions() -> dict[str, str]:
     return {tool.name: tool.description or "" for tool in tools}
 
 
-def test_registers_the_p1_session_media_timeline_cut_and_job_tools() -> None:
+def test_registers_the_session_media_timeline_cut_titling_and_job_tools() -> None:
     assert tool_names() == {
         "get_status",
         "list_projects",
@@ -38,6 +38,9 @@ def test_registers_the_p1_session_media_timeline_cut_and_job_tools() -> None:
         "get_cut_schema",
         "validate_cut",
         "build_timeline",
+        "get_titles_schema",
+        "validate_titles",
+        "apply_titles",
         "get_job",
         "list_jobs",
         "run_python",

--- a/tests/test_titles_tools.py
+++ b/tests/test_titles_tools.py
@@ -291,6 +291,62 @@ def test_the_clear_is_never_a_ripple_delete(attach: Attach, tmp_path: Path) -> N
     assert [ripple for _, ripple in timeline.deleted_clips] == [False]
 
 
+def test_the_same_file_lands_on_a_rebuilt_version_at_its_own_markers(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """AC3, and the reason offsets are counted from markers rather than timeline frames.
+
+    A rebuild produces a new version whose songs sit at different absolute frames — a
+    tightened segment moves everything after it. The titles file is applied unchanged to
+    both, and lands correctly on both, because it never mentions a timeline frame.
+    """
+    v3 = a_timeline("sunset-set v3")
+    v4 = a_timeline(
+        "sunset-set v4",
+        markers={0: a_marker("sunset-boulevard"), 4200: a_marker("night-ferry")},
+    )
+    a_session(attach, timeline=v3, timelines=[v3, v4])
+    file = a_titles_file(tmp_path, valid_doc())
+
+    apply_titles(file)
+    rebuilt = apply_titles(a_titles_file(tmp_path, valid_doc(timeline="sunset-set v4")))
+
+    assert rebuilt["ok"] is True
+    assert [item.GetStart() for item in titles_on(v3)] == [
+        SONG_ONE + 240,
+        SONG_ONE + 960,
+        SONG_TWO + 120,
+    ]
+    # night-ferry is 800 frames earlier on v4, and its title moved with it.
+    assert [item.GetStart() for item in titles_on(v4)] == [
+        SONG_ONE + 240,
+        SONG_ONE + 960,
+        SONG_ONE + 4200 + 120,
+    ]
+    assert [text_of(item) for item in titles_on(v4)] == [
+        "Sunset Boulevard",
+        "Bass — Ana Ruiz",
+        "Night Ferry",
+    ]
+
+
+def test_a_rebuilt_version_gets_its_own_titles_track_and_leaves_the_old_one_alone(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    v3 = a_timeline("sunset-set v3")
+    v4 = a_timeline("sunset-set v4")
+    a_session(attach, timeline=v3, timelines=[v3, v4])
+
+    apply_titles(a_titles_file(tmp_path, valid_doc()))
+    second = apply_titles(a_titles_file(tmp_path, valid_doc(timeline="sunset-set v4")))
+
+    assert second["track"]["created"] is True
+    assert second["cleared"] == 0, "a fresh version has no titles of its own to clear"
+    assert len(titles_on(v3)) == 3
+
+
 def test_an_existing_titles_track_is_adopted_rather_than_added(
     attach: Attach,
     tmp_path: Path,
@@ -317,14 +373,6 @@ def test_the_topmost_titles_track_wins_when_the_project_has_two(
 
     assert result["track"]["index"] == 3
     assert len(titles_on(timeline, 3)) == 3
-
-
-def test_the_track_name_can_be_chosen_in_the_file(attach: Attach, tmp_path: Path) -> None:
-    timeline = a_session(attach)
-    result = apply_titles(a_titles_file(tmp_path, valid_doc(track="Lower Thirds")))
-
-    assert result["track"]["name"] == "Lower Thirds"
-    assert timeline.GetTrackName("video", TITLES_TRACK) == "Lower Thirds"
 
 
 # --- fades ------------------------------------------------------------------------------
@@ -361,11 +409,26 @@ def test_an_event_with_no_fade_block_gets_no_spline_at_all(
                                  "detail": "no fade asked for"}
 
 
-def test_a_fade_in_only_leaves_the_title_up_at_the_end(attach: Attach, tmp_path: Path) -> None:
+def test_a_fade_in_only_holds_full_opacity_to_the_last_frame(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """The end is keyframed even though it is not fading: what a spline does past its
+    last keyframe is an extrapolation setting nobody here has set."""
     timeline = a_session(attach)
     apply_titles(a_titles_file(tmp_path, one_event(fade={"in": 24})))
 
-    assert keyframes_of(titles_on(timeline)[0]) == {0.0: 0.0, 24.0: 1.0}
+    assert keyframes_of(titles_on(timeline)[0]) == {0.0: 0.0, 24.0: 1.0, 479.0: 1.0}
+
+
+def test_a_fade_out_only_holds_full_opacity_from_the_first_frame(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    apply_titles(a_titles_file(tmp_path, one_event(fade={"out": 36})))
+
+    assert keyframes_of(titles_on(timeline)[0]) == {0.0: 1.0, 443.0: 1.0, 479.0: 0.0}
 
 
 def test_a_build_that_cannot_animate_still_places_the_title(

--- a/tests/test_titles_tools.py
+++ b/tests/test_titles_tools.py
@@ -1,0 +1,728 @@
+"""apply_titles at the Resolve seam: what lands on the Titles track, and what never starts.
+
+Three things are under test and nothing else matters as much:
+
+* a valid titles file becomes frame-exact Text+ instances on one owned track, each with
+  its own words and its own opacity spline;
+* running it again produces the same track rather than a second copy of it, which is the
+  whole point of a declarative apply — rebuild the cut, re-apply the titles;
+* everything that could half-apply one — an invalid file, a song with no marker, a locked
+  track, a clear that did not clear, an append that slid, instances sharing one comp —
+  stops with a structured failure, and the ones that can stop *before* the track is
+  cleared do.
+
+The fake models the append footguns confirmed on live Resolve (#18) and the Fusion ones
+found by the Text+ probe (#41): a template whose instances share a comp, a build that
+answers ``None`` for a method it does not have, an input that will not animate. A wrapper
+that trusted Resolve's return value fails these tests rather than a real concert.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.tools.titles import apply_titles, get_titles_schema, validate_titles
+
+from .conftest import Attach
+from .fakes import (
+    FakeFusionComp,
+    FakeFusionTool,
+    FakeMediaPool,
+    FakeMediaPoolItem,
+    FakeTimeline,
+    FakeTimelineItem,
+    FakeTrack,
+    media_pool,
+    studio,
+    text_plus_template,
+)
+
+TITLES_TRACK = 2
+"""Where the tool puts its own track on a timeline that arrives with one video track."""
+
+SONG_ONE = 3600
+"""Record frame of the first blue marker — the timeline starts at an hour of timecode."""
+
+SONG_TWO = 9000
+
+
+def a_titles_file(tmp_path: Path, doc: Any, name: str = "titles.json") -> str:
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def valid_doc(**overrides: Any) -> dict[str, Any]:
+    """A title card and a personnel card on one song, a title on the next."""
+    doc: dict[str, Any] = {
+        "schema": 1,
+        "templates": {
+            "title": {"clip": "Song Title", "bin": "Titles/Templates"},
+            "personnel": {"clip": "Personnel"},
+        },
+        "songs": [
+            {
+                "key": "sunset-boulevard",
+                "events": [
+                    {
+                        "id": "t01",
+                        "kind": "title",
+                        "text": "Sunset Boulevard",
+                        "in": 240,
+                        "out": 720,
+                        "fade": {"in": 24, "out": 36},
+                    },
+                    {
+                        "id": "t02",
+                        "kind": "personnel",
+                        "text": "Bass — Ana Ruiz",
+                        "in": 960,
+                        "out": 1320,
+                    },
+                ],
+            },
+            {
+                "key": "night-ferry",
+                "events": [
+                    {"id": "t03", "kind": "title", "text": "Night Ferry", "in": 120, "out": 480}
+                ],
+            },
+        ],
+    }
+    doc.update(overrides)
+    return doc
+
+
+def one_event(**overrides: Any) -> dict[str, Any]:
+    """The smallest file that places something: one song, one title, no fade."""
+    event: dict[str, Any] = {
+        "id": "t01",
+        "kind": "title",
+        "text": "Sunset Boulevard",
+        "in": 240,
+        "out": 720,
+    }
+    event.update(overrides)
+    return valid_doc(songs=[{"key": "sunset-boulevard", "events": [event]}])
+
+
+def a_marker(name: str, color: str = "Blue") -> dict[str, Any]:
+    return {"color": color, "name": name, "note": "", "duration": 1, "customData": ""}
+
+
+def a_timeline(
+    name: str = "sunset-set v3",
+    video: list[FakeTrack] | None = None,
+    markers: dict[Any, dict[str, Any]] | None = None,
+    missing: set[str] | None = None,
+) -> FakeTimeline:
+    """A built cut at an hour of timecode, with its songs marked in blue."""
+    return FakeTimeline(
+        name,
+        start_frame=SONG_ONE,
+        end_frame=20000,
+        missing=missing,
+        video=video
+        if video is not None
+        else [FakeTrack("Video 1", [FakeTimelineItem("C0012.mp4", SONG_ONE, 12000)])],
+        markers=markers
+        if markers is not None
+        else {
+            0: a_marker("sunset-boulevard"),
+            SONG_TWO - SONG_ONE: a_marker("night-ferry"),
+            120: a_marker("tighten this", color="Red"),
+        },
+    )
+
+
+def a_pool(**templates: FakeMediaPoolItem) -> FakeMediaPool:
+    return media_pool(
+        {
+            "Titles/Templates": [templates.get("title", text_plus_template("Song Title"))],
+            "Titles": [templates.get("personnel", text_plus_template("Personnel"))],
+        }
+    )
+
+
+def a_session(
+    attach: Attach,
+    timeline: FakeTimeline | None = None,
+    pool: FakeMediaPool | None = None,
+    timelines: list[FakeTimeline] | None = None,
+) -> FakeTimeline:
+    """Attach a Studio with one marked cut open and the two templates in the pool."""
+    cut = timeline if timeline is not None else a_timeline()
+    held: list[FakeTimeline | None] = list(timelines or [cut])
+    attach(studio(timeline=cut, timelines=held, pool=pool or a_pool()))
+    return cut
+
+
+def titles_on(timeline: FakeTimeline, track: int = TITLES_TRACK) -> list[FakeTimelineItem]:
+    return list(timeline.GetItemListInTrack("video", track) or [])
+
+
+def text_of(item: FakeTimelineItem) -> Any:
+    return item.comps[0].tools[0].GetInput("StyledText")
+
+
+def keyframes_of(item: FakeTimelineItem) -> dict[float, float]:
+    spline = item.comps[0].tools[0].animated.get("Opacity1")
+    return {} if spline is None else spline.keyframes
+
+
+# --- the happy path ---------------------------------------------------------------------
+
+
+def test_a_titles_file_lands_on_its_own_track_at_the_right_frames(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["ok"] is True
+    assert [(item.GetStart(), item.GetDuration()) for item in titles_on(timeline)] == [
+        (SONG_ONE + 240, 480),
+        (SONG_ONE + 960, 360),
+        (SONG_TWO + 120, 360),
+    ]
+
+
+def test_every_instance_gets_its_own_words(attach: Attach, tmp_path: Path) -> None:
+    timeline = a_session(attach)
+    apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert [text_of(item) for item in titles_on(timeline)] == [
+        "Sunset Boulevard",
+        "Bass — Ana Ruiz",
+        "Night Ferry",
+    ]
+
+
+def test_the_track_is_created_named_and_left_on_top(attach: Attach, tmp_path: Path) -> None:
+    timeline = a_session(attach)
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["track"] == {"index": TITLES_TRACK, "name": "Titles", "created": True}
+    assert timeline.GetTrackName("video", TITLES_TRACK) == "Titles"
+    assert timeline.GetTrackCount("video") == TITLES_TRACK
+
+
+def test_the_cut_underneath_is_never_touched(attach: Attach, tmp_path: Path) -> None:
+    timeline = a_session(attach)
+    apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    v1 = timeline.GetItemListInTrack("video", 1) or []
+    assert [(item.GetName(), item.GetStart()) for item in v1] == [("C0012.mp4", SONG_ONE)]
+
+
+def test_the_report_names_every_title_it_placed(attach: Attach, tmp_path: Path) -> None:
+    a_session(attach)
+    placed = apply_titles(a_titles_file(tmp_path, valid_doc()))["placed"]
+
+    assert [one["id"] for one in placed] == ["t01", "t02", "t03"]
+    assert placed[0]["song"] == "sunset-boulevard"
+    assert placed[0]["template"] == "title"
+    assert placed[0]["record"]["frames"] == SONG_ONE + 240
+    assert placed[0]["duration"]["frames"] == 480
+    assert placed[0]["node"]["name"] == "Template Text"
+
+
+def test_the_report_echoes_the_file_it_applied(attach: Attach, tmp_path: Path) -> None:
+    a_session(attach)
+    file = a_titles_file(tmp_path, valid_doc())
+    result = apply_titles(file)
+
+    assert result["titles_file"] == file
+    assert len(result["content_hash"]) == 32
+
+
+def test_a_marked_song_with_no_titles_is_reported_as_a_warning(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    a_session(attach)
+    result = apply_titles(a_titles_file(tmp_path, one_event()))
+
+    assert [warning["rule"] for warning in result["warnings"]] == ["W2"]
+    assert result["ok"] is True
+
+
+# --- re-running -------------------------------------------------------------------------
+
+
+def test_applying_twice_replaces_the_titles_rather_than_stacking_them(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    file = a_titles_file(tmp_path, valid_doc())
+
+    first = apply_titles(file)
+    second = apply_titles(file)
+
+    assert (first["cleared"], second["cleared"]) == (0, 3)
+    assert second["track"]["created"] is False
+    assert len(titles_on(timeline)) == 3
+
+
+def test_a_re_run_after_an_edit_shows_the_new_words_and_nothing_of_the_old(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    apply_titles(a_titles_file(tmp_path, one_event()))
+    apply_titles(a_titles_file(tmp_path, one_event(text="Sunset Blvd.", out=600)))
+
+    assert [(text_of(item), item.GetDuration()) for item in titles_on(timeline)] == [
+        ("Sunset Blvd.", 360)
+    ]
+
+
+def test_the_clear_is_never_a_ripple_delete(attach: Attach, tmp_path: Path) -> None:
+    """A ripple would drag the cut on the tracks below along with the titles."""
+    timeline = a_session(attach)
+    file = a_titles_file(tmp_path, valid_doc())
+    apply_titles(file)
+    apply_titles(file)
+
+    assert [ripple for _, ripple in timeline.deleted_clips] == [False]
+
+
+def test_an_existing_titles_track_is_adopted_rather_than_added(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(
+        attach,
+        a_timeline(video=[FakeTrack("Video 1"), FakeTrack("Titles")]),
+    )
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["track"] == {"index": TITLES_TRACK, "name": "Titles", "created": False}
+    assert timeline.GetTrackCount("video") == TITLES_TRACK
+
+
+def test_the_topmost_titles_track_wins_when_the_project_has_two(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(
+        attach,
+        a_timeline(video=[FakeTrack("Titles"), FakeTrack("Video 2"), FakeTrack("Titles")]),
+    )
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["track"]["index"] == 3
+    assert len(titles_on(timeline, 3)) == 3
+
+
+def test_the_track_name_can_be_chosen_in_the_file(attach: Attach, tmp_path: Path) -> None:
+    timeline = a_session(attach)
+    result = apply_titles(a_titles_file(tmp_path, valid_doc(track="Lower Thirds")))
+
+    assert result["track"]["name"] == "Lower Thirds"
+    assert timeline.GetTrackName("video", TITLES_TRACK) == "Lower Thirds"
+
+
+# --- fades ------------------------------------------------------------------------------
+
+
+def test_a_fade_is_written_as_opacity_keyframes_over_the_instance(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    # The instance is 480 frames, so its comp renders 0-479: up over 24, down over 36.
+    assert keyframes_of(titles_on(timeline)[0]) == {0.0: 0.0, 24.0: 1.0, 443.0: 1.0, 479.0: 0.0}
+
+
+def test_a_fade_that_read_back_is_reported_as_verified(attach: Attach, tmp_path: Path) -> None:
+    a_session(attach)
+    placed = apply_titles(a_titles_file(tmp_path, valid_doc()))["placed"]
+
+    assert placed[0]["fade"]["verified"] is True
+    assert (placed[0]["fade"]["in"], placed[0]["fade"]["out"]) == (24, 36)
+
+
+def test_an_event_with_no_fade_block_gets_no_spline_at_all(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    placed = apply_titles(a_titles_file(tmp_path, valid_doc()))["placed"]
+
+    assert keyframes_of(titles_on(timeline)[1]) == {}
+    assert placed[1]["fade"] == {"in": 0, "out": 0, "keyframes": [], "verified": True,
+                                 "detail": "no fade asked for"}
+
+
+def test_a_fade_in_only_leaves_the_title_up_at_the_end(attach: Attach, tmp_path: Path) -> None:
+    timeline = a_session(attach)
+    apply_titles(a_titles_file(tmp_path, one_event(fade={"in": 24})))
+
+    assert keyframes_of(titles_on(timeline)[0]) == {0.0: 0.0, 24.0: 1.0}
+
+
+def test_a_build_that_cannot_animate_still_places_the_title(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """The words are the title; the fade is how it arrives. Losing one must not lose both."""
+    template = FakeMediaPoolItem(
+        "Song Title",
+        properties={"Type": "Generator", "File Path": ""},
+        template_comp=FakeFusionComp([FakeFusionTool()], missing={"BezierSpline"}),
+    )
+    timeline = a_session(attach, pool=a_pool(title=template))
+    result = apply_titles(a_titles_file(tmp_path, one_event(fade={"in": 24, "out": 24})))
+
+    assert result["ok"] is True
+    assert text_of(titles_on(timeline)[0]) == "Sunset Boulevard"
+    assert result["placed"][0]["fade"]["verified"] is False
+    assert "BezierSpline" in result["placed"][0]["fade"]["detail"]
+
+
+def test_a_text_plus_node_without_the_opacity_input_reports_an_unwritten_fade(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    template = FakeMediaPoolItem(
+        "Song Title",
+        properties={"Type": "Generator", "File Path": ""},
+        template_comp=FakeFusionComp([FakeFusionTool(animatable=False)]),
+    )
+    a_session(attach, pool=a_pool(title=template))
+    result = apply_titles(a_titles_file(tmp_path, one_event(fade={"in": 24, "out": 24})))
+
+    assert result["ok"] is True
+    assert "Opacity1" in result["placed"][0]["fade"]["detail"]
+
+
+def test_a_build_that_will_not_read_an_input_at_a_time_reports_the_fade_unverified(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    template = FakeMediaPoolItem(
+        "Song Title",
+        properties={"Type": "Generator", "File Path": ""},
+        template_comp=FakeFusionComp([FakeFusionTool(reads_at_a_time=False)]),
+    )
+    timeline = a_session(attach, pool=a_pool(title=template))
+    result = apply_titles(a_titles_file(tmp_path, one_event(fade={"in": 24, "out": 24})))
+
+    assert result["placed"][0]["fade"]["verified"] is False
+    assert keyframes_of(titles_on(timeline)[0]) != {}
+
+
+def test_a_spline_that_refuses_a_keyframe_reports_the_fade_unwritten(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    template = FakeMediaPoolItem(
+        "Song Title",
+        properties={"Type": "Generator", "File Path": ""},
+        template_comp=FakeFusionComp([FakeFusionTool()], takes_keyframes=False),
+    )
+    a_session(attach, pool=a_pool(title=template))
+    result = apply_titles(a_titles_file(tmp_path, one_event(fade={"in": 24, "out": 24})))
+
+    assert result["ok"] is True
+    assert "keyframe" in result["placed"][0]["fade"]["detail"]
+
+
+def test_a_comp_that_will_not_say_its_range_fades_over_the_instance_instead(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    template = FakeMediaPoolItem(
+        "Song Title",
+        properties={"Type": "Generator", "File Path": ""},
+        template_comp=FakeFusionComp([FakeFusionTool()], render_range=None),
+    )
+    timeline = a_session(attach, pool=a_pool(title=template))
+    apply_titles(a_titles_file(tmp_path, one_event(fade={"in": 24, "out": 24})))
+
+    assert keyframes_of(titles_on(timeline)[0]) == {0.0: 0.0, 24.0: 1.0, 455.0: 1.0, 479.0: 0.0}
+
+
+# --- what never starts --------------------------------------------------------------------
+
+
+def test_an_invalid_file_leaves_the_timeline_exactly_as_it_was(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    result = apply_titles(a_titles_file(tmp_path, valid_doc(schema=9)))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "titles_invalid"
+    assert timeline.GetTrackCount("video") == 1
+
+
+def test_a_song_with_no_blue_marker_is_refused_before_anything_is_cleared(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach, a_timeline(markers={0: a_marker("a-different-song")}))
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["error"]["code"] == "titles_invalid"
+    assert {finding["rule"] for finding in result["error"]["detail"]["errors"]} == {"T7"}
+    assert timeline.GetTrackCount("video") == 1
+
+
+def test_a_marker_of_another_colour_does_not_anchor_a_song(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """Blue is reserved for song starts; a red review note is the director's, not a key."""
+    a_session(attach, a_timeline(markers={0: a_marker("sunset-boulevard", color="Red")}))
+    result = apply_titles(a_titles_file(tmp_path, one_event()))
+
+    assert result["error"]["code"] == "titles_invalid"
+
+
+def test_a_template_missing_from_the_pool_is_refused_with_its_name(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    a_session(attach, pool=media_pool({"Titles": [text_plus_template("Personnel")]}))
+    result = apply_titles(a_titles_file(tmp_path, one_event()))
+
+    errors = result["error"]["detail"]["errors"]
+    assert [finding["rule"] for finding in errors] == ["T5"]
+    assert "Song Title" in errors[0]["message"]
+
+
+def test_a_template_in_the_wrong_bin_does_not_answer_for_the_declared_one(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    a_session(attach, pool=media_pool({"Archive": [text_plus_template("Song Title")]}))
+    result = apply_titles(a_titles_file(tmp_path, one_event()))
+
+    assert result["error"]["detail"]["errors"][0]["rule"] == "T5"
+
+
+def test_a_locked_titles_track_is_refused_before_the_clear(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(
+        attach,
+        a_timeline(
+            video=[
+                FakeTrack("Video 1"),
+                FakeTrack("Titles", [FakeTimelineItem("old title", SONG_ONE, 100)], locked=True),
+            ]
+        ),
+    )
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["error"]["code"] == "titles_apply_failed"
+    assert len(titles_on(timeline)) == 1
+
+
+def test_a_build_without_delete_clips_says_so_rather_than_doubling_the_titles(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    a_session(
+        attach,
+        a_timeline(
+            video=[
+                FakeTrack("Video 1"),
+                FakeTrack("Titles", [FakeTimelineItem("old title", SONG_ONE, 100)]),
+            ],
+            missing={"DeleteClips"},
+        ),
+    )
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["error"]["code"] == "titles_apply_failed"
+    assert "DeleteClips" in result["error"]["cause"]
+
+
+def test_a_clear_that_leaves_the_titles_standing_stops_the_apply(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(
+        attach,
+        a_timeline(
+            video=[
+                FakeTrack("Video 1"),
+                FakeTrack("Titles", [FakeTimelineItem("old title", SONG_ONE, 100)]),
+            ]
+        ),
+    )
+    timeline.delete_clips_leaves_them = True
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["error"]["code"] == "titles_apply_failed"
+    assert result["error"]["detail"]["remaining"] == 1
+
+
+def test_a_track_that_cannot_be_named_is_refused_so_the_next_apply_finds_it(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    timeline.set_track_name_result = False
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["error"]["code"] == "titles_apply_failed"
+    assert result["error"]["detail"]["track_index"] == TITLES_TRACK
+
+
+def test_an_append_that_lands_nowhere_is_caught_by_reading_the_track_back(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    pool = a_pool()
+    pool.appends_land_nowhere = True
+    a_session(attach, pool=pool)
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["error"]["code"] == "titles_apply_failed"
+    assert len(result["error"]["detail"]["adrift"]) == 3
+
+
+def test_a_template_too_short_for_the_span_is_named_as_such(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    pool = a_pool()
+    pool.append_result = []
+    a_session(attach, pool=pool)
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["error"]["code"] == "titles_apply_failed"
+    assert "shorter than the span" in result["error"]["fix"]
+
+
+def test_instances_sharing_one_comp_are_caught_by_reading_every_title_back(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """The failure mode the Text+ probe exists to detect: one comp, so one title, twice."""
+    pool = a_pool()
+    pool.appends_share_one_comp = True
+    a_session(attach, pool=pool)
+    result = apply_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["error"]["code"] == "titles_apply_failed"
+    assert "share" in result["error"]["fix"]
+
+
+def test_a_template_clip_with_no_fusion_comp_is_not_a_title_template(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    plain = FakeMediaPoolItem("Song Title", properties={"Type": "Video"})
+    a_session(attach, pool=a_pool(title=plain))
+    result = apply_titles(a_titles_file(tmp_path, one_event()))
+
+    assert result["error"]["code"] == "title_template_unusable"
+
+
+def test_a_comp_with_no_text_plus_node_says_what_it_holds_instead(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    template = FakeMediaPoolItem(
+        "Song Title",
+        properties={"Type": "Generator", "File Path": ""},
+        template_comp=FakeFusionComp([FakeFusionTool(tool_id="Background", name="Backdrop")]),
+    )
+    a_session(attach, pool=a_pool(title=template))
+    result = apply_titles(a_titles_file(tmp_path, one_event()))
+
+    assert result["error"]["code"] == "title_template_unusable"
+    assert "Backdrop" in result["error"]["cause"]
+
+
+def test_a_missing_titles_file_is_a_wrong_call_not_a_finding(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    a_session(attach)
+    result = apply_titles(str(tmp_path / "nothing.json"))
+
+    assert result["error"]["code"] == "invalid_request"
+
+
+def test_a_file_that_is_not_json_comes_back_as_t1(attach: Attach, tmp_path: Path) -> None:
+    a_session(attach)
+    path = tmp_path / "titles.json"
+    path.write_text("{ nope", encoding="utf-8")
+    result = apply_titles(str(path))
+
+    assert result["error"]["detail"]["errors"][0]["rule"] == "T1"
+
+
+# --- reaching the right timeline ----------------------------------------------------------
+
+
+def test_the_named_timeline_is_opened_before_anything_is_appended(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """AppendToTimeline writes to whatever is current, so titling the wrong cut is one
+    missed switch away."""
+    wanted = a_timeline("sunset-set v3")
+    open_cut = a_timeline("holiday-gig v1", markers={})
+    a_session(attach, timeline=open_cut, timelines=[open_cut, wanted])
+
+    result = apply_titles(a_titles_file(tmp_path, valid_doc(timeline="sunset-set v3")))
+
+    assert result["ok"] is True
+    assert len(titles_on(wanted)) == 3
+    assert open_cut.GetTrackCount("video") == 1
+
+
+def test_a_timeline_the_project_does_not_have_is_named(attach: Attach, tmp_path: Path) -> None:
+    a_session(attach)
+    result = apply_titles(a_titles_file(tmp_path, valid_doc(timeline="sunset-set v9")))
+
+    assert result["error"]["code"] == "timeline_not_found"
+
+
+# --- the dry run and the contract ---------------------------------------------------------
+
+
+def test_the_dry_run_reports_the_same_findings_without_touching_the_timeline(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach, a_timeline(markers={0: a_marker("a-different-song")}))
+    result = validate_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert result["valid"] is False
+    assert {finding["rule"] for finding in result["errors"]} == {"T7"}
+    assert timeline.GetTrackCount("video") == 1
+
+
+def test_the_dry_run_passes_a_file_the_apply_would_accept(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    a_session(attach)
+    result = validate_titles(a_titles_file(tmp_path, valid_doc()))
+
+    assert (result["valid"], result["events"], result["timeline"]) == (True, 3, "sunset-set v3")
+
+
+def test_the_schema_serves_the_example_and_every_rule() -> None:
+    result = get_titles_schema()
+
+    assert result["schema"] == 1
+    assert '"in": 240' in result["annotated_example"]
+    assert {rule["rule"] for rule in result["rules"]} >= {"T1", "T7", "T8", "W1", "W2"}
+    assert {rule["severity"] for rule in result["rules"]} == {"error", "warning"}

--- a/tests/test_titles_tools.py
+++ b/tests/test_titles_tools.py
@@ -318,7 +318,7 @@ def test_the_same_file_lands_on_a_rebuilt_version_at_its_own_markers(
         SONG_ONE + 960,
         SONG_TWO + 120,
     ]
-    # night-ferry is 800 frames earlier on v4, and its title moved with it.
+    # night-ferry is marked 1200 frames earlier on v4, and its title moved with it.
     assert [item.GetStart() for item in titles_on(v4)] == [
         SONG_ONE + 240,
         SONG_ONE + 960,
@@ -429,6 +429,19 @@ def test_a_fade_out_only_holds_full_opacity_from_the_first_frame(
     apply_titles(a_titles_file(tmp_path, one_event(fade={"out": 36})))
 
     assert keyframes_of(titles_on(timeline)[0]) == {0.0: 1.0, 443.0: 1.0, 479.0: 0.0}
+
+
+def test_a_title_that_fades_almost_its_whole_length_still_ends_clear(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """The degenerate fade T4 still permits: an in-ramp that would land on the last frame
+    takes the frame the out-ramp has to end clear on, so it is pulled back one."""
+    timeline = a_session(attach)
+    apply_titles(a_titles_file(tmp_path, one_event(out=250, fade={"in": 9, "out": 1})))
+
+    # The instance is 10 frames, so its comp renders 0-9.
+    assert keyframes_of(titles_on(timeline)[0]) == {0.0: 0.0, 8.0: 1.0, 9.0: 0.0}
 
 
 def test_a_build_that_cannot_animate_still_places_the_title(

--- a/tests/test_titles_validate.py
+++ b/tests/test_titles_validate.py
@@ -1,0 +1,329 @@
+"""The titles-file rules, as pure functions over a document and a reading of the project.
+
+Everything here is a decision the server makes about a file, so it all verifies at the
+fake tier — no Resolve, and for the structural pass not even a fake one. The project pass
+takes the marker and pool facts as data, which is what lets "that song is marked twice"
+and "that template name matches two clips" be tested without either ever existing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from resolve_mcp.findings import Finding
+from resolve_mcp.titles.validate import (
+    TemplateFacts,
+    plan,
+    validate_project,
+    validate_structure,
+)
+
+
+def valid_doc(**overrides: Any) -> dict[str, Any]:
+    """Two songs, three events — a title card and a personnel card, then a second song."""
+    doc: dict[str, Any] = {
+        "schema": 1,
+        "templates": {
+            "title": {"clip": "Song Title", "bin": "Titles/Templates"},
+            "personnel": {"clip": "Personnel"},
+        },
+        "songs": [
+            {
+                "key": "sunset-boulevard",
+                "events": [
+                    {
+                        "id": "t01",
+                        "kind": "title",
+                        "text": "Sunset Boulevard",
+                        "in": 240,
+                        "out": 720,
+                        "fade": {"in": 24, "out": 36},
+                    },
+                    {
+                        "id": "t02",
+                        "kind": "personnel",
+                        "text": "Bass — Ana Ruiz",
+                        "in": 960,
+                        "out": 1320,
+                    },
+                ],
+            },
+            {
+                "key": "night-ferry",
+                "events": [
+                    {"id": "t03", "kind": "title", "text": "Night Ferry", "in": 120, "out": 480},
+                ],
+            },
+        ],
+    }
+    doc.update(overrides)
+    return doc
+
+
+def rules_of(findings: Sequence[Finding]) -> list[str]:
+    return [finding.rule for finding in findings]
+
+
+def only(findings: Sequence[Finding], rule: str) -> list[Finding]:
+    return [finding for finding in findings if finding.rule == rule]
+
+
+def an_event(**overrides: Any) -> dict[str, Any]:
+    event = {"id": "t01", "kind": "title", "text": "Sunset Boulevard", "in": 0, "out": 240}
+    event.update(overrides)
+    return event
+
+
+def one_song(*events: dict[str, Any], key: str = "sunset-boulevard") -> dict[str, Any]:
+    return valid_doc(songs=[{"key": key, "events": list(events)}])
+
+
+# --- the structural pass ------------------------------------------------------------------
+
+
+def test_a_well_formed_file_has_nothing_to_say_about_it() -> None:
+    assert validate_structure(valid_doc()) == []
+
+
+def test_a_file_that_is_not_an_object_is_t1() -> None:
+    assert rules_of(validate_structure([1, 2, 3])) == ["T1"]
+
+
+def test_an_unsupported_schema_version_is_t1() -> None:
+    findings = validate_structure(valid_doc(schema=2))
+    assert rules_of(findings) == ["T1"]
+    assert "schema 1" in findings[0].message
+
+
+def test_a_file_with_no_templates_is_t1_because_a_title_needs_one() -> None:
+    findings = validate_structure(valid_doc(templates={}))
+    assert "templates" in findings[0].message
+
+
+def test_an_event_with_no_text_is_t1() -> None:
+    doc = one_song({"id": "t01", "kind": "title", "in": 0, "out": 240})
+    assert "text" in only(validate_structure(doc), "T1")[0].message
+
+
+def test_a_blank_text_is_t1_because_the_server_never_writes_the_words() -> None:
+    doc = one_song(an_event(text="   "))
+    assert "text" in only(validate_structure(doc), "T1")[0].message
+
+
+def test_a_non_integer_offset_is_t1() -> None:
+    doc = one_song(an_event(**{"in": 1.5}))
+    assert "integer frame offset" in only(validate_structure(doc), "T1")[0].message
+
+
+def test_an_unknown_kind_is_t1() -> None:
+    doc = one_song(an_event(kind="lower-third"))
+    assert "kind" in only(validate_structure(doc), "T1")[0].message
+
+
+def test_a_negative_fade_is_t1() -> None:
+    doc = one_song(an_event(fade={"in": -12}))
+    assert "fade.in" in only(validate_structure(doc), "T1")[0].message
+
+
+def test_a_fade_that_is_not_an_object_is_t1() -> None:
+    doc = one_song(an_event(fade=24))
+    assert "fade" in only(validate_structure(doc), "T1")[0].message
+
+
+def test_a_shape_failure_silences_the_later_rules() -> None:
+    """Rules past T1 read fields whose types they can no longer trust."""
+    doc = one_song(an_event(id="t01", **{"out": 0}), an_event(id="t01", text=None))
+    assert set(rules_of(validate_structure(doc))) == {"T1"}
+
+
+def test_two_events_with_one_id_are_t2() -> None:
+    doc = one_song(an_event(id="t01"), an_event(id="t01", **{"in": 300, "out": 500}))
+    assert rules_of(validate_structure(doc)) == ["T2"]
+
+
+def test_two_songs_with_one_key_are_t2() -> None:
+    doc = valid_doc(
+        songs=[
+            {"key": "sunset-boulevard", "events": [an_event(id="t01")]},
+            {"key": "sunset-boulevard", "events": [an_event(id="t02")]},
+        ]
+    )
+    assert rules_of(validate_structure(doc)) == ["T2"]
+
+
+def test_an_event_with_no_frames_in_it_is_t3() -> None:
+    doc = one_song(an_event(**{"in": 240, "out": 240}))
+    assert rules_of(validate_structure(doc)) == ["T3"]
+
+
+def test_fades_longer_than_the_title_are_t4() -> None:
+    doc = one_song(an_event(**{"in": 0, "out": 48}, fade={"in": 36, "out": 36}))
+    findings = only(validate_structure(doc), "T4")
+    assert "48 frames" in findings[0].message
+
+
+def test_fades_that_exactly_fill_the_title_are_allowed() -> None:
+    doc = one_song(an_event(**{"in": 0, "out": 48}, fade={"in": 24, "out": 24}))
+    assert validate_structure(doc) == []
+
+
+def test_t4_stays_quiet_on_an_event_t3_has_already_failed() -> None:
+    doc = one_song(an_event(**{"in": 0, "out": 0}, fade={"in": 24, "out": 24}))
+    assert rules_of(validate_structure(doc)) == ["T3"]
+
+
+def test_an_undeclared_template_is_t5() -> None:
+    doc = one_song(an_event(template="lower-third"))
+    findings = only(validate_structure(doc), "T5")
+    assert "lower-third" in findings[0].message
+
+
+def test_kind_picks_the_template_when_the_event_does_not() -> None:
+    doc = one_song(an_event(kind="personnel", text="Bass — Ana Ruiz"))
+    assert validate_structure(doc) == []
+
+
+def test_a_custom_event_must_name_its_own_template() -> None:
+    doc = one_song(an_event(kind="custom"))
+    assert rules_of(validate_structure(doc)) == ["T5"]
+
+
+def test_the_png_route_is_refused_until_the_png_tool_lands() -> None:
+    doc = one_song(an_event(route="png"))
+    findings = only(validate_structure(doc), "T6")
+    assert "textplus" in findings[0].message
+
+
+def test_a_song_with_no_events_is_only_a_warning() -> None:
+    doc = valid_doc(songs=[{"key": "sunset-boulevard", "events": []}])
+    findings = validate_structure(doc)
+    assert rules_of(findings) == ["W1"]
+    assert findings[0].severity == "warning"
+
+
+# --- the project pass ---------------------------------------------------------------------
+
+ANCHORS: Mapping[str, Sequence[int]] = {"sunset-boulevard": [3600], "night-ferry": [9000]}
+SPAN = (3600, 20000)
+TEMPLATES = (
+    TemplateFacts("title", "Song Title", "Titles/Templates", 1, ("Titles/Templates",)),
+    TemplateFacts("personnel", "Personnel", None, 1, ("Titles",)),
+)
+
+
+def project_findings(
+    doc: dict[str, Any],
+    anchors: Mapping[str, Sequence[int]] = ANCHORS,
+    templates: Sequence[TemplateFacts] = TEMPLATES,
+    span: tuple[int, int] = SPAN,
+) -> list[Finding]:
+    return validate_project(doc, anchors=anchors, templates=templates, span=span)
+
+
+def test_a_file_that_matches_the_project_has_nothing_to_say_about_it() -> None:
+    assert project_findings(valid_doc()) == []
+
+
+def test_a_song_with_no_marker_is_t7_and_says_what_is_marked() -> None:
+    findings = only(project_findings(valid_doc(), anchors={"night-ferry": [9000]}), "T7")
+    assert "sunset-boulevard" in findings[0].message
+    assert "night-ferry" in findings[0].message
+
+
+def test_a_song_marked_twice_is_t7_because_the_key_must_choose() -> None:
+    anchors = {**ANCHORS, "night-ferry": [9000, 14000]}
+    findings = only(project_findings(valid_doc(), anchors=anchors), "T7")
+    assert "9000, 14000" in findings[0].message
+
+
+def test_a_template_that_is_in_no_bin_is_t5() -> None:
+    absent = (TemplateFacts("title", "Song Title", "Titles/Templates", 0), *TEMPLATES[1:])
+    findings = only(project_findings(valid_doc(), templates=absent), "T5")
+    assert "Song Title" in findings[0].message
+
+
+def test_a_template_name_matching_two_clips_is_t5() -> None:
+    twice = (
+        TemplateFacts("title", "Song Title", None, 2, ("Titles", "Archive/Titles")),
+        *TEMPLATES[1:],
+    )
+    findings = only(project_findings(valid_doc(), templates=twice), "T5")
+    assert "Archive/Titles" in findings[0].message
+
+
+def test_an_event_past_the_end_of_the_timeline_is_t9() -> None:
+    findings = only(project_findings(valid_doc(), span=(3600, 4000)), "T9")
+    assert {finding.id for finding in findings} == {"t01", "t02", "t03"}
+
+
+def test_an_event_before_the_timeline_starts_is_t9() -> None:
+    doc = one_song(an_event(**{"in": -3600, "out": -3000}))
+    assert [finding.rule for finding in project_findings(doc) if finding.severity == "error"] == [
+        "T9"
+    ]
+
+
+def test_two_titles_over_one_frame_are_t8_because_the_track_shows_one() -> None:
+    doc = one_song(
+        an_event(id="t01", **{"in": 0, "out": 480}),
+        an_event(id="t02", **{"in": 240, "out": 600}),
+    )
+    findings = only(project_findings(doc), "T8")
+    assert findings[0].id == "t02"
+    assert "'t01'" in findings[0].message
+
+
+def test_titles_that_only_touch_at_a_boundary_do_not_overlap() -> None:
+    doc = one_song(
+        an_event(id="t01", **{"in": 0, "out": 480}),
+        an_event(id="t02", **{"in": 480, "out": 600}),
+    )
+    assert only(project_findings(doc), "T8") == []
+
+
+def test_overlap_is_judged_across_songs_not_only_inside_one() -> None:
+    doc = valid_doc(
+        songs=[
+            {"key": "sunset-boulevard", "events": [an_event(id="t01", **{"in": 0, "out": 6000})]},
+            {"key": "night-ferry", "events": [an_event(id="t02", **{"in": 0, "out": 240})]},
+        ]
+    )
+    assert rules_of(project_findings(doc)) == ["T8"]
+
+
+def test_a_marked_song_with_no_title_is_only_a_warning() -> None:
+    doc = one_song(an_event(), key="sunset-boulevard")
+    findings = project_findings(doc)
+    assert rules_of(findings) == ["W2"]
+    assert findings[0].id == "night-ferry"
+
+
+def test_a_song_whose_key_is_unresolved_is_left_out_of_the_later_rules() -> None:
+    """T7 already said so; positions derived from a guessed anchor would be noise."""
+    doc = one_song(an_event(**{"in": 0, "out": 999999}))
+    assert rules_of(project_findings(doc, anchors={})) == ["T7"]
+
+
+# --- the plan ------------------------------------------------------------------------------
+
+
+def test_events_are_positioned_forward_from_their_song_marker() -> None:
+    placed = plan(valid_doc(), ANCHORS)
+    assert [(event.id, event.record_in, event.duration) for event in placed] == [
+        ("t01", 3840, 480),
+        ("t02", 4560, 360),
+        ("t03", 9120, 360),
+    ]
+
+
+def test_a_plan_carries_the_fades_and_the_template_each_event_resolved_to() -> None:
+    first, second, _ = plan(valid_doc(), ANCHORS)
+    assert (first.fade_in, first.fade_out) == (24, 36)
+    assert (second.fade_in, second.fade_out) == (0, 0)
+    assert (first.template, second.template) == ("title", "personnel")
+
+
+def test_a_planned_event_knows_where_it_ends() -> None:
+    first = plan(valid_doc(), ANCHORS)[0]
+    assert first.record_out == first.record_in + first.duration == 4320


### PR DESCRIPTION
Closes #42.

Declarative Text+ titling that never touches the cut. `titles.json` holds per-song events keyed by the blue marker naming the song; `apply_titles` owns the topmost video track called `Titles`, clearing it whole and re-placing from the file on every run. Rebuild the cut, mark the songs on the new version, re-apply the same file unchanged.

**Test seam:** fake tier for every decision (the rules, the track ownership, the clear, the placement verification, the read-back, the fade keyframes), live smoke for the three ACs no fake can answer. 84 new tests; 584 pass in the fake tier.

## What it does

- **`titles.json`** (schema v1, served by `get_titles_schema`) — `templates` naming GUI-authored Text+ clips already in the media pool, then `songs[]` each with `events[]`. Event `in`/`out` are **frames from the song's blue marker**, not timeline frames, which is what lets one file survive a rebuild. Optional `fade: {in, out}` in frames.
- **9 hard rules (T1–T9) + 2 warnings**, split as the cut's are: structure from the document alone, project rules over marker and pool facts gathered once. Every error aborts *before* the Titles track is looked at, so a refused apply leaves the previous titles exactly where they were.
- **Fades** are a BezierSpline on the Text+ node's `Opacity1`, keyframed by index assignment (#5's verified pattern) inside each placed instance — the only fade the scripting API exposes at all. A fade this Resolve build will not write is reported per event rather than sinking the title it belongs to.
- Every footgun #41 found live is guarded: the target timeline is made current **and verified** before any append (an unverified switch would title the operator's open cut), placements are read back off the track, and every title is read back after *all* the writes so instances sharing one comp are caught.

## Decisions worth your attention

1. **Three tools, where the catalog names one.** #14 §7 says "Catalog impact: no new tools". I shipped `get_titles_schema` and `validate_titles` alongside `apply_titles`, on the `get_cut_schema`/`validate_cut`/`build_timeline` precedent: a file-based contract the agent must author is not guessable without a served schema, and a dry run matters *more* here than for the cut, because the apply mutates a timeline you already have rather than making a new version. This overrides a settled line — say the word and I will fold them back.
2. **Event times are offsets from the song's blue marker.** #14 §1 makes the marker name the song key ("explicit join to data, never positional") but does not spell out what `in`/`out` count from. Offsets are what make AC3 mean anything; absolute frames would re-break on every rebuild.
3. **Templates must already be in the media pool.** `apply_titles` does not import a `.drb`. #41 established the template is human-authored in the GUI, and the human is already there; the error names the missing clip and the available ones. There is currently **no tool that imports a `.drb`** — flagged below.
4. **Overlapping events are refused (T8), not spilled onto a second track.** #14 says one `Titles` track, singular. Two titles over one frame cannot both be placed on it, and Resolve would slide the second rather than refuse it.
5. **W2 is a warning, not an error.** #14 §2's hard rule ("every blue marker's key exists in the file") is about `songs.json`, which no tool owns yet. Titling a set song-by-song is normal, so a marked song with no titles is reported, not blocked.

## Review

`/code-review` against `origin/main` — two axes, parallel sub-agents. Standards found no hard violations and 9 judgement calls; Spec found 11 items. Fixed:

**Standards**
- `resolve/titles.py` was doing two jobs (Divergent Change) → split along the seam its neighbours already use: `titles.py` holds the contract and pre-flight (as `cut.py` does), new `apply.py` holds the writes (as `build.py` does).
- `(track, track_name, timeline)` travelled through five helpers and four failure details (Data Clump) → `OwnedTrack`, whose name is a constant property so no caller can widen what "owned" means.
- `LoadedCut`/`LoadedTitles` were one type under two names (Mysterious Name — the distinction the docstrings promised did not exist in the type system) → deleted; callers use `LoadedDocument`.
- `_order = ordered` (Middle Man) → deleted; stale `Finding`/`severity_of` re-exports removed from both validators, importers repointed at `findings.py`.
- Three copies of the "a method this build does not have answers `None`" idiom in `fakes.py` (Duplicated Code) → one `AnswersNone` base. `FakeFusionTool`'s hand-maintained field-name frozenset (fragile against a new `__init__` field) → a `_built` sentinel.
- **Held:** `_is_int`/`_kind` stay duplicated across the two validators. They are one-line type predicates; the shared modules now own the finding *shape* and the document *reading*, and churning a merged validator to hoist two predicates adds review surface without changing behaviour.

**Spec**
- Removed the per-file `"track"` override — #14 says the topmost `Titles` track, singular, and a tool that can be pointed at any track can clear one it does not own.
- A fade now keyframes **both** comp ends even when only one end fades: what a spline does outside its keyframes is an extrapolation setting nothing here sets, so a fade-out-only title was relying on Fusion holding full opacity backwards.
- **AC3 was covered at no seam.** Two tests now apply one file unchanged to two timeline versions whose songs sit at different absolute frames — this is fake-tier-checkable and should not have been deferred as live-unrun.
- The served schema no longer advertises `set_title_text` (#43's tool, unshipped); the no-Text+-node failure now names the Fusion-macro case #5 raised instead of leaving it a mystery.

A focused re-check of the fix diff found two more, both fixed in a second round:
- **A valid file could silently lose its own fade-out.** With `fade_in + fade_out == duration` (which T4 permits), an in-ramp landing on the comp's last frame overwrote the keyframe the out-ramp needed to end clear on: the title finished at full opacity while the report still said it faded out. The in-ramp is now pulled back one frame when a title fades both ways. Test added at that exact shape.
- A test comment misstated the frame arithmetic (800 vs 1200) in the test whose whole point is explaining why offsets follow markers.

Review: clean — two rounds of findings fixed and re-checked; fake tier 584 passed, mypy strict and ruff clean; live ACs unrun, named on the ticket.


Post-open merge of origin/main (all seven parallel P1 branches landed first): unions in server registration, INSTRUCTIONS, README, live smoke and the tool list; UnsupportedCutFeatureError stays deleted (#30 shipped overlays, removing its only raise site); takes.py repointed at the shared document/findings modules this branch extracted; plus an import-sort fix. Fake tier, mypy, ruff clean.
Review: clean — focused pass on the conflict-resolution diff
