### PR TITLE
P1: Two-pass stem separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Zero-config by default; every path has an environment override.
 | --- | --- | --- |
 | `RESOLVE_SCRIPT_API` | `%PROGRAMDATA%\Blackmagic Design\DaVinci Resolve\Support\Developer\Scripting` | Scripting API root (holds `Modules/DaVinciResolveScript.py`) |
 | `RESOLVE_SCRIPT_LIB` | `C:\Program Files\Blackmagic Design\DaVinci Resolve\fusionscript.dll` | Scripting library |
-| `RESOLVE_MCP_CACHE` | `%LOCALAPPDATA%\resolve-mcp` | Cache root: snapshots, job records, cached results, acquired audio, model weights |
+| `RESOLVE_MCP_CACHE` | `%LOCALAPPDATA%\resolve-mcp` | Cache root: snapshots, job records, cached results, acquired audio, separated stems, model weights |
 | `RESOLVE_MCP_FFMPEG` | `ffmpeg` (found on PATH) | ffmpeg executable used for per-clip audio extraction |
 | `RESOLVE_MCP_AUDIO_SEPARATOR` | `audio-separator` (found on PATH) | python-audio-separator CLI used for stem separation |
 | `RESOLVE_MCP_STEM_MODEL` | `htdemucs_ft.yaml` | Pass one: the 4-stem model (vocals, drums, bass, other) |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ with audio acquisition, and the `run_python` escape hatch.
 | `inspect_timeline` | One timeline at a chosen detail and range, in dual time |
 | `export_timeline` | Writes a timeline out as OTIO, FCPXML or DRT |
 | `import_timeline` | Materialises a **new** timeline from such a file — never overwrites one |
+| `separate_stems` | Two-pass GPU stem separation: mix → 4 stems, drums → kick/snare/toms |
 | `get_job` | Polls one background job: progress, result, or a structured failure |
 | `list_jobs` | Lists jobs newest first — how a restarted session finds what it started |
 | `run_python` | Escape hatch: runs scripting-API Python in the server process |
@@ -64,6 +65,11 @@ audio mapping says the audio is linked or offset away from the file.
 - Resolve running, with a project open, before the first Resolve-touching tool call
 - **ffmpeg on PATH** for per-clip audio extraction (`RESOLVE_MCP_FFMPEG` points at it
   elsewhere). Timeline-scope audio goes through Resolve's own render queue and needs none.
+- **[python-audio-separator](https://github.com/nomadkaraoke/python-audio-separator) on
+  PATH** for `separate_stems` (`pip install "audio-separator[gpu]"`, or
+  `RESOLVE_MCP_AUDIO_SEPARATOR` points at the executable). It is run as a subprocess, not
+  imported, so it can live in its own environment and its torch/CUDA stack never loads
+  into the server. The two model files download on first use.
 
 ## Install
 
@@ -97,6 +103,9 @@ Zero-config by default; every path has an environment override.
 | `RESOLVE_SCRIPT_LIB` | `C:\Program Files\Blackmagic Design\DaVinci Resolve\fusionscript.dll` | Scripting library |
 | `RESOLVE_MCP_CACHE` | `%LOCALAPPDATA%\resolve-mcp` | Cache root: snapshots, job records, cached results, acquired audio, model weights |
 | `RESOLVE_MCP_FFMPEG` | `ffmpeg` (found on PATH) | ffmpeg executable used for per-clip audio extraction |
+| `RESOLVE_MCP_AUDIO_SEPARATOR` | `audio-separator` (found on PATH) | python-audio-separator CLI used for stem separation |
+| `RESOLVE_MCP_STEM_MODEL` | `htdemucs_ft.yaml` | Pass one: the 4-stem model (vocals, drums, bass, other) |
+| `RESOLVE_MCP_DRUM_MODEL` | `MDX23C-DrumSep-6stem-FT.ckpt` | Pass two: the drum decomposition model (kick, snare, toms) |
 | `RESOLVE_MCP_LOG_LEVEL` | `INFO` | Log level for the stderr logger |
 | `RESOLVE_MCP_ALLOW_ANY_PYTHON` | unset | Bypass the interpreter check (see ADR 0001) |
 

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -25,12 +25,18 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path, PureWindowsPath
-from typing import Any
+from typing import Any, NamedTuple
 
 from ..config import Config, get_config
-from ..errors import AudioExportError, AudioExtractionError, AudioMappingError, RenderQueueError
+from ..errors import (
+    AudioExportError,
+    AudioExtractionError,
+    AudioMappingError,
+    InvalidRequestError,
+    RenderQueueError,
+)
 from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, start_job
 from ..logging_config import get_logger
@@ -51,6 +57,10 @@ DEFAULT_BIT_DEPTH = 24
 
 TIMELINE_KIND = "acquire_timeline_audio"
 CLIP_KIND = "acquire_clip_audio"
+
+TIMELINE_SCOPE = "timeline"
+CLIP_SCOPE = "clip"
+SCOPES = (TIMELINE_SCOPE, CLIP_SCOPE)
 
 RENDER_FORMAT = "wav"
 RENDER_CODEC = "lpcm"
@@ -117,12 +127,7 @@ def acquire_timeline_audio(
     project = current_project(connection, "No project is open, so there is no timeline to export.")
     found = find_timeline(project, timeline)
     name = str(found.GetName() or "timeline")
-    params = {
-        "scope": "timeline",
-        "timeline": name,
-        "sample_rate": sample_rate,
-        "bit_depth": bit_depth,
-    }
+    params = _timeline_params(name, sample_rate, bit_depth)
     fingerprint = timeline_fingerprint(Reader(connection), found)
     key = cache.cache_key(TIMELINE_KIND, [fingerprint], params)
 
@@ -239,31 +244,8 @@ def acquire_clip_audio(
     for real, and a caller can hand in its own to exercise the route without ffmpeg.
     """
     config = config or get_config()
-    pool = media.media_pool(connection)
-    located = media.find_clip(pool, clip, bin)
-    reported = media.properties(located.clip)
-    source = reported.get(media.FILE_PATH, "")
-    if not source or media.is_offline(source):
-        raise AudioExtractionError(
-            cause=f"{clip!r} has no readable file on disk.",
-            fix="relink_media points a clip back at its media; list_media shows what is offline.",
-            detail={"clip": clip, "file_path": source},
-        )
-
-    conflict = mapping_conflict(media.audio_mapping(located.clip), source)
-    if conflict is not None:
-        raise AudioMappingError(
-            cause=f"{clip!r} does not carry its own audio: {conflict}",
-            detail={"clip": clip, "file_path": source},
-        )
-
-    params = {
-        "scope": "clip",
-        "clip": clip,
-        "bin": located.bin_path,
-        "sample_rate": sample_rate,
-        "bit_depth": bit_depth,
-    }
+    located, source = _locate_clip(connection, clip, bin)
+    params = _clip_params(clip, located.bin_path, sample_rate, bit_depth)
     key = cache.cache_key(CLIP_KIND, [cache.fingerprint(source)], params)
 
     def work(progress: Progress) -> JobOutput:
@@ -348,6 +330,136 @@ def _walk(value: Any, path: tuple[str, ...] = ()) -> Iterator[tuple[tuple[str, .
 
 def _looks_like_a_path(value: str) -> bool:
     return ("/" in value or "\\" in value) and PureWindowsPath(value).suffix != ""
+
+
+# --- what an analysis job asks for ---------------------------------------------------------
+
+
+class Source(NamedTuple):
+    """A scope resolved to what identifies it, and to a way of acquiring its audio.
+
+    Every job that runs *on* audio — stems, beats, transcript — has the same problem: its
+    cache key has to be computable in the starter, before the audio exists, or a rerun
+    would re-export a whole concert only to discover it had the answer already. So the
+    identity is read here, up front and cheaply, while the acquisition itself is deferred
+    into ``start`` to run inside the calling job's own thread. That keeps the tool call as
+    short as one Resolve read and leaves the export where the agent can watch it.
+    """
+
+    fingerprint: dict[str, Any]
+    params: dict[str, Any]
+    start: Callable[[], dict[str, Any]]
+
+
+def audio_source(
+    connection: ResolveConnection,
+    scope: str = TIMELINE_SCOPE,
+    timeline: str | None = None,
+    clip: str | None = None,
+    bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    bit_depth: int = DEFAULT_BIT_DEPTH,
+    refresh: bool = False,
+    runner: ffmpeg.Runner | None = None,
+    config: Config | None = None,
+) -> Source:
+    """Resolve a scope now; hand back the fingerprint, the params, and how to acquire it.
+
+    The refusals a route makes before it starts — offline media, audio Resolve has linked
+    away — happen here too, so an analysis tool declines for the same reason and with the
+    same advice the acquisition tool would have given, rather than failing a job later.
+    """
+    config = config or get_config()
+    if scope == TIMELINE_SCOPE:
+        project = current_project(connection, "No project is open, so there is no timeline.")
+        found = find_timeline(project, timeline)
+        name = str(found.GetName() or "timeline")
+        return Source(
+            timeline_fingerprint(Reader(connection), found),
+            _timeline_params(name, sample_rate, bit_depth),
+            lambda: acquire_timeline_audio(
+                connection,
+                timeline=name,
+                sample_rate=sample_rate,
+                bit_depth=bit_depth,
+                refresh=refresh,
+                config=config,
+            ),
+        )
+
+    if scope == CLIP_SCOPE:
+        if not clip:
+            raise InvalidRequestError(
+                cause="A clip scope needs a clip to read.",
+                fix="Name the clip, or use scope=timeline for the timeline mix.",
+                detail={"scope": scope},
+            )
+        located, source = _locate_clip(connection, clip, bin)
+        return Source(
+            cache.fingerprint(source),
+            _clip_params(clip, located.bin_path, sample_rate, bit_depth),
+            lambda: acquire_clip_audio(
+                connection,
+                clip,
+                bin=bin,
+                sample_rate=sample_rate,
+                bit_depth=bit_depth,
+                refresh=refresh,
+                runner=runner,
+                config=config,
+            ),
+        )
+
+    raise InvalidRequestError(
+        cause=f"{scope!r} is not an audio scope.",
+        fix=f"Use one of {', '.join(SCOPES)}: timeline for the mix, clip for one source file.",
+        detail={"requested": scope, "scopes": list(SCOPES)},
+    )
+
+
+def _locate_clip(
+    connection: ResolveConnection,
+    clip: str,
+    bin: str | None,  # noqa: A002 - "bin" is the Resolve term the agent uses
+) -> tuple[media.LocatedClip, str]:
+    """Find the clip and prove its audio is readable off its own file, or refuse."""
+    pool = media.media_pool(connection)
+    located = media.find_clip(pool, clip, bin)
+    reported = media.properties(located.clip)
+    source = reported.get(media.FILE_PATH, "")
+    if not source or media.is_offline(source):
+        raise AudioExtractionError(
+            cause=f"{clip!r} has no readable file on disk.",
+            fix="relink_media points a clip back at its media; list_media shows what is offline.",
+            detail={"clip": clip, "file_path": source},
+        )
+
+    conflict = mapping_conflict(media.audio_mapping(located.clip), source)
+    if conflict is not None:
+        raise AudioMappingError(
+            cause=f"{clip!r} does not carry its own audio: {conflict}",
+            detail={"clip": clip, "file_path": source},
+        )
+    return located, source
+
+
+def _timeline_params(name: str, sample_rate: int, bit_depth: int) -> dict[str, Any]:
+    return {
+        "scope": TIMELINE_SCOPE,
+        "timeline": name,
+        "sample_rate": sample_rate,
+        "bit_depth": bit_depth,
+    }
+
+
+def _clip_params(clip: str, bin_path: str, sample_rate: int, bit_depth: int) -> dict[str, Any]:
+    return {
+        "scope": CLIP_SCOPE,
+        "clip": clip,
+        "bin": bin_path,
+        "sample_rate": sample_rate,
+        "bit_depth": bit_depth,
+    }
 
 
 # --- shared ------------------------------------------------------------------------------

--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -1,0 +1,184 @@
+"""Running python-audio-separator, without loading it into this process.
+
+It brings torch and a CUDA runtime with it. Importing that here would cost seconds of
+startup on every attach, hold GPU memory for a whole session, and put a model load between
+the agent and a Resolve call — so it runs as a subprocess through the CLI it ships, and the
+server never imports it at all. That also keeps it out of ``pyproject.toml``: the models
+live in whatever environment the director installed them into, and a machine with no GPU
+runs every test in this repo.
+
+The shape is the one ``ffmpeg`` already uses: the subprocess call is a parameter
+(``runner``), so command construction, progress parsing, the missing-binary case and every
+refusal are testable with no models and no GPU present.
+
+Two things here are decisions rather than plumbing:
+
+* **Output is read line by line, not collected at the end.** A concert pass runs for
+  minutes and the percentages it prints are the only progress that exists; waiting for the
+  process to exit would make the job silent for the whole run.
+
+* **Stems are matched by the label the separator parenthesises, not by predicting
+  filenames.** It writes ``<input>_(Drums)_<model>.wav``, and the input to the second pass
+  is already a labelled file — so the *last* parenthesised label is this file's own stem.
+  Reading the label back is what makes a model that renames its outputs a clear failure
+  ("produced no toms stem") instead of a silently missing file.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections import deque
+from collections.abc import Callable, Iterable, Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+from ..config import Config, get_config
+from ..errors import SeparatorUnavailableError, StemSeparationError
+from ..logging_config import get_logger
+
+log = get_logger("audio")
+
+OUTPUT_FORMAT = "WAV"
+OUTPUT_TAIL = 40
+"""Lines of the separator's own output kept for a failure message."""
+
+LABEL = re.compile(r"\(([^()]+)\)")
+PERCENT = re.compile(r"(\d{1,3})\s*%")
+FULL = 100.0
+
+
+class Completed(NamedTuple):
+    """What the runner reports back once the separator has exited."""
+
+    returncode: int
+    output: str
+
+
+Lines = Callable[[str], None]
+Runner = Callable[[Sequence[str], Lines], Completed]
+Fraction = Callable[[float], None]
+
+
+def command(executable: str, model: str, source: Path | str, out_dir: Path | str) -> list[str]:
+    """The audio-separator invocation, as a list — never a shell string."""
+    return [
+        executable,
+        str(source),
+        "--model_filename",
+        model,
+        "--output_dir",
+        str(out_dir),
+        "--output_format",
+        OUTPUT_FORMAT,
+    ]
+
+
+def label_of(path: Path | str) -> str | None:
+    """The stem this file holds, read off the label the separator wrote into its name."""
+    found = LABEL.findall(Path(path).stem)
+    return found[-1].strip().lower() if found else None
+
+
+def collect(out_dir: Path | str) -> dict[str, Path]:
+    """Every labelled stem in a directory, keyed by its label."""
+    found: dict[str, Path] = {}
+    for one in sorted(Path(out_dir).glob("*.wav")):
+        label = label_of(one)
+        if label is not None:
+            found[label] = one
+    return found
+
+
+def separate(
+    source: Path | str,
+    out_dir: Path | str,
+    model: str,
+    wanted: Sequence[str],
+    progress: Fraction | None = None,
+    runner: Runner | None = None,
+    config: Config | None = None,
+) -> dict[str, Path]:
+    """Run one pass, and return the stems it wrote — or fail naming what it left out."""
+    config = config or get_config()
+    destination = Path(out_dir)
+    destination.mkdir(parents=True, exist_ok=True)
+    argv = command(config.audio_separator, model, source, destination)
+    tail: deque[str] = deque(maxlen=OUTPUT_TAIL)
+
+    def on_line(line: str) -> None:
+        text = line.strip()
+        if not text:
+            return
+        tail.append(text)
+        fraction = _percent(text)
+        if fraction is not None and progress is not None:
+            progress(fraction)
+
+    log.info("Separating %s with %s", Path(source).name, model)
+    try:
+        finished = (runner or _run)(argv, on_line)
+    except FileNotFoundError as exc:
+        raise SeparatorUnavailableError(
+            cause=f"No audio-separator at {config.audio_separator!r}.",
+            detail={"executable": config.audio_separator, "model": model},
+        ) from exc
+
+    output = "\n".join(tail) or finished.output
+    if finished.returncode != 0:
+        raise StemSeparationError(
+            cause=(
+                f"audio-separator refused {Path(source).name} with {model} "
+                f"(exit {finished.returncode})."
+            ),
+            detail={"model": model, "exit_code": finished.returncode, "output": output},
+        )
+
+    produced = collect(destination)
+    missing = [one for one in wanted if one not in produced]
+    if missing:
+        raise StemSeparationError(
+            cause=f"{model} produced no {', '.join(missing)} stem.",
+            detail={
+                "model": model,
+                "expected": list(wanted),
+                "produced": sorted(produced),
+                "output": output,
+            },
+        )
+    log.info("%s produced %s", model, ", ".join(sorted(produced)))
+    return produced
+
+
+def missing_from(out_dir: Path | str, wanted: Iterable[str]) -> list[str]:
+    """Which of these stems are not already sitting in this directory."""
+    produced = collect(out_dir)
+    return [one for one in wanted if one not in produced]
+
+
+def _percent(line: str) -> float | None:
+    """The progress bar's own percentage, as a fraction — ``None`` for any other line."""
+    found = PERCENT.search(line)
+    if found is None:
+        return None
+    return min(int(found.group(1)) / FULL, 1.0)
+
+
+def _run(argv: Sequence[str], on_line: Lines) -> Completed:
+    """The real call: stderr folded into stdout, read as it arrives.
+
+    Universal newlines makes the progress bar's carriage returns line breaks, which is the
+    only reason a tqdm bar can be followed line by line at all.
+    """
+    with subprocess.Popen(
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    ) as process:
+        if process.stdout is not None:
+            for line in process.stdout:
+                on_line(line)
+        returncode = process.wait()
+    return Completed(returncode, "")

--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -31,7 +31,6 @@ import subprocess
 from collections import deque
 from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
-from typing import NamedTuple
 
 from ..config import Config, get_config
 from ..errors import SeparatorUnavailableError, StemSeparationError
@@ -48,15 +47,15 @@ PERCENT = re.compile(r"(\d{1,3})\s*%")
 FULL = 100.0
 
 
-class Completed(NamedTuple):
-    """What the runner reports back once the separator has exited."""
-
-    returncode: int
-    output: str
-
-
 Lines = Callable[[str], None]
-Runner = Callable[[Sequence[str], Lines], Completed]
+Runner = Callable[[Sequence[str], Lines], int]
+"""Run the argv, hand every output line to the sink, and return the exit code.
+
+Unlike ffmpeg's runner there is nothing else to report: everything the separator says
+arrives through the sink as it says it, so the caller already holds the output by the time
+the process exits.
+"""
+
 Fraction = Callable[[float], None]
 
 
@@ -117,21 +116,20 @@ def separate(
 
     log.info("Separating %s with %s", Path(source).name, model)
     try:
-        finished = (runner or _run)(argv, on_line)
+        returncode = (runner or _run)(argv, on_line)
     except FileNotFoundError as exc:
         raise SeparatorUnavailableError(
             cause=f"No audio-separator at {config.audio_separator!r}.",
             detail={"executable": config.audio_separator, "model": model},
         ) from exc
 
-    output = "\n".join(tail) or finished.output
-    if finished.returncode != 0:
+    output = "\n".join(tail)
+    if returncode != 0:
         raise StemSeparationError(
             cause=(
-                f"audio-separator refused {Path(source).name} with {model} "
-                f"(exit {finished.returncode})."
+                f"audio-separator refused {Path(source).name} with {model} (exit {returncode})."
             ),
-            detail={"model": model, "exit_code": finished.returncode, "output": output},
+            detail={"model": model, "exit_code": returncode, "output": output},
         )
 
     produced = collect(destination)
@@ -164,7 +162,7 @@ def _percent(line: str) -> float | None:
     return min(int(found.group(1)) / FULL, 1.0)
 
 
-def _run(argv: Sequence[str], on_line: Lines) -> Completed:
+def _run(argv: Sequence[str], on_line: Lines) -> int:
     """The real call: stderr folded into stdout, read as it arrives.
 
     Universal newlines makes the progress bar's carriage returns line breaks, which is the
@@ -180,5 +178,4 @@ def _run(argv: Sequence[str], on_line: Lines) -> Completed:
         if process.stdout is not None:
             for line in process.stdout:
                 on_line(line)
-        returncode = process.wait()
-    return Completed(returncode, "")
+        return process.wait()

--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -44,6 +44,9 @@ OUTPUT_TAIL = 40
 
 LABEL = re.compile(r"\(([^()]+)\)")
 PERCENT = re.compile(r"(\d{1,3})\s*%")
+DOWNLOAD = re.compile(r"download", re.IGNORECASE)
+"""A first run fetches its model and prints a bar for that too. It is not the separation."""
+
 FULL = 100.0
 
 
@@ -155,7 +158,15 @@ def missing_from(out_dir: Path | str, wanted: Iterable[str]) -> list[str]:
 
 
 def _percent(line: str) -> float | None:
-    """The progress bar's own percentage, as a fraction — ``None`` for any other line."""
+    """The separation bar's own percentage, as a fraction — ``None`` for any other line.
+
+    A model download prints a bar of its own, and it is not progress through this pass: it
+    runs to 100% before the separation has started, and reporting it would have the job
+    look finished and then apparently restart. Dropping it costs nothing if the wording
+    ever changes — the reading is simply reported as the separation's own.
+    """
+    if DOWNLOAD.search(line):
+        return None
     found = PERCENT.search(line)
     if found is None:
         return None

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -10,10 +10,11 @@ Three decisions worth knowing:
 * **The job's key and the stems' key are not the same key, on purpose.** The job is keyed
   the way its acquisition is keyed — a timeline fingerprint, a clip's path/size/mtime —
   because that is all that can be known in the starter, before any audio exists. The stems
-  on disk are keyed by the *content hash* of the audio that produced them plus the params
-  (#22: "workers key off content hash of cached audio + params hash"), so audio that comes
-  back byte-identical under a moved fingerprint costs nothing: the directory is already
-  there and both passes are skipped. ``refresh`` overrides both.
+  on disk are keyed by the *content hash* of the audio that produced them plus the models
+  run on it (#22: "workers key off content hash of cached audio + params hash"), and by
+  nothing about where that audio came from — so a renamed timeline, or the same file
+  reached as a clip rather than through the mix, finds its stems already there and skips
+  both passes. ``refresh`` overrides both.
 
 * **Acquisition runs inside this job.** #12 puts the export inside the starter rather than
   making the agent sequence one, so the stems job starts the acquisition job and follows
@@ -34,10 +35,11 @@ from pathlib import Path
 from typing import Any
 
 from ..config import Config, get_config
-from ..errors import ChainedJobError, InternalError
-from ..jobs import cache, store
+from ..errors import InternalError
+from ..jobs import cache
 from ..jobs import runner as job_runner
 from ..jobs.runner import JobOutput, Progress, start_job
+from ..jobs.store import JobRecord
 from ..logging_config import get_logger
 from ..naming import slug
 from ..resolve.connection import ResolveConnection
@@ -52,6 +54,9 @@ DRUM_STEMS = ("kick", "snare", "toms")
 DRUM_SOURCE = "drums"
 """Which of the four stems the second pass decomposes."""
 
+SEPARATION = ("model", "drum_model", "stems", "drum_stems")
+"""The params that change what the stems *are*, as opposed to where the audio came from."""
+
 MIX_PASS = "mix"
 DRUM_PASS = "drums"
 
@@ -60,7 +65,6 @@ ACQUIRE_CEILING = 0.25
 PASS_ONE_CEILING = 0.6
 PASS_TWO_CEILING = 0.9
 COLLECTING = 0.95
-POLL_SECONDS = 0.1
 
 PERCENT = 100
 
@@ -113,7 +117,7 @@ def acquired(
     source: acquire.Source,
     progress: Progress,
     config: Config | None = None,
-    poll: float = POLL_SECONDS,
+    poll: float = job_runner.FOLLOW_POLL,
     sleep: Callable[[float], None] = time.sleep,
 ) -> dict[str, Any]:
     """Run the acquisition this separation needs, and report it as this job's first quarter.
@@ -124,28 +128,35 @@ def acquired(
     """
     config = config or get_config()
     progress(ACQUIRE_FLOOR, "acquiring the audio")
-    record = source.start()
+    started = source.start()
     span = ACQUIRE_CEILING - ACQUIRE_FLOOR
 
-    while record["state"] == store.RUNNING:
-        fraction = float(record.get("progress") or 0.0)
-        progress(ACQUIRE_FLOOR + span * fraction, str(record.get("step") or "acquiring the audio"))
-        sleep(poll)
-        job_id = str(record["job_id"])
-        record = store.load(job_id, config).payload()
-        if record["state"] == store.RUNNING and not job_runner.alive(job_id):
-            raise InternalError(
-                cause=f"The acquisition {job_id} stopped without finishing its record.",
-                detail={"job_id": job_id, "step": record.get("step")},
-            )
+    def watch(record: JobRecord) -> None:
+        progress(ACQUIRE_FLOOR + span * record.progress, record.step or "acquiring the audio")
 
-    if record["state"] == store.FAILED:
-        raise ChainedJobError(record.get("error") or {}, str(record["job_id"]))
+    finished = job_runner.follow(
+        str(started["job_id"]),
+        watch,
+        poll=poll,
+        sleep=sleep,
+        config=config,
+    )
+    if finished.result is None:
+        raise InternalError(cause=f"The acquisition {finished.job_id} finished with no audio.")
+    return finished.result
 
-    result = record.get("result")
-    if not isinstance(result, dict):
-        raise InternalError(cause=f"The acquisition {record['job_id']} finished with no audio.")
-    return result
+
+def stem_key(audio: dict[str, Any], params: dict[str, Any]) -> str:
+    """What the stems on disk are keyed by: the audio's own bytes and the models run on it.
+
+    Deliberately not the whole job params. Scope, timeline name and bin say where the audio
+    came from, not what it is — a renamed timeline, or the same file reached as a clip
+    rather than through the mix, is the same audio, and separating it twice would pay the
+    GPU twice for a byte-identical answer (#22 story 26: analysis is paid for once per
+    media state). Sample rate and bit depth are in the bytes already.
+    """
+    settings = {name: params[name] for name in SEPARATION if name in params}
+    return cache.cache_key(KIND, [{"content_sha256": audio["content_sha256"]}], settings)
 
 
 def two_pass(
@@ -158,7 +169,7 @@ def two_pass(
 ) -> JobOutput:
     """The worker: four stems, then the drum stem decomposed into kick, snare and toms."""
     config = config or get_config()
-    key = cache.cache_key(KIND, [{"content_sha256": audio["content_sha256"]}], params)
+    key = stem_key(audio, params)
     directory = config.stems_dir / f"{slug(Path(str(audio['path'])).stem, 'stems')}-{key[:12]}"
     mix_dir = directory / MIX_PASS
     drums_dir = directory / DRUM_PASS
@@ -212,10 +223,19 @@ def _already_separated(mix_dir: Path, drums_dir: Path) -> bool:
 
 
 def _pass(progress: Progress, floor: float, ceiling: float, step: str) -> separator.Fraction:
-    """Map one pass's own 0-1 onto the slice of the job that pass is."""
+    """Map one pass's own 0-1 onto the slice of the job that pass is, and never go back.
+
+    A first run downloads its model and prints a progress bar for *that* before the one for
+    the separation, so the percentages restart mid-pass. Reporting the restart would have
+    the agent watch a job apparently lose ground; the highest reading so far is the honest
+    summary of a pass made of several bars.
+    """
     span = ceiling - floor
+    highest = 0.0
 
     def report(fraction: float) -> None:
-        progress(floor + span * fraction, f"{step} ({int(fraction * PERCENT)}%)")
+        nonlocal highest
+        highest = max(highest, fraction)
+        progress(floor + span * highest, f"{step} ({int(highest * PERCENT)}%)")
 
     return report

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -1,0 +1,221 @@
+"""Two passes, because fill detection needs near-clean drums.
+
+Pass one splits the mix into four stems; pass two takes the drum stem alone and decomposes
+it into kick, snare and toms. Running the drum model on the full mix is what the second
+pass exists to avoid — it has bass and vocals bleeding into every hit, and a fill detector
+reading that is reading the band, not the drummer.
+
+Three decisions worth knowing:
+
+* **The job's key and the stems' key are not the same key, on purpose.** The job is keyed
+  the way its acquisition is keyed — a timeline fingerprint, a clip's path/size/mtime —
+  because that is all that can be known in the starter, before any audio exists. The stems
+  on disk are keyed by the *content hash* of the audio that produced them plus the params
+  (#22: "workers key off content hash of cached audio + params hash"), so audio that comes
+  back byte-identical under a moved fingerprint costs nothing: the directory is already
+  there and both passes are skipped. ``refresh`` overrides both.
+
+* **Acquisition runs inside this job.** #12 puts the export inside the starter rather than
+  making the agent sequence one, so the stems job starts the acquisition job and follows
+  it, mapping its progress into the first quarter of its own. Its failure arrives as this
+  job's failure with the acquisition's own cause and fix (see ``ChainedJobError``) —
+  a render queue problem reads as a render queue problem either way.
+
+* **Each pass writes into its own directory.** Pass two reads the drum stem pass one
+  wrote; sharing a directory would have the decomposition land beside — and, with a model
+  that labels its output ``(Drums)``, on top of — the file it is reading.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..config import Config, get_config
+from ..errors import ChainedJobError, InternalError
+from ..jobs import cache, store
+from ..jobs import runner as job_runner
+from ..jobs.runner import JobOutput, Progress, start_job
+from ..logging_config import get_logger
+from ..naming import slug
+from ..resolve.connection import ResolveConnection
+from . import acquire, ffmpeg, separator
+
+log = get_logger("audio")
+
+KIND = "separate_stems"
+
+FOUR_STEMS = ("vocals", "drums", "bass", "other")
+DRUM_STEMS = ("kick", "snare", "toms")
+DRUM_SOURCE = "drums"
+"""Which of the four stems the second pass decomposes."""
+
+MIX_PASS = "mix"
+DRUM_PASS = "drums"
+
+ACQUIRE_FLOOR = 0.02
+ACQUIRE_CEILING = 0.25
+PASS_ONE_CEILING = 0.6
+PASS_TWO_CEILING = 0.9
+COLLECTING = 0.95
+POLL_SECONDS = 0.1
+
+PERCENT = 100
+
+
+def separate_stems(
+    connection: ResolveConnection,
+    scope: str = acquire.TIMELINE_SCOPE,
+    timeline: str | None = None,
+    clip: str | None = None,
+    bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
+    refresh: bool = False,
+    runner: separator.Runner | None = None,
+    ffmpeg_runner: ffmpeg.Runner | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Start a two-pass separation job. Returns the job record, not the stems.
+
+    ``runner`` and ``ffmpeg_runner`` are the two subprocess seams: the default shells out
+    for real, and a caller can hand in its own to exercise the route without the models or
+    ffmpeg installed.
+    """
+    config = config or get_config()
+    source = acquire.audio_source(
+        connection,
+        scope,
+        timeline=timeline,
+        clip=clip,
+        bin=bin,
+        refresh=refresh,
+        runner=ffmpeg_runner,
+        config=config,
+    )
+    params = {
+        **source.params,
+        "model": config.stem_model,
+        "drum_model": config.drum_model,
+        "stems": list(FOUR_STEMS),
+        "drum_stems": list(DRUM_STEMS),
+    }
+    key = cache.cache_key(KIND, [source.fingerprint], params)
+
+    def work(progress: Progress) -> JobOutput:
+        audio = acquired(source, progress, config)
+        return two_pass(audio, params, progress, runner=runner, reuse=not refresh, config=config)
+
+    return start_job(KIND, params, work, cache_key=key, refresh=refresh, config=config)
+
+
+def acquired(
+    source: acquire.Source,
+    progress: Progress,
+    config: Config | None = None,
+    poll: float = POLL_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    """Run the acquisition this separation needs, and report it as this job's first quarter.
+
+    A cache hit comes back completed from the starter and is never waited on at all; a real
+    export is followed record by record, because for a concert that render is minutes of
+    the job and a poller that sees nothing move assumes a hang.
+    """
+    config = config or get_config()
+    progress(ACQUIRE_FLOOR, "acquiring the audio")
+    record = source.start()
+    span = ACQUIRE_CEILING - ACQUIRE_FLOOR
+
+    while record["state"] == store.RUNNING:
+        fraction = float(record.get("progress") or 0.0)
+        progress(ACQUIRE_FLOOR + span * fraction, str(record.get("step") or "acquiring the audio"))
+        sleep(poll)
+        job_id = str(record["job_id"])
+        record = store.load(job_id, config).payload()
+        if record["state"] == store.RUNNING and not job_runner.alive(job_id):
+            raise InternalError(
+                cause=f"The acquisition {job_id} stopped without finishing its record.",
+                detail={"job_id": job_id, "step": record.get("step")},
+            )
+
+    if record["state"] == store.FAILED:
+        raise ChainedJobError(record.get("error") or {}, str(record["job_id"]))
+
+    result = record.get("result")
+    if not isinstance(result, dict):
+        raise InternalError(cause=f"The acquisition {record['job_id']} finished with no audio.")
+    return result
+
+
+def two_pass(
+    audio: dict[str, Any],
+    params: dict[str, Any],
+    progress: Progress,
+    runner: separator.Runner | None = None,
+    reuse: bool = True,
+    config: Config | None = None,
+) -> JobOutput:
+    """The worker: four stems, then the drum stem decomposed into kick, snare and toms."""
+    config = config or get_config()
+    key = cache.cache_key(KIND, [{"content_sha256": audio["content_sha256"]}], params)
+    directory = config.stems_dir / f"{slug(Path(str(audio['path'])).stem, 'stems')}-{key[:12]}"
+    mix_dir = directory / MIX_PASS
+    drums_dir = directory / DRUM_PASS
+
+    reused = reuse and _already_separated(mix_dir, drums_dir)
+    if reused:
+        log.info("Stems for %s are already on disk at %s", audio["path"], directory)
+        stems = separator.collect(mix_dir)
+        drums = separator.collect(drums_dir)
+    else:
+        stems = separator.separate(
+            audio["path"],
+            mix_dir,
+            config.stem_model,
+            FOUR_STEMS,
+            progress=_pass(progress, ACQUIRE_CEILING, PASS_ONE_CEILING, "separating four stems"),
+            runner=runner,
+            config=config,
+        )
+        progress(PASS_ONE_CEILING, "decomposing the drum stem")
+        drums = separator.separate(
+            stems[DRUM_SOURCE],
+            drums_dir,
+            config.drum_model,
+            DRUM_STEMS,
+            progress=_pass(progress, PASS_ONE_CEILING, PASS_TWO_CEILING, "decomposing the drums"),
+            runner=runner,
+            config=config,
+        )
+
+    progress(COLLECTING, "collecting the stems")
+    result = {
+        "key": key,
+        "directory": str(directory),
+        "stems": {name: str(path) for name, path in stems.items()},
+        "drums": {name: str(path) for name, path in drums.items()},
+        "models": {"stems": config.stem_model, "drums": config.drum_model},
+        "audio": audio,
+        "reused": reused,
+    }
+    artifacts = tuple([*stems.values(), *drums.values()])
+    log.info("Separated %s into %d stems at %s", audio["path"], len(artifacts), directory)
+    return JobOutput(result, artifacts)
+
+
+def _already_separated(mix_dir: Path, drums_dir: Path) -> bool:
+    """Both passes are on disk in full — a partial run is worth redoing, not patching."""
+    return not separator.missing_from(mix_dir, FOUR_STEMS) and not separator.missing_from(
+        drums_dir, DRUM_STEMS
+    )
+
+
+def _pass(progress: Progress, floor: float, ceiling: float, step: str) -> separator.Fraction:
+    """Map one pass's own 0-1 onto the slice of the job that pass is."""
+    span = ceiling - floor
+
+    def report(fraction: float) -> None:
+        progress(floor + span * fraction, f"{step} ({int(fraction * PERCENT)}%)")
+
+    return report

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -97,13 +97,7 @@ def separate_stems(
         runner=ffmpeg_runner,
         config=config,
     )
-    params = {
-        **source.params,
-        "model": config.stem_model,
-        "drum_model": config.drum_model,
-        "stems": list(FOUR_STEMS),
-        "drum_stems": list(DRUM_STEMS),
-    }
+    params = {**source.params, **separation_params(config)}
     key = cache.cache_key(KIND, [source.fingerprint], params)
 
     def work(progress: Progress) -> JobOutput:
@@ -146,6 +140,17 @@ def acquired(
     return finished.result
 
 
+def separation_params(config: Config | None = None) -> dict[str, Any]:
+    """What is being run, as opposed to what it is being run on. Keys the stems on disk."""
+    config = config or get_config()
+    return {
+        "model": config.stem_model,
+        "drum_model": config.drum_model,
+        "stems": list(FOUR_STEMS),
+        "drum_stems": list(DRUM_STEMS),
+    }
+
+
 def stem_key(audio: dict[str, Any], params: dict[str, Any]) -> str:
     """What the stems on disk are keyed by: the audio's own bytes and the models run on it.
 
@@ -155,7 +160,7 @@ def stem_key(audio: dict[str, Any], params: dict[str, Any]) -> str:
     GPU twice for a byte-identical answer (#22 story 26: analysis is paid for once per
     media state). Sample rate and bit depth are in the bytes already.
     """
-    settings = {name: params[name] for name in SEPARATION if name in params}
+    settings = {name: params.get(name) for name in SEPARATION}
     return cache.cache_key(KIND, [{"content_sha256": audio["content_sha256"]}], settings)
 
 
@@ -223,19 +228,18 @@ def _already_separated(mix_dir: Path, drums_dir: Path) -> bool:
 
 
 def _pass(progress: Progress, floor: float, ceiling: float, step: str) -> separator.Fraction:
-    """Map one pass's own 0-1 onto the slice of the job that pass is, and never go back.
+    """Map one pass's own 0-1 onto the slice of the job that pass is.
 
-    A first run downloads its model and prints a progress bar for *that* before the one for
-    the separation, so the percentages restart mid-pass. Reporting the restart would have
-    the agent watch a job apparently lose ground; the highest reading so far is the honest
-    summary of a pass made of several bars.
+    The bar always tracks the newest reading, including one lower than the last. A first
+    run prints a bar for the model download before the bar for the separation, and
+    ``separator`` drops the download's percentages precisely so that this stays rare — but
+    holding the highest reading instead would be worse than a backslide: a download bar
+    ends at 100%, so the separation that follows it, the long part, would report a frozen
+    number for its whole run. A number that moves is the point.
     """
     span = ceiling - floor
-    highest = 0.0
 
     def report(fraction: float) -> None:
-        nonlocal highest
-        highest = max(highest, fraction)
-        progress(floor + span * highest, f"{step} ({int(highest * PERCENT)}%)")
+        progress(floor + span * fraction, f"{step} ({int(fraction * PERCENT)}%)")
 
     return report

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -17,6 +17,9 @@ DEFAULT_SCRIPT_LIB = Path("C:/Program Files/Blackmagic Design/DaVinci Resolve/fu
 DEFAULT_LOG_LEVEL = "INFO"
 CACHE_DIR_NAME = "resolve-mcp"
 DEFAULT_FFMPEG = "ffmpeg"
+DEFAULT_AUDIO_SEPARATOR = "audio-separator"
+DEFAULT_STEM_MODEL = "htdemucs_ft.yaml"
+DEFAULT_DRUM_MODEL = "MDX23C-DrumSep-6stem-FT.ckpt"
 
 
 TRUTHY = {"1", "true", "yes", "on"}
@@ -31,6 +34,9 @@ class Config:
     log_level: str
     allow_any_python: bool = False
     ffmpeg: str = DEFAULT_FFMPEG
+    audio_separator: str = DEFAULT_AUDIO_SEPARATOR
+    stem_model: str = DEFAULT_STEM_MODEL
+    drum_model: str = DEFAULT_DRUM_MODEL
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> Config:
@@ -46,6 +52,9 @@ class Config:
             log_level=env.get("RESOLVE_MCP_LOG_LEVEL") or DEFAULT_LOG_LEVEL,
             allow_any_python=(env.get(BYPASS_ENV) or "").lower() in TRUTHY,
             ffmpeg=env.get("RESOLVE_MCP_FFMPEG") or DEFAULT_FFMPEG,
+            audio_separator=env.get("RESOLVE_MCP_AUDIO_SEPARATOR") or DEFAULT_AUDIO_SEPARATOR,
+            stem_model=env.get("RESOLVE_MCP_STEM_MODEL") or DEFAULT_STEM_MODEL,
+            drum_model=env.get("RESOLVE_MCP_DRUM_MODEL") or DEFAULT_DRUM_MODEL,
         )
 
     @property
@@ -77,6 +86,11 @@ class Config:
     def audio_dir(self) -> Path:
         """Acquired WAVs. Analysis workers key off the content hash of what lands here."""
         return self.cache_dir / "audio"
+
+    @property
+    def stems_dir(self) -> Path:
+        """Separated stems, one directory per content hash + params, two passes inside it."""
+        return self.cache_dir / "stems"
 
     @property
     def interchange_dir(self) -> Path:

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -7,6 +7,7 @@ into a tool result.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 RESOLVE_FIX = (
@@ -331,6 +332,50 @@ class AudioMappingError(ResolveMcpError):
         "Acquire this audio from the timeline instead (scope=timeline): only the render "
         "route captures audio Resolve has linked or offset away from the source file."
     )
+
+
+class SeparatorUnavailableError(ResolveMcpError):
+    """python-audio-separator is not installed — stem separation cannot run without it."""
+
+    code = "separator_unavailable"
+    default_fix = (
+        "Install it with pip install audio-separator[gpu] and make sure the audio-separator "
+        "command is on PATH, or point RESOLVE_MCP_AUDIO_SEPARATOR at the executable."
+    )
+
+
+class StemSeparationError(ResolveMcpError):
+    """The separator ran and did not produce the stems that were asked for."""
+
+    code = "stem_separation_failed"
+    default_fix = (
+        "Check the model name (RESOLVE_MCP_STEM_MODEL, RESOLVE_MCP_DRUM_MODEL) is one "
+        "audio-separator knows, and that the GPU has memory free. The separator's own "
+        "message is in detail.output."
+    )
+
+
+class ChainedJobError(ResolveMcpError):
+    """A job this one had to run first failed. Its cause, fix and code travel back unchanged.
+
+    Relabelling it as a stems failure would hide what actually broke: a render queue that
+    refused the export is a render queue problem whether the agent asked for audio or for
+    stems, and the advice that fixes it is the advice the acquisition already wrote.
+    """
+
+    code = "chained_job_failed"
+
+    def __init__(self, error: Mapping[str, Any], job_id: str) -> None:
+        detail = dict(error.get("detail") or {})
+        detail["job_id"] = job_id
+        super().__init__(
+            cause=str(error.get("cause") or f"The job {job_id} this one depends on failed."),
+            fix=str(error.get("fix")) if error.get("fix") else None,
+            detail=detail,
+        )
+        code = error.get("code")
+        if code:
+            self.code = str(code)
 
 
 class InternalError(ResolveMcpError):

--- a/src/resolve_mcp/jobs/runner.py
+++ b/src/resolve_mcp/jobs/runner.py
@@ -28,12 +28,13 @@ Four decisions:
 from __future__ import annotations
 
 import threading
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, NamedTuple
 
 from ..config import Config, get_config
-from ..errors import InternalError, ResolveMcpError
+from ..errors import ChainedJobError, InternalError, ResolveMcpError
 from ..logging_config import get_logger
 from . import cache, store
 from .store import JobRecord
@@ -41,6 +42,7 @@ from .store import JobRecord
 log = get_logger("jobs")
 
 WAIT_TIMEOUT = 30.0
+FOLLOW_POLL = 0.1
 WAITING = "waiting for Resolve"
 
 RESOLVE_LOCK = threading.Lock()
@@ -63,6 +65,7 @@ class JobOutput(NamedTuple):
 
 Progress = Callable[[float, str], None]
 Work = Callable[[Progress], JobOutput]
+Watch = Callable[[JobRecord], None]
 
 
 def start_job(
@@ -161,6 +164,42 @@ def alive(job_id: str) -> bool:
     with _threads_lock:
         thread = _threads.get(job_id)
     return thread is not None and thread.is_alive()
+
+
+def follow(
+    job_id: str,
+    watch: Watch | None = None,
+    poll: float = FOLLOW_POLL,
+    sleep: Callable[[float], None] = time.sleep,
+    config: Config | None = None,
+) -> JobRecord:
+    """Wait for a job this job started, reporting it as it goes, and raise what it raised.
+
+    ``wait_for`` joins a thread and hands back whatever the record says; this is the other
+    half of "for chained work" — the caller sees each record as it lands, so a render that
+    is minutes of the parent job is minutes the parent job can report, and a failure comes
+    back as an exception carrying the child's own cause and fix rather than as a result the
+    caller has to inspect. A cache hit is already finished and is never waited on at all.
+    """
+    record = store.load(job_id, config)
+    while record.state == store.RUNNING:
+        if watch is not None:
+            watch(record)
+        sleep(poll)
+        record = store.load(job_id, config)
+        if record.state == store.RUNNING and not alive(job_id):
+            # The thread may have closed the record between that read and this check, so
+            # the answer is the record read *after* the thread is known to be gone.
+            record = store.load(job_id, config)
+            if record.state == store.RUNNING:
+                raise InternalError(
+                    cause=f"The {record.kind} job {job_id} stopped without finishing.",
+                    detail={"job_id": job_id, "step": record.step, "progress": record.progress},
+                )
+
+    if record.state == store.FAILED:
+        raise ChainedJobError(record.error or {}, job_id)
+    return record
 
 
 def wait_for(job_id: str, timeout: float = WAIT_TIMEOUT, config: Config | None = None) -> JobRecord:

--- a/src/resolve_mcp/jobs/runner.py
+++ b/src/resolve_mcp/jobs/runner.py
@@ -151,6 +151,18 @@ def _work(record: JobRecord, work: Work, config: Config) -> None:
     store.finish(record, result=output.result, config=config)
 
 
+def alive(job_id: str) -> bool:
+    """Whether a worker thread for this job is still running in this process.
+
+    A job that a chained job is following can only be finished by that thread. If the
+    thread is gone while the record still says running, nothing will ever close it, and a
+    follower that kept polling would wait forever.
+    """
+    with _threads_lock:
+        thread = _threads.get(job_id)
+    return thread is not None and thread.is_alive()
+
+
 def wait_for(job_id: str, timeout: float = WAIT_TIMEOUT, config: Config | None = None) -> JobRecord:
     """Block until the job is off the thread pool — for chained work, and for tests.
 

--- a/src/resolve_mcp/jobs/store.py
+++ b/src/resolve_mcp/jobs/store.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import itertools
 import json
 import os
+import time
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
@@ -43,6 +44,10 @@ STATES = (RUNNING, COMPLETED, FAILED)
 
 SESSION = uuid.uuid4().hex
 """This server process. Records written under any other session predate a restart."""
+
+REPLACE_ATTEMPTS = 20
+REPLACE_PAUSE = 0.01
+"""How long a record write waits out a reader holding the file open. See ``_replace``."""
 
 _sequence = itertools.count()
 """Breaks ties in "newest first": the Windows clock is coarser than two starts in a row."""
@@ -115,7 +120,7 @@ def save(record: JobRecord, config: Config | None = None) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
     scratch = target.with_suffix(".writing")
     scratch.write_text(json.dumps(record.payload(), indent=2), encoding="utf-8")
-    os.replace(scratch, target)
+    _replace(scratch, target)
 
 
 def finish(
@@ -158,9 +163,28 @@ def load_all(state: str | None = None, config: Config | None = None) -> list[Job
     return [one for one in found if one.state == state]
 
 
+def _replace(scratch: Path, target: Path) -> None:
+    """Put the new record in place, waiting out a reader that has the old one open.
+
+    Windows refuses to replace a file while another handle holds it, and a reader is
+    exactly what polling is — ``get_job`` on one side, a job following the job it chained
+    on the other. The window is microseconds wide, so a short retry closes it. Letting the
+    error out instead would kill the worker thread mid-save and leave the record saying
+    ``running`` forever, which is the one failure the whole store exists to prevent.
+    """
+    for attempt in range(REPLACE_ATTEMPTS):
+        try:
+            os.replace(scratch, target)
+            return
+        except PermissionError:
+            if attempt == REPLACE_ATTEMPTS - 1:
+                raise
+            time.sleep(REPLACE_PAUSE)
+
+
 def _read(path: Path) -> JobRecord | None:
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw = json.loads(_read_text(path))
     except FileNotFoundError:
         return None
     except (OSError, ValueError):
@@ -171,6 +195,23 @@ def _read(path: Path) -> JobRecord | None:
         return None
     known = {name: raw[name] for name in JobRecord.__dataclass_fields__ if name in raw}
     return JobRecord(**known)
+
+
+def _read_text(path: Path) -> str:
+    """Read the record, waiting out the instant a writer is swapping it in underneath.
+
+    The same Windows rule from the other side: a read can land in the moment the replace
+    holds the file. Missing that would report a running job as gone, which reads as a far
+    worse failure than the pause it costs to try again.
+    """
+    for attempt in range(REPLACE_ATTEMPTS):
+        try:
+            return path.read_text(encoding="utf-8")
+        except PermissionError:
+            if attempt == REPLACE_ATTEMPTS - 1:
+                raise
+            time.sleep(REPLACE_PAUSE)
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
 def _recovered(record: JobRecord, config: Config) -> JobRecord:

--- a/src/resolve_mcp/jobs/store.py
+++ b/src/resolve_mcp/jobs/store.py
@@ -25,6 +25,7 @@ import json
 import os
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -45,9 +46,9 @@ STATES = (RUNNING, COMPLETED, FAILED)
 SESSION = uuid.uuid4().hex
 """This server process. Records written under any other session predate a restart."""
 
-REPLACE_ATTEMPTS = 20
-REPLACE_PAUSE = 0.01
-"""How long a record write waits out a reader holding the file open. See ``_replace``."""
+SHARING_ATTEMPTS = 20
+SHARING_PAUSE = 0.01
+"""How long either side of a poll waits out the other's handle. See ``_sharing``."""
 
 _sequence = itertools.count()
 """Breaks ties in "newest first": the Windows clock is coarser than two starts in a row."""
@@ -120,7 +121,7 @@ def save(record: JobRecord, config: Config | None = None) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
     scratch = target.with_suffix(".writing")
     scratch.write_text(json.dumps(record.payload(), indent=2), encoding="utf-8")
-    _replace(scratch, target)
+    _sharing(lambda: os.replace(scratch, target))
 
 
 def finish(
@@ -163,28 +164,30 @@ def load_all(state: str | None = None, config: Config | None = None) -> list[Job
     return [one for one in found if one.state == state]
 
 
-def _replace(scratch: Path, target: Path) -> None:
-    """Put the new record in place, waiting out a reader that has the old one open.
+def _sharing[T](attempt: Callable[[], T]) -> T:
+    """Do it again if the other side of a poll had the file open.
 
-    Windows refuses to replace a file while another handle holds it, and a reader is
-    exactly what polling is — ``get_job`` on one side, a job following the job it chained
-    on the other. The window is microseconds wide, so a short retry closes it. Letting the
-    error out instead would kill the worker thread mid-save and leave the record saying
-    ``running`` forever, which is the one failure the whole store exists to prevent.
+    Windows refuses to replace a file while another handle holds it, and refuses the read
+    that lands mid-replace — and polling is exactly two handles on one record: ``get_job``
+    or a chained job on one side, the worker saving its progress on the other. The window
+    is microseconds wide, so a short retry closes it. Letting the error out would kill the
+    worker thread mid-save and leave the record saying ``running`` forever, which is the
+    one failure the whole store exists to prevent; on the reading side it would report a
+    running job as gone.
     """
-    for attempt in range(REPLACE_ATTEMPTS):
+    for attempt_number in range(SHARING_ATTEMPTS):
         try:
-            os.replace(scratch, target)
-            return
+            return attempt()
         except PermissionError:
-            if attempt == REPLACE_ATTEMPTS - 1:
+            if attempt_number == SHARING_ATTEMPTS - 1:
                 raise
-            time.sleep(REPLACE_PAUSE)
+            time.sleep(SHARING_PAUSE)
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
 def _read(path: Path) -> JobRecord | None:
     try:
-        raw = json.loads(_read_text(path))
+        raw = json.loads(_sharing(lambda: path.read_text(encoding="utf-8")))
     except FileNotFoundError:
         return None
     except (OSError, ValueError):
@@ -197,21 +200,6 @@ def _read(path: Path) -> JobRecord | None:
     return JobRecord(**known)
 
 
-def _read_text(path: Path) -> str:
-    """Read the record, waiting out the instant a writer is swapping it in underneath.
-
-    The same Windows rule from the other side: a read can land in the moment the replace
-    holds the file. Missing that would report a running job as gone, which reads as a far
-    worse failure than the pause it costs to try again.
-    """
-    for attempt in range(REPLACE_ATTEMPTS):
-        try:
-            return path.read_text(encoding="utf-8")
-        except PermissionError:
-            if attempt == REPLACE_ATTEMPTS - 1:
-                raise
-            time.sleep(REPLACE_PAUSE)
-    raise AssertionError("unreachable")  # pragma: no cover
 
 
 def _recovered(record: JobRecord, config: Config) -> JobRecord:

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from . import __version__
 from .config import get_config
 from .logging_config import configure_logging, get_logger
-from .tools import cut, escape_hatch, jobs, media, project, timeline
+from .tools import cut, escape_hatch, jobs, media, project, stems, timeline
 
 log = get_logger("server")
 
@@ -49,6 +49,7 @@ def build_server() -> FastMCP:
         *media.TOOLS,
         *timeline.TOOLS,
         *cut.TOOLS,
+        *stems.TOOLS,
         *jobs.TOOLS,
         *escape_hatch.TOOLS,
     ):

--- a/src/resolve_mcp/tools/stems.py
+++ b/src/resolve_mcp/tools/stems.py
@@ -1,0 +1,51 @@
+"""The stem separation starter — the first of the typed heavy-compute tools.
+
+Acquiring the audio is inside this call rather than a step the agent sequences (#12), so
+one tool call covers "get me the drums for this timeline" end to end and the agent polls
+one job for the whole of it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..audio import stems
+from ..resolve.connection import get_connection
+from .envelope import tool
+
+
+@tool
+def separate_stems(
+    scope: str = "timeline",
+    timeline: str | None = None,
+    clip: str | None = None,
+    bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
+    refresh: bool = False,
+) -> dict[str, Any]:
+    """Split audio into stems on the GPU, in two passes, as a background job.
+
+    Returns a job_id immediately — poll it with get_job. Pass one splits the mix into
+    vocals, drums, bass and other; pass two decomposes the drum stem into kick, snare and
+    toms, which is what fill detection reads. The result is paths on disk, not audio.
+
+    scope=timeline exports and separates the timeline mix (the only route that captures
+    Resolve's own summing of the tracks); scope=clip reads one media pool clip's file
+    directly, which is faster but does not see any level or mapping the director set. Both
+    are cached by content and parameters, so a rerun on unchanged media is instant; pass
+    refresh=true when you changed something no reading can see, such as a clip's level.
+    """
+    return {
+        "job": stems.separate_stems(
+            get_connection(),
+            scope=scope,
+            timeline=timeline,
+            clip=clip,
+            bin=bin,
+            refresh=refresh,
+        )
+    }
+
+
+TOOLS: tuple[Any, ...] = (separate_stems,)
+
+__all__ = ["TOOLS", "separate_stems"]

--- a/src/resolve_mcp/tools/stems.py
+++ b/src/resolve_mcp/tools/stems.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..audio import stems
+from ..audio import acquire, stems
 from ..resolve.connection import get_connection
 from .envelope import tool
 
 
 @tool
 def separate_stems(
-    scope: str = "timeline",
+    scope: str = acquire.TIMELINE_SCOPE,
     timeline: str | None = None,
     clip: str | None = None,
     bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import contextlib
 import math
 import wave
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -1322,6 +1322,48 @@ class FakeConnector:
         if not self._handles:
             return None
         return self._handles.pop(0)
+
+
+class FakeSeparator:
+    """Stand in for the audio-separator CLI, one pass per call.
+
+    It writes real WAVs under the naming convention the real thing uses —
+    ``<input>_(Label)_<model>.wav`` — because the stems are matched by reading that label
+    back, so a fake that wrote arbitrary names would prove nothing about the mapping. Each
+    positional argument is one pass's labels; the last one repeats if it is called again.
+    """
+
+    def __init__(
+        self,
+        *passes: Sequence[str],
+        returncode: int = 0,
+        output: Sequence[str] = (),
+    ) -> None:
+        self.passes = [tuple(one) for one in passes]
+        self.returncode = returncode
+        self.output = tuple(output)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: Sequence[str], on_line: Callable[[str], None]) -> Any:
+        from resolve_mcp.audio.separator import Completed
+
+        self.calls.append(list(argv))
+        for line in self.output:
+            on_line(line)
+        if self.returncode == 0:
+            for label in self._labels():
+                write_wav(self._target(argv, label), seconds=0.2)
+        return Completed(self.returncode, "\n".join(self.output))
+
+    def _labels(self) -> tuple[str, ...]:
+        if not self.passes:
+            return ()
+        return self.passes[min(len(self.calls) - 1, len(self.passes) - 1)]
+
+    def _target(self, argv: Sequence[str], label: str) -> Path:
+        out_dir = Path(argv[list(argv).index("--output_dir") + 1])
+        model = Path(argv[list(argv).index("--model_filename") + 1]).stem
+        return out_dir / f"{Path(argv[1]).stem}_({label.title()})_{model}.wav"
 
 
 def write_wav(

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1330,7 +1330,9 @@ class FakeSeparator:
     It writes real WAVs under the naming convention the real thing uses —
     ``<input>_(Label)_<model>.wav`` — because the stems are matched by reading that label
     back, so a fake that wrote arbitrary names would prove nothing about the mapping. Each
-    positional argument is one pass's labels; the last one repeats if it is called again.
+    positional argument is one pass's labels, and the sequence starts over on the call
+    after the last: a second separation of the same audio is another first pass, not a
+    seventh one.
     """
 
     def __init__(
@@ -1344,21 +1346,19 @@ class FakeSeparator:
         self.output = tuple(output)
         self.calls: list[list[str]] = []
 
-    def __call__(self, argv: Sequence[str], on_line: Callable[[str], None]) -> Any:
-        from resolve_mcp.audio.separator import Completed
-
+    def __call__(self, argv: Sequence[str], on_line: Callable[[str], None]) -> int:
         self.calls.append(list(argv))
         for line in self.output:
             on_line(line)
         if self.returncode == 0:
             for label in self._labels():
                 write_wav(self._target(argv, label), seconds=0.2)
-        return Completed(self.returncode, "\n".join(self.output))
+        return self.returncode
 
     def _labels(self) -> tuple[str, ...]:
         if not self.passes:
             return ()
-        return self.passes[min(len(self.calls) - 1, len(self.passes) - 1)]
+        return self.passes[(len(self.calls) - 1) % len(self.passes)]
 
     def _target(self, argv: Sequence[str], label: str) -> Path:
         out_dir = Path(argv[list(argv).index("--output_dir") + 1])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,6 +74,26 @@ def test_artifacts_live_under_the_cache_root(tmp_path: Path) -> None:
     assert config.job_dir == tmp_path / "jobs"
     assert config.result_dir == tmp_path / "results"
     assert config.audio_dir == tmp_path / "audio"
+    assert config.stems_dir == tmp_path / "stems"
+
+
+def test_the_separator_and_its_two_models_are_overridable() -> None:
+    """The models are named, not discovered: a rename must not silently change a cache key."""
+    assert Config.from_env({}).audio_separator == "audio-separator"
+    assert Config.from_env({}).stem_model.startswith("htdemucs")
+    assert "DrumSep" in Config.from_env({}).drum_model
+
+    config = Config.from_env(
+        {
+            "RESOLVE_MCP_AUDIO_SEPARATOR": r"D:\tools\audio-separator.exe",
+            "RESOLVE_MCP_STEM_MODEL": "htdemucs_6s.yaml",
+            "RESOLVE_MCP_DRUM_MODEL": "drumsep.ckpt",
+        }
+    )
+
+    assert config.audio_separator == r"D:\tools\audio-separator.exe"
+    assert config.stem_model == "htdemucs_6s.yaml"
+    assert config.drum_model == "drumsep.ckpt"
 
 
 def test_ffmpeg_is_a_bare_name_on_path_until_told_otherwise() -> None:

--- a/tests/test_job_runner.py
+++ b/tests/test_job_runner.py
@@ -8,15 +8,15 @@ never do is stall, so that is the property under test.
 from __future__ import annotations
 
 import threading
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
 from resolve_mcp.config import get_config
 from resolve_mcp.errors import ChainedJobError, InternalError, MediaOperationError
-from resolve_mcp.jobs import cache, store
+from resolve_mcp.jobs import cache, runner, store
 from resolve_mcp.jobs.runner import JobOutput, Progress, follow, start_job, wait_for
-from resolve_mcp.jobs.store import JobRecord
 
 
 def test_the_starter_returns_before_the_work_finishes() -> None:
@@ -51,7 +51,11 @@ def test_following_a_job_reports_it_on_the_way_and_hands_back_its_record() -> No
     started = start_job("acquire_timeline_audio", {}, work)
     threading.Timer(0.05, release.set).start()
 
-    finished = follow(started["job_id"], lambda record: seen.append(record.progress), poll=0.01)
+    finished = follow(
+        started["job_id"],
+        lambda record: seen.append(record.progress),
+        poll=0.01,
+    )
 
     assert finished.state == "completed"
     assert finished.result == {"path": "D:/mix.wav"}
@@ -86,24 +90,25 @@ def test_a_job_whose_thread_is_gone_fails_its_follower_rather_than_hanging() -> 
     assert raised.value.detail["job_id"] == orphan.job_id
 
 
-def test_a_job_that_finishes_between_the_read_and_the_thread_check_is_not_called_dead() -> None:
-    """The record read after the thread is known gone is the authoritative one."""
-    release = threading.Event()
+def test_a_job_that_finishes_between_the_read_and_the_thread_check_is_not_called_dead(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The authoritative record is the one read *after* the thread is known to be gone.
 
-    def work(progress: Progress) -> JobOutput:
-        release.wait(timeout=5)
-        return JobOutput({"done": True})
+    The window is a real one and too narrow to hit by running a thread, so the reads are
+    stubbed: a record still saying running, then a dead thread, then the completed record
+    the worker wrote on its way out. Reading it in that order is the whole fix.
+    """
+    running = store.new_job("acquire_timeline_audio", {})
+    completed = replace(running, state="completed", result={"done": True})
+    reads = iter([running, running, completed])
+    monkeypatch.setattr(runner, "alive", lambda job_id: False)
+    monkeypatch.setattr(store, "load", lambda job_id, config=None: next(reads))
 
-    started = start_job("acquire_timeline_audio", {}, work)
-    watched: list[JobRecord] = []
-
-    def watch(record: JobRecord) -> None:
-        watched.append(record)
-        release.set()
-
-    finished = follow(started["job_id"], watch, poll=0.05)
+    finished = follow(running.job_id, poll=0.0)
 
     assert finished.state == "completed"
+    assert finished.result == {"done": True}
 
 
 def test_progress_from_the_worker_is_visible_to_a_poller() -> None:

--- a/tests/test_job_runner.py
+++ b/tests/test_job_runner.py
@@ -13,9 +13,10 @@ from pathlib import Path
 import pytest
 
 from resolve_mcp.config import get_config
-from resolve_mcp.errors import MediaOperationError
+from resolve_mcp.errors import ChainedJobError, InternalError, MediaOperationError
 from resolve_mcp.jobs import cache, store
-from resolve_mcp.jobs.runner import JobOutput, Progress, start_job, wait_for
+from resolve_mcp.jobs.runner import JobOutput, Progress, follow, start_job, wait_for
+from resolve_mcp.jobs.store import JobRecord
 
 
 def test_the_starter_returns_before_the_work_finishes() -> None:
@@ -35,6 +36,74 @@ def test_the_starter_returns_before_the_work_finishes() -> None:
 
     assert finished.state == "completed"
     assert finished.result == {"done": True}
+
+
+def test_following_a_job_reports_it_on_the_way_and_hands_back_its_record() -> None:
+    """How a job chains on another: the child's progress is the parent's to report."""
+    release = threading.Event()
+    seen: list[float] = []
+
+    def work(progress: Progress) -> JobOutput:
+        progress(0.5, "halfway")
+        release.wait(timeout=5)
+        return JobOutput({"path": "D:/mix.wav"})
+
+    started = start_job("acquire_timeline_audio", {}, work)
+    threading.Timer(0.05, release.set).start()
+
+    finished = follow(started["job_id"], lambda record: seen.append(record.progress), poll=0.01)
+
+    assert finished.state == "completed"
+    assert finished.result == {"path": "D:/mix.wav"}
+    assert seen
+
+
+def test_a_followed_job_that_fails_raises_its_own_cause_and_code() -> None:
+    """Relabelling it would hide what broke: the child's advice is the advice that fixes it."""
+
+    def work(progress: Progress) -> JobOutput:
+        raise MediaOperationError(cause="The pool refused the clip.", fix="Check the bin.")
+
+    started = start_job("acquire_clip_audio", {}, work)
+
+    with pytest.raises(ChainedJobError) as raised:
+        follow(started["job_id"], poll=0.01)
+
+    assert raised.value.code == "media_operation_failed"
+    assert raised.value.cause == "The pool refused the clip."
+    assert raised.value.fix == "Check the bin."
+    assert raised.value.detail["job_id"] == started["job_id"]
+
+
+def test_a_job_whose_thread_is_gone_fails_its_follower_rather_than_hanging() -> None:
+    """A record left saying running has nobody to finish it — waiting would be forever."""
+    orphan = store.new_job("acquire_timeline_audio", {})
+
+    with pytest.raises(InternalError) as raised:
+        follow(orphan.job_id, poll=0.01)
+
+    assert "without finishing" in raised.value.cause
+    assert raised.value.detail["job_id"] == orphan.job_id
+
+
+def test_a_job_that_finishes_between_the_read_and_the_thread_check_is_not_called_dead() -> None:
+    """The record read after the thread is known gone is the authoritative one."""
+    release = threading.Event()
+
+    def work(progress: Progress) -> JobOutput:
+        release.wait(timeout=5)
+        return JobOutput({"done": True})
+
+    started = start_job("acquire_timeline_audio", {}, work)
+    watched: list[JobRecord] = []
+
+    def watch(record: JobRecord) -> None:
+        watched.append(record)
+        release.set()
+
+    finished = follow(started["job_id"], watch, poll=0.05)
+
+    assert finished.state == "completed"
 
 
 def test_progress_from_the_worker_is_visible_to_a_poller() -> None:

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -8,6 +8,7 @@ findable, and one that was still running has to be honest about having died.
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,8 @@ import pytest
 from resolve_mcp.config import get_config
 from resolve_mcp.errors import JobNotFoundError
 from resolve_mcp.jobs import store
+
+SAVES = 300
 
 
 def test_a_new_job_starts_running_and_lands_on_disk() -> None:
@@ -36,6 +39,38 @@ def test_progress_reads_back_from_disk_not_from_memory() -> None:
 
     assert reloaded.progress == pytest.approx(0.4)
     assert reloaded.step == "separating"
+
+
+def test_a_record_written_while_it_is_being_polled_survives_both_sides() -> None:
+    """The bug this guards, found by the first job to follow another job's record.
+
+    On Windows a replace fails while a reader holds the file, and a read fails mid-replace.
+    Unguarded, the write killed the worker thread mid-save and left the record saying
+    running forever — which is exactly what a polling agent, or a chained job, provokes.
+    """
+    record = store.new_job("separate_stems", {"scope": "timeline"})
+    done = threading.Event()
+    escaped: list[BaseException] = []
+
+    def writing() -> None:
+        try:
+            for index in range(SAVES):
+                record.progress = index / SAVES
+                store.save(record)
+            store.finish(record, result={"stems": 4})
+        except BaseException as exc:  # noqa: BLE001 - the point is that nothing escapes
+            escaped.append(exc)
+        finally:
+            done.set()
+
+    writer = threading.Thread(target=writing)
+    writer.start()
+    while not done.is_set():
+        store.load(record.job_id)
+    writer.join(timeout=10)
+
+    assert escaped == []
+    assert store.load(record.job_id).state == "completed"
 
 
 def test_an_unknown_job_id_names_the_tool_that_lists_them() -> None:

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -41,12 +41,41 @@ def test_progress_reads_back_from_disk_not_from_memory() -> None:
     assert reloaded.step == "separating"
 
 
+def test_a_write_that_loses_the_race_with_a_reader_is_tried_again() -> None:
+    """The rule the retry encodes, testable off Windows where the race cannot happen.
+
+    A reader holding the file is a refusal to wait out, not a failure to report: giving up
+    would kill the worker thread mid-save and leave the record saying running forever.
+    """
+    attempts: list[int] = []
+
+    def flaky() -> str:
+        attempts.append(len(attempts))
+        if len(attempts) < 3:
+            raise PermissionError(32, "The process cannot access the file")
+        return "written"
+
+    assert store._sharing(flaky) == "written"
+    assert len(attempts) == 3
+
+
+def test_a_reader_that_never_lets_go_is_still_an_error() -> None:
+    """Retrying forever would hide a genuinely locked cache directory."""
+
+    def locked() -> str:
+        raise PermissionError(32, "The process cannot access the file")
+
+    with pytest.raises(PermissionError):
+        store._sharing(locked)
+
+
 def test_a_record_written_while_it_is_being_polled_survives_both_sides() -> None:
     """The bug this guards, found by the first job to follow another job's record.
 
     On Windows a replace fails while a reader holds the file, and a read fails mid-replace.
     Unguarded, the write killed the worker thread mid-save and left the record saying
     running forever — which is exactly what a polling agent, or a chained job, provokes.
+    Only Windows can fail this one; the retry itself is pinned by the two tests above.
     """
     record = store.new_job("separate_stems", {"scope": "timeline"})
     done = threading.Event()

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -28,6 +29,9 @@ from typing import Any
 import pytest
 
 from resolve_mcp.audio.acquire import acquire_timeline_audio
+from resolve_mcp.audio.stems import DRUM_STEMS, FOUR_STEMS, two_pass
+from resolve_mcp.config import get_config
+from resolve_mcp.jobs import cache
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.resolve.connection import get_connection
 from resolve_mcp.tools.cut import build_timeline, validate_cut
@@ -44,6 +48,7 @@ from resolve_mcp.tools.timeline import (
 )
 
 from . import otio
+from .fakes import write_wav
 from .text_plus_probe import TEMPLATE_ENV, probe_template_append
 
 pytestmark = pytest.mark.live
@@ -508,6 +513,31 @@ def test_the_render_queue_exports_the_real_timeline_mix() -> None:
 
     again = acquire_timeline_audio(get_connection())
     assert again["cached"] is True, "an unchanged timeline must be a cache hit"
+
+
+@pytest.mark.skipif(shutil.which("audio-separator") is None, reason="audio-separator not on PATH")
+def test_the_real_separator_produces_the_stems_the_two_passes_expect() -> None:
+    """The AC no seam can check: that these models exist and label their output that way.
+
+    The fakes prove the two commands, the progress mapping, the caching and every refusal.
+    What they cannot prove is that ``htdemucs_ft.yaml`` and the DrumSep checkpoint are
+    names audio-separator resolves, that the drum model yields kick/snare/toms at all, or
+    that the real CLI writes ``<input>_(Label)_<model>.wav`` — the naming the stem mapping
+    reads back. Slow: the first run downloads both models.
+    """
+    fixture = write_wav(Path(get_config().cache_dir) / "live" / "separator-probe.wav", seconds=4.0)
+    audio = {
+        "path": str(fixture),
+        "content_sha256": cache.content_hash(fixture),
+        "scope": "live",
+    }
+
+    output = two_pass(audio, {"scope": "live"}, lambda fraction, step: None)
+
+    assert set(output.result["stems"]) >= set(FOUR_STEMS)
+    assert set(output.result["drums"]) >= set(DRUM_STEMS)
+    assert all(Path(one).stat().st_size > 0 for one in output.result["stems"].values())
+    assert all(Path(one).stat().st_size > 0 for one in output.result["drums"].values())
 
 
 def test_snapshot_writes_a_real_drp(tmp_path: Path) -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -515,8 +515,7 @@ def test_the_render_queue_exports_the_real_timeline_mix() -> None:
     assert again["cached"] is True, "an unchanged timeline must be a cache hit"
 
 
-@pytest.mark.skipif(shutil.which("audio-separator") is None, reason="audio-separator not on PATH")
-def test_the_real_separator_produces_the_stems_the_two_passes_expect() -> None:
+def test_the_real_separator_produces_the_stems_the_two_passes_expect(tmp_path: Path) -> None:
     """The AC no seam can check: that these models exist and label their output that way.
 
     The fakes prove the two commands, the progress mapping, the caching and every refusal.
@@ -524,8 +523,15 @@ def test_the_real_separator_produces_the_stems_the_two_passes_expect() -> None:
     names audio-separator resolves, that the drum model yields kick/snare/toms at all, or
     that the real CLI writes ``<input>_(Label)_<model>.wav`` — the naming the stem mapping
     reads back. Slow: the first run downloads both models.
+
+    The skip asks the *configured* executable, not the default name: a director who pointed
+    ``RESOLVE_MCP_AUDIO_SEPARATOR`` at an install off PATH would otherwise silently skip the
+    one check no fake can stand in for.
     """
-    fixture = write_wav(Path(get_config().cache_dir) / "live" / "separator-probe.wav", seconds=4.0)
+    if shutil.which(get_config().audio_separator) is None:
+        pytest.skip(f"No audio-separator at {get_config().audio_separator!r}")
+
+    fixture = write_wav(tmp_path / "separator-probe.wav", seconds=4.0)
     audio = {
         "path": str(fixture),
         "content_sha256": cache.content_hash(fixture),

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -29,7 +29,7 @@ from typing import Any
 import pytest
 
 from resolve_mcp.audio.acquire import acquire_timeline_audio
-from resolve_mcp.audio.stems import DRUM_STEMS, FOUR_STEMS, two_pass
+from resolve_mcp.audio.stems import DRUM_STEMS, FOUR_STEMS, separation_params, two_pass
 from resolve_mcp.config import get_config
 from resolve_mcp.jobs import cache
 from resolve_mcp.jobs.runner import wait_for
@@ -538,7 +538,7 @@ def test_the_real_separator_produces_the_stems_the_two_passes_expect(tmp_path: P
         "scope": "live",
     }
 
-    output = two_pass(audio, {"scope": "live"}, lambda fraction, step: None)
+    output = two_pass(audio, separation_params(), lambda fraction, step: None)
 
     assert set(output.result["stems"]) >= set(FOUR_STEMS)
     assert set(output.result["drums"]) >= set(DRUM_STEMS)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,6 +38,7 @@ def test_registers_the_p1_session_media_timeline_cut_and_job_tools() -> None:
         "get_cut_schema",
         "validate_cut",
         "build_timeline",
+        "separate_stems",
         "get_job",
         "list_jobs",
         "run_python",

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -1,0 +1,433 @@
+"""Two-pass stem separation.
+
+The separator is a subprocess, so the seam is the same one ffmpeg uses: the call is a
+parameter, and every decision around it — the two commands, which file pass two reads,
+where the stems land, what a refusal looks like, what a rerun costs — is verified with the
+CLI substituted. What no seam here can answer is whether audio-separator on the 4080 Super
+produces those models' stems at all; that is the live tier, and it is why the fake writes
+real WAVs under the real naming convention rather than empty files.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.audio import separator
+from resolve_mcp.audio.acquire import audio_source
+from resolve_mcp.audio.ffmpeg import Completed as FfmpegCompleted
+from resolve_mcp.audio.ffmpeg import Runner as FfmpegRunner
+from resolve_mcp.audio.stems import (
+    DRUM_STEMS,
+    FOUR_STEMS,
+    KIND,
+    acquired,
+    separate_stems,
+    two_pass,
+)
+from resolve_mcp.config import get_config
+from resolve_mcp.errors import InvalidRequestError, StemSeparationError
+from resolve_mcp.jobs import cache
+from resolve_mcp.jobs.runner import Progress, wait_for
+from resolve_mcp.resolve.connection import get_connection
+
+from .conftest import Attach
+from .fakes import (
+    FakeMediaPoolItem,
+    FakeSeparator,
+    FakeTimeline,
+    media_pool,
+    studio,
+    write_wav,
+)
+
+FIXTURE_SECONDS = 2.0
+SIX_DRUM_STEMS = ("kick", "snare", "toms", "hh", "ride", "crash")
+
+
+@pytest.fixture
+def fixture_audio(tmp_path: Path) -> Path:
+    """Two seconds of tone standing in for a concert."""
+    return write_wav(tmp_path / "media" / "drums.wav", seconds=FIXTURE_SECONDS)
+
+
+@pytest.fixture
+def separating() -> FakeSeparator:
+    """A separator that produces four stems on the first pass and six drums on the second."""
+    return FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS)
+
+
+# --- the two passes ----------------------------------------------------------------------
+
+
+def test_four_stems_land_on_disk_keyed_by_content_hash_and_params(
+    attach: Attach,
+    separating: FakeSeparator,
+) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+
+    record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    stems = record.result["stems"]
+    assert set(stems) == set(FOUR_STEMS)
+    assert all(Path(one).exists() for one in stems.values())
+
+    expected = cache.cache_key(
+        KIND,
+        [{"content_sha256": record.result["audio"]["content_sha256"]}],
+        record.params,
+    )
+    assert record.result["key"] == expected
+    assert Path(record.result["directory"]).name.endswith(expected[:12])
+    assert Path(record.result["directory"]).parent == get_config().stems_dir
+
+
+def test_the_drum_stem_is_what_the_second_pass_decomposes(
+    attach: Attach,
+    separating: FakeSeparator,
+) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+
+    record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    assert record.result is not None
+    assert record.result["stems"]["drums"] == separating.calls[1][1]
+    assert set(DRUM_STEMS) <= set(record.result["drums"])
+    assert all(Path(one).exists() for one in record.result["drums"].values())
+
+
+def test_each_pass_runs_its_own_model(attach: Attach, separating: FakeSeparator) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    config = get_config()
+
+    record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    assert len(separating.calls) == 2
+    assert _flag(separating.calls[0], "--model_filename") == config.stem_model
+    assert _flag(separating.calls[1], "--model_filename") == config.drum_model
+    assert record.result is not None
+    assert record.result["models"] == {"stems": config.stem_model, "drums": config.drum_model}
+
+
+def test_the_stems_of_both_passes_are_kept_apart_on_disk(
+    attach: Attach,
+    separating: FakeSeparator,
+) -> None:
+    """One directory per pass, or the drum decomposition overwrites the drum stem it read."""
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+
+    record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    assert record.result is not None
+    drum_stem = Path(record.result["stems"]["drums"])
+    assert drum_stem.parent != Path(record.result["drums"]["kick"]).parent
+    assert drum_stem.exists()
+
+
+# --- progress ----------------------------------------------------------------------------
+
+
+def test_progress_climbs_through_both_passes(tmp_path: Path) -> None:
+    """A concert separation runs for minutes; a poller has to see which pass it is in."""
+    steps: list[tuple[float, str]] = []
+    audio = _acquired(tmp_path)
+    separating = FakeSeparator(
+        FOUR_STEMS,
+        SIX_DRUM_STEMS,
+        output=("  0%|          | 0/10", " 50%|#####     | 5/10", "100%|##########| 10/10"),
+    )
+
+    two_pass(audio, {"scope": "clip"}, _recording(steps), runner=separating)
+
+    assert [fraction for fraction, _ in steps] == sorted(fraction for fraction, _ in steps)
+    first = [step for fraction, step in steps if "50%" in step]
+    assert any("four stems" in step for step in first)
+    assert any("drum" in step for _, step in steps)
+    assert steps[-1][0] == pytest.approx(0.95, abs=0.05)
+
+
+def test_the_acquisition_is_reported_as_the_first_quarter_of_the_job(attach: Attach) -> None:
+    """The export runs inside this job, so its own progress has to be visible from here."""
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    steps: list[tuple[float, str]] = []
+    source = audio_source(get_connection())
+
+    acquired(source, _recording(steps), poll=0.01)
+
+    assert steps
+    assert all(0.0 <= fraction <= 0.25 for fraction, _ in steps)
+    assert any("export" in step or "audio" in step for _, step in steps)
+
+
+# --- caching -----------------------------------------------------------------------------
+
+
+def test_a_rerun_on_an_unchanged_timeline_never_separates_again(
+    attach: Attach,
+    separating: FakeSeparator,
+) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    first = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    again = separate_stems(get_connection(), runner=separating)
+
+    assert again["state"] == "completed"
+    assert again["cached"] is True
+    assert again["result"] == first.result
+    assert len(separating.calls) == 2
+
+
+def test_refresh_separates_again(attach: Attach, separating: FakeSeparator) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    again = wait_for(separate_stems(get_connection(), runner=separating, refresh=True)["job_id"])
+
+    assert again.state == "completed", again.error
+    assert again.cached is False
+    assert len(separating.calls) == 4
+
+
+def test_the_same_audio_under_a_new_fingerprint_reuses_the_stems_on_disk(
+    tmp_path: Path,
+    separating: FakeSeparator,
+) -> None:
+    """The directory is keyed by content, so an edit that did not change the mix is free."""
+    audio = _acquired(tmp_path)
+    two_pass(audio, {"scope": "timeline"}, _ignored, runner=separating)
+
+    output = two_pass(audio, {"scope": "timeline"}, _ignored, runner=separating)
+
+    assert len(separating.calls) == 2
+    assert output.result["reused"] is True
+    assert all(Path(one).exists() for one in output.result["stems"].values())
+
+
+def test_the_stems_a_job_owns_are_what_its_cache_entry_verifies(
+    attach: Attach,
+    separating: FakeSeparator,
+) -> None:
+    """Delete a stem and the next run redoes the work rather than pointing at a gone file."""
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    first = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+    assert first.result is not None
+    Path(first.result["drums"]["kick"]).unlink()
+
+    again = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    assert again.cached is False
+    assert again.state == "completed", again.error
+    assert Path(again.result["drums"]["kick"]).exists() if again.result else False
+
+
+# --- failures ----------------------------------------------------------------------------
+
+
+def test_no_separator_on_the_machine_is_a_named_failure(attach: Attach) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+
+    record = wait_for(separate_stems(get_connection(), runner=_absent)["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "separator_unavailable"
+    assert "RESOLVE_MCP_AUDIO_SEPARATOR" in record.error["fix"]
+
+
+def test_the_separators_own_complaint_travels_back_with_the_failure(attach: Attach) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    refusing = FakeSeparator(FOUR_STEMS, returncode=1, output=("No such model: htdemucs_ft.yaml",))
+
+    record = wait_for(separate_stems(get_connection(), runner=refusing)["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "stem_separation_failed"
+    assert "No such model" in record.error["detail"]["output"]
+
+
+def test_a_model_that_leaves_a_stem_out_fails_naming_it(attach: Attach) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    partial = FakeSeparator(FOUR_STEMS, ("kick", "snare"))
+
+    record = wait_for(separate_stems(get_connection(), runner=partial)["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "stem_separation_failed"
+    assert "toms" in record.error["cause"]
+    assert record.error["detail"]["produced"]
+
+
+def test_a_failed_export_fails_the_stem_job_with_the_exports_own_advice(
+    attach: Attach,
+    separating: FakeSeparator,
+) -> None:
+    """The acquisition runs inside this job, so its failure has to arrive as this job's."""
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    project = resolve.current_project
+    assert project is not None
+    project.accepts_job = False
+    attach(resolve)
+
+    record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "audio_export_failed"
+    assert "audio on it" in record.error["fix"]
+    assert separating.calls == []
+
+
+# --- scopes ------------------------------------------------------------------------------
+
+
+def test_a_source_clip_is_extracted_then_separated(
+    attach: Attach,
+    fixture_audio: Path,
+    separating: FakeSeparator,
+) -> None:
+    attach(studio(pool=media_pool({"": [_clip(fixture_audio)]})))
+
+    record = wait_for(
+        separate_stems(
+            get_connection(),
+            scope="clip",
+            clip="drums.wav",
+            runner=separating,
+            ffmpeg_runner=_copying(),
+        )["job_id"]
+    )
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert record.result["audio"]["scope"] == "clip"
+    assert record.result["audio"]["duration_seconds"] == pytest.approx(FIXTURE_SECONDS, abs=0.01)
+    assert set(record.result["stems"]) == set(FOUR_STEMS)
+
+
+def test_a_clip_scope_with_no_clip_named_is_refused_before_a_job_starts(attach: Attach) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+
+    with pytest.raises(InvalidRequestError) as raised:
+        separate_stems(get_connection(), scope="clip")
+
+    assert "clip" in raised.value.fix
+
+
+def test_an_unknown_scope_says_which_two_there_are(attach: Attach) -> None:
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+
+    with pytest.raises(InvalidRequestError) as raised:
+        separate_stems(get_connection(), scope="project")
+
+    assert "timeline" in raised.value.fix
+    assert "clip" in raised.value.fix
+
+
+# --- the separator wrapper ----------------------------------------------------------------
+
+
+def test_the_command_names_the_model_the_source_and_the_output_directory() -> None:
+    argv = separator.command("audio-separator", "htdemucs_ft.yaml", Path("D:/a.wav"), Path("D:/o"))
+
+    assert argv[0] == "audio-separator"
+    assert argv[1] == str(Path("D:/a.wav"))
+    assert _flag(argv, "--model_filename") == "htdemucs_ft.yaml"
+    assert _flag(argv, "--output_dir") == str(Path("D:/o"))
+    assert _flag(argv, "--output_format").lower() == "wav"
+
+
+def test_a_stem_is_recognised_by_the_last_label_the_separator_parenthesises() -> None:
+    """Pass two reads a file that is already labelled, so its own label is the last one."""
+    assert separator.label_of(Path("mix_(Drums)_htdemucs.wav")) == "drums"
+    assert separator.label_of(Path("mix_(Drums)_htdemucs_(Snare)_MDX23C.wav")) == "snare"
+    assert separator.label_of(Path("no-label-at-all.wav")) is None
+
+
+def test_progress_comes_off_the_percentages_the_separator_prints(tmp_path: Path) -> None:
+    seen: list[float] = []
+    counting = FakeSeparator(("drums",), output=("Loading model", " 50%|#####  | 5/10", "100%|"))
+
+    separator.separate(
+        write_wav(tmp_path / "mix.wav", seconds=0.2),
+        tmp_path / "out",
+        "htdemucs_ft.yaml",
+        ("drums",),
+        progress=seen.append,
+        runner=counting,
+    )
+
+    assert seen == [0.5, 1.0]
+
+
+def test_a_separator_that_writes_nothing_at_all_is_a_failure_not_an_empty_result(
+    tmp_path: Path,
+) -> None:
+    silent = FakeSeparator(())
+
+    with pytest.raises(StemSeparationError) as raised:
+        separator.separate(
+            write_wav(tmp_path / "mix.wav", seconds=0.2),
+            tmp_path / "out",
+            "htdemucs_ft.yaml",
+            ("drums",),
+            runner=silent,
+        )
+
+    assert "drums" in raised.value.cause
+
+
+# --- helpers -------------------------------------------------------------------------------
+
+
+def _flag(argv: Sequence[str], name: str) -> str:
+    return argv[list(argv).index(name) + 1]
+
+
+def _ignored(fraction: float, step: str) -> None:
+    """A progress callback for the tests that are not about progress."""
+
+
+def _recording(steps: list[tuple[float, str]]) -> Progress:
+    def report(fraction: float, step: str) -> None:
+        steps.append((fraction, step))
+
+    return report
+
+
+def _acquired(tmp_path: Path) -> dict[str, Any]:
+    """What an acquisition job hands the worker: a WAV on disk and its content hash."""
+    path = write_wav(tmp_path / "cache" / "audio" / "mix.wav", seconds=0.5)
+    return {
+        "path": str(path),
+        "duration_seconds": 0.5,
+        "content_sha256": cache.content_hash(path),
+        "scope": "timeline",
+    }
+
+
+def _clip(source: Path) -> FakeMediaPoolItem:
+    return FakeMediaPoolItem(
+        source.name,
+        file_path=str(source),
+        properties={"Type": "Audio", "Audio Ch": "2"},
+    )
+
+
+def _copying() -> FfmpegRunner:
+    def runner(argv: Sequence[str]) -> FfmpegCompleted:
+        shutil.copyfile(argv[argv.index("-i") + 1], argv[-1])
+        return FfmpegCompleted(0, "")
+
+    return runner
+
+
+def _absent(argv: Sequence[str], on_line: separator.Lines) -> separator.Completed:
+    raise FileNotFoundError(argv[0])

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -25,6 +25,7 @@ from resolve_mcp.audio.stems import (
     DRUM_STEMS,
     FOUR_STEMS,
     KIND,
+    SEPARATION,
     acquired,
     separate_stems,
     two_pass,
@@ -81,7 +82,7 @@ def test_four_stems_land_on_disk_keyed_by_content_hash_and_params(
     expected = cache.cache_key(
         KIND,
         [{"content_sha256": record.result["audio"]["content_sha256"]}],
-        record.params,
+        {name: record.params[name] for name in SEPARATION},
     )
     assert record.result["key"] == expected
     assert Path(record.result["directory"]).name.endswith(expected[:12])
@@ -152,6 +153,18 @@ def test_progress_climbs_through_both_passes(tmp_path: Path) -> None:
     assert steps[-1][0] == pytest.approx(0.95, abs=0.05)
 
 
+def test_a_percentage_that_restarts_mid_pass_never_reports_lost_ground(tmp_path: Path) -> None:
+    """A first run prints a bar for the model download before the bar for the separation."""
+    steps: list[tuple[float, str]] = []
+    restarting = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, output=(" 80%|", "  5%|", " 40%|"))
+
+    two_pass(_acquired(tmp_path), _params(), _recording(steps), runner=restarting)
+
+    fractions = [fraction for fraction, _ in steps]
+    assert fractions == sorted(fractions)
+    assert max(fraction for fraction, step in steps if "four stems" in step) == pytest.approx(0.53)
+
+
 def test_the_acquisition_is_reported_as_the_first_quarter_of_the_job(attach: Attach) -> None:
     """The export runs inside this job, so its own progress has to be visible from here."""
     attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
@@ -209,6 +222,35 @@ def test_the_same_audio_under_a_new_fingerprint_reuses_the_stems_on_disk(
     assert all(Path(one).exists() for one in output.result["stems"].values())
 
 
+def test_where_the_audio_came_from_is_not_part_of_the_stems_key(
+    tmp_path: Path,
+    separating: FakeSeparator,
+) -> None:
+    """A renamed timeline is the same audio; separating it again would pay the GPU twice."""
+    audio = _acquired(tmp_path)
+    first = two_pass(audio, _params(timeline="sunset-set v3"), _ignored, runner=separating)
+
+    renamed = two_pass(audio, _params(timeline="sunset-set v4"), _ignored, runner=separating)
+
+    assert renamed.result["directory"] == first.result["directory"]
+    assert renamed.result["reused"] is True
+    assert len(separating.calls) == 2
+
+
+def test_a_different_model_is_a_different_stems_key(
+    tmp_path: Path,
+    separating: FakeSeparator,
+) -> None:
+    """The other half of that: what the stems *are* must still move the key."""
+    audio = _acquired(tmp_path)
+    first = two_pass(audio, _params(), _ignored, runner=separating)
+
+    other = two_pass(audio, _params(model="htdemucs_6s.yaml"), _ignored, runner=separating)
+
+    assert other.result["directory"] != first.result["directory"]
+    assert len(separating.calls) == 4
+
+
 def test_the_stems_a_job_owns_are_what_its_cache_entry_verifies(
     attach: Attach,
     separating: FakeSeparator,
@@ -223,7 +265,8 @@ def test_the_stems_a_job_owns_are_what_its_cache_entry_verifies(
 
     assert again.cached is False
     assert again.state == "completed", again.error
-    assert Path(again.result["drums"]["kick"]).exists() if again.result else False
+    assert again.result is not None
+    assert Path(again.result["drums"]["kick"]).exists()
 
 
 # --- failures ----------------------------------------------------------------------------
@@ -402,6 +445,18 @@ def _recording(steps: list[tuple[float, str]]) -> Progress:
     return report
 
 
+def _params(timeline: str = "sunset-set v3", model: str = "htdemucs_ft.yaml") -> dict[str, Any]:
+    """A job's params: where the audio came from, and what is being run on it."""
+    return {
+        "scope": "timeline",
+        "timeline": timeline,
+        "model": model,
+        "drum_model": "MDX23C-DrumSep-6stem-FT.ckpt",
+        "stems": list(FOUR_STEMS),
+        "drum_stems": list(DRUM_STEMS),
+    }
+
+
 def _acquired(tmp_path: Path) -> dict[str, Any]:
     """What an acquisition job hands the worker: a WAV on disk and its content hash."""
     path = write_wav(tmp_path / "cache" / "audio" / "mix.wav", seconds=0.5)
@@ -429,5 +484,5 @@ def _copying() -> FfmpegRunner:
     return runner
 
 
-def _absent(argv: Sequence[str], on_line: separator.Lines) -> separator.Completed:
+def _absent(argv: Sequence[str], on_line: separator.Lines) -> int:
     raise FileNotFoundError(argv[0])

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -28,9 +28,10 @@ from resolve_mcp.audio.stems import (
     SEPARATION,
     acquired,
     separate_stems,
+    separation_params,
     two_pass,
 )
-from resolve_mcp.config import get_config
+from resolve_mcp.config import Config, get_config, set_config
 from resolve_mcp.errors import InvalidRequestError, StemSeparationError
 from resolve_mcp.jobs import cache
 from resolve_mcp.jobs.runner import Progress, wait_for
@@ -153,16 +154,27 @@ def test_progress_climbs_through_both_passes(tmp_path: Path) -> None:
     assert steps[-1][0] == pytest.approx(0.95, abs=0.05)
 
 
-def test_a_percentage_that_restarts_mid_pass_never_reports_lost_ground(tmp_path: Path) -> None:
-    """A first run prints a bar for the model download before the bar for the separation."""
+def test_the_model_downloads_own_bar_is_not_this_passs_progress(tmp_path: Path) -> None:
+    """A first run fetches the model and prints a bar for that, ending at 100%, first.
+
+    Reporting it would run the pass to its ceiling before the separation had started, and
+    then either freeze there for the long part or visibly fall back.
+    """
     steps: list[tuple[float, str]] = []
-    restarting = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, output=(" 80%|", "  5%|", " 40%|"))
+    downloading = FakeSeparator(
+        FOUR_STEMS,
+        SIX_DRUM_STEMS,
+        output=(
+            "Downloading model htdemucs_ft.yaml:  50%|#####     |",
+            "Downloading model htdemucs_ft.yaml: 100%|##########|",
+            " 20%|##        | 2/10",
+        ),
+    )
 
-    two_pass(_acquired(tmp_path), _params(), _recording(steps), runner=restarting)
+    two_pass(_acquired(tmp_path), _params(), _recording(steps), runner=downloading)
 
-    fractions = [fraction for fraction, _ in steps]
-    assert fractions == sorted(fractions)
-    assert max(fraction for fraction, step in steps if "four stems" in step) == pytest.approx(0.53)
+    first = [fraction for fraction, step in steps if "four stems" in step]
+    assert first == [pytest.approx(0.32)]  # 20% of the pass one slice, and nothing before it
 
 
 def test_the_acquisition_is_reported_as_the_first_quarter_of_the_job(attach: Attach) -> None:
@@ -241,14 +253,22 @@ def test_a_different_model_is_a_different_stems_key(
     tmp_path: Path,
     separating: FakeSeparator,
 ) -> None:
-    """The other half of that: what the stems *are* must still move the key."""
-    audio = _acquired(tmp_path)
-    first = two_pass(audio, _params(), _ignored, runner=separating)
+    """The other half of that: what the stems *are* must still move the key.
 
-    other = two_pass(audio, _params(model="htdemucs_6s.yaml"), _ignored, runner=separating)
+    The model comes from config on both runs, so this pins the model actually run as well
+    as the key derived from it — a key that moved while the command did not would be worse
+    than no key at all.
+    """
+    audio = _acquired(tmp_path)
+    first = two_pass(audio, separation_params(), _ignored, runner=separating)
+
+    set_config(_configured(tmp_path, stem_model="htdemucs_6s.yaml"))
+    other = two_pass(audio, separation_params(), _ignored, runner=separating)
 
     assert other.result["directory"] != first.result["directory"]
     assert len(separating.calls) == 4
+    assert _flag(separating.calls[0], "--model_filename") == "htdemucs_ft.yaml"
+    assert _flag(separating.calls[2], "--model_filename") == "htdemucs_6s.yaml"
 
 
 def test_the_stems_a_job_owns_are_what_its_cache_entry_verifies(
@@ -445,16 +465,19 @@ def _recording(steps: list[tuple[float, str]]) -> Progress:
     return report
 
 
-def _params(timeline: str = "sunset-set v3", model: str = "htdemucs_ft.yaml") -> dict[str, Any]:
+def _params(timeline: str = "sunset-set v3") -> dict[str, Any]:
     """A job's params: where the audio came from, and what is being run on it."""
-    return {
-        "scope": "timeline",
-        "timeline": timeline,
-        "model": model,
-        "drum_model": "MDX23C-DrumSep-6stem-FT.ckpt",
-        "stems": list(FOUR_STEMS),
-        "drum_stems": list(DRUM_STEMS),
-    }
+    return {"scope": "timeline", "timeline": timeline, **separation_params()}
+
+
+def _configured(tmp_path: Path, stem_model: str) -> Config:
+    """The same cache root the fixture set up, with a different pass-one model."""
+    return Config.from_env(
+        {
+            "RESOLVE_MCP_CACHE": str(tmp_path / "cache"),
+            "RESOLVE_MCP_STEM_MODEL": stem_model,
+        }
+    )
 
 
 def _acquired(tmp_path: Path) -> dict[str, Any]:


### PR DESCRIPTION
Closes #36.

## What landed

Two-pass stem separation. Pass one splits the mix into vocals/drums/bass/other; pass two decomposes the drum stem alone into kick/snare/toms — the near-clean drum audio fill detection reads. `separate_stems` is the first typed heavy starter an MCP client can see: it acquires its own audio (timeline mix or one source clip, per #12's "audio export *internal* to the starters"), follows that acquisition as the first quarter of its own progress, and returns a `job_id` immediately.

**python-audio-separator runs as a subprocess through its CLI, not as an import.** Its torch/CUDA stack never loads into the server, it stays out of `pyproject.toml` (the models live in whatever environment the director installed them into), and the call is a parameter — so the two commands, the progress parsing, the stem mapping and every refusal are testable on a machine with no models and no GPU.

**Two keys, deliberately.** The job is keyed the way its acquisition is keyed (a timeline fingerprint, a clip's path/size/mtime) because that is all that can be known in the starter, before any audio exists. The stems on disk are keyed by the content hash of the audio plus the models run on it — and by nothing about where that audio came from, so a renamed timeline, or the same file reached as a clip rather than through the mix, finds its stems already there and skips both passes. `refresh` overrides both.

**A job-store bug this ticket exposed.** On Windows `os.replace` fails while a reader holds the record open, and a read fails mid-replace. Unguarded, the write killed the worker thread mid-save and left the job reading `running` forever — this is the first job to poll another job's record, but a polling agent hits the same race through `get_job`. Both sides now wait the window out, and a chained job that sees a dead thread behind a running record fails with a cause instead of waiting for a record nobody will ever write. Edits to #32's infrastructure (`jobs/store.py`, `jobs/runner.follow`) are that fix, not stem work.

## Test seam

Fake tier (`uv run pytest -m 'not live'`), at the subprocess seam `ffmpeg` already established: the separator call is a parameter, and `FakeSeparator` writes real WAVs under the real `<input>_(Label)_<model>.wav` naming, because the stems are matched by reading that label back. All three ACs are verified there. One live-marked test carries what no seam can answer — that those model names resolve, that the drum model yields kick/snare/toms, and that the real CLI writes that naming.

## Review

Two-axis review (`/code-review`) against `origin/main`, then a focused pass over the fix diff. Findings and resolutions:

**Spec axis**

1. *Scope, timeline name and bin leaked into the on-disk stems key* — a renamed timeline re-separated byte-identical audio, against story 26 ("analysis is paid for once per media state"). **Fixed**: `stem_key` keys on the content hash and the separation params only; sample rate and bit depth are in the bytes already. Pinned by `test_where_the_audio_came_from_is_not_part_of_the_stems_key`.
2. *A percentage bar that restarts mid-pass* (a first run prints a bar for the model download). **Fixed**, then re-fixed — see the focused pass below.
3. *Nothing asserts the separation runs on the GPU* rather than a CPU build, which turns minutes into hours silently. **Held**: no seam can see it and guessing at the CLI's device wording would be fragile. It is a live-tier observation instead — named under "Needs from you".
4. *`params` records three drum stems while the default 6-stem model returns six*, all of which land in the result. **Held**: the three are what the job *requires*, the rest are reported as found; it would only mislead if a drum model changed stem count without changing filename.
5. *`acquire.Source` and the store edits are groundwork/infrastructure landing here.* **Accepted and called out** above rather than changed — both are required by this ticket.

**Standards axis**

6. *The live separator gate hardcoded the default executable name*, so a director with `RESOLVE_MCP_AUDIO_SEPARATOR` set would silently skip the one check no fake can make. **Fixed**: it asks the configured executable, and writes its probe into `tmp_path` rather than the real cache root.
7. *Following a chained job walked raw record dicts in the audio package* (Feature Envy). **Fixed**: moved to `runner.follow`, beside `wait_for`, typed on `JobRecord`.
8. *Two identical Windows retry loops in the store* (Duplicated Code). **Fixed**: one `_sharing` helper.
9. *`separator.Completed.output` was never set by the real runner* (Speculative Generality). **Fixed**: the runner returns an exit code; everything the separator says arrives through the line sink.
10. *README's cache-root row, a loose assert, the tool's hardcoded default scope.* **Fixed.**

**Both axes, independently: a TOCTOU in the follower** — the record was read before the liveness check, so a job finishing between the two failed a *successful* export with `internal_error`. **Fixed**: the authoritative read is the one after the thread is known gone.

**Focused pass over the fix diff** (this is why there are three commits):

11. *The clamp added for finding 2 was worse than the bug.* The download bar ends at 100%, so the separation that follows it — the long part — would report a frozen number for its whole run. **Fixed**: the separator drops the download's percentages by name, and the pass tracks the newest reading again.
12. *Four tests pinned nothing*, each confirmed by re-running with the fix reverted: the TOCTOU test never reached its branch (now stubs the read sequence, and fails without the re-read — verified); the store's race test can only fail on Windows while CI is ubuntu (the retry is now pinned directly); the progress test used percentages that never reached 100%, the exact failing case; the model-key test passed a model in params while the run used config (now moves the config and asserts the command too).
13. *`stem_key` silently omitted a missing param.* **Fixed**: all four keys are read whether present or not.

Review: clean — two-axis review plus a focused pass over the fix diff; 13 findings, 10 fixed, 3 held with reasons above.


Post-open merge of origin/main (#29, #30, #33, #34, #35 landed first): main had refactored the acquisition layer (fingerprint and current_timeline into resolve.timeline, keyed_name, the band progress helper, the shared resolve_mcp.ffmpeg Runner) — the stems Source/audio_source seam was rebased onto those, dropping the branch-local duplicates; stale audio.ffmpeg imports repointed; everything else was unions (server registration, errors, config dirs, README, live smoke). Fake tier, mypy, ruff clean.
Review: clean — focused pass on the conflict-resolution diff
