### PR TITLE
Count takes by the plural getter, and sweep every API name against a live dir() (#68)

### DIFF
--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -255,6 +255,11 @@ class FakeTimelineItem(AnswersNone):
     (``GetTakeCount`` is not an API method at all; the real one is ``GetTakesCount``, which
     is why that particular name was the one caught being ``None``.)
 
+    That singular is answered as ``None`` on *every* item, without a test opting in
+    (:data:`NOT_AN_API_METHOD`): it is not a build difference a test would choose to model
+    but a name no Resolve has, and the whole cost of #68 was that reading it looked like
+    reading zero takes.
+
     The take selector is modelled with the same suspicion as the append: ``AddTake`` and
     ``SelectTakeByIndex`` both answer ``Bool``, so ``takes_land`` and ``select_take_lands``
     model the answer that lies — a truthy return over a selector that did not change.
@@ -304,8 +309,14 @@ class FakeTimelineItem(AnswersNone):
         self._refuses = set(refuses or ())
         self._end_is_inclusive = end_is_inclusive
         self.comps: list[FakeFusionComp] = list(comps or ())
-        self._missing = set(missing or ())
+        self._missing = set(missing or ()) | FakeTimelineItem.NOT_AN_API_METHOD
         self._owner = owner
+
+    #: Names no Resolve build declares, so the live object answers them with ``None``
+    #: rather than not having them. ``GetTakeCount`` is the singular a wrapper reaches for
+    #: when it means ``GetTakesCount`` (#68); confirmed on Studio 21.0.3.7 as absent from
+    #: ``dir(item)`` with the attribute reading back ``None``.
+    NOT_AN_API_METHOD = frozenset({"GetTakeCount"})
 
     SOURCE_GETTERS = ("GetSourceStartFrame", "GetSourceEndFrame")
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -255,10 +255,8 @@ class FakeTimelineItem(AnswersNone):
     (``GetTakeCount`` is not an API method at all; the real one is ``GetTakesCount``, which
     is why that particular name was the one caught being ``None``.)
 
-    That singular is answered as ``None`` on *every* item, without a test opting in
-    (:data:`NOT_AN_API_METHOD`): it is not a build difference a test would choose to model
-    but a name no Resolve has, and the whole cost of #68 was that reading it looked like
-    reading zero takes.
+    A name in :attr:`NOT_API_METHODS` is answered that way on *every* item, without a test
+    opting in — see the constant for why that set is not the same thing as ``missing``.
 
     The take selector is modelled with the same suspicion as the append: ``AddTake`` and
     ``SelectTakeByIndex`` both answer ``Bool``, so ``takes_land`` and ``select_take_lands``
@@ -266,6 +264,12 @@ class FakeTimelineItem(AnswersNone):
     ``FinalizeTake`` is deliberately absent: it collapses a selector permanently, so a
     wrapper that called it should fail loudly here rather than quietly on a real cut.
     """
+
+    #: Names no Resolve build declares, as against ``missing``, which is a name some build
+    #: has and this one does not: nothing can opt out of these, because there is no build
+    #: to opt into. ``GetTakeCount`` is the singular a wrapper reaches for when it means
+    #: ``GetTakesCount`` (#68), and reading it looked exactly like reading zero takes.
+    NOT_API_METHODS = frozenset({"GetTakeCount"})
 
     def __init__(
         self,
@@ -309,14 +313,8 @@ class FakeTimelineItem(AnswersNone):
         self._refuses = set(refuses or ())
         self._end_is_inclusive = end_is_inclusive
         self.comps: list[FakeFusionComp] = list(comps or ())
-        self._missing = set(missing or ()) | FakeTimelineItem.NOT_AN_API_METHOD
+        self._missing = set(missing or ()) | FakeTimelineItem.NOT_API_METHODS
         self._owner = owner
-
-    #: Names no Resolve build declares, so the live object answers them with ``None``
-    #: rather than not having them. ``GetTakeCount`` is the singular a wrapper reaches for
-    #: when it means ``GetTakesCount`` (#68); confirmed on Studio 21.0.3.7 as absent from
-    #: ``dir(item)`` with the attribute reading back ``None``.
-    NOT_AN_API_METHOD = frozenset({"GetTakeCount"})
 
     SOURCE_GETTERS = ("GetSourceStartFrame", "GetSourceEndFrame")
 

--- a/tests/test_timeline_tools.py
+++ b/tests/test_timeline_tools.py
@@ -346,11 +346,11 @@ def test_a_selector_is_counted_by_the_plural_name_the_api_really_declares(
 ) -> None:
     """``GetTakeCount`` is not an API method, and asking for it counts nothing.
 
-    Verified live on Studio 21.0.3.7: the singular is absent from ``dir(item)`` and the
-    attribute reads back as ``None``, which :class:`Reader` cannot tell from a getter that
-    is not there — so it takes the default branch and every clip reports zero takes,
-    silently and forever (#68). Only the plural ``GetTakesCount`` counts a selector, so
-    this test fails against the singular rather than degrading to a plausible zero.
+    The singular reads back as ``None`` (see ``FakeTimelineItem.NOT_API_METHODS``), which
+    ``Reader`` cannot tell from a getter that is not there — so it takes the default branch
+    and every clip reports zero takes, silently and forever (#68). Only the plural
+    ``GetTakesCount`` counts a selector, so this test fails against the singular rather
+    than degrading to a plausible zero.
     """
     item = FakeTimelineItem("C0012.mp4", 0, 10, takes=3)
     # The premise: the fake answers the wrong name the way a live item does.

--- a/tests/test_timeline_tools.py
+++ b/tests/test_timeline_tools.py
@@ -341,6 +341,27 @@ def test_a_shot_reports_the_media_pool_clip_it_came_from(attach: Attach) -> None
     assert reported["enabled"] is True
 
 
+def test_a_selector_is_counted_by_the_plural_name_the_api_really_declares(
+    attach: Attach,
+) -> None:
+    """``GetTakeCount`` is not an API method, and asking for it counts nothing.
+
+    Verified live on Studio 21.0.3.7: the singular is absent from ``dir(item)`` and the
+    attribute reads back as ``None``, which :class:`Reader` cannot tell from a getter that
+    is not there — so it takes the default branch and every clip reports zero takes,
+    silently and forever (#68). Only the plural ``GetTakesCount`` counts a selector, so
+    this test fails against the singular rather than degrading to a plausible zero.
+    """
+    item = FakeTimelineItem("C0012.mp4", 0, 10, takes=3)
+    # The premise: the fake answers the wrong name the way a live item does.
+    assert item.GetTakeCount is None
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", [item])])))
+
+    result = inspect_timeline(detail="clips")
+
+    assert result["tracks"][0]["items"][0]["takes"] == 3
+
+
 def test_the_out_point_is_one_past_the_last_frame_whatever_get_end_says(attach: Attach) -> None:
     """Half-open [in, out) is the cut file's convention; GetEnd is not trusted to agree."""
     item = FakeTimelineItem("C0012.mp4", 100, 60, end_is_inclusive=True)


### PR DESCRIPTION
Closes #68.

`GetTakeCount` is not a Resolve method — `GetTakesCount` is. Because fusionscript answers every attribute name with `None` rather than raising, `Reader.optional` could not tell the wrong name from a getter that is not there: it took the default branch and reported zero takes on every clip, silently.

The read itself was corrected while building the take selectors (9f31039, merged with #26), so the production half of this ticket was already on `main`. What was still missing was a seam that would catch it coming back. The fake raised `AttributeError` for the singular — the one shape the real API never has — so it agreed with the wrapper about the answer (zero) for the wrong reason, and would have kept agreeing with a `hasattr` guard that live Resolve passes and then kills.

**Seam:** fake tier. `FakeTimelineItem` now answers `NOT_API_METHODS` with `None` on every item, without a test opting in: unlike `missing`, these are not build differences a test would choose to model but names no Resolve has, so there is no build to opt into. The new test asserts that shape as its premise and then asserts a three-take selector counts as three, which fails against the singular instead of degrading to a plausible zero.

**AC3 sweep — run live, on Resolve Studio 21.0.3.7, python.org CPython 3.12 (read-only `dir()`, no writes to the open project):**

- Every API name the wrappers pass as a string (21 Resolve names) is present and callable on the object it is called on, cross-checked against the shipped scripting README (15 Jul 2026), which declares `GetTakesCount` at line 523.
- Of 79 distinct capitalised attribute calls in `src/`, 57 are present on the live objects and 17 are Python stdlib or local constructors, not Resolve at all. A second pass confirmed `GetClipList`/`GetSubFolderList` on a real `Folder`.
- `GetTakeCount` is the only mismatch found: absent from `dir(item)`, attribute reads back `None`.
- **Unchecked:** five Fusion names — `GetToolList`, `BezierSpline`, `GetAttrs`, `GetInput`, `SetInput`. They belong to the Fusion API, not the Resolve README, and the open project had no Fusion comp to read. Carried to #79 with the live AC.

`EXPORT_FCPXML_1_11` is named in `interchange.py` and is not in this build's README; it is deliberate and correct — `_export_type` walks newest-first and skips a constant the build does not define, which is the documented intent of that tuple.

AC4 (`inspect_timeline` reports a non-zero `takes` on a clip with alternates) is a live smoke AC and is unrun; it needs a project with a real multi-take clip, and is tracked in #79.

## Review

`/code-review` (two-axis, Standards and Spec as parallel sub-agents) against `origin/main...HEAD`.

**Standards — no hard violations; five judgement calls, four fixed in 83dae07:**
- Duplicated Code: the live-verified fact was restated four times → it now lives on the constant, and the class docstring and the test cite it.
- Mysterious Name: `NOT_AN_API_METHOD` was singular for a set → renamed `NOT_API_METHODS`, matching its neighbour `SOURCE_GETTERS`.
- Ordering: the constant was defined after the line that reads it → moved above `__init__`.
- Sphinx role: `:data:` → `:attr:` for a class attribute.
- Not changed: the one-member frozenset was flagged as weak Speculative Generality and judged earned by the registry framing — the reviewer's own recommendation.

**Spec — three findings, all resolved:**
- The sweep covered only string-named reads, not the ~60 direct attribute calls, and the narrowing was unstated → the gap is closed above, and the rationale is that a direct call on a `None` attribute dies loudly while a `getattr`-with-default read degrades silently, which is what made #68 invisible.
- The unchecked Fusion names had no home → named above and carried to #79.
- The live evidence lived only in a commit message, against CLAUDE.md's "its result goes on the ticket" → it is in this PR body and on #68.
- Scope creep: none material. Forcing the name into every item is OR'd into `missing`, not a second mechanism, which is what the ticket asked for.

Fake tier green (`uv run pytest -m 'not live'`), mypy strict clean, ruff clean.

Review: clean — two-axis review run on the branch; five judgement calls and three spec findings, all fixed in 83dae07 or answered above, and the fix diff re-checked.
