### PR TITLE
P1: Music analysis — structure (tune boundaries + solo changes)

### DIFF
--- a/src/resolve_mcp/analysis/applause.py
+++ b/src/resolve_mcp/analysis/applause.py
@@ -1,0 +1,297 @@
+"""Where the room claps, and therefore where one tune ends and the next begins.
+
+A jazz set has no verses and no choruses to segment; what it has is applause (#22). Between
+two bursts of it is a tune, and that is the only structure boundary a concert recording
+offers reliably — so tune boundaries are read off an audio tagger (PANNs) rather than off a
+music-structure model that would look for a pop form that is not there.
+
+The tagger is behind a callable (ADR 0002) for the same reasons the beat model is: it drags
+in torch, no test in this repo can say whether it heard applause correctly, and everything
+after it — which runs of probability are a burst, which gaps between bursts are a tune —
+is ordinary arithmetic that a test can pin exactly. Three rules do that work:
+
+* **A burst has to last.** A single frame over the threshold is a snare hit the model liked
+  the look of; ``minimum_seconds`` is what separates that from a room.
+* **A burst has holes.** Applause dips as it swells; two runs a beat apart are one burst,
+  which is what ``gap_seconds`` closes.
+* **A gap between bursts is not always a tune.** Announcing the band takes twenty seconds
+  and is bounded by applause at both ends, so anything under ``minimum_seconds`` of music
+  is banter and is left out of the boundaries rather than reported as a very short tune.
+"""
+
+from __future__ import annotations
+
+import importlib
+import statistics
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import numpy as np
+
+from ..errors import AnalysisDependencyError, AnalysisFailedError, ResolveMcpError
+from ..logging_config import get_logger
+
+log = get_logger("analysis")
+
+MODULE = "panns_inference"
+INSTALL = "uv pip install panns-inference"
+LABELS = ("applause", "cheering", "clapping", "crowd")
+"""The AudioSet classes that mean "the room", taken together rather than one at a time —
+a hall reads as applause, a small club as cheering, and the boundary is the same event."""
+
+MODEL_SAMPLE_RATE = 32_000
+"""What PANNs was trained at. Anything else is resampled before it is tagged."""
+
+CHUNK_SECONDS = 60.0
+"""How much audio goes through the model at once. A concert does not fit in GPU memory."""
+
+DEFAULT_THRESHOLD = 0.3
+DEFAULT_MINIMUM_SECONDS = 3.0
+DEFAULT_GAP_SECONDS = 1.5
+DEFAULT_TUNE_SECONDS = 60.0
+"""Under a minute between two bursts of applause is an announcement, not a tune."""
+
+
+class Curve(NamedTuple):
+    """How likely the room is clapping, frame by frame. ``seconds`` is each frame's start."""
+
+    seconds: tuple[float, ...]
+    probability: tuple[float, ...]
+
+
+class Span(NamedTuple):
+    """One burst of applause."""
+
+    start: float
+    end: float
+    peak: float
+
+    @property
+    def seconds(self) -> float:
+        return round(self.end - self.start, 3)
+
+
+class Tune(NamedTuple):
+    """Music between two bursts of applause — or between a burst and the end of the file."""
+
+    start: float
+    end: float
+    applause_before: float | None
+    applause_after: float | None
+
+    @property
+    def seconds(self) -> float:
+        return round(self.end - self.start, 3)
+
+
+Tagger = Callable[[Path], Curve]
+
+
+def tag(path: Path, tagger: Tagger | None = None) -> Curve:
+    """Run the tagger and hand back its curve, or say that the tagging failed.
+
+    Same contract as beat detection: a model that falls over is an ``analysis_failed`` the
+    agent can act on, not an internal error.
+    """
+    chosen = tagger or panns_tagger
+    try:
+        curve = chosen(Path(path))
+    except ResolveMcpError:
+        raise
+    except Exception as exc:
+        raise AnalysisFailedError(
+            cause=f"Applause tagging failed on {Path(path).name}: {type(exc).__name__}: {exc}.",
+            detail={"path": str(path)},
+        ) from exc
+    return Curve(
+        seconds=tuple(float(one) for one in curve.seconds),
+        probability=tuple(float(one) for one in curve.probability),
+    )
+
+
+def panns_tagger(path: Path) -> Curve:
+    """The real thing: PANNs' frame-wise tags, reduced to one applause probability per frame.
+
+    The file goes through the model a minute at a time. An hour of concert at the model's
+    own 32 kHz is a hundred million samples, and handing that to a CNN in one call is how a
+    job dies on the GPU rather than returning a boundary list.
+    """
+    module = _loaded()
+    detector = module.SoundEventDetection(checkpoint_path=None)
+    wanted = _wanted(module)
+    log.info("Tagging %s for applause with PANNs", path.name)
+
+    seconds: list[float] = []
+    probability: list[float] = []
+    for offset, chunk in _chunks(path):
+        framewise = np.asarray(detector.inference(chunk[None, :]))[0]
+        best = framewise[:, wanted].max(axis=1)
+        step = len(chunk) / MODEL_SAMPLE_RATE / max(len(best), 1)
+        seconds.extend(offset + index * step for index in range(len(best)))
+        probability.extend(float(one) for one in best)
+    return Curve(seconds=tuple(seconds), probability=tuple(probability))
+
+
+def _loaded() -> Any:
+    """Import the tagger only when a job needs it — it is a torch stack, not a dependency."""
+    try:
+        return importlib.import_module(MODULE)
+    except ImportError as exc:
+        raise AnalysisDependencyError(
+            cause="panns_inference is not installed, so applause cannot be detected.",
+            fix=(
+                f"Install it on the machine running the server ({INSTALL}), or run the job "
+                "with tunes=false for solo changes only."
+            ),
+            detail={"module": MODULE},
+        ) from exc
+
+
+def _wanted(module: Any) -> list[int]:
+    """Which of AudioSet's 527 classes count as the room."""
+    found = [
+        index
+        for index, label in enumerate(module.labels)
+        if any(one in str(label).lower() for one in LABELS)
+    ]
+    if not found:
+        raise AnalysisFailedError(
+            cause="PANNs reported no applause-like class, so its labels are not what we expect.",
+            fix="Check the installed panns_inference version.",
+            detail={"module": MODULE, "wanted": list(LABELS)},
+        )
+    return found
+
+
+def _chunks(path: Path) -> list[tuple[float, np.ndarray[Any, Any]]]:
+    """The file as mono at the model's sample rate, in chunks, each with its offset."""
+    from scipy.signal import resample_poly
+
+    from . import decode
+
+    audio = decode.read(path)
+    mono = audio.mono()
+    if audio.sample_rate != MODEL_SAMPLE_RATE:
+        divisor = np.gcd(MODEL_SAMPLE_RATE, audio.sample_rate)
+        mono = resample_poly(
+            mono,
+            MODEL_SAMPLE_RATE // divisor,
+            audio.sample_rate // divisor,
+        ).astype(np.float32)
+    size = int(CHUNK_SECONDS * MODEL_SAMPLE_RATE)
+    return [
+        (first / MODEL_SAMPLE_RATE, np.ascontiguousarray(mono[first : first + size]))
+        for first in range(0, max(len(mono), 1), size)
+    ]
+
+
+def spans(
+    curve: Curve,
+    threshold: float = DEFAULT_THRESHOLD,
+    minimum_seconds: float = DEFAULT_MINIMUM_SECONDS,
+    gap_seconds: float = DEFAULT_GAP_SECONDS,
+) -> tuple[Span, ...]:
+    """The bursts of applause in a probability curve: runs over the threshold, joined, sieved."""
+    if not curve.seconds:
+        return ()
+    steps = _steps(curve.seconds)
+    runs = _runs(curve, threshold, steps)
+    return tuple(one for one in _joined(runs, gap_seconds) if one.seconds >= minimum_seconds)
+
+
+def _steps(seconds: Sequence[float]) -> list[float]:
+    """How long each frame lasts. The last one lasts as long as the frame before it."""
+    gaps = [later - earlier for earlier, later in zip(seconds, seconds[1:], strict=False)]
+    return [*gaps, gaps[-1] if gaps else 0.0]
+
+
+def _runs(curve: Curve, threshold: float, steps: Sequence[float]) -> list[Span]:
+    """Every unbroken run of frames at or over the threshold, in the order they happen."""
+    found: list[Span] = []
+    start: float | None = None
+    peak = 0.0
+    for seconds, probability in zip(curve.seconds, curve.probability, strict=True):
+        if probability >= threshold:
+            start = seconds if start is None else start
+            peak = max(peak, probability)
+            continue
+        if start is not None:
+            found.append(Span(round(start, 3), round(seconds, 3), round(peak, 4)))
+            start, peak = None, 0.0
+    if start is not None:
+        last = curve.seconds[-1] + steps[-1]
+        found.append(Span(round(start, 3), round(last, 3), round(peak, 4)))
+    return found
+
+
+def _joined(runs: Sequence[Span], gap_seconds: float) -> list[Span]:
+    """Two runs closer together than ``gap_seconds`` are one burst with a hole in it."""
+    joined: list[Span] = []
+    for one in runs:
+        if joined and one.start - joined[-1].end < gap_seconds:
+            previous = joined[-1]
+            joined[-1] = Span(previous.start, one.end, max(previous.peak, one.peak))
+            continue
+        joined.append(one)
+    return joined
+
+
+def tunes(
+    applause: Sequence[Span],
+    duration_seconds: float,
+    minimum_seconds: float = DEFAULT_TUNE_SECONDS,
+) -> tuple[Tune, ...]:
+    """The music between the bursts: one record per tune, with the applause on either side.
+
+    A set with no applause found in it is one tune, which is the honest answer — the file is
+    music from end to end as far as anything measured here can tell.
+    """
+    found: list[Tune] = []
+    opened = 0.0
+    before: float | None = None
+    for span in applause:
+        found.append(Tune(round(opened, 3), round(span.start, 3), before, span.seconds))
+        opened, before = span.end, span.seconds
+    found.append(Tune(round(opened, 3), round(duration_seconds, 3), before, None))
+    return tuple(one for one in found if one.seconds >= minimum_seconds)
+
+
+def numbered(found: Sequence[Tune]) -> tuple[dict[str, Any], ...]:
+    """One record per tune, numbered from one — the rows a songs.json author reads."""
+    return tuple(
+        {
+            "tune": index,
+            "t": one.start,
+            "end": one.end,
+            "seconds": one.seconds,
+            "applause_before": one.applause_before,
+            "applause_after": one.applause_after,
+        }
+        for index, one in enumerate(found, start=1)
+    )
+
+
+def gist(curve: Curve, applause: Sequence[Span], found: Sequence[Tune]) -> dict[str, Any]:
+    """How many tunes, how much clapping, and which tune is the long one — no lists.
+
+    The boundaries themselves are on disk. A set is a dozen records; what belongs in a tool
+    result is the shape of the set, and "the file has 12 tunes, the longest starts at 41:12".
+    """
+    longest = max(found, key=lambda one: one.seconds, default=None)
+    shortest = min(found, key=lambda one: one.seconds, default=None)
+    return {
+        "count": len(found),
+        "applause_count": len(applause),
+        "applause_seconds": round(sum(one.seconds for one in applause), 3),
+        "peak_probability": round(max(curve.probability), 4) if curve.probability else None,
+        "median_probability": (
+            round(statistics.median(curve.probability), 4) if curve.probability else None
+        ),
+        "longest": _summary(longest),
+        "shortest": _summary(shortest),
+    }
+
+
+def _summary(one: Tune | None) -> dict[str, Any] | None:
+    return None if one is None else {"t": one.start, "seconds": one.seconds}

--- a/src/resolve_mcp/analysis/beats.py
+++ b/src/resolve_mcp/analysis/beats.py
@@ -115,13 +115,19 @@ def _downbeat_flags(grid: BeatGrid) -> tuple[bool, ...]:
     """Match each downbeat to the nearest beat rather than trusting float equality."""
     flags = [False] * len(grid.beats)
     for downbeat in grid.downbeats:
-        nearest = _nearest(grid.beats, downbeat)
-        if nearest is not None and abs(grid.beats[nearest] - downbeat) <= DOWNBEAT_TOLERANCE:
-            flags[nearest] = True
+        found = nearest(grid.beats, downbeat)
+        if found is not None and abs(grid.beats[found] - downbeat) <= DOWNBEAT_TOLERANCE:
+            flags[found] = True
     return tuple(flags)
 
 
-def _nearest(beats: Sequence[float], seconds: float) -> int | None:
+def nearest(beats: Sequence[float], seconds: float) -> int | None:
+    """Index of the beat — or downbeat — closest to a time, or ``None`` if there is no grid.
+
+    Public because snapping to the grid is not only this module's business: a solo change
+    measured off an energy curve is called on the bar it lands nearest (#38), and one bisect
+    over a sorted list is the whole of that operation.
+    """
     if not beats:
         return None
     after = bisect.bisect_left(beats, seconds)

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -1,0 +1,107 @@
+"""What every analysis half does the same way: identify the audio, cache it, write it out.
+
+A "half" is one measurement of one file — the beat grid, the energy curve, the tune
+boundaries — cached on its own terms rather than on the job's. That distinction is the
+reason this module exists: the job is keyed on everything it was asked for, which is right
+for the job and wrong for its parts, because asking again with a finer energy hop must not
+re-run a beat model over an hour of concert (#22, story 26 — analysis is paid for once per
+media state). Two jobs that need the same measurement share the entry: structure analysis
+needs downbeats to snap solo changes to, and it reads the same beats half ``analyze_music``
+wrote rather than paying for a second one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from ..config import Config
+from ..errors import InvalidRequestError
+from ..jobs import cache
+from ..naming import slug
+from . import records
+
+
+def readable(audio: str | Path) -> Path:
+    """The audio as a path, or the error that says what to pass instead."""
+    source = Path(audio)
+    if not source.is_file():
+        raise InvalidRequestError(
+            cause=f"There is no file at {source}.",
+            fix=(
+                "Pass the path to the master mix, or the path an acquire_timeline_audio job "
+                "returned. Analysis reads WAV."
+            ),
+            detail={"requested": str(source)},
+        )
+    return source
+
+
+def identity(source: Path, config: Config) -> dict[str, Any]:
+    """Hash what this server wrote; fingerprint what the director handed over.
+
+    Audio this server wrote is hashed, because it is the substrate later analysis keys off
+    and a false hit there would attribute one concert's beats to another; a master the
+    director handed over is fingerprinted, because it is tens of gigabytes that sit
+    unchanged for months and reading all of it would stall the starter that is supposed to
+    return a job id at once.
+    """
+    if inside(source, config.audio_dir):
+        return {"sha256": cache.content_hash(source)}
+    return cache.fingerprint(source)
+
+
+def inside(source: Path, directory: Path) -> bool:
+    return source.resolve().is_relative_to(directory.resolve())
+
+
+def cached(
+    kind: str,
+    key: str,
+    build: Callable[[Path], dict[str, Any]],
+    source: Path,
+    refresh: bool,
+    config: Config,
+) -> dict[str, Any]:
+    """This half, computed or reused, and its file named after its own key.
+
+    Named after the key rather than the job's, so the same half asked for twice under
+    different job settings is one file rather than two identical ones.
+    """
+    if not refresh:
+        hit = cache.lookup(key, config)
+        if hit is not None:
+            return hit
+    label = kind.rsplit(":", 1)[-1]
+    target = config.analysis_dir / f"{slug(source.stem, 'analysis')}-{key[:12]}-{label}.json"
+    result = build(target)
+    cache.remember(key, kind, result, [Path(result["path"])], config)
+    return result
+
+
+def audio_gist(described: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "path": described["path"],
+        "duration_seconds": described["duration_seconds"],
+        "sample_rate": described["sample_rate"],
+        "channels": described["channels"],
+    }
+
+
+def written(
+    target: Path,
+    kind: str,
+    described: Mapping[str, Any],
+    gist: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """One file per half: a header of gist stats, then one record per line."""
+    header = {
+        "kind": kind,
+        "audio": described["path"],
+        "duration_seconds": described["duration_seconds"],
+        **gist,
+    }
+    records.write(target, header, kind, list(rows))
+    return {"path": str(target), **gist}

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -53,6 +53,7 @@ def identity(source: Path, config: Config) -> dict[str, Any]:
 
 
 def inside(source: Path, directory: Path) -> bool:
+    """Whether this path is one of ours — under a directory this server writes into."""
     return source.resolve().is_relative_to(directory.resolve())
 
 
@@ -81,6 +82,7 @@ def cached(
 
 
 def audio_gist(described: Mapping[str, Any]) -> dict[str, Any]:
+    """What every analysis result says about the file it read, before any measurement."""
     return {
         "path": described["path"],
         "duration_seconds": described["duration_seconds"],

--- a/src/resolve_mcp/analysis/music.py
+++ b/src/resolve_mcp/analysis/music.py
@@ -10,22 +10,14 @@ master mix — no stems, no Resolve. Three consequences worth stating:
   and seven thousand energy windows; what a tool result can carry is "120 bpm, in four,
   loudest at 41:12, here are the two paths".
 
-* **Each half is cached on its own terms.** The job is keyed on everything it was asked
-  for, which is right for the job and wrong for its halves: asking again with a finer
-  energy hop must not re-run a beat model over an hour of concert (#22, story 26 — analysis
-  is paid for once per media state). So beats and energy are each their own cache entry,
-  keyed on the audio and only the settings that shape them.
-
-How the audio is identified follows ``jobs.cache``'s rule rather than inventing one: audio
-this server wrote is hashed, because it is the substrate later analysis keys off and a
-false hit there would attribute one concert's beats to another; a master the director
-handed over is fingerprinted, because it is tens of gigabytes that sit unchanged for months
-and reading all of it would stall the starter that is supposed to return a job id at once.
+* **Each half is cached on its own terms** — see ``halves``, which also owns how the audio
+  is identified and what a half's file looks like. Beats and energy are each their own
+  cache entry, keyed on the audio and only the settings that shape them, so asking again
+  with a finer energy hop does not re-run a beat model over an hour of concert.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -34,9 +26,8 @@ from ..config import Config, get_config
 from ..errors import InvalidRequestError
 from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, start_job
-from ..naming import slug
 from . import beats as beats_module
-from . import records
+from . import halves
 
 if TYPE_CHECKING:  # pragma: no cover - the worker imports these when it runs
     from .energy import Measurement
@@ -61,7 +52,7 @@ def analyze_music(
 ) -> dict[str, Any]:
     """Start the analysis job. Returns the job record, not the analysis."""
     config = config or get_config()
-    source = _readable(audio)
+    source = halves.readable(audio)
     _asked_for_something(beats, energy)
     _sane_windows(window_seconds, hop_seconds)
 
@@ -71,7 +62,7 @@ def analyze_music(
         "window_seconds": float(window_seconds),
         "hop_seconds": float(hop_seconds),
     }
-    identity = _identity(source, config)
+    identity = halves.identity(source, config)
     key = cache.cache_key(KIND, [identity], settings)
 
     def work(progress: Progress) -> JobOutput:
@@ -97,20 +88,6 @@ def analyze_music(
     )
 
 
-def _readable(audio: str | Path) -> Path:
-    source = Path(audio)
-    if not source.is_file():
-        raise InvalidRequestError(
-            cause=f"There is no file at {source}.",
-            fix=(
-                "Pass the path to the master mix, or the path an acquire_timeline_audio job "
-                "returned. Analysis reads WAV."
-            ),
-            detail={"requested": str(source)},
-        )
-    return source
-
-
 def _asked_for_something(beats: bool, energy: bool) -> None:
     if not beats and not energy:
         raise InvalidRequestError(
@@ -130,15 +107,13 @@ def _sane_windows(window_seconds: float, hop_seconds: float) -> None:
         )
 
 
-def _identity(source: Path, config: Config) -> dict[str, Any]:
-    """Hash what this server wrote; fingerprint what the director handed over."""
-    if _inside(source, config.audio_dir):
-        return {"sha256": cache.content_hash(source)}
-    return cache.fingerprint(source)
+def beats_key(identity: dict[str, Any]) -> str:
+    """What the beat grid for this audio is cached under, wherever it is asked for.
 
-
-def _inside(source: Path, directory: Path) -> bool:
-    return source.resolve().is_relative_to(directory.resolve())
+    Public because it is shared: structure analysis snaps solo changes to downbeats, and
+    reading this half is how it gets them without running the beat model a second time.
+    """
+    return cache.cache_key(f"{KIND}:{BEATS}", [identity], {})
 
 
 def analyze(
@@ -154,19 +129,19 @@ def analyze(
     config = config or get_config()
     target = config.analysis_dir
     target.mkdir(parents=True, exist_ok=True)
-    identity = identity or _identity(source, config)
+    identity = identity or halves.identity(source, config)
 
     progress(0.05, "reading the audio")
     described = wav.describe(source)
-    result: dict[str, Any] = {"audio": _audio_gist(described)}
+    result: dict[str, Any] = {"audio": halves.audio_gist(described)}
     artifacts: list[Path] = []
 
     if settings[BEATS]:
         progress(0.1, "finding beats and downbeats")
-        result[BEATS] = _half(
-            BEATS,
-            cache.cache_key(f"{KIND}:{BEATS}", [identity], {}),
-            lambda path: _beats(source, path, described, detector),
+        result[BEATS] = halves.cached(
+            f"{KIND}:{BEATS}",
+            beats_key(identity),
+            lambda path: beats_half(source, path, described, detector),
             source,
             refresh,
             config,
@@ -176,8 +151,8 @@ def analyze(
     if settings[ENERGY]:
         progress(0.6, "measuring loudness and onset density")
         shape = {name: settings[name] for name in ("window_seconds", "hop_seconds")}
-        result[ENERGY] = _half(
-            ENERGY,
+        result[ENERGY] = halves.cached(
+            f"{KIND}:{ENERGY}",
             cache.cache_key(f"{KIND}:{ENERGY}", [identity], shape),
             lambda path: _energy(source, path, described, shape),
             source,
@@ -190,47 +165,16 @@ def analyze(
     return JobOutput(result, tuple(artifacts))
 
 
-def _half(
-    kind: str,
-    key: str,
-    build: Callable[[Path], dict[str, Any]],
-    source: Path,
-    refresh: bool,
-    config: Config,
-) -> dict[str, Any]:
-    """This half of the analysis, computed or reused, and its file named after its own key.
-
-    Named after the key rather than the job's, so the same half asked for twice under
-    different job settings is one file rather than two identical ones.
-    """
-    if not refresh:
-        hit = cache.lookup(key, config)
-        if hit is not None:
-            return hit
-    target = config.analysis_dir / f"{slug(source.stem, 'analysis')}-{key[:12]}-{kind}.json"
-    result = build(target)
-    cache.remember(key, f"{KIND}:{kind}", result, [Path(result["path"])], config)
-    return result
-
-
-def _audio_gist(described: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "path": described["path"],
-        "duration_seconds": described["duration_seconds"],
-        "sample_rate": described["sample_rate"],
-        "channels": described["channels"],
-    }
-
-
-def _beats(
+def beats_half(
     source: Path,
     target: Path,
     described: dict[str, Any],
     detector: beats_module.Detector | None,
 ) -> dict[str, Any]:
+    """The beat grid for this audio, written out. Shared with structure analysis."""
     grid = beats_module.detect(source, detector)
     rows = beats_module.numbered(grid)
-    return _written(target, BEATS, described, beats_module.gist(grid, rows), list(rows))
+    return halves.written(target, BEATS, described, beats_module.gist(grid, rows), list(rows))
 
 
 def _energy(
@@ -255,7 +199,7 @@ def _energy(
         }
         for point in measured.points
     ]
-    return _written(target, ENERGY, described, _energy_gist(measured, window, hop), rows)
+    return halves.written(target, ENERGY, described, _energy_gist(measured, window, hop), rows)
 
 
 def _energy_gist(measured: Measurement, window: float, hop: float) -> dict[str, Any]:
@@ -275,19 +219,3 @@ def _energy_gist(measured: Measurement, window: float, hop: float) -> dict[str, 
     }
 
 
-def _written(
-    target: Path,
-    kind: str,
-    described: dict[str, Any],
-    gist: dict[str, Any],
-    rows: list[dict[str, Any]],
-) -> dict[str, Any]:
-    """One file per half: a header of gist stats, then one record per line."""
-    header = {
-        "kind": kind,
-        "audio": described["path"],
-        "duration_seconds": described["duration_seconds"],
-        **gist,
-    }
-    records.write(target, header, kind, rows)
-    return {"path": str(target), **gist}

--- a/src/resolve_mcp/analysis/music.py
+++ b/src/resolve_mcp/analysis/music.py
@@ -107,13 +107,29 @@ def _sane_windows(window_seconds: float, hop_seconds: float) -> None:
         )
 
 
-def beats_key(identity: dict[str, Any]) -> str:
-    """What the beat grid for this audio is cached under, wherever it is asked for.
+def beats_of(
+    source: Path,
+    described: dict[str, Any],
+    identity: dict[str, Any],
+    detector: beats_module.Detector | None = None,
+    refresh: bool = False,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """The beat grid for this audio, computed or reused — the entry every job shares.
 
     Public because it is shared: structure analysis snaps solo changes to downbeats, and
-    reading this half is how it gets them without running the beat model a second time.
+    calling this is how it gets them without running the beat model a second time. The key
+    and the kind stay here together rather than being rebuilt by each caller, because a
+    caller that assembled one of them differently would quietly get its own cache entry.
     """
-    return cache.cache_key(f"{KIND}:{BEATS}", [identity], {})
+    return halves.cached(
+        f"{KIND}:{BEATS}",
+        cache.cache_key(f"{KIND}:{BEATS}", [identity], {}),
+        lambda path: beats_half(source, path, described, detector),
+        source,
+        refresh,
+        config or get_config(),
+    )
 
 
 def analyze(
@@ -138,14 +154,7 @@ def analyze(
 
     if settings[BEATS]:
         progress(0.1, "finding beats and downbeats")
-        result[BEATS] = halves.cached(
-            f"{KIND}:{BEATS}",
-            beats_key(identity),
-            lambda path: beats_half(source, path, described, detector),
-            source,
-            refresh,
-            config,
-        )
+        result[BEATS] = beats_of(source, described, identity, detector, refresh, config)
         artifacts.append(Path(result[BEATS]["path"]))
 
     if settings[ENERGY]:

--- a/src/resolve_mcp/analysis/records.py
+++ b/src/resolve_mcp/analysis/records.py
@@ -38,6 +38,16 @@ def write(
     return path
 
 
+def read(path: Path) -> dict[str, Any]:
+    """A file this module wrote, back as one dict — header keys and all of its records.
+
+    For a worker reading another worker's half, not for a tool result: the layout above is
+    what keeps an agent out of the whole file, and this is the one caller that wants it.
+    """
+    loaded: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return loaded
+
+
 def _rows(rows: Sequence[Mapping[str, Any]]) -> list[str]:
     """Each record on its own line, comma-separated the way JSON wants."""
     written = [json.dumps(dict(row)) for row in rows]

--- a/src/resolve_mcp/analysis/solos.py
+++ b/src/resolve_mcp/analysis/solos.py
@@ -358,6 +358,8 @@ def changes(
     A stem taking the front and the residual's timbre stepping at the same moment is one
     event seen twice — the horn leaving ``other`` is why the vocal is now clear of it — so
     the timbre reading is dropped when a lead change is already within ``together_seconds``.
+    Only against the lead changes: two timbre steps close together are two handovers inside
+    the residual, and ``steps`` has already decided how close two of those may be.
     """
     found = [
         Change(
@@ -372,6 +374,7 @@ def changes(
         for index, one in enumerate(built)
         if one.start > opened
     ]
+    leads = tuple(found)
     found.extend(
         Change(
             seconds=one.seconds,
@@ -383,7 +386,7 @@ def changes(
             detail=one.semitones,
         )
         for one in stepped
-        if all(abs(one.seconds - lead.measured) >= together_seconds for lead in found)
+        if all(abs(one.seconds - lead.measured) >= together_seconds for lead in leads)
     )
     return tuple(sorted(found, key=lambda one: one.measured))
 
@@ -401,9 +404,9 @@ def snapped(
     """
     called: list[Change] = []
     for one in found:
-        nearest = beats_module.nearest(downbeats, one.measured)
-        near = nearest is not None and abs(downbeats[nearest] - one.measured) <= tolerance
-        when = round(downbeats[nearest], 3) if near and nearest is not None else one.measured
+        index = beats_module.nearest(downbeats, one.measured)
+        near = index is not None and abs(downbeats[index] - one.measured) <= tolerance
+        when = round(downbeats[index], 3) if near and index is not None else one.measured
         called.append(one._replace(seconds=when, downbeat=near))
     return tuple(called)
 

--- a/src/resolve_mcp/analysis/solos.py
+++ b/src/resolve_mcp/analysis/solos.py
@@ -1,0 +1,446 @@
+"""Where the front of the band changes hands.
+
+No separator ships a horn stem or a piano stem, so nothing here can name the soloist (#22:
+"who-is-soloing = timbre/activity analysis on the residual stem"). What it can do is say
+*when* the front changed, which is what a cut needs: an editor goes wide on the head, tight
+on the soloist, and the wrong frame to make that move on is anywhere but the change.
+
+Two signals, because a jazz set hands the tune over in two different ways:
+
+* **Across the stems.** The vocal takes it, then the horns; the bass takes a chorus. That
+  is one stem lifting while the others sit, and it is read off the four energy curves.
+* **Inside the residual.** Tenor out, piano in — both live in ``other``, the energy barely
+  moves, and the only thing that changes is the timbre. That is a step in the residual
+  stem's brightness, and it is the reason this module reads the residual twice.
+
+The measurement that makes the first signal work is **prominence over a stem's own quiet
+baseline**, not its level. Drums are the loudest stem in almost every mix and are almost
+never the soloist; a stem that never varies is a stem that is accompanying. So each curve is
+measured against its own 5th percentile — how far this stem has lifted over how quiet it
+gets — which is comparable across stems in a way that dB in the mix is not. The baseline is
+held within ``RANGE_DB`` of the stem's own peak so that a stem which falls silent for part
+of a set does not read as leading the whole of it on the strength of a -120 LUFS floor.
+
+Change points are then snapped to the nearest downbeat, because a solo change that is going
+to be cut on is cut on the bar, and the energy window that found it is seconds wide.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from . import beats as beats_module
+
+if TYPE_CHECKING:  # pragma: no cover - the worker imports these when it runs
+    from .decode import Audio
+
+DEFAULT_WINDOW_SECONDS = 4.0
+DEFAULT_HOP_SECONDS = 1.0
+DEFAULT_MINIMUM_SECONDS = 12.0
+"""Shorter than this and it is a stab, a fill or a trade, not the front changing hands."""
+DEFAULT_MARGIN_DB = 3.0
+"""How far clear of the next stem a stem has to be before it is out front rather than level."""
+DEFAULT_SNAP_SECONDS = 2.0
+DEFAULT_SEMITONES = 4.0
+"""How far the residual's brightness has to step before it is a different instrument."""
+
+QUIET_PERCENTILE = 5.0
+RANGE_DB = 40.0
+
+RESIDUAL = "other"
+"""The stem the horns and the piano land in — everything no model has a stem for."""
+
+LEAD = "lead"
+TIMBRE = "timbre"
+
+BRIGHTNESS_WINDOW = 2048
+BRIGHTNESS_HOP = 1024
+BRIGHTNESS_CHUNK = 4096
+BRIGHTNESS_FLOOR = 1e-9
+
+
+class Voice(NamedTuple):
+    """One stem's loudness curve. ``seconds`` is where each window starts."""
+
+    name: str
+    seconds: tuple[float, ...]
+    lufs: tuple[float, ...]
+
+
+class Run(NamedTuple):
+    """A stretch of the set with one stem out front."""
+
+    name: str
+    start: float
+    end: float
+    margin_db: float
+
+    @property
+    def seconds(self) -> float:
+        return round(self.end - self.start, 3)
+
+
+class Step(NamedTuple):
+    """A step in the residual stem's brightness — a handover inside one stem."""
+
+    seconds: float
+    before: float
+    after: float
+
+    @property
+    def semitones(self) -> float:
+        return round(12.0 * math.log2(self.after / self.before), 2)
+
+
+class Change(NamedTuple):
+    """One change point. ``seconds`` is where it is called; ``measured`` is where it was seen."""
+
+    seconds: float
+    measured: float
+    downbeat: bool
+    signal: str
+    left: str | None
+    entered: str
+    detail: float
+
+
+def voices(
+    stems: Mapping[str, Path],
+    window_seconds: float = DEFAULT_WINDOW_SECONDS,
+    hop_seconds: float = DEFAULT_HOP_SECONDS,
+) -> tuple[Voice, ...]:
+    """Read each stem once and keep its loudness curve. The rest of this module is arithmetic.
+
+    Each window is dated at its **centre**, not where it starts. An energy window is seconds
+    of audio and a handover inside it moves both curves from the moment it happens, so the
+    window where one stem passes the other is the window straddling the change — dating it
+    by its leading edge would report every solo change half a window early, every time.
+    """
+    from . import decode
+    from . import energy as energy_module
+
+    middle = window_seconds / 2.0
+    found: list[Voice] = []
+    for name in sorted(stems):
+        curve = energy_module.curve(decode.read(stems[name]), window_seconds, hop_seconds)
+        found.append(
+            Voice(
+                name=name,
+                seconds=tuple(round(point.seconds + middle, 3) for point in curve),
+                lufs=tuple(point.lufs for point in curve),
+            )
+        )
+    return tuple(found)
+
+
+def prominence(voice: Voice) -> NDArray[np.float64]:
+    """How far this stem has lifted over its own quiet baseline, in dB, floored at zero.
+
+    The baseline is the stem's 5th percentile, held within ``RANGE_DB`` of its own peak: a
+    stem that is digital silence for part of a set has a percentile down at the silence
+    floor, and without the clamp its every note would read as a hundred dB of lift.
+    """
+    values = np.asarray(voice.lufs, dtype=np.float64)
+    if values.size == 0:
+        return values
+    baseline = max(float(np.percentile(values, QUIET_PERCENTILE)), float(values.max()) - RANGE_DB)
+    return np.clip(values - baseline, 0.0, RANGE_DB)
+
+
+def runs(
+    found: Sequence[Voice],
+    margin_db: float = DEFAULT_MARGIN_DB,
+    minimum_seconds: float = DEFAULT_MINIMUM_SECONDS,
+) -> tuple[Run, ...]:
+    """Which stem is out front, window by window, collapsed into stretches.
+
+    A window where no stem is clear of the others by ``margin_db`` does not end the stretch
+    it falls in: the front does not change hands because two players were level for a bar.
+    It takes a *different* stem leading to end one, and a stretch too short to be a solo is
+    folded back into the one before it.
+    """
+    shared = min((len(one.lufs) for one in found), default=0)
+    if not found or shared == 0:
+        return ()
+    seconds = found[0].seconds[:shared]
+    lifts = {one.name: prominence(one)[:shared] for one in found}
+
+    built: list[Run] = []
+    for index, when in enumerate(seconds):
+        name, margin = _front(lifts, index, margin_db)
+        if name is None:
+            continue
+        if built and built[-1].name == name:
+            continue
+        built.append(Run(name, round(float(when), 3), 0.0, round(margin, 2)))
+    return _sieved(_closed(built, seconds), minimum_seconds)
+
+
+def _front(
+    lifts: Mapping[str, NDArray[np.float64]],
+    index: int,
+    margin_db: float,
+) -> tuple[str | None, float]:
+    """The stem out front in this window and by how much, or nobody and how close it was.
+
+    A lone stem is measured against a stem sitting at its own baseline, so a single-stem
+    reading still has to lift to lead rather than leading by default.
+    """
+    ranked = sorted(((float(one[index]), name) for name, one in lifts.items()), reverse=True)
+    best, name = ranked[0]
+    second = ranked[1][0] if len(ranked) > 1 else 0.0
+    return (name if best - second >= margin_db else None), best - second
+
+
+def _closed(built: Sequence[Run], seconds: Sequence[float]) -> list[Run]:
+    """Every stretch ends where the next one starts; the last ends with the audio."""
+    if not built:
+        return []
+    hop = seconds[1] - seconds[0] if len(seconds) > 1 else 0.0
+    ends = [*(one.start for one in built[1:]), round(float(seconds[-1] + hop), 3)]
+    return [
+        Run(one.name, one.start, end, one.margin_db)
+        for one, end in zip(built, ends, strict=True)
+    ]
+
+
+def _sieved(built: Sequence[Run], minimum_seconds: float) -> tuple[Run, ...]:
+    """Drop stretches too short to be a solo, and join what that leaves touching."""
+    kept: list[Run] = []
+    for one in built:
+        if one.seconds < minimum_seconds and kept:
+            kept[-1] = Run(kept[-1].name, kept[-1].start, one.end, kept[-1].margin_db)
+            continue
+        if kept and kept[-1].name == one.name:
+            margin = max(kept[-1].margin_db, one.margin_db)
+            kept[-1] = Run(kept[-1].name, kept[-1].start, one.end, margin)
+            continue
+        kept.append(one)
+    return tuple(one for one in kept if one.seconds >= minimum_seconds)
+
+
+def brightness(
+    audio: Audio,
+    window_seconds: float = DEFAULT_WINDOW_SECONDS,
+    hop_seconds: float = DEFAULT_HOP_SECONDS,
+) -> tuple[tuple[float, ...], tuple[float, ...]]:
+    """The residual stem's spectral centroid per window, in hertz — its brightness curve.
+
+    Short frames averaged into the analysis window rather than one transform per window: a
+    four-second FFT of a concert is both slow and smeared, and what is wanted is the timbre
+    of the window's notes, not its lowest partial. Windows are dated at their centre, for
+    the same reason the loudness curves are.
+    """
+    centroids, times = _centroids(audio)
+    if centroids.size == 0:
+        return (), ()
+    last_start = max(float(audio.duration_seconds) - window_seconds, 0.0)
+    starts = np.arange(0.0, last_start + 1e-9, hop_seconds)
+    opened = np.searchsorted(times, starts, side="left")
+    closed = np.searchsorted(times, starts + window_seconds, side="left")
+    kept = [
+        (float(start) + window_seconds / 2.0, float(np.median(centroids[first:last])))
+        for start, first, last in zip(starts, opened, closed, strict=True)
+        if last > first
+    ]
+    return tuple(round(one, 3) for one, _ in kept), tuple(round(one, 1) for _, one in kept)
+
+
+def _centroids(audio: Audio) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Centre of gravity of each short-time spectrum, and when each frame starts."""
+    mono = audio.mono()
+    if mono.size < BRIGHTNESS_WINDOW:
+        return np.zeros(0, dtype=np.float64), np.zeros(0, dtype=np.float64)
+
+    window = np.hanning(BRIGHTNESS_WINDOW).astype(np.float32)
+    count = 1 + (mono.size - BRIGHTNESS_WINDOW) // BRIGHTNESS_HOP
+    frames = np.lib.stride_tricks.as_strided(
+        mono,
+        shape=(count, BRIGHTNESS_WINDOW),
+        strides=(mono.strides[0] * BRIGHTNESS_HOP, mono.strides[0]),
+    )
+    hertz = np.fft.rfftfreq(BRIGHTNESS_WINDOW, 1.0 / audio.sample_rate)
+
+    found = np.empty(count, dtype=np.float64)
+    for first in range(0, count, BRIGHTNESS_CHUNK):
+        last = min(first + BRIGHTNESS_CHUNK, count)
+        magnitudes = np.abs(np.fft.rfft(frames[first:last] * window, axis=1)).astype(np.float64)
+        totals = magnitudes.sum(axis=1)
+        found[first:last] = (magnitudes @ hertz) / np.maximum(totals, BRIGHTNESS_FLOOR)
+    times = np.arange(count, dtype=np.float64) * BRIGHTNESS_HOP / audio.sample_rate
+    return found, times
+
+
+def steps(
+    seconds: Sequence[float],
+    hertz: Sequence[float],
+    semitones: float = DEFAULT_SEMITONES,
+    minimum_seconds: float = DEFAULT_MINIMUM_SECONDS,
+) -> tuple[Step, ...]:
+    """Where the brightness curve steps rather than drifts.
+
+    Each candidate is judged by the median brightness of the ``minimum_seconds`` before it
+    against the ``minimum_seconds`` after it, in semitones so that a step means the same
+    thing at 400 Hz and at 4 kHz. A drift fails that test by construction — its two medians
+    are only half a window apart however far the curve has travelled.
+
+    That test is deliberately blunt about *where* the step is: a median stops moving once
+    half its window is past the step, so every index for a window either side of one reads
+    the same. So detection is one pass and localisation is another — inside each run of
+    candidates the step is called where a short median either side of it disagrees most,
+    which is the step itself and nowhere else.
+    """
+    values = np.asarray(hertz, dtype=np.float64)
+    hop = seconds[1] - seconds[0] if len(seconds) > 1 else 0.0
+    span = max(int(round(minimum_seconds / hop)), 1) if hop > 0 else 0
+    if span == 0 or values.size < span * 2:
+        return ()
+
+    found = [
+        index
+        for index in range(span, values.size - span + 1)
+        if abs(_shift(values, index, span)) >= semitones
+    ]
+    return tuple(
+        Step(
+            round(float(seconds[index]), 3),
+            round(float(np.median(values[index - span : index])), 1),
+            round(float(np.median(values[index : index + span])), 1),
+        )
+        for index in [_peak(values, run, span) for run in _grouped(found)]
+    )
+
+
+def _shift(values: NDArray[np.float64], index: int, span: int) -> float:
+    """How far the curve steps at this index, in semitones, over ``span`` windows either side."""
+    before = float(np.median(values[max(index - span, 0) : index]))
+    after = float(np.median(values[index : index + span]))
+    if before <= 0.0 or after <= 0.0:
+        return 0.0
+    return 12.0 * math.log2(after / before)
+
+
+def _grouped(found: Sequence[int]) -> list[list[int]]:
+    """Consecutive candidate indices are one step seen from several windows."""
+    runs: list[list[int]] = []
+    for index in found:
+        if runs and index == runs[-1][-1] + 1:
+            runs[-1].append(index)
+            continue
+        runs.append([index])
+    return runs
+
+
+def _peak(values: NDArray[np.float64], run: Sequence[int], span: int) -> int:
+    """Where inside a run of candidates the step actually is, by a short median either side."""
+    close = max(span // 4, 1)
+    return max(run, key=lambda index: (abs(_shift(values, index, close)), -index))
+
+
+def changes(
+    built: Sequence[Run],
+    stepped: Sequence[Step] = (),
+    together_seconds: float = DEFAULT_WINDOW_SECONDS,
+    opened: float = 0.0,
+) -> tuple[Change, ...]:
+    """Every point where the front changed, from both signals, each event reported once.
+
+    Whoever is out front in the first window did not take it there — that is the state the
+    measurement opened in, and ``opened`` is when that was, so a set that starts mid-solo
+    reports its first *change* rather than its first soloist.
+
+    A stem taking the front and the residual's timbre stepping at the same moment is one
+    event seen twice — the horn leaving ``other`` is why the vocal is now clear of it — so
+    the timbre reading is dropped when a lead change is already within ``together_seconds``.
+    """
+    found = [
+        Change(
+            seconds=one.start,
+            measured=one.start,
+            downbeat=False,
+            signal=LEAD,
+            left=(built[index - 1].name if index else None),
+            entered=one.name,
+            detail=one.margin_db,
+        )
+        for index, one in enumerate(built)
+        if one.start > opened
+    ]
+    found.extend(
+        Change(
+            seconds=one.seconds,
+            measured=one.seconds,
+            downbeat=False,
+            signal=TIMBRE,
+            left=RESIDUAL,
+            entered=RESIDUAL,
+            detail=one.semitones,
+        )
+        for one in stepped
+        if all(abs(one.seconds - lead.measured) >= together_seconds for lead in found)
+    )
+    return tuple(sorted(found, key=lambda one: one.measured))
+
+
+def snapped(
+    found: Sequence[Change],
+    downbeats: Sequence[float],
+    tolerance: float = DEFAULT_SNAP_SECONDS,
+) -> tuple[Change, ...]:
+    """Call each change on the nearest downbeat, unless the nearest one is too far to mean it.
+
+    An energy window is seconds wide, so the measured time is approximate and the downbeat
+    inside it is the frame worth cutting on. A downbeat half a chorus away is not: past
+    ``tolerance`` the measured time stands, and the record says it was not snapped.
+    """
+    called: list[Change] = []
+    for one in found:
+        nearest = beats_module.nearest(downbeats, one.measured)
+        near = nearest is not None and abs(downbeats[nearest] - one.measured) <= tolerance
+        when = round(downbeats[nearest], 3) if near and nearest is not None else one.measured
+        called.append(one._replace(seconds=when, downbeat=near))
+    return tuple(called)
+
+
+def numbered(found: Sequence[Change]) -> tuple[dict[str, Any], ...]:
+    """One record per change: when it is called, when it was seen, and what changed."""
+    return tuple(
+        {
+            "change": index,
+            "t": one.seconds,
+            "measured_t": one.measured,
+            "downbeat": one.downbeat,
+            "signal": one.signal,
+            "from": one.left,
+            "to": one.entered,
+            "detail": one.detail,
+        }
+        for index, one in enumerate(found, start=1)
+    )
+
+
+def gist(built: Sequence[Run], found: Sequence[Change]) -> dict[str, Any]:
+    """How many changes, how many landed on a downbeat, and who held the front longest."""
+    longest = max(built, key=lambda one: one.seconds, default=None)
+    seconds_in_front: dict[str, float] = {}
+    for one in built:
+        seconds_in_front[one.name] = round(seconds_in_front.get(one.name, 0.0) + one.seconds, 3)
+    held = (
+        None
+        if longest is None
+        else {"stem": longest.name, "t": longest.start, "seconds": longest.seconds}
+    )
+    return {
+        "count": len(found),
+        "snapped": sum(1 for one in found if one.downbeat),
+        "timbre_changes": sum(1 for one in found if one.signal == TIMBRE),
+        "runs": len(built),
+        "seconds_in_front": seconds_in_front,
+        "longest_lead": held,
+    }

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -253,7 +253,10 @@ def analyze(
             f"{KIND}:{SOLOS}",
             cache.cache_key(
                 f"{KIND}:{SOLOS}",
-                [identity, stem_identity or _stem_identity(stems, config)],
+                [
+                    identity,
+                    stem_identity if stem_identity is not None else _stem_identity(stems, config),
+                ],
                 shape,
             ),
             lambda path: _solos(

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -46,7 +46,15 @@ TUNES = "tunes"
 SOLOS = "solos"
 
 APPLAUSE_SHAPE = ("threshold", "burst_seconds", "gap_seconds", "tune_seconds")
-SOLO_SHAPE = ("window_seconds", "hop_seconds", "solo_seconds", "margin_db", "semitones")
+SOLO_SHAPE = (
+    "window_seconds",
+    "hop_seconds",
+    "solo_seconds",
+    "margin_db",
+    "semitones",
+    "snap_seconds",
+)
+"""Every setting that changes what the solo half says — and so what it is keyed on."""
 
 
 def analyze_structure(
@@ -91,7 +99,8 @@ def analyze_structure(
         "snap_seconds": float(snap_seconds),
     }
     identity = halves.identity(source, config)
-    key = cache.cache_key(KIND, [identity, _stem_identity(found, config)], settings)
+    stem_identity = _stem_identity(found, config)
+    key = cache.cache_key(KIND, [identity, stem_identity], settings)
 
     def work(progress: Progress) -> JobOutput:
         return analyze(
@@ -100,6 +109,7 @@ def analyze_structure(
             progress,
             identity=identity,
             stems=found,
+            stem_identity=stem_identity,
             tagger=tagger,
             detector=detector,
             refresh=refresh,
@@ -159,6 +169,7 @@ def _stems(stems: str | Path | None, solos: bool) -> dict[str, Path]:
                 "Run separate_stems first and pass the directory from its result as stems, "
                 "or ask for solos=false."
             ),
+            detail={SOLOS: solos, "stems": None},
         )
     directory = Path(stems)
     inner = directory / stems_module.MIX_PASS
@@ -198,12 +209,18 @@ def analyze(
     progress: Progress,
     identity: dict[str, Any] | None = None,
     stems: Mapping[str, Path] | None = None,
+    stem_identity: Mapping[str, Any] | None = None,
     tagger: applause_module.Tagger | None = None,
     detector: beats_module.Detector | None = None,
     refresh: bool = False,
     config: Config | None = None,
 ) -> JobOutput:
-    """The worker: find the boundaries that were asked for, write them out, return the gist."""
+    """The worker: find the boundaries that were asked for, write them out, return the gist.
+
+    ``identity`` and ``stem_identity`` come from the starter, which already worked them out
+    to key the job — fingerprinting the same stems a second time here would read a gigabyte
+    of WAV to learn what the caller is holding.
+    """
     from ..audio import wav
 
     config = config or get_config()
@@ -232,19 +249,18 @@ def analyze(
     if settings[SOLOS]:
         progress(0.6, "measuring the stems")
         shape = {name: settings[name] for name in SOLO_SHAPE}
-        stem_shape = {**shape, "snap_seconds": settings["snap_seconds"]}
         result[SOLOS] = halves.cached(
             f"{KIND}:{SOLOS}",
             cache.cache_key(
                 f"{KIND}:{SOLOS}",
-                [identity, _stem_identity(stems, config)],
-                stem_shape,
+                [identity, stem_identity or _stem_identity(stems, config)],
+                shape,
             ),
             lambda path: _solos(
                 source,
                 path,
                 described,
-                stem_shape,
+                shape,
                 stems,
                 identity,
                 detector,
@@ -351,13 +367,6 @@ def _downbeats(
     to learn what is already on disk is the cost that keying halves separately exists to
     avoid.
     """
-    half = halves.cached(
-        f"{music.KIND}:{music.BEATS}",
-        music.beats_key(dict(identity)),
-        lambda path: music.beats_half(source, path, dict(described), detector),
-        source,
-        refresh,
-        config,
-    )
+    half = music.beats_of(source, dict(described), dict(identity), detector, refresh, config)
     rows: Sequence[Mapping[str, Any]] = records.read(Path(half["path"]))[music.BEATS]
     return tuple(float(row["t"]) for row in rows if row["downbeat"])

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -1,0 +1,363 @@
+"""The structure analysis job: where the tunes are, and where the front changes hands.
+
+Two halves, because they answer the two questions a concert's shape is made of (#22, story
+29) and they need different substrate:
+
+* **Tune boundaries** come off the master mix. Applause is the only reliable segmentation a
+  jazz set offers — there is no verse and no chorus to find — so the mix is tagged for it
+  and the music between the bursts is the tune. This is what a ``songs.json`` author reads
+  before placing a single marker (#22, story 33).
+
+* **Solo changes** come off the stems, because "who is out front" is not a question the mix
+  can answer. They are also snapped to downbeats, which means this job needs a beat grid —
+  and it reads the one ``analyze_music`` writes rather than paying for a second detection,
+  because both halves are keyed on the audio rather than on the job that asked (see
+  ``halves``). Ask for solo changes on audio whose beats are already analysed and the beat
+  model does not run at all.
+
+Nothing here touches Resolve, and neither half is on by default in the sense that matters:
+each drags in its own heavy dependency — a tagger for one, a separation run for the other —
+so a caller asks for what it is prepared to pay for and gets a structured error naming the
+install when it is not there.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from ..audio import separator
+from ..audio import stems as stems_module
+from ..config import Config, get_config
+from ..errors import InvalidRequestError
+from ..jobs import cache
+from ..jobs.runner import JobOutput, Progress, start_job
+from ..logging_config import get_logger
+from . import applause as applause_module
+from . import beats as beats_module
+from . import halves, music, records
+from . import solos as solos_module
+
+log = get_logger("analysis")
+
+KIND = "analyze_structure"
+TUNES = "tunes"
+SOLOS = "solos"
+
+APPLAUSE_SHAPE = ("threshold", "burst_seconds", "gap_seconds", "tune_seconds")
+SOLO_SHAPE = ("window_seconds", "hop_seconds", "solo_seconds", "margin_db", "semitones")
+
+
+def analyze_structure(
+    audio: str | Path,
+    tunes: bool = True,
+    solos: bool = False,
+    stems: str | Path | None = None,
+    threshold: float = applause_module.DEFAULT_THRESHOLD,
+    burst_seconds: float = applause_module.DEFAULT_MINIMUM_SECONDS,
+    gap_seconds: float = applause_module.DEFAULT_GAP_SECONDS,
+    tune_seconds: float = applause_module.DEFAULT_TUNE_SECONDS,
+    window_seconds: float = solos_module.DEFAULT_WINDOW_SECONDS,
+    hop_seconds: float = solos_module.DEFAULT_HOP_SECONDS,
+    solo_seconds: float = solos_module.DEFAULT_MINIMUM_SECONDS,
+    margin_db: float = solos_module.DEFAULT_MARGIN_DB,
+    semitones: float = solos_module.DEFAULT_SEMITONES,
+    snap_seconds: float = solos_module.DEFAULT_SNAP_SECONDS,
+    refresh: bool = False,
+    tagger: applause_module.Tagger | None = None,
+    detector: beats_module.Detector | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Start the structure job. Returns the job record, not the structure."""
+    config = config or get_config()
+    source = halves.readable(audio)
+    _asked_for_something(tunes, solos)
+    _sane_numbers(threshold, window_seconds, hop_seconds)
+    found = _stems(stems, solos)
+
+    settings: dict[str, Any] = {
+        TUNES: tunes,
+        SOLOS: solos,
+        "threshold": float(threshold),
+        "burst_seconds": float(burst_seconds),
+        "gap_seconds": float(gap_seconds),
+        "tune_seconds": float(tune_seconds),
+        "window_seconds": float(window_seconds),
+        "hop_seconds": float(hop_seconds),
+        "solo_seconds": float(solo_seconds),
+        "margin_db": float(margin_db),
+        "semitones": float(semitones),
+        "snap_seconds": float(snap_seconds),
+    }
+    identity = halves.identity(source, config)
+    key = cache.cache_key(KIND, [identity, _stem_identity(found, config)], settings)
+
+    def work(progress: Progress) -> JobOutput:
+        return analyze(
+            source,
+            settings,
+            progress,
+            identity=identity,
+            stems=found,
+            tagger=tagger,
+            detector=detector,
+            refresh=refresh,
+            config=config,
+        )
+
+    return start_job(
+        KIND,
+        {"audio": source.name, "stems": str(stems) if stems else None, **settings},
+        work,
+        cache_key=key,
+        refresh=refresh,
+        config=config,
+    )
+
+
+def _asked_for_something(tunes: bool, solos: bool) -> None:
+    if not tunes and not solos:
+        raise InvalidRequestError(
+            cause="Neither tune boundaries nor solo changes were asked for.",
+            fix="Leave tunes on, or turn on solos, or both.",
+            detail={TUNES: tunes, SOLOS: solos},
+        )
+
+
+def _sane_numbers(threshold: float, window_seconds: float, hop_seconds: float) -> None:
+    if not 0.0 < threshold <= 1.0 or window_seconds <= 0 or hop_seconds <= 0:
+        raise InvalidRequestError(
+            cause="The applause threshold must be a probability, and the windows positive.",
+            fix=(
+                f"Defaults are threshold={applause_module.DEFAULT_THRESHOLD}, "
+                f"window_seconds={solos_module.DEFAULT_WINDOW_SECONDS}, "
+                f"hop_seconds={solos_module.DEFAULT_HOP_SECONDS}."
+            ),
+            detail={
+                "threshold": threshold,
+                "window_seconds": window_seconds,
+                "hop_seconds": hop_seconds,
+            },
+        )
+
+
+def _stems(stems: str | Path | None, solos: bool) -> dict[str, Path]:
+    """The separated stems to read, from the directory a ``separate_stems`` job returned.
+
+    That job writes each pass into its own directory, so the path it hands back holds the
+    four stems one level down; both that path and the pass directory itself are accepted,
+    because an agent reading the job record has one and an agent looking at the disk has
+    the other.
+    """
+    if not solos:
+        return {}
+    if stems is None:
+        raise InvalidRequestError(
+            cause="Solo changes are measured on the stems, and no stems directory was given.",
+            fix=(
+                "Run separate_stems first and pass the directory from its result as stems, "
+                "or ask for solos=false."
+            ),
+        )
+    directory = Path(stems)
+    inner = directory / stems_module.MIX_PASS
+    found = separator.collect(inner if inner.is_dir() else directory)
+    if not found:
+        raise InvalidRequestError(
+            cause=f"There are no separated stems in {directory}.",
+            fix=(
+                "Pass the directory a separate_stems job returned — the one holding the "
+                f"{stems_module.MIX_PASS} pass — and check the job completed."
+            ),
+            detail={"requested": str(directory)},
+        )
+    return found
+
+
+def _stem_identity(found: Mapping[str, Path], config: Config) -> dict[str, Any]:
+    """What the stems are, for keying: their own directory name, or their bytes.
+
+    Stems this server separated live in a directory named after the content hash of the
+    audio they came from and the models that made them, so the name *is* the identity and
+    reading a gigabyte of WAV back to learn what it already says would be waste. Stems from
+    anywhere else are fingerprinted one by one, because nothing about the name is known.
+    """
+    if not found:
+        return {}
+    directory = next(iter(found.values())).parent.resolve()
+    if halves.inside(directory, config.stems_dir):
+        keyed = directory.relative_to(config.stems_dir.resolve()).parts[0]
+        return {"stems": keyed, "names": sorted(found)}
+    return {"files": [cache.fingerprint(found[name]) for name in sorted(found)]}
+
+
+def analyze(
+    source: Path,
+    settings: dict[str, Any],
+    progress: Progress,
+    identity: dict[str, Any] | None = None,
+    stems: Mapping[str, Path] | None = None,
+    tagger: applause_module.Tagger | None = None,
+    detector: beats_module.Detector | None = None,
+    refresh: bool = False,
+    config: Config | None = None,
+) -> JobOutput:
+    """The worker: find the boundaries that were asked for, write them out, return the gist."""
+    from ..audio import wav
+
+    config = config or get_config()
+    config.analysis_dir.mkdir(parents=True, exist_ok=True)
+    identity = identity or halves.identity(source, config)
+    stems = stems or {}
+
+    progress(0.05, "reading the audio")
+    described = wav.describe(source)
+    result: dict[str, Any] = {"audio": halves.audio_gist(described)}
+    artifacts: list[Path] = []
+
+    if settings[TUNES]:
+        progress(0.1, "listening for applause")
+        shape = {name: settings[name] for name in APPLAUSE_SHAPE}
+        result[TUNES] = halves.cached(
+            f"{KIND}:{TUNES}",
+            cache.cache_key(f"{KIND}:{TUNES}", [identity], shape),
+            lambda path: _tunes(source, path, described, shape, tagger),
+            source,
+            refresh,
+            config,
+        )
+        artifacts.append(Path(result[TUNES]["path"]))
+
+    if settings[SOLOS]:
+        progress(0.6, "measuring the stems")
+        shape = {name: settings[name] for name in SOLO_SHAPE}
+        stem_shape = {**shape, "snap_seconds": settings["snap_seconds"]}
+        result[SOLOS] = halves.cached(
+            f"{KIND}:{SOLOS}",
+            cache.cache_key(
+                f"{KIND}:{SOLOS}",
+                [identity, _stem_identity(stems, config)],
+                stem_shape,
+            ),
+            lambda path: _solos(
+                source,
+                path,
+                described,
+                stem_shape,
+                stems,
+                identity,
+                detector,
+                refresh,
+                config,
+            ),
+            source,
+            refresh,
+            config,
+        )
+        artifacts.append(Path(result[SOLOS]["path"]))
+
+    progress(0.95, "written")
+    return JobOutput(result, tuple(artifacts))
+
+
+def _tunes(
+    source: Path,
+    target: Path,
+    described: Mapping[str, Any],
+    shape: Mapping[str, Any],
+    tagger: applause_module.Tagger | None,
+) -> dict[str, Any]:
+    curve = applause_module.tag(source, tagger)
+    spans = applause_module.spans(
+        curve,
+        float(shape["threshold"]),
+        float(shape["burst_seconds"]),
+        float(shape["gap_seconds"]),
+    )
+    found = applause_module.tunes(
+        spans,
+        float(described["duration_seconds"]),
+        float(shape["tune_seconds"]),
+    )
+    gist = {**applause_module.gist(curve, spans, found), **shape}
+    log.info("Found %d tunes and %d bursts of applause in %s", len(found), len(spans), source.name)
+    return halves.written(target, TUNES, described, gist, applause_module.numbered(found))
+
+
+def _solos(
+    source: Path,
+    target: Path,
+    described: Mapping[str, Any],
+    shape: Mapping[str, Any],
+    stems: Mapping[str, Path],
+    identity: Mapping[str, Any],
+    detector: beats_module.Detector | None,
+    refresh: bool,
+    config: Config,
+) -> dict[str, Any]:
+    window = float(shape["window_seconds"])
+    hop = float(shape["hop_seconds"])
+    minimum = float(shape["solo_seconds"])
+
+    voices = solos_module.voices(stems, window, hop)
+    runs = solos_module.runs(voices, float(shape["margin_db"]), minimum)
+    stepped = _timbre(stems, window, hop, minimum, float(shape["semitones"]))
+    opened = voices[0].seconds[0] if voices and voices[0].seconds else 0.0
+    changes = solos_module.snapped(
+        solos_module.changes(runs, stepped, window, opened),
+        _downbeats(source, described, identity, detector, refresh, config),
+        float(shape["snap_seconds"]),
+    )
+    gist = {
+        **solos_module.gist(runs, changes),
+        **shape,
+        "stem_count": len(stems),
+        "residual": solos_module.RESIDUAL in stems,
+    }
+    log.info("Found %d solo changes across %d stems in %s", len(changes), len(stems), source.name)
+    return halves.written(target, SOLOS, described, gist, solos_module.numbered(changes))
+
+
+def _timbre(
+    stems: Mapping[str, Path],
+    window: float,
+    hop: float,
+    minimum: float,
+    semitones: float,
+) -> tuple[solos_module.Step, ...]:
+    """Brightness steps inside the residual stem — nothing, if there is no residual stem."""
+    from . import decode
+
+    residual = stems.get(solos_module.RESIDUAL)
+    if residual is None:
+        return ()
+    seconds, hertz = solos_module.brightness(decode.read(residual), window, hop)
+    return solos_module.steps(seconds, hertz, semitones, minimum)
+
+
+def _downbeats(
+    source: Path,
+    described: Mapping[str, Any],
+    identity: Mapping[str, Any],
+    detector: beats_module.Detector | None,
+    refresh: bool,
+    config: Config,
+) -> tuple[float, ...]:
+    """The downbeats to snap to, from the beats half — computed here only if nobody has yet.
+
+    Deliberately the *same* cache entry ``analyze_music`` writes, not a private copy: the
+    grid for a piece of audio is the grid, and a second detection over an hour of concert
+    to learn what is already on disk is the cost that keying halves separately exists to
+    avoid.
+    """
+    half = halves.cached(
+        f"{music.KIND}:{music.BEATS}",
+        music.beats_key(dict(identity)),
+        lambda path: music.beats_half(source, path, dict(described), detector),
+        source,
+        refresh,
+        config,
+    )
+    rows: Sequence[Mapping[str, Any]] = records.read(Path(half["path"]))[music.BEATS]
+    return tuple(float(row["t"]) for row in rows if row["downbeat"])

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..analysis import music, silence, transcribe, transcript, whisper
+from ..analysis import applause, music, silence, solos, structure, transcribe, transcript, whisper
 from ..resolve.connection import get_connection
 from .envelope import tool
 
@@ -45,6 +45,54 @@ def analyze_music(
             energy=energy,
             window_seconds=window_seconds,
             hop_seconds=hop_seconds,
+            refresh=refresh,
+        )
+    }
+
+
+@tool
+def analyze_structure(
+    audio: str,
+    tunes: bool = True,
+    solos: bool = False,
+    stems: str | None = None,
+    threshold: float = applause.DEFAULT_THRESHOLD,
+    tune_seconds: float = applause.DEFAULT_TUNE_SECONDS,
+    solo_seconds: float = solos.DEFAULT_MINIMUM_SECONDS,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    """Start tune-boundary and solo-change analysis of a concert. Returns a job to poll.
+
+    A jazz set has no verses to segment, so the boundaries come from the room: applause is
+    tagged on the master mix, and the music between two bursts is a tune. The tunes file
+    holds one record per tune — its number, start, end, length, and the seconds of applause
+    on either side of it — which is what a songs.json author reads before placing markers.
+    Inline you get how many tunes, how much clapping, and where the longest one starts.
+
+    solos=true adds the second half and needs stems: pass the directory a separate_stems
+    job returned. It measures which stem is out front over its own quiet baseline, and
+    where the residual stem's brightness steps — one horn out, piano in, both inside
+    `other` — and writes one record per change point: where it is called, where it was
+    measured, whether it landed on a downbeat, and what handed over to what. Change points
+    are snapped to the nearest downbeat within a couple of seconds, so this half reads the
+    beat grid — analyze_music's if it exists, or it detects one and leaves it for that tool
+    to reuse.
+
+    Nothing here names the soloist: no separator ships a horn stem or a piano stem, so what
+    is measured is that the front changed and when. threshold moves how sure the tagger has
+    to be that it is hearing a room; tune_seconds is how much music has to sit between two
+    bursts before it is a tune rather than an announcement; solo_seconds is the same idea
+    for a stretch out front. Reruns on unchanged audio come back from cache immediately.
+    """
+    return {
+        "job": structure.analyze_structure(
+            audio,
+            tunes=tunes,
+            solos=solos,
+            stems=stems,
+            threshold=threshold,
+            tune_seconds=tune_seconds,
+            solo_seconds=solo_seconds,
             refresh=refresh,
         )
     }
@@ -97,6 +145,6 @@ def transcribe_audio(
     }
 
 
-TOOLS: tuple[Any, ...] = (transcribe_audio, analyze_music)
+TOOLS: tuple[Any, ...] = (transcribe_audio, analyze_music, analyze_structure)
 
-__all__ = ["TOOLS", "analyze_music", "transcribe_audio"]
+__all__ = ["TOOLS", "analyze_music", "analyze_structure", "transcribe_audio"]

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -59,6 +59,7 @@ def analyze_structure(
     threshold: float = applause.DEFAULT_THRESHOLD,
     tune_seconds: float = applause.DEFAULT_TUNE_SECONDS,
     solo_seconds: float = solos.DEFAULT_MINIMUM_SECONDS,
+    snap_seconds: float = solos.DEFAULT_SNAP_SECONDS,
     refresh: bool = False,
 ) -> dict[str, Any]:
     """Start tune-boundary and solo-change analysis of a concert. Returns a job to poll.
@@ -82,7 +83,9 @@ def analyze_structure(
     is measured is that the front changed and when. threshold moves how sure the tagger has
     to be that it is hearing a room; tune_seconds is how much music has to sit between two
     bursts before it is a tune rather than an announcement; solo_seconds is the same idea
-    for a stretch out front. Reruns on unchanged audio come back from cache immediately.
+    for a stretch out front; snap_seconds is how far a change may reach for a downbeat
+    before it is called where it was measured instead. Reruns on unchanged audio come back
+    from cache immediately.
     """
     return {
         "job": structure.analyze_structure(
@@ -93,6 +96,7 @@ def analyze_structure(
             threshold=threshold,
             tune_seconds=tune_seconds,
             solo_seconds=solo_seconds,
+            snap_seconds=snap_seconds,
             refresh=refresh,
         )
     }

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import contextlib
 import math
+import random
 import wave
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -1714,6 +1715,37 @@ def write_clicks(
             envelope = 1.0 - offset / decay
             wobble = math.sin(2 * math.pi * 2_000.0 * offset / sample_rate)
             samples[start + offset] = int(peak * envelope * envelope * wobble)
+    return _write_samples(path, samples, sample_rate, bit_depth, channels)
+
+
+def write_sections(
+    path: Path,
+    sections: Sequence[tuple[str, float]],
+    sample_rate: int = 8_000,
+    bit_depth: int = 24,
+    channels: int = 2,
+    frequency: float = 440.0,
+    amplitude: float = 0.3,
+    seed: int = 7,
+) -> Path:
+    """A concert-shaped WAV: ``("tone" | "noise" | "silence", seconds)`` laid end to end.
+
+    The applause half of structure analysis reads a tagger, not the waveform, so what this
+    fixture has to be right about is its *shape* — where the music stops, how long the room
+    goes on for, and how long the whole file is, since the last tune ends where the file
+    does. The noise is seeded so a boundary assertion means the same thing on every run.
+    """
+    noise = random.Random(seed)
+    peak = 2 ** (bit_depth - 1) * amplitude
+    samples: list[int] = []
+    for kind, seconds in sections:
+        for index in range(int(seconds * sample_rate)):
+            if kind == "silence":
+                samples.append(0)
+            elif kind == "noise":
+                samples.append(int(peak * noise.uniform(-1.0, 1.0)))
+            else:
+                samples.append(int(peak * math.sin(2 * math.pi * frequency * index / sample_rate)))
     return _write_samples(path, samples, sample_rate, bit_depth, channels)
 
 

--- a/tests/test_applause_spans.py
+++ b/tests/test_applause_spans.py
@@ -1,0 +1,152 @@
+"""Applause probability to tune boundaries: the arithmetic between the model and the file.
+
+PANNs is behind a tagger (ADR 0002) and what it hears is its own business. What is checked
+here is everything after it: which runs of high probability are a burst of applause rather
+than a snare roll, which gaps between bursts are a tune rather than stage banter, and what
+the boundary times are. A jazz set is the case that matters — a tune ends, the room claps,
+the next one starts — so the fixtures are shaped like one.
+"""
+
+from __future__ import annotations
+
+from resolve_mcp.analysis import applause
+
+STEP = 0.5
+"""Seconds per frame in these fixtures. The real tagger's frames are shorter; nothing here
+depends on that beyond the arithmetic of turning frame indices back into seconds."""
+
+
+def _curve(*probability: float) -> applause.Curve:
+    seconds = tuple(round(index * STEP, 6) for index in range(len(probability)))
+    return applause.Curve(seconds=seconds, probability=tuple(probability))
+
+
+def _concert(*sections: tuple[float, float]) -> applause.Curve:
+    """A curve built from ``(probability, seconds)`` sections laid end to end."""
+    probability: list[float] = []
+    for level, seconds in sections:
+        probability.extend([level] * int(round(seconds / STEP)))
+    return _curve(*probability)
+
+
+def _spans(
+    curve: applause.Curve,
+    threshold: float = 0.5,
+    minimum_seconds: float = 1.0,
+    gap_seconds: float = 1.0,
+) -> tuple[applause.Span, ...]:
+    return applause.spans(curve, threshold, minimum_seconds, gap_seconds)
+
+
+# --- which runs of probability are applause -------------------------------------------
+
+
+def test_a_run_above_the_threshold_is_a_span() -> None:
+    found = _spans(_concert((0.0, 4.0), (0.9, 3.0), (0.0, 4.0)))
+
+    assert len(found) == 1
+    assert found[0].start == 4.0
+    assert found[0].end == 7.0
+    assert found[0].seconds == 3.0
+    assert found[0].peak == 0.9
+
+
+def test_a_run_shorter_than_the_minimum_is_not_applause() -> None:
+    """A hand-clap in the tune, or a cymbal the model likes the look of, is not a boundary."""
+    found = _spans(_concert((0.0, 4.0), (0.9, 0.5), (0.0, 4.0)), minimum_seconds=2.0)
+
+    assert found == ()
+
+
+def test_a_dip_inside_one_burst_does_not_split_it() -> None:
+    """Applause has holes in it. Two spans a beat apart are one burst, not two boundaries."""
+    found = _spans(
+        _concert((0.0, 4.0), (0.9, 2.0), (0.1, 0.5), (0.8, 2.0), (0.0, 4.0)),
+        gap_seconds=1.0,
+    )
+
+    assert len(found) == 1
+    assert found[0].start == 4.0
+    assert found[0].end == 8.5
+
+
+def test_two_bursts_further_apart_than_the_gap_stay_two() -> None:
+    found = _spans(_concert((0.0, 2.0), (0.9, 2.0), (0.0, 3.0), (0.9, 2.0)), gap_seconds=1.0)
+
+    assert [(one.start, one.end) for one in found] == [(2.0, 4.0), (7.0, 9.0)]
+
+
+def test_applause_running_to_the_end_of_the_file_closes_at_the_end() -> None:
+    found = _spans(_concert((0.0, 2.0), (0.9, 2.0)))
+
+    assert found[-1].end == 4.0
+
+
+def test_an_empty_curve_finds_nothing() -> None:
+    assert applause.spans(applause.Curve((), ())) == ()
+
+
+# --- which gaps between applause are tunes ---------------------------------------------
+
+
+def test_the_music_between_two_bursts_is_a_tune() -> None:
+    curve = _concert((0.0, 30.0), (0.9, 4.0), (0.0, 30.0), (0.9, 4.0))
+    found = applause.tunes(_spans(curve), duration_seconds=68.0, minimum_seconds=10.0)
+
+    assert [(one.start, one.end) for one in found] == [(0.0, 30.0), (34.0, 64.0)]
+    assert found[0].applause_before is None
+    assert found[0].applause_after == 4.0
+    assert found[1].applause_before == 4.0
+
+
+def test_the_last_tune_runs_to_the_end_of_the_file() -> None:
+    curve = _concert((0.0, 20.0), (0.9, 4.0), (0.0, 20.0))
+    found = applause.tunes(_spans(curve), duration_seconds=44.0, minimum_seconds=10.0)
+
+    assert found[-1].end == 44.0
+    assert found[-1].applause_after is None
+
+
+def test_stage_banter_between_two_bursts_is_not_a_tune() -> None:
+    """Announcing the band takes twenty seconds. A tune does not."""
+    curve = _concert((0.0, 30.0), (0.9, 4.0), (0.0, 8.0), (0.9, 4.0), (0.0, 30.0))
+    found = applause.tunes(_spans(curve), duration_seconds=76.0, minimum_seconds=20.0)
+
+    assert [(one.start, one.end) for one in found] == [(0.0, 30.0), (46.0, 76.0)]
+
+
+def test_a_concert_with_no_applause_at_all_is_one_tune() -> None:
+    found = applause.tunes((), duration_seconds=300.0, minimum_seconds=20.0)
+
+    assert [(one.start, one.end) for one in found] == [(0.0, 300.0)]
+    assert found[0].applause_before is None and found[0].applause_after is None
+
+
+# --- what is written and what comes back ------------------------------------------------
+
+
+def test_every_tune_is_one_record_with_its_own_number() -> None:
+    curve = _concert((0.0, 30.0), (0.9, 4.0), (0.0, 30.0))
+    rows = applause.numbered(applause.tunes(_spans(curve), 64.0, minimum_seconds=10.0))
+
+    assert [row["tune"] for row in rows] == [1, 2]
+    assert set(rows[0]) == {"tune", "t", "end", "seconds", "applause_before", "applause_after"}
+    assert rows[0]["t"] == 0.0
+    assert rows[1]["applause_before"] == 4.0
+
+
+def test_the_gist_counts_the_tunes_and_the_applause_without_listing_them() -> None:
+    """It rides back in a tool result, so it is stats — the boundaries themselves are on disk."""
+    curve = _concert((0.0, 30.0), (0.9, 4.0), (0.0, 20.0))
+    found = _spans(curve)
+    tunes = applause.tunes(found, 54.0, minimum_seconds=10.0)
+
+    summary = applause.gist(curve, found, tunes)
+
+    assert summary["count"] == 2
+    assert summary["applause_count"] == 1
+    assert summary["applause_seconds"] == 4.0
+    assert summary["longest"]["seconds"] == 30.0
+    assert summary["shortest"]["seconds"] == 20.0
+    assert summary["peak_probability"] == 0.9
+    assert not any(isinstance(value, list) for value in summary.values())

--- a/tests/test_live_analysis.py
+++ b/tests/test_live_analysis.py
@@ -1,12 +1,12 @@
 """The one analysis path no fake can stand in for: the real model, actually loaded.
 
-ADR 0002 injects the beat model at a seam, which makes every decision around it testable
-and leaves exactly one thing unverified — whether ``beat_this_detector`` calls the installed
-package correctly. Its return arity and units are the kind of thing that is right or wrong
-on the first real run and nowhere before it, so it gets a live test rather than nothing,
-in the spirit of ADR 0001's interpreter guard.
+ADR 0002 injects each model at a seam, which makes every decision around them testable and
+leaves exactly one thing unverified per model — whether the default detector calls the
+installed package correctly. Return arity, units and frame rates are the kind of thing that
+is right or wrong on the first real run and nowhere before it, so they get live tests rather
+than nothing, in the spirit of ADR 0001's interpreter guard.
 
-Runs only under ``-m live``, and skips even there if beat_this is not installed — the point
+Runs only under ``-m live``, and skips even there if the model is not installed — the point
 is to be run on the machine that has it, and to say so on the ticket when it has not been.
 """
 
@@ -16,12 +16,15 @@ from pathlib import Path
 
 import pytest
 
-from resolve_mcp.analysis import beats
+from resolve_mcp.analysis import applause, beats
 
-from .fakes import write_clicks
+from .fakes import write_clicks, write_sections
 
 CLICK_SECONDS = 20.0
 CLICK_BPM = 120.0
+
+APPLAUSE_SECONDS = 8.0
+ROOM_SECONDS = 6.0
 
 
 @pytest.mark.live
@@ -38,3 +41,29 @@ def test_the_installed_beat_model_hears_a_click_track(tmp_path: Path) -> None:
     # Downbeats are the second of the two lists the model returns, and a subset of the first.
     assert grid.downbeats
     assert set(grid.downbeats) <= set(grid.beats)
+
+
+@pytest.mark.live
+def test_the_installed_applause_tagger_returns_a_curve_over_the_whole_file(
+    tmp_path: Path,
+) -> None:
+    """Not whether PANNs is right about a synthetic room — whether the call is right.
+
+    What a wrong call gets wrong is the shape: a curve in frames rather than seconds, a
+    curve covering only the first chunk, or probabilities that are logits. Those are all
+    visible on any audio at all, and none of them are visible without the model installed.
+    """
+    pytest.importorskip(applause.MODULE, reason="panns_inference is not installed")
+    path = write_sections(
+        tmp_path / "room.wav",
+        (("tone", APPLAUSE_SECONDS), ("noise", ROOM_SECONDS), ("tone", APPLAUSE_SECONDS)),
+        sample_rate=44_100,
+    )
+    total = APPLAUSE_SECONDS * 2 + ROOM_SECONDS
+
+    curve = applause.tag(path)
+
+    assert curve.seconds and len(curve.seconds) == len(curve.probability)
+    assert all(0.0 <= one <= 1.0 for one in curve.probability)
+    assert curve.seconds[0] < 1.0
+    assert curve.seconds[-1] == pytest.approx(total, abs=1.0)

--- a/tests/test_music_structure.py
+++ b/tests/test_music_structure.py
@@ -1,0 +1,407 @@
+"""The structure job: tune boundaries from applause, solo changes from the stems.
+
+The tagger and the beat detector are both injectable (ADR 0002), so what is verified here is
+every decision the worker makes around them — which boundaries land on disk, what comes back
+inline, what a rerun costs, and which errors an agent gets — on a concert-shaped fixture of a
+few seconds. Whether PANNs hears a room is the model's business.
+
+The fixture is a concert in miniature: music, a burst of applause, music. The tagger is told
+where the applause is; the file is what says where the last tune ends.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.analysis import applause as applause_module
+from resolve_mcp.analysis import beats as beats_module
+from resolve_mcp.analysis import music, structure
+from resolve_mcp.analysis import solos as solos_module
+from resolve_mcp.analysis.beats import BeatGrid
+from resolve_mcp.config import get_config
+from resolve_mcp.jobs import store
+from resolve_mcp.jobs.runner import wait_for
+from resolve_mcp.tools import analysis as analysis_tools
+
+from .fakes import write_sections, write_wav
+
+SAMPLE_RATE = 8_000
+TUNE_SECONDS = 4.0
+APPLAUSE_SECONDS = 2.0
+FRAME = 0.5
+
+SOLO_SECONDS = 12.0
+DOWNBEAT_OFFSET = 0.25
+
+
+@pytest.fixture
+def concert(tmp_path: Path) -> Path:
+    """Four seconds of music, two of applause, four more — a set with two tunes in it."""
+    return write_sections(
+        tmp_path / "media" / "concert.wav",
+        (("tone", TUNE_SECONDS), ("noise", APPLAUSE_SECONDS), ("tone", TUNE_SECONDS)),
+        sample_rate=SAMPLE_RATE,
+    )
+
+
+def _tagger(*sections: tuple[float, float]) -> applause_module.Tagger:
+    """A tagger that hears the room where the fixture puts it, frame by frame."""
+    probability: list[float] = []
+    for level, seconds in sections:
+        probability.extend([level] * int(round(seconds / FRAME)))
+    curve = applause_module.Curve(
+        seconds=tuple(round(index * FRAME, 6) for index in range(len(probability))),
+        probability=tuple(probability),
+    )
+
+    def tag(path: Path) -> applause_module.Curve:
+        return curve
+
+    return tag
+
+
+def _heard() -> applause_module.Tagger:
+    """The tagger for the fixture: quiet, a burst over the applause, quiet again."""
+    return _tagger((0.05, TUNE_SECONDS), (0.9, APPLAUSE_SECONDS), (0.05, TUNE_SECONDS))
+
+
+def _tagger_that_must_not_run() -> applause_module.Tagger:
+    def tag(path: Path) -> applause_module.Curve:
+        raise AssertionError("the tagger ran again for audio already analysed")
+
+    return tag
+
+
+def _grid(seconds: float = 24.0) -> BeatGrid:
+    """A steady grid whose downbeats sit a quarter-second off the round numbers.
+
+    Off the round numbers on purpose: a change point measured on a one-second hop lands on
+    a whole second, so a snap that moved it is visible and one that did not is too.
+    """
+    beats = tuple(round(DOWNBEAT_OFFSET + index * 0.5, 6) for index in range(int(seconds / 0.5)))
+    return BeatGrid(beats=beats, downbeats=beats[::4])
+
+
+def _detector(grid: BeatGrid | None = None) -> beats_module.Detector:
+    def detect(path: Path) -> BeatGrid:
+        return grid if grid is not None else _grid()
+
+    return detect
+
+
+def _detector_that_must_not_run() -> beats_module.Detector:
+    def detect(path: Path) -> BeatGrid:
+        raise AssertionError("the beat model ran again for a grid already on disk")
+
+    return detect
+
+
+def _stems(tmp_path: Path, seconds: float = 24.0) -> Path:
+    """Three stems of a two-solo set: the vocal has the first half, the horns the second.
+
+    The drums play throughout at one level, because a stem that never varies is the case
+    the prominence measurement exists to rule out — it is the loudest stem in the room and
+    it is not soloing.
+    """
+    directory = tmp_path / "stems" / "concert-abc123" / "mix"
+    half = seconds / 2
+    write_wav(
+        directory / "concert_(Vocals)_model.wav",
+        seconds=seconds,
+        sample_rate=SAMPLE_RATE,
+        silence=((half, seconds),),
+    )
+    write_wav(
+        directory / "concert_(Other)_model.wav",
+        seconds=seconds,
+        sample_rate=SAMPLE_RATE,
+        frequency=880.0,
+        silence=((0.0, half),),
+    )
+    write_wav(
+        directory / "concert_(Drums)_model.wav",
+        seconds=seconds,
+        sample_rate=SAMPLE_RATE,
+        frequency=110.0,
+        amplitude=0.5,
+    )
+    return directory.parent
+
+
+@pytest.fixture
+def stems(tmp_path: Path) -> Path:
+    return _stems(tmp_path)
+
+
+@pytest.fixture
+def solo_audio(tmp_path: Path) -> Path:
+    return write_wav(tmp_path / "media" / "set.wav", seconds=24.0, sample_rate=SAMPLE_RATE)
+
+
+def _started(**kwargs: Any) -> dict[str, Any]:
+    settings: dict[str, Any] = {
+        "burst_seconds": 1.0,
+        "gap_seconds": 1.0,
+        "tune_seconds": 2.0,
+    }
+    settings.update(kwargs)
+    return structure.analyze_structure(**settings)
+
+
+def _finished(started: dict[str, Any]) -> store.JobRecord:
+    return wait_for(started["job_id"])
+
+
+def _result(started: dict[str, Any]) -> dict[str, Any]:
+    record = _finished(started)
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    return record.result
+
+
+def _solos(audio: Path, stems: Path, **kwargs: Any) -> dict[str, Any]:
+    settings: dict[str, Any] = {
+        "audio": audio,
+        "tunes": False,
+        "solos": True,
+        "stems": stems,
+        "solo_seconds": SOLO_SECONDS / 2,
+        "detector": _detector(),
+    }
+    settings.update(kwargs)
+    return _started(**settings)
+
+
+# --- what lands on disk ----------------------------------------------------------------
+
+
+def test_tune_boundaries_land_on_disk_with_the_applause_between_them(concert: Path) -> None:
+    result = _result(_started(audio=concert, tagger=_heard()))
+
+    written = json.loads(Path(result["tunes"]["path"]).read_text(encoding="utf-8"))
+
+    assert [(one["t"], one["end"]) for one in written["tunes"]] == [(0.0, 4.0), (6.0, 10.0)]
+    assert written["tunes"][0]["applause_after"] == 2.0
+    assert written["tunes"][1]["applause_before"] == 2.0
+    assert written["tunes"][1]["applause_after"] is None
+
+
+def test_the_last_tune_ends_where_the_file_does(concert: Path) -> None:
+    """The tagger says where the room is; only the audio says where the set stops."""
+    result = _result(_started(audio=concert, tagger=_heard()))
+
+    written = json.loads(Path(result["tunes"]["path"]).read_text(encoding="utf-8"))
+
+    assert written["tunes"][-1]["end"] == pytest.approx(written["duration_seconds"], abs=0.01)
+
+
+def test_the_tunes_file_is_readable_in_slices(concert: Path) -> None:
+    result = _result(_started(audio=concert, tagger=_heard()))
+
+    lines = Path(result["tunes"]["path"]).read_text(encoding="utf-8").splitlines()
+    rows = [line for line in lines if line.lstrip().startswith('{"tune":')]
+
+    assert len(rows) == result["tunes"]["count"] == 2
+
+
+def test_solo_changes_land_on_disk_snapped_to_a_downbeat(solo_audio: Path, stems: Path) -> None:
+    result = _result(_solos(solo_audio, stems))
+
+    written = json.loads(Path(result["solos"]["path"]).read_text(encoding="utf-8"))
+    change = written["solos"][0]
+
+    assert change["measured_t"] == pytest.approx(SOLO_SECONDS, abs=2.0)
+    assert change["t"] in _grid().downbeats
+    assert abs(change["t"] - change["measured_t"]) <= solos_module.DEFAULT_SNAP_SECONDS
+    assert change["downbeat"] is True
+    assert change["from"] == "vocals"
+    assert change["to"] == "other"
+    assert change["signal"] == "lead"
+
+
+def test_the_steady_stem_never_takes_the_front(solo_audio: Path, stems: Path) -> None:
+    """The drums are the loudest stem in the mix and are not soloing in this fixture."""
+    result = _result(_solos(solo_audio, stems))
+
+    written = json.loads(Path(result["solos"]["path"]).read_text(encoding="utf-8"))
+
+    assert "drums" not in {one["to"] for one in written["solos"]}
+    assert "drums" not in written["seconds_in_front"]
+
+
+def test_the_two_halves_are_separate_files(solo_audio: Path, stems: Path) -> None:
+    result = _result(
+        _solos(solo_audio, stems, tunes=True, tagger=_tagger((0.05, 24.0)))
+    )
+
+    assert result["tunes"]["path"] != result["solos"]["path"]
+    assert Path(result["tunes"]["path"]).parent == get_config().analysis_dir
+
+
+# --- what comes back inline -------------------------------------------------------------
+
+
+def test_gist_stats_come_back_inline_and_the_boundaries_do_not(concert: Path) -> None:
+    result = _result(_started(audio=concert, tagger=_heard()))
+
+    assert result["tunes"]["count"] == 2
+    assert result["tunes"]["applause_count"] == 1
+    assert result["tunes"]["applause_seconds"] == 2.0
+    assert result["tunes"]["longest"]["seconds"] == 4.0
+    assert result["audio"]["duration_seconds"] == pytest.approx(10.0, abs=0.01)
+    assert not any(isinstance(value, list) for value in result["tunes"].values())
+
+
+def test_the_solo_gist_says_who_held_the_front_and_how_much_snapped(
+    solo_audio: Path,
+    stems: Path,
+) -> None:
+    result = _result(_solos(solo_audio, stems))
+
+    assert result["solos"]["count"] == 1
+    assert result["solos"]["snapped"] == 1
+    assert result["solos"]["longest_lead"]["stem"] in {"vocals", "other"}
+    assert result["solos"]["stem_count"] == 3
+    assert result["solos"]["residual"] is True
+
+
+# --- what a rerun costs -----------------------------------------------------------------
+
+
+def test_a_rerun_does_not_tag_the_room_again(concert: Path) -> None:
+    _result(_started(audio=concert, tagger=_heard()))
+
+    result = _result(_started(audio=concert, tagger=_tagger_that_must_not_run()))
+
+    assert result["tunes"]["count"] == 2
+
+
+def test_refresh_tags_the_room_again(concert: Path) -> None:
+    _result(_started(audio=concert, tagger=_heard()))
+
+    started = _started(audio=concert, tagger=_tagger_that_must_not_run(), refresh=True)
+
+    record = _finished(started)
+    assert record.state == "failed"
+
+
+def test_solo_changes_reuse_the_beat_grid_music_analysis_already_wrote(
+    solo_audio: Path,
+    stems: Path,
+) -> None:
+    """One grid per piece of audio: the second job to want downbeats reads the first's."""
+    _result(music.analyze_music(solo_audio, energy=False, detector=_detector()))
+
+    result = _result(_solos(solo_audio, stems, detector=_detector_that_must_not_run()))
+
+    assert result["solos"]["count"] == 1
+
+
+def test_music_analysis_reuses_the_beat_grid_this_job_wrote(
+    solo_audio: Path,
+    stems: Path,
+) -> None:
+    _result(_solos(solo_audio, stems))
+
+    beats = _result(
+        music.analyze_music(solo_audio, energy=False, detector=_detector_that_must_not_run())
+    )
+
+    assert beats["beats"]["count"] > 0
+
+
+def test_a_finer_solo_window_does_not_re_tag_the_room(concert: Path, stems: Path) -> None:
+    """The halves are keyed apart, so changing one does not pay for the other again."""
+    _result(_solos(concert, stems, tunes=True, tagger=_heard()))
+
+    result = _result(
+        _solos(
+            concert,
+            stems,
+            tunes=True,
+            tagger=_tagger_that_must_not_run(),
+            hop_seconds=0.5,
+        )
+    )
+
+    assert result["tunes"]["count"] == 2
+
+
+# --- what an agent gets when it is wrong ------------------------------------------------
+
+
+def test_asking_for_solos_without_stems_is_refused_before_any_job_starts(
+    concert: Path,
+) -> None:
+    with pytest.raises(Exception, match="stems"):
+        _started(audio=concert, solos=True, tunes=False)
+
+    assert store.load_all() == []
+
+
+def test_asking_for_neither_half_is_refused(concert: Path) -> None:
+    with pytest.raises(Exception, match="[Nn]either"):
+        _started(audio=concert, tunes=False, solos=False)
+
+    assert store.load_all() == []
+
+
+def test_a_stems_directory_with_no_stems_in_it_is_refused(concert: Path, tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    with pytest.raises(Exception, match="separated stems"):
+        _started(audio=concert, solos=True, tunes=False, stems=empty)
+
+
+def test_an_impossible_threshold_is_refused(concert: Path) -> None:
+    with pytest.raises(Exception, match="probability"):
+        _started(audio=concert, threshold=1.5)
+
+
+def test_a_missing_tagger_names_the_install(concert: Path, monkeypatch: Any) -> None:
+    real = importlib.import_module
+
+    def missing(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == applause_module.MODULE:
+            raise ImportError(name)
+        return real(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", missing)
+
+    record = _finished(_started(audio=concert))
+
+    assert record.error is not None
+    assert record.error["code"] == "analysis_dependency_missing"
+    assert "panns" in record.error["fix"]
+
+
+def test_a_tagger_that_falls_over_is_an_analysis_failure(concert: Path) -> None:
+    def broken(path: Path) -> applause_module.Curve:
+        raise RuntimeError("out of memory")
+
+    record = _finished(_started(audio=concert, tagger=broken))
+
+    assert record.error is not None
+    assert record.error["code"] == "analysis_failed"
+    assert "out of memory" in record.error["cause"]
+
+
+# --- the tool seam ------------------------------------------------------------------------
+
+
+def test_the_tool_returns_a_job_and_never_the_boundaries(concert: Path) -> None:
+    envelope = analysis_tools.analyze_structure(str(concert))
+
+    assert envelope["ok"] is True
+    assert envelope["job"]["kind"] == structure.KIND
+    assert "tunes" not in envelope
+
+
+def test_the_tool_is_registered() -> None:
+    assert analysis_tools.analyze_structure in analysis_tools.TOOLS

--- a/tests/test_music_structure.py
+++ b/tests/test_music_structure.py
@@ -20,7 +20,7 @@ import pytest
 
 from resolve_mcp.analysis import applause as applause_module
 from resolve_mcp.analysis import beats as beats_module
-from resolve_mcp.analysis import music, structure
+from resolve_mcp.analysis import decode, music, structure
 from resolve_mcp.analysis import solos as solos_module
 from resolve_mcp.analysis.beats import BeatGrid
 from resolve_mcp.config import get_config
@@ -288,6 +288,23 @@ def test_refresh_tags_the_room_again(concert: Path) -> None:
 
     record = _finished(started)
     assert record.state == "failed"
+
+
+def test_a_rerun_does_not_read_the_stems_again(
+    solo_audio: Path,
+    stems: Path,
+    monkeypatch: Any,
+) -> None:
+    """Separated stems are gigabytes of WAV; a second answer comes off the cache entry."""
+    first = _result(_solos(solo_audio, stems))
+
+    def must_not_run(path: Path | str) -> Any:
+        raise AssertionError("the stems were decoded again for a set already analysed")
+
+    monkeypatch.setattr(decode, "read", must_not_run)
+    second = _result(_solos(solo_audio, stems))
+
+    assert second["solos"] == first["solos"]
 
 
 def test_solo_changes_reuse_the_beat_grid_music_analysis_already_wrote(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -46,6 +46,7 @@ def test_registers_the_p1_session_media_timeline_cut_titling_render_and_job_tool
         "detect_scene_cuts",
         "transcribe_audio",
         "analyze_music",
+        "analyze_structure",
         "separate_stems",
         "list_render_presets",
         "render_timeline",

--- a/tests/test_solo_changes.py
+++ b/tests/test_solo_changes.py
@@ -171,6 +171,19 @@ def test_a_timbre_step_at_the_same_moment_as_a_handover_is_one_change() -> None:
     assert [one.signal for one in found] == [solos.LEAD]
 
 
+def test_two_timbre_steps_close_together_are_both_reported() -> None:
+    """A timbre step is suppressed by a lead change, never by another timbre step.
+
+    ``steps`` has already decided how close two handovers inside the residual may be; a
+    second rule here would silently drop the piano coming in after the tenor went out.
+    """
+    stepped = (solos.Step(20.0, 600.0, 1500.0), solos.Step(22.0, 1500.0, 600.0))
+
+    found = solos.changes((), stepped, together_seconds=4.0)
+
+    assert [one.seconds for one in found] == [20.0, 22.0]
+
+
 def test_change_records_name_what_left_and_what_took_over() -> None:
     runs = _runs(
         _voice("other", (-18.0, 12.0), (-30.0, 12.0)),

--- a/tests/test_solo_changes.py
+++ b/tests/test_solo_changes.py
@@ -1,0 +1,203 @@
+"""Where the front of the band changes hands, from stem energy and residual timbre.
+
+No model says who is soloing — no separator ships a horn stem or a piano stem (#22). What
+exists is four stems and the arithmetic over them, so that is what is under test: which stem
+is out front over its own norm, when that changes, when the residual stem's brightness steps
+(one horn out, piano in, both inside ``other``), and where those change points land once
+they are snapped to the nearest downbeat.
+
+The fixtures are curves rather than audio: the reading of a WAV is ``energy``'s business and
+is tested there. What can be got wrong here is the rules.
+"""
+
+from __future__ import annotations
+
+from resolve_mcp.analysis import solos
+
+HOP = 1.0
+
+
+def _voice(name: str, *sections: tuple[float, float]) -> solos.Voice:
+    """A stem's loudness curve from ``(lufs, seconds)`` sections laid end to end."""
+    lufs: list[float] = []
+    for level, seconds in sections:
+        lufs.extend([level] * int(round(seconds / HOP)))
+    starts = tuple(round(index * HOP, 6) for index in range(len(lufs)))
+    return solos.Voice(name=name, seconds=starts, lufs=tuple(lufs))
+
+
+def _runs(*voices: solos.Voice, minimum_seconds: float = 4.0) -> tuple[solos.Run, ...]:
+    return solos.runs(voices, margin_db=3.0, minimum_seconds=minimum_seconds)
+
+
+# --- who is out front -------------------------------------------------------------------
+
+
+def test_the_stem_that_lifts_over_its_own_quiet_baseline_leads() -> None:
+    """Absolute level says drums — they are always loudest. What leads is what lifts.
+
+    A stem that never varies is never taking a solo, however hot it sits in the mix; the
+    horn that comes up twelve dB over its own quiet baseline is.
+    """
+    horn = _voice("other", (-30.0, 10.0), (-18.0, 10.0))
+    drums = _voice("drums", (-12.0, 10.0), (-12.0, 10.0))
+
+    found = _runs(horn, drums)
+
+    assert [one.name for one in found] == ["other"]
+    assert found[0].start == 10.0
+
+
+def test_a_handover_is_one_run_each_side_of_it() -> None:
+    vocals = _voice("vocals", (-18.0, 12.0), (-30.0, 12.0))
+    other = _voice("other", (-30.0, 12.0), (-18.0, 12.0))
+
+    found = _runs(vocals, other)
+
+    assert [(one.name, one.start, one.end) for one in found] == [
+        ("vocals", 0.0, 12.0),
+        ("other", 12.0, 24.0),
+    ]
+
+
+def test_two_stems_within_the_margin_do_not_hand_over() -> None:
+    """Head in, horns and piano together. Neither is soloing, and nothing changed."""
+    other = _voice("other", (-20.0, 10.0), (-19.0, 10.0))
+    vocals = _voice("vocals", (-20.0, 10.0), (-20.0, 10.0))
+
+    found = _runs(other, vocals, minimum_seconds=4.0)
+
+    assert solos.changes(found, ()) == ()
+
+
+def test_a_blip_shorter_than_the_minimum_is_not_a_solo() -> None:
+    """Four bars of a horn stab inside a piano solo is not the horn taking the tune."""
+    piano = _voice("other", (-18.0, 20.0), (-30.0, 3.0), (-18.0, 20.0))
+    horn = _voice("vocals", (-30.0, 20.0), (-18.0, 3.0), (-30.0, 20.0))
+
+    found = _runs(piano, horn, minimum_seconds=8.0)
+
+    assert [one.name for one in found] == ["other"]
+    assert found[0].end == 43.0
+
+
+def test_stems_of_unequal_length_measure_over_what_they_share() -> None:
+    """A stem a window short must not shorten the answer or raise."""
+    long = _voice("other", (-18.0, 12.0), (-30.0, 12.0))
+    entering = _voice("vocals", (-30.0, 12.0), (-18.0, 12.0))
+    short = solos.Voice(entering.name, entering.seconds[:-2], entering.lufs[:-2])
+
+    found = _runs(long, short)
+
+    assert [one.name for one in found] == ["other", "vocals"]
+    assert found[-1].end == 22.0
+
+
+# --- the residual stem's timbre ---------------------------------------------------------
+
+
+def test_a_step_in_brightness_is_a_change_inside_the_residual_stem() -> None:
+    """Tenor out, piano in: same stem, same energy, a different instrument."""
+    seconds = tuple(float(index) for index in range(40))
+    hertz = tuple(600.0 if one < 20 else 1_500.0 for one in range(40))
+
+    found = solos.steps(seconds, hertz, semitones=4.0, minimum_seconds=8.0)
+
+    assert len(found) == 1
+    assert found[0].seconds == 20.0
+    assert found[0].after > found[0].before
+
+
+def test_brightness_drifting_slowly_is_not_a_change() -> None:
+    seconds = tuple(float(index) for index in range(40))
+    hertz = tuple(600.0 + 4.0 * index for index in range(40))
+
+    assert solos.steps(seconds, hertz, semitones=4.0, minimum_seconds=8.0) == ()
+
+
+def test_one_step_is_reported_once_rather_than_at_every_window_near_it() -> None:
+    seconds = tuple(float(index) for index in range(60))
+    hertz = tuple(600.0 if one < 30 else 1_800.0 for one in range(60))
+
+    assert len(solos.steps(seconds, hertz, semitones=4.0, minimum_seconds=8.0)) == 1
+
+
+# --- change points, snapped to downbeats ------------------------------------------------
+
+
+def test_a_change_point_snaps_to_the_nearest_downbeat() -> None:
+    changes = solos.changes(_runs(_voice("other", (-18.0, 12.0), (-30.0, 12.0)),
+                                  _voice("vocals", (-30.0, 12.0), (-18.0, 12.0))), ())
+
+    snapped = solos.snapped(changes, downbeats=(9.6, 11.6, 13.6), tolerance=2.0)
+
+    assert snapped[0].measured == 12.0
+    assert snapped[0].seconds == 11.6
+    assert snapped[0].downbeat is True
+
+
+def test_a_change_point_with_no_downbeat_near_it_keeps_its_measured_time() -> None:
+    """A snap that reaches half a chorus away is a worse answer than not snapping."""
+    changes = solos.changes(_runs(_voice("other", (-18.0, 12.0), (-30.0, 12.0)),
+                                  _voice("vocals", (-30.0, 12.0), (-18.0, 12.0))), ())
+
+    snapped = solos.snapped(changes, downbeats=(0.0, 40.0), tolerance=2.0)
+
+    assert snapped[0].seconds == 12.0
+    assert snapped[0].downbeat is False
+
+
+def test_with_no_grid_at_all_nothing_snaps() -> None:
+    changes = solos.changes(_runs(_voice("other", (-18.0, 12.0), (-30.0, 12.0)),
+                                  _voice("vocals", (-30.0, 12.0), (-18.0, 12.0))), ())
+
+    snapped = solos.snapped(changes, downbeats=(), tolerance=2.0)
+
+    assert snapped[0].seconds == 12.0
+    assert snapped[0].downbeat is False
+
+
+def test_a_timbre_step_at_the_same_moment_as_a_handover_is_one_change() -> None:
+    """The horn leaving ``other`` and the vocal taking the front is one event, reported once."""
+    runs = _runs(
+        _voice("other", (-18.0, 12.0), (-30.0, 12.0)),
+        _voice("vocals", (-30.0, 12.0), (-18.0, 12.0)),
+    )
+    seconds = tuple(float(index) for index in range(24))
+    hertz = tuple(600.0 if one < 12 else 1_800.0 for one in range(24))
+
+    found = solos.changes(runs, solos.steps(seconds, hertz, semitones=4.0, minimum_seconds=6.0))
+
+    assert [one.signal for one in found] == [solos.LEAD]
+
+
+def test_change_records_name_what_left_and_what_took_over() -> None:
+    runs = _runs(
+        _voice("other", (-18.0, 12.0), (-30.0, 12.0)),
+        _voice("vocals", (-30.0, 12.0), (-18.0, 12.0)),
+    )
+    rows = solos.numbered(solos.snapped(solos.changes(runs, ()), (11.6,), tolerance=2.0))
+
+    assert rows[0]["change"] == 1
+    assert rows[0]["from"] == "other"
+    assert rows[0]["to"] == "vocals"
+    assert rows[0]["signal"] == solos.LEAD
+    assert rows[0]["t"] == 11.6
+    assert rows[0]["measured_t"] == 12.0
+    assert rows[0]["downbeat"] is True
+
+
+def test_the_gist_says_how_long_each_stem_led_and_how_many_changes_snapped() -> None:
+    runs = _runs(
+        _voice("other", (-18.0, 12.0), (-30.0, 12.0)),
+        _voice("vocals", (-30.0, 12.0), (-18.0, 12.0)),
+    )
+    changes = solos.snapped(solos.changes(runs, ()), (11.6,), tolerance=2.0)
+
+    summary = solos.gist(runs, changes)
+
+    assert summary["count"] == 1
+    assert summary["snapped"] == 1
+    assert summary["longest_lead"]["stem"] in {"other", "vocals"}
+    assert summary["longest_lead"]["seconds"] == 12.0
+    assert not any(isinstance(value, list) for value in summary.values())


### PR DESCRIPTION
Closes #38.

## What this builds

Two halves of one job, `analyze_structure`, both writing timestamped JSON with gist stats inline (#22 story 29):

- **Tune boundaries** from applause on the master mix. PANNs sits behind an injectable `Tagger` (ADR 0002); the arithmetic after the curve — which runs of probability are a burst, which gaps between bursts are a tune rather than stage banter — is the part under test. Rows are tunes with the applause on either side, which is what a `songs.json` author reads before placing markers (#22 story 33).
- **Solo changes** from the stems. Two signals: which stem is out front, measured as prominence over that stem's *own quiet baseline* rather than its level (the drums are the loudest stem in the room and are never the soloist), and steps in the residual stem's brightness, so a horn-to-piano handover inside `other` is visible at all — the spec's "who-is-soloing = timbre/activity analysis on the residual stem". Change points snap to the nearest downbeat within a tolerance and record when they did not.

The beat grid the snap needs is the same cache entry `analyze_music` writes, so whichever job wants downbeats first pays for them once. That sharing is what `analysis/halves.py` extracts — identity, per-half caching and the records file layout, previously private to `music.py`.

## Test seam

Fake tier (CLAUDE.md: the model is injected, the decisions are tested). Pure-signal tests in `test_applause_spans.py` and `test_solo_changes.py`; the job's disk / inline / cache / error behaviour in `test_music_structure.py`, on a concert-shaped fixture (music, applause, music) built by a new `fakes.write_sections`.

**Unrun live AC:** whether `panns_inference` returns the curve shape assumed — frames in seconds, probabilities in 0-1, covering the whole file across chunks. Covered by `test_the_installed_applause_tagger_returns_a_curve_over_the_whole_file` (marked `live`, skips without the package), to be run on the Windows box.

## Review

Two-axis `/code-review` against `origin/main`, then a focused re-check of the fix diff.

**Spec axis — 3 findings, all fixed:**
1. `solos.changes` extended a list from a generator reading that same list, so an accepted timbre change suppressed any *later* timbre step within `together_seconds` — the piano coming in after the tenor went out was silently dropped. Suppression is against the lead changes only, as the docstring always claimed. Pinned by a test.
2. `snap_seconds` decides whether a change snaps at all and was reachable from the worker but not from the tool. Exposed.
3. The solos half's caching was untested. A rerun now has to answer without decoding the stems again.

**Standards axis — 1 hard finding, 5 judgement calls; 6 fixed, 1 held:**
4. Two helpers promoted into `halves` kept their private silence — docstrings added (hard: house standard is a prose docstring on every public function).
5. The beats cache entry was assembled by hand in two modules; `music.beats_of` now owns key and kind together and both jobs call it.
6. `snap_seconds` was left out of `SOLO_SHAPE` and patched back in beside it, leaving the tuple naming a shape it no longer described.
7. The stems were fingerprinted twice on a cache miss — the starter's identity is threaded to the worker.
8. Missing `detail` on the no-stems error; an index shadowing the function that produced it.
9. *Held:* duplicated worker preamble between `music.analyze` and `structure.analyze`. What is genuinely shared — identity, per-half caching, file layout — is already in `halves`; the rest is two jobs with different halves, params and progress bands, and a "worker preamble" abstraction would be shape without meaning.

The re-check of the fix diff found one more (a falsy-empty-dict fallback), fixed in `2ce8f18`.

Fake tier 864 passed, mypy strict clean, ruff clean.

Review: clean — two-axis review, findings above fixed except one held with reason; fix diff re-checked.
