### PR TITLE
P1: Music analysis - drum-fill detection (#39)

### DIFF
--- a/docs/adr/0002-analysis-models-are-injected-not-depended-on.md
+++ b/docs/adr/0002-analysis-models-are-injected-not-depended-on.md
@@ -49,9 +49,12 @@ def detect(path: Path, detector: Detector | None = None) -> BeatGrid: ...
   the interpreter in ADR 0001 — it fails loudly with a fix, rather than silently. The
   second is not a testable claim; it was settled by measurement in the research tickets and
   is re-checked by ear on real concerts.
-- Later analysis tickets (#38 drum fills, #39 solos, #40 applause) inherit the shape: one
-  seam per model, the same missing-dependency error, the same split between what the model
-  says and what the worker does with it.
+- Later analysis tickets (#38 structure and solo changes, #39 drum fills) inherit the
+  shape: one seam per model, the same missing-dependency error, the same split between what
+  the model says and what the worker does with it. #39 shows the shape holds even when the
+  seam has no model behind it — its default transcriber is this repo's own onset detector
+  run per drum stem, and the seam earns its keep by letting the rule layer be tested on
+  exact hits rather than on synthesized audio.
 - The arithmetic that *is* a published standard gets held to it rather than to a fixture:
   the BS.1770 loudness filter is checked against the coefficients the standard tabulates,
   so "the numbers look plausible" is never the assertion.

--- a/docs/adr/0003-stems-are-fingerprinted-because-their-path-is-a-content-hash.md
+++ b/docs/adr/0003-stems-are-fingerprinted-because-their-path-is-a-content-hash.md
@@ -1,0 +1,55 @@
+# ADR 0003 — Stems are fingerprinted, because their path already is a content hash
+
+- **Status**: accepted
+- **Date**: 2026-08-05
+- **Context**: P1 ([#39](https://github.com/danielbaldwin47/resolve-mcp/issues/39)) — the first job that keys off separated stems rather than off a mix
+
+## Context
+
+The build spec ([#22](https://github.com/danielbaldwin47/resolve-mcp/issues/22), story 26)
+says job results are "cached on disk keyed by content hash + parameters", and
+`jobs/cache.py` splits that into a rule with two halves: media the director handed over is
+fingerprinted (path, size, mtime), because a concert master is tens of gigabytes that would
+take minutes to read on every run; audio this server wrote is hashed for real, because it
+is the substrate later analysis keys off and a false hit there would attribute one
+concert's beats to another.
+
+Drum-fill detection is the first job whose inputs are neither. Its three drum stems were
+written by this server, which puts them on the hashing side of the rule — but there are
+three of them, each as long as the concert, and they are hashed in the *starter*, whose
+entire contract is to return a job id at once (#22, story 25: "heavy compute … returns a
+`job_id` immediately … so that the stdio connection never stalls"). Reading three
+concert-length WAVs before the first byte of the response is exactly the stall the rule's
+fingerprint half exists to avoid.
+
+## Decision
+
+Stems are fingerprinted, not hashed. The reason it is safe here and nowhere else is the
+path: `audio/stems.py` writes a separation into
+
+```
+<stems_dir>/<slug>-<key[:12]>/{mix,drums}/
+```
+
+where `key` is derived from the **content hash of the audio that was separated** plus the
+separation parameters. A stem's path therefore already carries the content identity of
+everything upstream of it, and size and mtime catch a rewrite in place. Fingerprinting
+these files is not a weaker identity than hashing them — it is the same identity, read off
+a name instead of off two gigabytes.
+
+`cache.identity(path, written_under)` holds the general rule, so two jobs keying off the
+same master agree about what it is; `analysis/fills.py:_key` is the one caller that departs
+from it, and says so.
+
+## Consequences
+
+- The fill job's starter returns in the time it takes to stat three files, on a concert or
+  on a fixture.
+- The exemption is **tied to how stems are named**, not to stems as a category. If a future
+  route ever writes stems into a directory whose name is not derived from a content hash,
+  this reasoning lapses and that route must hash them. A test that asserts the directory
+  layout (`tests/test_stem_separation.py`, and the layout the fill fixture mimics) is what
+  keeps the premise honest.
+- Stems copied somewhere else by hand and passed as an explicit mapping get fingerprint
+  identity without the naming guarantee. That is the same trade the director's own master
+  already gets, and the cost of being wrong is one redundant rerun, not a wrong answer.

--- a/src/resolve_mcp/analysis/drums.py
+++ b/src/resolve_mcp/analysis/drums.py
@@ -1,0 +1,88 @@
+"""What the drummer hit, and when — one record per hit, per decomposed stem.
+
+Separation (#36) already did the hard part. Once kick, snare and toms are three files
+rather than one kit, "transcribe the drums" stops being a model problem and becomes onset
+detection on near-clean audio: a transient in the toms file is a tom, because nothing else
+is in that file. So the default transcriber is the spectral-flux detector the energy curve
+already uses, run per stem and labelled by the stem it came from — no new model, no new
+dependency, and the numbers are checkable on fixture audio.
+
+The seam is kept anyway (ADR 0002 shape). Onsets on a stem are a *reading*, and a better
+reading is a plausible upgrade — a real drum transcriber that separates rimshot from
+centre, or one that reports velocity properly. Callers pass a ``Transcriber`` and the rule
+layer downstream never knows the difference.
+
+Strength is peak amplitude just after the onset, not velocity. It is enough for "was that
+a ghost note or a hit" and deliberately not called velocity, which is a MIDI number this
+does not have.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import NamedTuple
+
+from ..errors import AnalysisFailedError, ResolveMcpError
+from ..logging_config import get_logger
+
+log = get_logger("analysis")
+
+STRENGTH_SECONDS = 0.05
+"""How much audio after an onset the strength is read off — a drum's attack, not its tail."""
+
+
+class Hit(NamedTuple):
+    """One drum stroke: when it landed, which stem it landed in, how hard it read."""
+
+    seconds: float
+    stem: str
+    strength: float
+
+
+Transcriber = Callable[[Mapping[str, Path]], "tuple[Hit, ...]"]
+"""Turn a mapping of stem label to WAV into every hit across them, in any order."""
+
+
+def transcribe(
+    stems: Mapping[str, Path],
+    transcriber: Transcriber | None = None,
+) -> tuple[Hit, ...]:
+    """Every hit across the stems, earliest first.
+
+    A transcriber that falls over is an ``analysis_failed`` rather than an internal error,
+    for the same reason a beat model that falls over is: the agent can act on it, and it is
+    not a bug in this server.
+    """
+    chosen = transcriber or onset_transcriber
+    try:
+        hits = chosen(dict(stems))
+    except ResolveMcpError:
+        raise
+    except Exception as exc:
+        raise AnalysisFailedError(
+            cause=f"Drum transcription failed: {type(exc).__name__}: {exc}.",
+            detail={"stems": sorted(stems)},
+        ) from exc
+    return tuple(sorted(hits, key=lambda hit: (hit.seconds, hit.stem)))
+
+
+def onset_transcriber(stems: Mapping[str, Path]) -> tuple[Hit, ...]:
+    """The default: transients per stem, each labelled with the stem it was found in."""
+    import numpy as np
+
+    from . import decode, energy
+
+    hits: list[Hit] = []
+    for label, path in sorted(stems.items()):
+        audio = decode.read(path)
+        mono = np.abs(audio.mono())
+        reach = max(int(STRENGTH_SECONDS * audio.sample_rate), 1)
+        times = energy.onsets(audio)
+        log.info("Found %d onsets in the %s stem", times.size, label)
+        for seconds in times:
+            first = min(int(seconds * audio.sample_rate), max(mono.size - 1, 0))
+            window = mono[first : first + reach]
+            strength = float(window.max()) if window.size else 0.0
+            hits.append(Hit(seconds=float(seconds), stem=label, strength=min(strength, 1.0)))
+    return tuple(hits)

--- a/src/resolve_mcp/analysis/fills.py
+++ b/src/resolve_mcp/analysis/fills.py
@@ -1,0 +1,510 @@
+"""Drum-fill candidates: where the kit stops keeping time and starts announcing something.
+
+The cut reacts to fills (#22, story 45), so the edit needs to know where they are. This is
+the rule layer over two readings that already exist — drum-stem hits (#36 separation, then
+``drums``) and the beat grid (#37) — and it is deliberately rules rather than a model:
+
+* **A fill is a local departure, not an absolute density.** A brushed ballad and a burning
+  up-tempo differ by an order of magnitude in hits per second, and neither is filling all
+  the time. So everything is measured against the median beat of this performance: busy
+  means busy *for this drummer, tonight*.
+
+* **Toms are the tell.** Kick and snare keep time; toms are mostly reserved for fills, so
+  tom activity on its own is enough to nominate a beat, and tom share is a quarter of the
+  confidence. Cymbals would be the other tell, and there is no cymbal stem — the
+  decomposition is kick, snare and toms (#36) — so a fill's crash resolution is inferred
+  from a hit landing on the following downbeat rather than heard.
+
+* **The grid decides the edges.** A candidate starts at a beat and ends at the beat it
+  resolves into, because that resolution point is what a cut is placed against. Nothing
+  here is reported off-grid.
+
+The output is candidates with confidence, and the word is meant: this file reports a
+reading, and whether a given burst is a fill, a solo trading four, or a drummer covering a
+mistake is the reading agent's call. That is also why a run longer than two bars is dropped
+rather than reported at low confidence — thirty seconds of continuous kit is a drum solo,
+which is a different question (#38), and calling it a long fill would be a wrong answer
+rather than an unsure one.
+"""
+
+from __future__ import annotations
+
+import bisect
+import json
+import statistics
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from ..audio import separator, wav
+from ..audio.stems import DRUM_STEMS
+from ..config import Config, get_config
+from ..errors import InvalidRequestError
+from ..jobs import cache
+from ..jobs.runner import JobOutput, Progress, start_job
+from ..naming import slug
+from . import beats as beats_module
+from . import drums, music, records
+
+KIND = "detect_drum_fills"
+FILLS = "fills"
+PLACES = 3
+
+TOM_STEM = "toms"
+BUSY_MULTIPLE = 1.6
+"""How much busier than the median beat a beat must be before it is part of a fill."""
+STRONG_MULTIPLE = 3.0
+"""The ratio at which the density factor is already as convinced as it gets."""
+MINIMUM_HITS = 3
+"""Hits in a beat below which "busier than usual" is noise, not a fill."""
+TOM_HITS = 2
+"""Toms in one beat are a fill on their own, however quiet the beat reads."""
+MAXIMUM_BEATS = 8
+"""Two bars in four. Longer is a solo, and this file does not answer that question."""
+MAXIMUM_GAP_BEATS = 1
+"""One beat the detector found nothing in does not end a fill that carries on after it."""
+TOM_SHARE = 0.5
+"""The tom share of a run at which the tom factor is fully convinced."""
+RESOLUTION_BEATS = 0.25
+"""How near the resolution point a hit must land to count as landing on it."""
+PHRASE_BARS = 4
+"""Bars to the phrase. A fill into bar 5 of 8 is doing more work than one into bar 4."""
+PHRASE_AT_BAR_LINE = 0.6
+PHRASE_MID_BAR = 0.15
+WEIGHTS = {"density": 0.35, "toms": 0.25, "resolution": 0.15, "phrase": 0.25}
+DEFAULT_MINIMUM_CONFIDENCE = 0.35
+"""Below this a candidate is counted but not written — the floor on what is worth reading."""
+
+
+class Candidate(NamedTuple):
+    """One run of fill-like playing, with the evidence that nominated it."""
+
+    start: float
+    end: float
+    beats: int
+    beat: int
+    bar: int
+    in_bar: int
+    hits: int
+    counts: dict[str, int]
+    density: float
+    density_ratio: float
+    resolves_at: float
+    resolves_into_bar: int | None
+    factors: dict[str, float]
+    confidence: float
+
+
+class Detection(NamedTuple):
+    """What was kept, what was weighed, and the baseline everything was weighed against."""
+
+    candidates: tuple[Candidate, ...]
+    considered: int
+    dropped: int
+    baseline: float
+
+
+# --- the rule layer -----------------------------------------------------------------
+
+
+def candidates(
+    hits: Sequence[drums.Hit],
+    grid: Sequence[Mapping[str, Any]],
+    minimum_confidence: float = DEFAULT_MINIMUM_CONFIDENCE,
+) -> Detection:
+    """Fill candidates over ``hits``, aligned to the numbered beat ``grid``.
+
+    ``grid`` is what ``beats.numbered`` produces and the beats half writes: one record per
+    beat carrying its time, bar and whether it starts one.
+    """
+    beats = list(grid)
+    if len(beats) < 2:
+        return Detection((), 0, 0, 0.0)
+
+    edges = _edges(beats)
+    tallies = _tally(hits, edges)
+    densities = [
+        sum(tally.values()) / (edges[index + 1] - edges[index])
+        for index, tally in enumerate(tallies)
+    ]
+    baseline = statistics.median(densities)
+    if baseline <= 0:
+        # Nothing to be busier than: a kit this quiet has no ordinary beat to depart from.
+        return Detection((), 0, 0, 0.0)
+
+    busy = [
+        (density >= baseline * BUSY_MULTIPLE and sum(tally.values()) >= MINIMUM_HITS)
+        or tally[TOM_STEM] >= TOM_HITS
+        for tally, density in zip(tallies, densities, strict=True)
+    ]
+    times = sorted(hit.seconds for hit in hits)
+
+    kept: list[Candidate] = []
+    considered = 0
+    dropped = 0
+    for first, last in _runs(busy):
+        if last - first + 1 > MAXIMUM_BEATS:
+            dropped += 1
+            continue
+        considered += 1
+        candidate = _weighed(beats, edges, tallies, baseline, times, first, last)
+        if candidate.confidence >= minimum_confidence:
+            kept.append(candidate)
+    return Detection(tuple(kept), considered, dropped, baseline)
+
+
+def _edges(beats: Sequence[Mapping[str, Any]]) -> list[float]:
+    """Beat times plus one more for the end of the last beat, so every beat has a span."""
+    times = [float(row["t"]) for row in beats]
+    intervals = [later - earlier for earlier, later in zip(times, times[1:], strict=False)]
+    usable = [one for one in intervals if one > 0]
+    return [*times, times[-1] + (statistics.median(usable) if usable else 1.0)]
+
+
+def _tally(hits: Sequence[drums.Hit], edges: Sequence[float]) -> list[Counter[str]]:
+    """Hits per stem per beat. Anything outside the grid belongs to no beat and is dropped."""
+    tallies: list[Counter[str]] = [Counter() for _ in range(len(edges) - 1)]
+    for hit in hits:
+        index = bisect.bisect_right(edges, hit.seconds) - 1
+        if 0 <= index < len(tallies):
+            tallies[index][hit.stem] += 1
+    return tallies
+
+
+def _runs(busy: Sequence[bool]) -> list[tuple[int, int]]:
+    """Busy beats grouped into runs, bridging a single quiet beat inside one."""
+    runs: list[tuple[int, int]] = []
+    first: int | None = None
+    last = 0
+    for index, flag in enumerate(busy):
+        if not flag:
+            continue
+        if first is None:
+            first = index
+        elif index - last - 1 > MAXIMUM_GAP_BEATS:
+            runs.append((first, last))
+            first = index
+        last = index
+    if first is not None:
+        runs.append((first, last))
+    return runs
+
+
+def _weighed(
+    beats: Sequence[Mapping[str, Any]],
+    edges: Sequence[float],
+    tallies: Sequence[Counter[str]],
+    baseline: float,
+    times: Sequence[float],
+    first: int,
+    last: int,
+) -> Candidate:
+    """One run turned into a candidate: its span, its counts, and how sure the rules are."""
+    counts: Counter[str] = Counter()
+    for tally in tallies[first : last + 1]:
+        counts.update(tally)
+    total = sum(counts.values())
+    start, end = edges[first], edges[last + 1]
+    length = last - first + 1
+    density = total / (end - start)
+
+    into = beats[last + 1] if last + 1 < len(beats) else None
+    tolerance = RESOLUTION_BEATS * (end - start) / length
+    factors = {
+        "density": _clamp((density / baseline - 1.0) / (STRONG_MULTIPLE - 1.0)),
+        "toms": _clamp(counts[TOM_STEM] / total / TOM_SHARE) if total else 0.0,
+        "resolution": 1.0 if _hit_near(times, end, tolerance) else 0.0,
+        "phrase": _phrase(into),
+    }
+    return Candidate(
+        start=round(start, PLACES),
+        end=round(end, PLACES),
+        beats=length,
+        beat=int(beats[first]["beat"]),
+        bar=int(beats[first]["bar"]),
+        in_bar=int(beats[first]["in_bar"]),
+        hits=total,
+        counts={stem: counts[stem] for stem in sorted(counts)},
+        density=round(density, PLACES),
+        density_ratio=round(density / baseline, PLACES),
+        resolves_at=round(end, PLACES),
+        resolves_into_bar=int(into["bar"]) if into is not None else None,
+        factors={name: round(value, PLACES) for name, value in factors.items()},
+        confidence=round(
+            _clamp(sum(WEIGHTS[name] * value for name, value in factors.items())), PLACES
+        ),
+    )
+
+
+def _phrase(into: Mapping[str, Any] | None) -> float:
+    """A fill into the top of a phrase is doing more work than one into any old bar line."""
+    if into is None or not into["downbeat"]:
+        return PHRASE_MID_BAR
+    return 1.0 if (int(into["bar"]) - 1) % PHRASE_BARS == 0 else PHRASE_AT_BAR_LINE
+
+
+def _hit_near(times: Sequence[float], seconds: float, tolerance: float) -> bool:
+    index = bisect.bisect_left(times, seconds - tolerance)
+    return index < len(times) and times[index] <= seconds + tolerance
+
+
+def _clamp(value: float) -> float:
+    return min(max(value, 0.0), 1.0)
+
+
+def rows(detection: Detection) -> tuple[dict[str, Any], ...]:
+    """One flat record per candidate — per-stem counts inlined so a grep on toms works."""
+    return tuple(
+        {
+            "start": one.start,
+            "end": one.end,
+            "duration": round(one.end - one.start, PLACES),
+            "beat": one.beat,
+            "bar": one.bar,
+            "in_bar": one.in_bar,
+            "beats": one.beats,
+            "resolves_at": one.resolves_at,
+            "resolves_into_bar": one.resolves_into_bar,
+            "hits": one.hits,
+            **{stem: one.counts.get(stem, 0) for stem in DRUM_STEMS},
+            "density": one.density,
+            "density_ratio": one.density_ratio,
+            "confidence": one.confidence,
+            "factors": one.factors,
+        }
+        for one in detection.candidates
+    )
+
+
+def gist(
+    detection: Detection,
+    minimum_confidence: float,
+    stems: Sequence[str],
+    hits: int,
+) -> dict[str, Any]:
+    """The stats worth returning inline: how many, how sure, and what they were measured against."""
+    kept = detection.candidates
+    strongest = max(kept, key=lambda one: one.confidence) if kept else None
+    return {
+        "count": len(kept),
+        "considered": detection.considered,
+        "below_confidence": detection.considered - len(kept),
+        "long_runs_dropped": detection.dropped,
+        "minimum_confidence": round(minimum_confidence, PLACES),
+        "baseline_hits_per_second": round(detection.baseline, PLACES),
+        "hits": hits,
+        "stems": list(stems),
+        "mean_confidence": (
+            round(statistics.mean(one.confidence for one in kept), PLACES) if kept else None
+        ),
+        "strongest": (
+            {"t": strongest.start, "confidence": strongest.confidence} if strongest else None
+        ),
+    }
+
+
+# --- the job ------------------------------------------------------------------------
+
+
+def detect_drum_fills(
+    stems: Mapping[str, str | Path] | str | Path,
+    audio: str | Path,
+    minimum_confidence: float = DEFAULT_MINIMUM_CONFIDENCE,
+    refresh: bool = False,
+    detector: beats_module.Detector | None = None,
+    transcriber: drums.Transcriber | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Start the fill job. Returns the job record, not the candidates."""
+    config = config or get_config()
+    source = _readable(audio)
+    found = _stems(stems)
+    _sane_floor(minimum_confidence)
+
+    settings = {"minimum_confidence": float(minimum_confidence)}
+    identity = cache.identity(source, config.audio_dir)
+    key = cache.cache_key(KIND, [identity, *_stem_inputs(found)], settings)
+
+    def work(progress: Progress) -> JobOutput:
+        return detect(
+            source,
+            found,
+            settings,
+            progress,
+            key=key,
+            identity=identity,
+            detector=detector,
+            transcriber=transcriber,
+            refresh=refresh,
+            config=config,
+        )
+
+    return start_job(
+        KIND,
+        {"audio": source.name, "stems": sorted(found), **settings},
+        work,
+        cache_key=key,
+        refresh=refresh,
+        config=config,
+    )
+
+
+def _readable(audio: str | Path) -> Path:
+    source = Path(audio)
+    if not source.is_file():
+        raise InvalidRequestError(
+            cause=f"There is no file at {source}.",
+            fix=(
+                "Pass the master mix the stems were separated from — the beat grid comes from "
+                "it, and fills are reported against that grid."
+            ),
+            detail={"requested": str(source)},
+        )
+    return source
+
+
+def _stems(stems: Mapping[str, str | Path] | str | Path) -> dict[str, Path]:
+    """The drum stems to read, from a separation's directory or from named paths.
+
+    Either shape a ``separate_stems`` result offers works, and both are narrowed to the
+    decomposed drum stems: handed the whole four-stem mapping, this reads the kit and not
+    the horns.
+    """
+    if isinstance(stems, str | Path):
+        given: list[str] = [str(stems)]
+        found = _collected(Path(stems))
+    else:
+        given = sorted(str(label) for label in stems)
+        found = {
+            str(label): Path(path) for label, path in stems.items() if str(label) in DRUM_STEMS
+        }
+        _all_on_disk(found)
+    if not found:
+        raise InvalidRequestError(
+            cause="None of the drum stems were named, so there is nothing to look for fills in.",
+            fix=(
+                "Pass the drums mapping a separate_stems job returned, or its directory. The "
+                f"stems this reads are {', '.join(DRUM_STEMS)}."
+            ),
+            detail={"wanted": list(DRUM_STEMS), "given": given},
+        )
+    return dict(sorted(found.items()))
+
+
+def _collected(directory: Path) -> dict[str, Path]:
+    if not directory.is_dir():
+        raise InvalidRequestError(
+            cause=f"There is no directory at {directory}.",
+            fix="Pass the directory a separate_stems job reported, or its drums mapping.",
+            detail={"requested": str(directory)},
+        )
+    return {
+        label: path
+        for label, path in separator.collect(directory).items()
+        if label in DRUM_STEMS
+    }
+
+
+def _all_on_disk(found: Mapping[str, Path]) -> None:
+    missing = sorted(label for label, path in found.items() if not path.is_file())
+    if missing:
+        raise InvalidRequestError(
+            cause=f"These drum stems are not on disk: {', '.join(missing)}.",
+            fix=(
+                "Run separate_stems again — the cache drops an entry whose files went missing, "
+                "so asking for them redoes the separation."
+            ),
+            detail={"missing": [str(found[label]) for label in missing]},
+        )
+
+
+def _sane_floor(minimum_confidence: float) -> None:
+    if not 0.0 <= minimum_confidence <= 1.0:
+        raise InvalidRequestError(
+            cause="The confidence floor is a fraction between 0 and 1.",
+            fix=f"The default is {DEFAULT_MINIMUM_CONFIDENCE}; 0 writes every candidate.",
+            detail={"minimum_confidence": minimum_confidence},
+        )
+
+
+def _stem_inputs(found: Mapping[str, Path]) -> list[dict[str, Any]]:
+    """Identity for the stems, fingerprinted rather than hashed — the path is the hash.
+
+    Every other input to an analysis job is hashed when this server wrote it, because a
+    false hit would attribute one concert's readings to another. Stems are the exception
+    and get away with it: a separation writes into a directory named after its own cache
+    key, which is derived from the content hash of the audio it separated. The path already
+    carries the content identity, size and mtime catch a rewrite in place, and reading three
+    concert-length WAVs would stall a starter whose whole job is to hand back an id at once.
+    """
+    return [{"stem": label, **cache.fingerprint(path)} for label, path in sorted(found.items())]
+
+
+def detect(
+    source: Path,
+    stems: Mapping[str, Path],
+    settings: Mapping[str, Any],
+    progress: Progress,
+    key: str | None = None,
+    identity: Mapping[str, Any] | None = None,
+    detector: beats_module.Detector | None = None,
+    transcriber: drums.Transcriber | None = None,
+    refresh: bool = False,
+    config: Config | None = None,
+) -> JobOutput:
+    """The worker: the grid, then the hits, then the rules over both."""
+    config = config or get_config()
+    config.analysis_dir.mkdir(parents=True, exist_ok=True)
+    described = wav.describe(source)
+    identity = dict(identity) if identity is not None else cache.identity(source, config.audio_dir)
+    key = key or cache.cache_key(KIND, [identity, *_stem_inputs(stems)], dict(settings))
+
+    progress(0.05, "reading the beat grid")
+    grid = _beat_grid(source, described, identity, detector, refresh, config)
+
+    progress(0.25, "transcribing the drum stems")
+    hits = drums.transcribe(stems, transcriber)
+
+    progress(0.8, "looking for fills")
+    floor = float(settings["minimum_confidence"])
+    detection = candidates(hits, grid, floor)
+    summary = gist(detection, floor, sorted(stems), len(hits))
+
+    progress(0.9, "writing the candidates")
+    target = config.analysis_dir / f"{slug(source.stem, 'analysis')}-{key[:12]}-{FILLS}.json"
+    header = {
+        "kind": FILLS,
+        "audio": described["path"],
+        "duration_seconds": described["duration_seconds"],
+        **summary,
+    }
+    records.write(target, header, FILLS, rows(detection))
+
+    progress(0.95, "written")
+    return JobOutput({"path": str(target), **summary}, (target,))
+
+
+def _beat_grid(
+    source: Path,
+    described: Mapping[str, Any],
+    identity: Mapping[str, Any],
+    detector: beats_module.Detector | None,
+    refresh: bool,
+    config: Config,
+) -> list[dict[str, Any]]:
+    """The numbered beats, read back from the half ``analyze_music`` shares with this job.
+
+    Sharing the entry rather than the code is the point: a master the agent already ran
+    music analysis over does not pay for the beat model twice (#22, story 26).
+    """
+    document = music.beats_half(
+        source,
+        described=dict(described),
+        identity=dict(identity),
+        detector=detector,
+        refresh=refresh,
+        config=config,
+    )
+    written = json.loads(Path(document["path"]).read_text(encoding="utf-8"))
+    return list(written[music.BEATS])

--- a/src/resolve_mcp/analysis/fills.py
+++ b/src/resolve_mcp/analysis/fills.py
@@ -42,9 +42,12 @@ from ..config import Config, get_config
 from ..errors import InvalidRequestError
 from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, start_job
+from ..logging_config import get_logger
 from ..naming import slug
 from . import beats as beats_module
 from . import drums, music, records
+
+log = get_logger("analysis")
 
 KIND = "detect_drum_fills"
 FILLS = "fills"
@@ -110,7 +113,7 @@ class Reading(NamedTuple):
     them, so they travel as one thing rather than as five arguments in the same order.
     """
 
-    beats: Sequence[Mapping[str, Any]]
+    grid: Sequence[Mapping[str, Any]]
     edges: Sequence[float]
     tallies: Sequence[Counter[str]]
     times: Sequence[float]
@@ -146,7 +149,7 @@ def candidates(
         return Detection((), 0, 0, 0.0)
 
     reading = Reading(
-        beats=beats,
+        grid=beats,
         edges=edges,
         tallies=tallies,
         times=sorted(hit.seconds for hit in hits),
@@ -223,7 +226,7 @@ def _weighed(reading: Reading, first: int, last: int) -> Candidate:
     length = last - first + 1
     density = total / (end - start)
 
-    into = reading.beats[last + 1] if last + 1 < len(reading.beats) else None
+    into = reading.grid[last + 1] if last + 1 < len(reading.grid) else None
     tolerance = RESOLUTION_BEATS * (end - start) / length
     factors = {
         "density": _clamp((density / reading.baseline - 1.0) / (STRONG_MULTIPLE - 1.0)),
@@ -235,9 +238,9 @@ def _weighed(reading: Reading, first: int, last: int) -> Candidate:
         start=round(start, PLACES),
         end=round(end, PLACES),
         beats=length,
-        beat=int(reading.beats[first]["beat"]),
-        bar=int(reading.beats[first]["bar"]),
-        in_bar=int(reading.beats[first]["in_bar"]),
+        beat=int(reading.grid[first]["beat"]),
+        bar=int(reading.grid[first]["bar"]),
+        in_bar=int(reading.grid[first]["in_bar"]),
         hits=total,
         counts={stem: counts[stem] for stem in sorted(counts)},
         density=round(density, PLACES),
@@ -386,6 +389,15 @@ def _stems(stems: Mapping[str, str | Path] | str | Path) -> dict[str, Path]:
             str(label): Path(path) for label, path in stems.items() if str(label) in DRUM_STEMS
         }
         _all_on_disk(found)
+    if found and len(found) < len(DRUM_STEMS):
+        # Not refused: some stems beat none. But a kit missing its toms scores every
+        # candidate with a tom factor of zero, and that is worth a line in the log rather
+        # than a mysteriously timid confidence read off a document weeks later.
+        log.warning(
+            "Looking for fills in %s only — %s missing, so confidence will read low",
+            ", ".join(sorted(found)),
+            ", ".join(one for one in DRUM_STEMS if one not in found),
+        )
     if not found:
         raise InvalidRequestError(
             cause="None of the drum stems were named, so there is nothing to look for fills in.",

--- a/src/resolve_mcp/analysis/fills.py
+++ b/src/resolve_mcp/analysis/fills.py
@@ -30,7 +30,6 @@ rather than an unsure one.
 from __future__ import annotations
 
 import bisect
-import json
 import statistics
 from collections import Counter
 from collections.abc import Mapping, Sequence
@@ -38,7 +37,7 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 from ..audio import separator, wav
-from ..audio.stems import DRUM_STEMS
+from ..audio.stems import DRUM_PASS, DRUM_STEMS
 from ..config import Config, get_config
 from ..errors import InvalidRequestError
 from ..jobs import cache
@@ -90,7 +89,6 @@ class Candidate(NamedTuple):
     counts: dict[str, int]
     density: float
     density_ratio: float
-    resolves_at: float
     resolves_into_bar: int | None
     factors: dict[str, float]
     confidence: float
@@ -102,6 +100,20 @@ class Detection(NamedTuple):
     candidates: tuple[Candidate, ...]
     considered: int
     dropped: int
+    baseline: float
+
+
+class Reading(NamedTuple):
+    """The performance as the rules see it: the grid, its spans, the hits in each, the norm.
+
+    Every one of these is derived from the same two inputs and every rule needs several of
+    them, so they travel as one thing rather than as five arguments in the same order.
+    """
+
+    beats: Sequence[Mapping[str, Any]]
+    edges: Sequence[float]
+    tallies: Sequence[Counter[str]]
+    times: Sequence[float]
     baseline: float
 
 
@@ -133,12 +145,18 @@ def candidates(
         # Nothing to be busier than: a kit this quiet has no ordinary beat to depart from.
         return Detection((), 0, 0, 0.0)
 
+    reading = Reading(
+        beats=beats,
+        edges=edges,
+        tallies=tallies,
+        times=sorted(hit.seconds for hit in hits),
+        baseline=baseline,
+    )
     busy = [
         (density >= baseline * BUSY_MULTIPLE and sum(tally.values()) >= MINIMUM_HITS)
         or tally[TOM_STEM] >= TOM_HITS
         for tally, density in zip(tallies, densities, strict=True)
     ]
-    times = sorted(hit.seconds for hit in hits)
 
     kept: list[Candidate] = []
     considered = 0
@@ -148,7 +166,7 @@ def candidates(
             dropped += 1
             continue
         considered += 1
-        candidate = _weighed(beats, edges, tallies, baseline, times, first, last)
+        candidate = _weighed(reading, first, last)
         if candidate.confidence >= minimum_confidence:
             kept.append(candidate)
     return Detection(tuple(kept), considered, dropped, baseline)
@@ -191,44 +209,39 @@ def _runs(busy: Sequence[bool]) -> list[tuple[int, int]]:
     return runs
 
 
-def _weighed(
-    beats: Sequence[Mapping[str, Any]],
-    edges: Sequence[float],
-    tallies: Sequence[Counter[str]],
-    baseline: float,
-    times: Sequence[float],
-    first: int,
-    last: int,
-) -> Candidate:
-    """One run turned into a candidate: its span, its counts, and how sure the rules are."""
+def _weighed(reading: Reading, first: int, last: int) -> Candidate:
+    """One run turned into a candidate: its span, its counts, and how sure the rules are.
+
+    The end of the span *is* the resolution point — the beat the fill lands into — because
+    a run is grown until the playing settles, and that beat is what a cut is placed against.
+    """
     counts: Counter[str] = Counter()
-    for tally in tallies[first : last + 1]:
+    for tally in reading.tallies[first : last + 1]:
         counts.update(tally)
     total = sum(counts.values())
-    start, end = edges[first], edges[last + 1]
+    start, end = reading.edges[first], reading.edges[last + 1]
     length = last - first + 1
     density = total / (end - start)
 
-    into = beats[last + 1] if last + 1 < len(beats) else None
+    into = reading.beats[last + 1] if last + 1 < len(reading.beats) else None
     tolerance = RESOLUTION_BEATS * (end - start) / length
     factors = {
-        "density": _clamp((density / baseline - 1.0) / (STRONG_MULTIPLE - 1.0)),
+        "density": _clamp((density / reading.baseline - 1.0) / (STRONG_MULTIPLE - 1.0)),
         "toms": _clamp(counts[TOM_STEM] / total / TOM_SHARE) if total else 0.0,
-        "resolution": 1.0 if _hit_near(times, end, tolerance) else 0.0,
+        "resolution": 1.0 if _hit_near(reading.times, end, tolerance) else 0.0,
         "phrase": _phrase(into),
     }
     return Candidate(
         start=round(start, PLACES),
         end=round(end, PLACES),
         beats=length,
-        beat=int(beats[first]["beat"]),
-        bar=int(beats[first]["bar"]),
-        in_bar=int(beats[first]["in_bar"]),
+        beat=int(reading.beats[first]["beat"]),
+        bar=int(reading.beats[first]["bar"]),
+        in_bar=int(reading.beats[first]["in_bar"]),
         hits=total,
         counts={stem: counts[stem] for stem in sorted(counts)},
         density=round(density, PLACES),
-        density_ratio=round(density / baseline, PLACES),
-        resolves_at=round(end, PLACES),
+        density_ratio=round(density / reading.baseline, PLACES),
         resolves_into_bar=int(into["bar"]) if into is not None else None,
         factors={name: round(value, PLACES) for name, value in factors.items()},
         confidence=round(
@@ -264,7 +277,6 @@ def rows(detection: Detection) -> tuple[dict[str, Any], ...]:
             "bar": one.bar,
             "in_bar": one.in_bar,
             "beats": one.beats,
-            "resolves_at": one.resolves_at,
             "resolves_into_bar": one.resolves_into_bar,
             "hits": one.hits,
             **{stem: one.counts.get(stem, 0) for stem in DRUM_STEMS},
@@ -324,7 +336,7 @@ def detect_drum_fills(
 
     settings = {"minimum_confidence": float(minimum_confidence)}
     identity = cache.identity(source, config.audio_dir)
-    key = cache.cache_key(KIND, [identity, *_stem_inputs(found)], settings)
+    key = _key(identity, found, settings)
 
     def work(progress: Progress) -> JobOutput:
         return detect(
@@ -351,17 +363,11 @@ def detect_drum_fills(
 
 
 def _readable(audio: str | Path) -> Path:
-    source = Path(audio)
-    if not source.is_file():
-        raise InvalidRequestError(
-            cause=f"There is no file at {source}.",
-            fix=(
-                "Pass the master mix the stems were separated from — the beat grid comes from "
-                "it, and fills are reported against that grid."
-            ),
-            detail={"requested": str(source)},
-        )
-    return source
+    return music.readable_audio(
+        audio,
+        "Pass the master mix the stems were separated from — the beat grid comes from it, "
+        "and fills are reported against that grid.",
+    )
 
 
 def _stems(stems: Mapping[str, str | Path] | str | Path) -> dict[str, Path]:
@@ -384,8 +390,9 @@ def _stems(stems: Mapping[str, str | Path] | str | Path) -> dict[str, Path]:
         raise InvalidRequestError(
             cause="None of the drum stems were named, so there is nothing to look for fills in.",
             fix=(
-                "Pass the drums mapping a separate_stems job returned, or its directory. The "
-                f"stems this reads are {', '.join(DRUM_STEMS)}."
+                "Pass the directory a separate_stems job reported — its second pass writes the "
+                f"{', '.join(DRUM_STEMS)} this reads. A four-stem separation on its own is not "
+                "enough; the drum pass is what fills are found in."
             ),
             detail={"wanted": list(DRUM_STEMS), "given": given},
         )
@@ -393,17 +400,29 @@ def _stems(stems: Mapping[str, str | Path] | str | Path) -> dict[str, Path]:
 
 
 def _collected(directory: Path) -> dict[str, Path]:
+    """The drum stems under a separation's directory — the pass's own, or the parent of it.
+
+    A separation writes its two passes into ``<directory>/mix`` and ``<directory>/drums``,
+    and the job reports the parent. That parent is what an agent has in hand, so it is what
+    this accepts, and the drum pass inside it is looked in first. The parent itself is
+    checked too, because a director who copied three stems into a folder of their own is
+    doing something reasonable and should not have to name a subdirectory that is not there.
+    """
     if not directory.is_dir():
         raise InvalidRequestError(
             cause=f"There is no directory at {directory}.",
-            fix="Pass the directory a separate_stems job reported, or its drums mapping.",
+            fix="Pass the directory a separate_stems job reported, or the drum pass inside it.",
             detail={"requested": str(directory)},
         )
-    return {
-        label: path
-        for label, path in separator.collect(directory).items()
-        if label in DRUM_STEMS
-    }
+    for candidate in (directory / DRUM_PASS, directory):
+        found = {
+            label: path
+            for label, path in separator.collect(candidate).items()
+            if label in DRUM_STEMS
+        }
+        if found:
+            return found
+    return {}
 
 
 def _all_on_disk(found: Mapping[str, Path]) -> None:
@@ -428,17 +447,21 @@ def _sane_floor(minimum_confidence: float) -> None:
         )
 
 
-def _stem_inputs(found: Mapping[str, Path]) -> list[dict[str, Any]]:
-    """Identity for the stems, fingerprinted rather than hashed — the path is the hash.
+def _key(
+    identity: Mapping[str, Any],
+    stems: Mapping[str, Path],
+    settings: Mapping[str, Any],
+) -> str:
+    """The job's key. One function, because the starter and the worker must agree on it.
 
-    Every other input to an analysis job is hashed when this server wrote it, because a
-    false hit would attribute one concert's readings to another. Stems are the exception
-    and get away with it: a separation writes into a directory named after its own cache
-    key, which is derived from the content hash of the audio it separated. The path already
-    carries the content identity, size and mtime catch a rewrite in place, and reading three
-    concert-length WAVs would stall a starter whose whole job is to hand back an id at once.
+    The stems are fingerprinted rather than hashed, which is the one place this pillar
+    departs from "hash what the server wrote" — see ADR 0003.
     """
-    return [{"stem": label, **cache.fingerprint(path)} for label, path in sorted(found.items())]
+    inputs = [
+        dict(identity),
+        *({"stem": label, **cache.fingerprint(path)} for label, path in sorted(stems.items())),
+    ]
+    return cache.cache_key(KIND, inputs, dict(settings))
 
 
 def detect(
@@ -453,15 +476,20 @@ def detect(
     refresh: bool = False,
     config: Config | None = None,
 ) -> JobOutput:
-    """The worker: the grid, then the hits, then the rules over both."""
+    """The worker: the grid, then the hits, then the rules over both.
+
+    The grid comes from the half ``analyze_music`` writes, under that half's own key: a
+    master the agent already ran music analysis over does not pay for the beat model a
+    second time (#22, story 26).
+    """
     config = config or get_config()
     config.analysis_dir.mkdir(parents=True, exist_ok=True)
     described = wav.describe(source)
-    identity = dict(identity) if identity is not None else cache.identity(source, config.audio_dir)
-    key = key or cache.cache_key(KIND, [identity, *_stem_inputs(stems)], dict(settings))
+    known = dict(identity) if identity is not None else cache.identity(source, config.audio_dir)
+    key = key or _key(known, stems, settings)
 
     progress(0.05, "reading the beat grid")
-    grid = _beat_grid(source, described, identity, detector, refresh, config)
+    grid = music.numbered_beats(source, described, known, detector, refresh, config)
 
     progress(0.25, "transcribing the drum stems")
     hits = drums.transcribe(stems, transcriber)
@@ -485,26 +513,3 @@ def detect(
     return JobOutput({"path": str(target), **summary}, (target,))
 
 
-def _beat_grid(
-    source: Path,
-    described: Mapping[str, Any],
-    identity: Mapping[str, Any],
-    detector: beats_module.Detector | None,
-    refresh: bool,
-    config: Config,
-) -> list[dict[str, Any]]:
-    """The numbered beats, read back from the half ``analyze_music`` shares with this job.
-
-    Sharing the entry rather than the code is the point: a master the agent already ran
-    music analysis over does not pay for the beat model twice (#22, story 26).
-    """
-    document = music.beats_half(
-        source,
-        described=dict(described),
-        identity=dict(identity),
-        detector=detector,
-        refresh=refresh,
-        config=config,
-    )
-    written = json.loads(Path(document["path"]).read_text(encoding="utf-8"))
-    return list(written[music.BEATS])

--- a/src/resolve_mcp/analysis/music.py
+++ b/src/resolve_mcp/analysis/music.py
@@ -25,6 +25,7 @@ and reading all of it would stall the starter that is supposed to return a job i
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -98,17 +99,11 @@ def analyze_music(
 
 
 def _readable(audio: str | Path) -> Path:
-    source = Path(audio)
-    if not source.is_file():
-        raise InvalidRequestError(
-            cause=f"There is no file at {source}.",
-            fix=(
-                "Pass the path to the master mix, or the path an acquire_timeline_audio job "
-                "returned. Analysis reads WAV."
-            ),
-            detail={"requested": str(source)},
-        )
-    return source
+    return readable_audio(
+        audio,
+        "Pass the path to the master mix, or the path an acquire_timeline_audio job "
+        "returned. Analysis reads WAV.",
+    )
 
 
 def _asked_for_something(beats: bool, energy: bool) -> None:
@@ -137,11 +132,11 @@ def _identity(source: Path, config: Config) -> dict[str, Any]:
 
 def beats_half(
     source: Path,
-    described: dict[str, Any] | None = None,
-    identity: dict[str, Any] | None = None,
-    detector: beats_module.Detector | None = None,
-    refresh: bool = False,
-    config: Config | None = None,
+    described: dict[str, Any],
+    identity: dict[str, Any],
+    detector: beats_module.Detector | None,
+    refresh: bool,
+    config: Config,
 ) -> dict[str, Any]:
     """The beats half on its own terms — the entry every job that needs a grid shares.
 
@@ -149,17 +144,49 @@ def beats_half(
     a second time on audio music analysis already ran over, so the half is callable on its
     own and the key stays exactly the one ``analyze`` writes.
     """
-    config = config or get_config()
-    shape = described if described is not None else wav.describe(source)
-    known = identity if identity is not None else _identity(source, config)
     return _half(
         BEATS,
-        cache.cache_key(f"{KIND}:{BEATS}", [known], {}),
-        lambda path: _beats(source, path, shape, detector),
+        cache.cache_key(f"{KIND}:{BEATS}", [identity], {}),
+        lambda path: _beats(source, path, described, detector),
         source,
         refresh,
         config,
     )
+
+
+def numbered_beats(
+    source: Path,
+    described: dict[str, Any],
+    identity: dict[str, Any],
+    detector: beats_module.Detector | None,
+    refresh: bool,
+    config: Config,
+) -> list[dict[str, Any]]:
+    """The beat records themselves, from the half above — computed or read back from disk.
+
+    The document is the interchange format, so a caller that wants the grid rather than a
+    path reads it the way an agent would. Reading it here rather than at the caller keeps
+    the file's layout the business of the module that writes it.
+    """
+    document = beats_half(source, described, identity, detector, refresh, config)
+    written = json.loads(Path(document["path"]).read_text(encoding="utf-8"))
+    return list(written[BEATS])
+
+
+def readable_audio(audio: str | Path, fix: str) -> Path:
+    """The path, if there is a file at it — the check every audio starter makes first.
+
+    The ``fix`` differs per job because the advice does: a fill job wants the master the
+    stems came from, and music analysis wants any master at all.
+    """
+    source = Path(audio)
+    if not source.is_file():
+        raise InvalidRequestError(
+            cause=f"There is no file at {source}.",
+            fix=fix,
+            detail={"requested": str(source)},
+        )
+    return source
 
 
 def analyze(

--- a/src/resolve_mcp/analysis/music.py
+++ b/src/resolve_mcp/analysis/music.py
@@ -132,13 +132,34 @@ def _sane_windows(window_seconds: float, hop_seconds: float) -> None:
 
 def _identity(source: Path, config: Config) -> dict[str, Any]:
     """Hash what this server wrote; fingerprint what the director handed over."""
-    if _inside(source, config.audio_dir):
-        return {"sha256": cache.content_hash(source)}
-    return cache.fingerprint(source)
+    return cache.identity(source, config.audio_dir)
 
 
-def _inside(source: Path, directory: Path) -> bool:
-    return source.resolve().is_relative_to(directory.resolve())
+def beats_half(
+    source: Path,
+    described: dict[str, Any] | None = None,
+    identity: dict[str, Any] | None = None,
+    detector: beats_module.Detector | None = None,
+    refresh: bool = False,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """The beats half on its own terms — the entry every job that needs a grid shares.
+
+    Drum-fill detection (#39) reports against this grid and must not pay for the beat model
+    a second time on audio music analysis already ran over, so the half is callable on its
+    own and the key stays exactly the one ``analyze`` writes.
+    """
+    config = config or get_config()
+    shape = described if described is not None else wav.describe(source)
+    known = identity if identity is not None else _identity(source, config)
+    return _half(
+        BEATS,
+        cache.cache_key(f"{KIND}:{BEATS}", [known], {}),
+        lambda path: _beats(source, path, shape, detector),
+        source,
+        refresh,
+        config,
+    )
 
 
 def analyze(
@@ -163,14 +184,7 @@ def analyze(
 
     if settings[BEATS]:
         progress(0.1, "finding beats and downbeats")
-        result[BEATS] = _half(
-            BEATS,
-            cache.cache_key(f"{KIND}:{BEATS}", [identity], {}),
-            lambda path: _beats(source, path, described, detector),
-            source,
-            refresh,
-            config,
-        )
+        result[BEATS] = beats_half(source, described, identity, detector, refresh, config)
         artifacts.append(Path(result[BEATS]["path"]))
 
     if settings[ENERGY]:

--- a/src/resolve_mcp/jobs/cache.py
+++ b/src/resolve_mcp/jobs/cache.py
@@ -54,6 +54,18 @@ def content_hash(path: Path | str) -> str:
     return digest.hexdigest()
 
 
+def identity(path: Path | str, written_under: Path) -> dict[str, Any]:
+    """Hash what this server wrote under ``written_under``; fingerprint anything else.
+
+    The rule at the top of this module, as one call — so two jobs keying off the same
+    master agree about what it is, rather than each deciding for itself.
+    """
+    resolved = Path(path)
+    if resolved.resolve().is_relative_to(written_under.resolve()):
+        return {"sha256": content_hash(resolved)}
+    return fingerprint(resolved)
+
+
 def cache_key(
     kind: str,
     inputs: Sequence[Mapping[str, Any]],

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..analysis import music, silence, transcribe, transcript, whisper
+from ..analysis import fills, music, silence, transcribe, transcript, whisper
 from ..resolve.connection import get_connection
 from .envelope import tool
 
@@ -97,6 +97,42 @@ def transcribe_audio(
     }
 
 
-TOOLS: tuple[Any, ...] = (transcribe_audio, analyze_music)
+@tool
+def detect_drum_fills(
+    stems: str,
+    audio: str,
+    minimum_confidence: float = fills.DEFAULT_MINIMUM_CONFIDENCE,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    """Start drum-fill detection over separated drum stems. Returns a job to poll.
 
-__all__ = ["TOOLS", "analyze_music", "transcribe_audio"]
+    stems is the directory a separate_stems job reported — the kick, snare and toms files
+    its second pass wrote. audio is the master mix those stems came from: fills are reported
+    against its beat grid, and if music analysis already ran over it the beats come from
+    cache rather than the model again.
+
+    The result names one JSON file and summarises it. Every candidate carries its start and
+    end (both on the grid), the bar and beat it starts on, the beat it resolves into, hits
+    per stem, how much busier it is than the median beat of this performance, and a 0-1
+    confidence with the four factors behind it — density, tom share, whether a hit lands on
+    the resolution point, and where that point sits in the phrase. Inline you get the count,
+    the mean confidence and the strongest candidate.
+
+    These are candidates, not verdicts: a burst of toms into a downbeat is evidence, and
+    whether it is a fill, a trade or a save is yours to read. Runs longer than two bars are
+    counted and left out — that is a drum solo, a different question. minimum_confidence is
+    the floor on what gets written; refresh redoes work the cache would answer for.
+    """
+    return {
+        "job": fills.detect_drum_fills(
+            stems,
+            audio,
+            minimum_confidence=minimum_confidence,
+            refresh=refresh,
+        )
+    }
+
+
+TOOLS: tuple[Any, ...] = (transcribe_audio, analyze_music, detect_drum_fills)
+
+__all__ = ["TOOLS", "analyze_music", "detect_drum_fills", "transcribe_audio"]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1726,6 +1726,37 @@ def write_clicks(
     return _write_samples(path, samples, sample_rate, bit_depth, channels)
 
 
+def write_hits(
+    path: Path,
+    times: Sequence[float],
+    seconds: float = 2.0,
+    sample_rate: int = 48_000,
+    bit_depth: int = 24,
+    channels: int = 2,
+    decay_seconds: float = 0.03,
+    amplitude: float = 0.5,
+    frequency: float = 2_000.0,
+) -> Path:
+    """A drum stem: decaying hits at exactly the times asked for, silence in between.
+
+    ``write_clicks`` puts a click on every beat, which is what a beat fixture wants and the
+    opposite of what a stem is — a kick stem is mostly nothing, and where its hits fall is
+    the thing under test. Passing no times writes the silence a stem the band did not play
+    would hold.
+    """
+    peak = 2 ** (bit_depth - 1) * amplitude
+    total = int(seconds * sample_rate)
+    decay = max(int(decay_seconds * sample_rate), 1)
+    samples = [0] * total
+    for when in times:
+        start = int(when * sample_rate)
+        for offset in range(min(decay, max(total - start, 0))):
+            envelope = 1.0 - offset / decay
+            wobble = math.sin(2 * math.pi * frequency * offset / sample_rate)
+            samples[start + offset] = int(peak * envelope * envelope * wobble)
+    return _write_samples(path, samples, sample_rate, bit_depth, channels)
+
+
 def _write_samples(
     path: Path,
     samples: list[int],

--- a/tests/test_drum_fills.py
+++ b/tests/test_drum_fills.py
@@ -1,0 +1,467 @@
+"""Drum-fill candidates: the rule layer, the transcription seam, the job, the cache (#39).
+
+The rule layer is where the decisions are, so most of this file is plain functions over
+hits and a beat grid — no audio, no job, no threads. The transcriber is checked separately
+on fixture audio, and the job on top of both, because that is where the caching lives.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.analysis import drums, fills, music
+from resolve_mcp.analysis.beats import BeatGrid, numbered
+from resolve_mcp.analysis.drums import Hit
+from resolve_mcp.audio.stems import DRUM_STEMS
+from resolve_mcp.config import get_config
+from resolve_mcp.errors import AnalysisFailedError, InvalidRequestError
+from resolve_mcp.jobs.runner import wait_for
+from resolve_mcp.jobs.store import JobRecord
+from resolve_mcp.tools import analysis as analysis_tools
+
+from .fakes import write_clicks, write_hits
+
+# --- a grid and some playing to hang the rules on -----------------------------------
+
+
+def grid(bars: int = 8, tempo: float = 120.0, meter: int = 4) -> tuple[dict[str, Any], ...]:
+    """``numbered`` rows for a steady grid — the same shape the beats half writes."""
+    step = 60.0 / tempo
+    beats = tuple(round(index * step, 6) for index in range(bars * meter))
+    downbeats = tuple(beats[index] for index in range(0, len(beats), meter))
+    return numbered(BeatGrid(beats=beats, downbeats=downbeats))
+
+
+def comping(rows: Sequence[Mapping[str, Any]]) -> list[Hit]:
+    """Ordinary playing: a kick on every beat and nothing else — the baseline to depart from."""
+    return [Hit(seconds=row["t"], stem="kick", strength=0.4) for row in rows]
+
+
+def burst(
+    rows: Sequence[Mapping[str, Any]],
+    beat: int,
+    count: int = 6,
+    stem: str = "toms",
+) -> list[Hit]:
+    """``count`` hits inside one beat — a fill's worth of activity in one place."""
+    step = _step(rows)
+    start = rows[beat - 1]["t"]
+    return [
+        Hit(seconds=start + index * step / count, stem=stem, strength=0.8)
+        for index in range(count)
+    ]
+
+
+def _step(rows: Sequence[Mapping[str, Any]]) -> float:
+    return float(rows[1]["t"]) - float(rows[0]["t"])
+
+
+# --- the rule layer -----------------------------------------------------------------
+
+
+def test_steady_comping_is_not_a_fill() -> None:
+    rows = grid()
+
+    found = fills.candidates(comping(rows), rows)
+
+    assert found.candidates == ()
+    assert found.considered == 0
+
+
+def test_a_tom_burst_before_a_downbeat_is_a_candidate_aligned_to_the_grid() -> None:
+    rows = grid()
+    # Bar 4 is beats 13-16; filling its last two beats resolves onto bar 5's downbeat.
+    hits = comping(rows) + burst(rows, 15) + burst(rows, 16)
+
+    found = fills.candidates(hits, rows)
+
+    assert len(found.candidates) == 1
+    one = found.candidates[0]
+    assert one.start == pytest.approx(rows[14]["t"])
+    assert one.end == pytest.approx(rows[16]["t"])
+    assert one.resolves_at == pytest.approx(rows[16]["t"])
+    assert (one.beat, one.bar, one.in_bar, one.beats) == (15, 4, 3, 2)
+    assert one.resolves_into_bar == 5
+    assert one.counts["toms"] == 12
+
+
+def test_confidence_is_highest_when_toms_land_before_a_phrase_boundary() -> None:
+    rows = grid()
+    # Bar 5 opens the second four-bar phrase; bar 4 opens nothing in particular.
+    phrase = fills.candidates(comping(rows) + burst(rows, 15) + burst(rows, 16), rows)
+    middle = fills.candidates(comping(rows) + burst(rows, 11) + burst(rows, 12), rows)
+
+    assert phrase.candidates[0].confidence > middle.candidates[0].confidence
+    assert phrase.candidates[0].factors["phrase"] == 1.0
+    assert middle.candidates[0].factors["phrase"] < 1.0
+
+
+def test_a_snare_only_burst_scores_below_the_same_burst_on_toms() -> None:
+    rows = grid()
+    toms = fills.candidates(comping(rows) + burst(rows, 15, stem="toms"), rows)
+    snare = fills.candidates(comping(rows) + burst(rows, 15, stem="snare"), rows)
+
+    assert toms.candidates[0].factors["toms"] > snare.candidates[0].factors["toms"]
+    assert toms.candidates[0].confidence > snare.candidates[0].confidence
+
+
+def test_a_run_that_outlasts_a_fill_is_dropped_and_counted() -> None:
+    rows = grid()
+    busy = [hit for beat in range(9, 9 + fills.MAXIMUM_BEATS + 1) for hit in burst(rows, beat)]
+
+    found = fills.candidates(comping(rows) + busy, rows)
+
+    assert found.candidates == ()
+    assert found.dropped == 1
+
+
+def test_one_quiet_beat_inside_a_fill_does_not_split_it() -> None:
+    rows = grid()
+    hits = comping(rows) + burst(rows, 13) + burst(rows, 15) + burst(rows, 16)
+
+    found = fills.candidates(hits, rows)
+
+    assert len(found.candidates) == 1
+    assert found.candidates[0].beats == 4
+    assert found.candidates[0].beat == 13
+
+
+def test_candidates_below_the_floor_are_left_out_but_still_counted() -> None:
+    rows = grid()
+    hits = comping(rows) + burst(rows, 11) + burst(rows, 12)
+
+    kept = fills.candidates(hits, rows, minimum_confidence=0.0)
+    dropped = fills.candidates(hits, rows, minimum_confidence=1.0)
+
+    assert len(kept.candidates) == 1
+    assert dropped.candidates == ()
+    assert dropped.considered == 1
+
+
+def test_a_grid_with_no_beats_yields_no_candidates_rather_than_failing() -> None:
+    found = fills.candidates([Hit(seconds=1.0, stem="toms", strength=0.9)], ())
+
+    assert found.candidates == ()
+    assert found.baseline == 0.0
+
+
+def test_rows_carry_the_times_confidence_and_counts_an_agent_reads() -> None:
+    rows = grid()
+    found = fills.candidates(comping(rows) + burst(rows, 15) + burst(rows, 16), rows)
+
+    record = fills.rows(found)[0]
+
+    assert record["start"] == pytest.approx(rows[14]["t"], abs=1e-3)
+    assert record["duration"] == pytest.approx(record["end"] - record["start"], abs=1e-3)
+    assert 0.0 <= record["confidence"] <= 1.0
+    assert record["toms"] == 12
+    assert set(record["factors"]) == {"density", "toms", "resolution", "phrase"}
+
+
+# --- the transcription seam ---------------------------------------------------------
+
+
+def test_the_onset_transcriber_finds_each_stem_hit_and_labels_it(tmp_path: Path) -> None:
+    stems = {
+        "kick": write_hits(tmp_path / "kick.wav", times=(0.5, 1.5), seconds=2.0),
+        "snare": write_hits(tmp_path / "snare.wav", times=(1.0,), seconds=2.0),
+    }
+
+    hits = drums.transcribe(stems)
+
+    assert [hit.stem for hit in hits] == ["kick", "snare", "kick"]
+    assert [round(hit.seconds, 1) for hit in hits] == [0.5, 1.0, 1.5]
+    assert all(0.0 < hit.strength <= 1.0 for hit in hits)
+
+
+def test_a_transcriber_that_falls_over_is_an_analysis_failure(tmp_path: Path) -> None:
+    def broken(stems: Mapping[str, Path]) -> tuple[Hit, ...]:
+        raise RuntimeError("no model")
+
+    with pytest.raises(AnalysisFailedError) as raised:
+        drums.transcribe({"toms": tmp_path / "toms.wav"}, broken)
+
+    assert "no model" in raised.value.cause
+
+
+# --- the job: what lands on disk, what comes back inline ----------------------------
+
+
+def stems_on_disk(tmp_path: Path) -> dict[str, Path]:
+    """Three drum stems in a directory, the way a separation job leaves them."""
+    directory = tmp_path / "stems" / "concert-abc123def456"
+    return {
+        label: write_hits(directory / f"concert_({label.title()})_model.wav", times=(), seconds=4.0)
+        for label in ("kick", "snare", "toms")
+    }
+
+
+def played(rows: Sequence[Mapping[str, Any]]) -> drums.Transcriber:
+    hits = tuple(comping(rows) + burst(rows, 15) + burst(rows, 16))
+
+    def transcriber(stems: Mapping[str, Path]) -> tuple[Hit, ...]:
+        return hits
+
+    return transcriber
+
+
+def detector_for(rows: Sequence[Mapping[str, Any]]) -> Any:
+    beats = tuple(row["t"] for row in rows)
+    downbeats = tuple(row["t"] for row in rows if row["downbeat"])
+
+    def detector(path: Path) -> BeatGrid:
+        return BeatGrid(beats=beats, downbeats=downbeats)
+
+    return detector
+
+
+def _finished(record: JobRecord) -> dict[str, Any]:
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    return record.result
+
+
+def test_the_job_writes_one_record_per_candidate_and_returns_the_gist(tmp_path: Path) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+    rows = grid()
+
+    result = _finished(
+        wait_for(
+            fills.detect_drum_fills(
+                stems_on_disk(tmp_path),
+                audio,
+                transcriber=played(rows),
+                detector=detector_for(rows),
+            )["job_id"]
+        )
+    )
+
+    written = Path(result["path"])
+    assert written.parent == get_config().analysis_dir
+    document = json.loads(written.read_text(encoding="utf-8"))
+    assert document["kind"] == fills.FILLS
+    assert len(document[fills.FILLS]) == result["count"] == 1
+    assert document[fills.FILLS][0]["confidence"] == pytest.approx(
+        result["strongest"]["confidence"]
+    )
+    assert result["stems"] == ["kick", "snare", "toms"]
+
+
+def test_the_document_holds_one_candidate_per_line(tmp_path: Path) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+    rows = grid()
+
+    result = _finished(
+        wait_for(
+            fills.detect_drum_fills(
+                stems_on_disk(tmp_path),
+                audio,
+                transcriber=played(rows),
+                detector=detector_for(rows),
+            )["job_id"]
+        )
+    )
+
+    lines = Path(result["path"]).read_text(encoding="utf-8").splitlines()
+    records = [line for line in lines if line.strip().startswith('{"start"')]
+    assert len(records) == 1
+
+
+def test_the_stems_directory_is_accepted_in_place_of_the_paths(tmp_path: Path) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+    rows = grid()
+    directory = next(iter(stems_on_disk(tmp_path).values())).parent
+
+    result = _finished(
+        wait_for(
+            fills.detect_drum_fills(
+                directory,
+                audio,
+                transcriber=played(rows),
+                detector=detector_for(rows),
+            )["job_id"]
+        )
+    )
+
+    assert result["stems"] == ["kick", "snare", "toms"]
+
+
+# --- the cache ----------------------------------------------------------------------
+
+
+def _must_not_run() -> drums.Transcriber:
+    def transcriber(stems: Mapping[str, Path]) -> tuple[Hit, ...]:
+        raise AssertionError("the cached result should have answered this")
+
+    return transcriber
+
+
+def test_asking_twice_answers_from_cache_without_transcribing_again(tmp_path: Path) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+    rows = grid()
+    stems = stems_on_disk(tmp_path)
+    first = _finished(
+        wait_for(
+            fills.detect_drum_fills(
+                stems, audio, transcriber=played(rows), detector=detector_for(rows)
+            )["job_id"]
+        )
+    )
+
+    again = fills.detect_drum_fills(stems, audio, transcriber=_must_not_run())
+
+    assert again["cached"] is True
+    assert again["result"] == first
+
+
+def test_refresh_redoes_the_work_the_cache_would_have_answered(tmp_path: Path) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+    rows = grid()
+    stems = stems_on_disk(tmp_path)
+    wait_for(
+        fills.detect_drum_fills(
+            stems, audio, transcriber=played(rows), detector=detector_for(rows)
+        )["job_id"]
+    )
+
+    record = wait_for(
+        fills.detect_drum_fills(
+            stems,
+            audio,
+            transcriber=played(rows),
+            detector=detector_for(rows),
+            refresh=True,
+        )["job_id"]
+    )
+
+    assert record.cached is False
+    assert _finished(record)["count"] == 1
+
+
+def test_a_different_floor_is_a_different_key(tmp_path: Path) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+    rows = grid()
+    stems = stems_on_disk(tmp_path)
+    wait_for(
+        fills.detect_drum_fills(
+            stems, audio, transcriber=played(rows), detector=detector_for(rows)
+        )["job_id"]
+    )
+
+    started = fills.detect_drum_fills(
+        stems,
+        audio,
+        minimum_confidence=0.9,
+        transcriber=played(rows),
+        detector=detector_for(rows),
+    )
+
+    assert started.get("cached") is not True
+
+
+def test_the_beat_grid_is_the_one_analyze_music_already_paid_for(tmp_path: Path) -> None:
+    """The two jobs share the beats cache entry, so the model runs once per master."""
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+    rows = grid()
+    wait_for(music.analyze_music(audio, energy=False, detector=detector_for(rows))["job_id"])
+
+    def detector_that_must_not_run(path: Path) -> BeatGrid:
+        raise AssertionError("beats were already detected for this audio")
+
+    result = _finished(
+        wait_for(
+            fills.detect_drum_fills(
+                stems_on_disk(tmp_path),
+                audio,
+                transcriber=played(rows),
+                detector=detector_that_must_not_run,
+            )["job_id"]
+        )
+    )
+
+    assert result["count"] == 1
+
+
+# --- what the starter refuses -------------------------------------------------------
+
+
+def test_a_missing_master_is_refused_before_a_job_exists(tmp_path: Path) -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        fills.detect_drum_fills(stems_on_disk(tmp_path), tmp_path / "nothing.wav")
+
+    assert "nothing.wav" in raised.value.cause
+
+
+def test_a_stems_directory_holding_no_drum_stems_is_refused(tmp_path: Path) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+    empty = tmp_path / "stems" / "nothing"
+    write_hits(empty / "concert_(Vocals)_model.wav", times=(), seconds=1.0)
+
+    with pytest.raises(InvalidRequestError) as raised:
+        fills.detect_drum_fills(empty, audio)
+
+    assert raised.value.detail["wanted"] == list(DRUM_STEMS)
+
+
+def test_a_named_stem_that_is_not_on_disk_is_refused(tmp_path: Path) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+
+    with pytest.raises(InvalidRequestError) as raised:
+        fills.detect_drum_fills({"toms": tmp_path / "gone.wav"}, audio)
+
+    assert "toms" in raised.value.cause
+
+
+@pytest.mark.parametrize("floor", [-0.1, 1.1])
+def test_a_confidence_floor_outside_zero_to_one_is_refused(tmp_path: Path, floor: float) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+
+    with pytest.raises(InvalidRequestError) as raised:
+        fills.detect_drum_fills(stems_on_disk(tmp_path), audio, minimum_confidence=floor)
+
+    assert raised.value.detail["minimum_confidence"] == floor
+
+
+# --- progress and the tool seam -----------------------------------------------------
+
+
+def test_progress_only_climbs_and_the_document_is_the_job_artifact(tmp_path: Path) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+    rows = grid()
+    steps: list[tuple[float, str]] = []
+
+    output = fills.detect(
+        audio,
+        stems_on_disk(tmp_path),
+        {"minimum_confidence": fills.DEFAULT_MINIMUM_CONFIDENCE},
+        lambda fraction, step: steps.append((fraction, step)),
+        transcriber=played(rows),
+        detector=detector_for(rows),
+    )
+
+    fractions = [fraction for fraction, _ in steps]
+    assert fractions == sorted(fractions)
+    assert [step for _, step in steps if "fill" in step]
+    assert output.artifacts == (Path(output.result["path"]),)
+
+
+def test_the_tool_returns_a_job_to_poll_inside_an_ok_envelope(tmp_path: Path) -> None:
+    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+    directory = next(iter(stems_on_disk(tmp_path).values())).parent
+
+    envelope = analysis_tools.detect_drum_fills(str(directory), str(audio))
+
+    assert envelope["ok"] is True
+    assert "job_id" in envelope["job"]
+
+
+def test_the_tool_reports_a_bad_request_as_a_structured_error(tmp_path: Path) -> None:
+    envelope = analysis_tools.detect_drum_fills(str(tmp_path), str(tmp_path / "nothing.wav"))
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["code"] == "invalid_request"

--- a/tests/test_drum_fills.py
+++ b/tests/test_drum_fills.py
@@ -3,6 +3,10 @@
 The rule layer is where the decisions are, so most of this file is plain functions over
 hits and a beat grid — no audio, no job, no threads. The transcriber is checked separately
 on fixture audio, and the job on top of both, because that is where the caching lives.
+
+The stem fixture writes into a ``drums`` subdirectory of a separation directory, because
+that is where the second pass actually puts them: the job reports the parent, and a fixture
+with a flatter layout than the real one would let a directory the agent cannot use pass.
 """
 
 from __future__ import annotations
@@ -15,21 +19,51 @@ from typing import Any
 import pytest
 
 from resolve_mcp.analysis import drums, fills, music
-from resolve_mcp.analysis.beats import BeatGrid, numbered
+from resolve_mcp.analysis.beats import BeatGrid, Detector, numbered
 from resolve_mcp.analysis.drums import Hit
-from resolve_mcp.audio.stems import DRUM_STEMS
+from resolve_mcp.audio.stems import DRUM_PASS, DRUM_STEMS
 from resolve_mcp.config import get_config
 from resolve_mcp.errors import AnalysisFailedError, InvalidRequestError
-from resolve_mcp.jobs.runner import wait_for
+from resolve_mcp.jobs.runner import JobOutput, wait_for
 from resolve_mcp.jobs.store import JobRecord
 from resolve_mcp.tools import analysis as analysis_tools
 
 from .fakes import write_clicks, write_hits
 
+
+@pytest.fixture
+def master(tmp_path: Path) -> Path:
+    """The mix the stems were separated from — what the beat grid is read off."""
+    return write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+
+
+@pytest.fixture
+def separation(tmp_path: Path) -> Path:
+    """A separation directory as ``separate_stems`` leaves it: two passes, one parent."""
+    directory = tmp_path / "stems" / "concert-abc123def456"
+    write_hits(directory / "mix" / "concert_(Drums)_model.wav", times=(), seconds=4.0)
+    for label in DRUM_STEMS:
+        write_hits(
+            directory / DRUM_PASS / f"concert_({label.title()})_model.wav",
+            times=(),
+            seconds=4.0,
+        )
+    return directory
+
+
+@pytest.fixture
+def stems(separation: Path) -> dict[str, Path]:
+    """The drums mapping, the shape the separation job reports alongside the directory."""
+    return {
+        label: separation / DRUM_PASS / f"concert_({label.title()})_model.wav"
+        for label in DRUM_STEMS
+    }
+
+
 # --- a grid and some playing to hang the rules on -----------------------------------
 
 
-def grid(bars: int = 8, tempo: float = 120.0, meter: int = 4) -> tuple[dict[str, Any], ...]:
+def _grid(bars: int = 8, tempo: float = 120.0, meter: int = 4) -> tuple[dict[str, Any], ...]:
     """``numbered`` rows for a steady grid — the same shape the beats half writes."""
     step = 60.0 / tempo
     beats = tuple(round(index * step, 6) for index in range(bars * meter))
@@ -37,12 +71,12 @@ def grid(bars: int = 8, tempo: float = 120.0, meter: int = 4) -> tuple[dict[str,
     return numbered(BeatGrid(beats=beats, downbeats=downbeats))
 
 
-def comping(rows: Sequence[Mapping[str, Any]]) -> list[Hit]:
+def _comping(rows: Sequence[Mapping[str, Any]]) -> list[Hit]:
     """Ordinary playing: a kick on every beat and nothing else — the baseline to depart from."""
     return [Hit(seconds=row["t"], stem="kick", strength=0.4) for row in rows]
 
 
-def burst(
+def _burst(
     rows: Sequence[Mapping[str, Any]],
     beat: int,
     count: int = 6,
@@ -65,18 +99,18 @@ def _step(rows: Sequence[Mapping[str, Any]]) -> float:
 
 
 def test_steady_comping_is_not_a_fill() -> None:
-    rows = grid()
+    rows = _grid()
 
-    found = fills.candidates(comping(rows), rows)
+    found = fills.candidates(_comping(rows), rows)
 
     assert found.candidates == ()
     assert found.considered == 0
 
 
 def test_a_tom_burst_before_a_downbeat_is_a_candidate_aligned_to_the_grid() -> None:
-    rows = grid()
+    rows = _grid()
     # Bar 4 is beats 13-16; filling its last two beats resolves onto bar 5's downbeat.
-    hits = comping(rows) + burst(rows, 15) + burst(rows, 16)
+    hits = _comping(rows) + _burst(rows, 15) + _burst(rows, 16)
 
     found = fills.candidates(hits, rows)
 
@@ -84,17 +118,16 @@ def test_a_tom_burst_before_a_downbeat_is_a_candidate_aligned_to_the_grid() -> N
     one = found.candidates[0]
     assert one.start == pytest.approx(rows[14]["t"])
     assert one.end == pytest.approx(rows[16]["t"])
-    assert one.resolves_at == pytest.approx(rows[16]["t"])
     assert (one.beat, one.bar, one.in_bar, one.beats) == (15, 4, 3, 2)
     assert one.resolves_into_bar == 5
     assert one.counts["toms"] == 12
 
 
 def test_confidence_is_highest_when_toms_land_before_a_phrase_boundary() -> None:
-    rows = grid()
+    rows = _grid()
     # Bar 5 opens the second four-bar phrase; bar 4 opens nothing in particular.
-    phrase = fills.candidates(comping(rows) + burst(rows, 15) + burst(rows, 16), rows)
-    middle = fills.candidates(comping(rows) + burst(rows, 11) + burst(rows, 12), rows)
+    phrase = fills.candidates(_comping(rows) + _burst(rows, 15) + _burst(rows, 16), rows)
+    middle = fills.candidates(_comping(rows) + _burst(rows, 11) + _burst(rows, 12), rows)
 
     assert phrase.candidates[0].confidence > middle.candidates[0].confidence
     assert phrase.candidates[0].factors["phrase"] == 1.0
@@ -102,27 +135,27 @@ def test_confidence_is_highest_when_toms_land_before_a_phrase_boundary() -> None
 
 
 def test_a_snare_only_burst_scores_below_the_same_burst_on_toms() -> None:
-    rows = grid()
-    toms = fills.candidates(comping(rows) + burst(rows, 15, stem="toms"), rows)
-    snare = fills.candidates(comping(rows) + burst(rows, 15, stem="snare"), rows)
+    rows = _grid()
+    toms = fills.candidates(_comping(rows) + _burst(rows, 15, stem="toms"), rows)
+    snare = fills.candidates(_comping(rows) + _burst(rows, 15, stem="snare"), rows)
 
     assert toms.candidates[0].factors["toms"] > snare.candidates[0].factors["toms"]
     assert toms.candidates[0].confidence > snare.candidates[0].confidence
 
 
 def test_a_run_that_outlasts_a_fill_is_dropped_and_counted() -> None:
-    rows = grid()
-    busy = [hit for beat in range(9, 9 + fills.MAXIMUM_BEATS + 1) for hit in burst(rows, beat)]
+    rows = _grid()
+    busy = [hit for beat in range(9, 9 + fills.MAXIMUM_BEATS + 1) for hit in _burst(rows, beat)]
 
-    found = fills.candidates(comping(rows) + busy, rows)
+    found = fills.candidates(_comping(rows) + busy, rows)
 
     assert found.candidates == ()
     assert found.dropped == 1
 
 
 def test_one_quiet_beat_inside_a_fill_does_not_split_it() -> None:
-    rows = grid()
-    hits = comping(rows) + burst(rows, 13) + burst(rows, 15) + burst(rows, 16)
+    rows = _grid()
+    hits = _comping(rows) + _burst(rows, 13) + _burst(rows, 15) + _burst(rows, 16)
 
     found = fills.candidates(hits, rows)
 
@@ -132,8 +165,8 @@ def test_one_quiet_beat_inside_a_fill_does_not_split_it() -> None:
 
 
 def test_candidates_below_the_floor_are_left_out_but_still_counted() -> None:
-    rows = grid()
-    hits = comping(rows) + burst(rows, 11) + burst(rows, 12)
+    rows = _grid()
+    hits = _comping(rows) + _burst(rows, 11) + _burst(rows, 12)
 
     kept = fills.candidates(hits, rows, minimum_confidence=0.0)
     dropped = fills.candidates(hits, rows, minimum_confidence=1.0)
@@ -150,9 +183,18 @@ def test_a_grid_with_no_beats_yields_no_candidates_rather_than_failing() -> None
     assert found.baseline == 0.0
 
 
+def test_a_kit_with_nothing_to_be_busier_than_yields_no_candidates() -> None:
+    rows = _grid()
+
+    found = fills.candidates(_burst(rows, 15), rows)
+
+    assert found.candidates == ()
+    assert found.baseline == 0.0
+
+
 def test_rows_carry_the_times_confidence_and_counts_an_agent_reads() -> None:
-    rows = grid()
-    found = fills.candidates(comping(rows) + burst(rows, 15) + burst(rows, 16), rows)
+    rows = _grid()
+    found = fills.candidates(_comping(rows) + _burst(rows, 15) + _burst(rows, 16), rows)
 
     record = fills.rows(found)[0]
 
@@ -167,12 +209,12 @@ def test_rows_carry_the_times_confidence_and_counts_an_agent_reads() -> None:
 
 
 def test_the_onset_transcriber_finds_each_stem_hit_and_labels_it(tmp_path: Path) -> None:
-    stems = {
+    kit = {
         "kick": write_hits(tmp_path / "kick.wav", times=(0.5, 1.5), seconds=2.0),
         "snare": write_hits(tmp_path / "snare.wav", times=(1.0,), seconds=2.0),
     }
 
-    hits = drums.transcribe(stems)
+    hits = drums.transcribe(kit)
 
     assert [hit.stem for hit in hits] == ["kick", "snare", "kick"]
     assert [round(hit.seconds, 1) for hit in hits] == [0.5, 1.0, 1.5]
@@ -180,7 +222,7 @@ def test_the_onset_transcriber_finds_each_stem_hit_and_labels_it(tmp_path: Path)
 
 
 def test_a_transcriber_that_falls_over_is_an_analysis_failure(tmp_path: Path) -> None:
-    def broken(stems: Mapping[str, Path]) -> tuple[Hit, ...]:
+    def broken(kit: Mapping[str, Path]) -> tuple[Hit, ...]:
         raise RuntimeError("no model")
 
     with pytest.raises(AnalysisFailedError) as raised:
@@ -192,25 +234,17 @@ def test_a_transcriber_that_falls_over_is_an_analysis_failure(tmp_path: Path) ->
 # --- the job: what lands on disk, what comes back inline ----------------------------
 
 
-def stems_on_disk(tmp_path: Path) -> dict[str, Path]:
-    """Three drum stems in a directory, the way a separation job leaves them."""
-    directory = tmp_path / "stems" / "concert-abc123def456"
-    return {
-        label: write_hits(directory / f"concert_({label.title()})_model.wav", times=(), seconds=4.0)
-        for label in ("kick", "snare", "toms")
-    }
+def _played(rows: Sequence[Mapping[str, Any]]) -> drums.Transcriber:
+    """A transcriber standing in for the kit: comping, and a fill into bar 5."""
+    hits = tuple(_comping(rows) + _burst(rows, 15) + _burst(rows, 16))
 
-
-def played(rows: Sequence[Mapping[str, Any]]) -> drums.Transcriber:
-    hits = tuple(comping(rows) + burst(rows, 15) + burst(rows, 16))
-
-    def transcriber(stems: Mapping[str, Path]) -> tuple[Hit, ...]:
+    def transcriber(kit: Mapping[str, Path]) -> tuple[Hit, ...]:
         return hits
 
     return transcriber
 
 
-def detector_for(rows: Sequence[Mapping[str, Any]]) -> Any:
+def _detector_for(rows: Sequence[Mapping[str, Any]]) -> Detector:
     beats = tuple(row["t"] for row in rows)
     downbeats = tuple(row["t"] for row in rows if row["downbeat"])
 
@@ -226,20 +260,28 @@ def _finished(record: JobRecord) -> dict[str, Any]:
     return record.result
 
 
-def test_the_job_writes_one_record_per_candidate_and_returns_the_gist(tmp_path: Path) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-    rows = grid()
-
-    result = _finished(
-        wait_for(
-            fills.detect_drum_fills(
-                stems_on_disk(tmp_path),
-                audio,
-                transcriber=played(rows),
-                detector=detector_for(rows),
-            )["job_id"]
-        )
+def _ran(
+    stems: Mapping[str, Path] | str | Path,
+    audio: Path,
+    rows: Sequence[Mapping[str, Any]],
+    **asked: Any,
+) -> dict[str, Any]:
+    """Run the job to completion with the grid and the playing injected."""
+    started = fills.detect_drum_fills(
+        stems,
+        audio,
+        transcriber=_played(rows),
+        detector=_detector_for(rows),
+        **asked,
     )
+    return _finished(wait_for(started["job_id"]))
+
+
+def test_the_job_writes_one_record_per_candidate_and_returns_the_gist(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    result = _ran(stems, master, _grid())
 
     written = Path(result["path"])
     assert written.parent == get_config().analysis_dir
@@ -249,180 +291,173 @@ def test_the_job_writes_one_record_per_candidate_and_returns_the_gist(tmp_path: 
     assert document[fills.FILLS][0]["confidence"] == pytest.approx(
         result["strongest"]["confidence"]
     )
-    assert result["stems"] == ["kick", "snare", "toms"]
+    assert result["stems"] == list(DRUM_STEMS)
 
 
-def test_the_document_holds_one_candidate_per_line(tmp_path: Path) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-    rows = grid()
-
-    result = _finished(
-        wait_for(
-            fills.detect_drum_fills(
-                stems_on_disk(tmp_path),
-                audio,
-                transcriber=played(rows),
-                detector=detector_for(rows),
-            )["job_id"]
-        )
-    )
+def test_the_document_holds_one_candidate_per_line(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    result = _ran(stems, master, _grid())
 
     lines = Path(result["path"]).read_text(encoding="utf-8").splitlines()
     records = [line for line in lines if line.strip().startswith('{"start"')]
     assert len(records) == 1
 
 
-def test_the_stems_directory_is_accepted_in_place_of_the_paths(tmp_path: Path) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-    rows = grid()
-    directory = next(iter(stems_on_disk(tmp_path).values())).parent
+def test_the_directory_a_separation_reports_is_accepted(
+    master: Path,
+    separation: Path,
+) -> None:
+    """The job hands back the parent of both passes, so the parent is what this takes."""
+    result = _ran(separation, master, _grid())
 
-    result = _finished(
-        wait_for(
-            fills.detect_drum_fills(
-                directory,
-                audio,
-                transcriber=played(rows),
-                detector=detector_for(rows),
-            )["job_id"]
-        )
-    )
+    assert result["stems"] == list(DRUM_STEMS)
+    assert result["count"] == 1
 
-    assert result["stems"] == ["kick", "snare", "toms"]
+
+def test_the_drum_pass_on_its_own_is_accepted_too(master: Path, separation: Path) -> None:
+    result = _ran(separation / DRUM_PASS, master, _grid())
+
+    assert result["stems"] == list(DRUM_STEMS)
+
+
+def test_the_four_stem_pass_is_not_mistaken_for_the_drum_stems(
+    master: Path,
+    separation: Path,
+) -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        fills.detect_drum_fills(separation / "mix", master)
+
+    assert raised.value.detail["wanted"] == list(DRUM_STEMS)
 
 
 # --- the cache ----------------------------------------------------------------------
 
 
 def _must_not_run() -> drums.Transcriber:
-    def transcriber(stems: Mapping[str, Path]) -> tuple[Hit, ...]:
+    def transcriber(kit: Mapping[str, Path]) -> tuple[Hit, ...]:
         raise AssertionError("the cached result should have answered this")
 
     return transcriber
 
 
-def test_asking_twice_answers_from_cache_without_transcribing_again(tmp_path: Path) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-    rows = grid()
-    stems = stems_on_disk(tmp_path)
-    first = _finished(
-        wait_for(
-            fills.detect_drum_fills(
-                stems, audio, transcriber=played(rows), detector=detector_for(rows)
-            )["job_id"]
-        )
-    )
+def test_asking_twice_answers_from_cache_without_transcribing_again(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    first = _ran(stems, master, _grid())
 
-    again = fills.detect_drum_fills(stems, audio, transcriber=_must_not_run())
+    again = fills.detect_drum_fills(stems, master, transcriber=_must_not_run())
 
     assert again["cached"] is True
     assert again["result"] == first
 
 
-def test_refresh_redoes_the_work_the_cache_would_have_answered(tmp_path: Path) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-    rows = grid()
-    stems = stems_on_disk(tmp_path)
-    wait_for(
-        fills.detect_drum_fills(
-            stems, audio, transcriber=played(rows), detector=detector_for(rows)
-        )["job_id"]
-    )
+def test_refresh_redoes_the_work_the_cache_would_have_answered(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    rows = _grid()
+    _ran(stems, master, rows)
 
-    record = wait_for(
-        fills.detect_drum_fills(
-            stems,
-            audio,
-            transcriber=played(rows),
-            detector=detector_for(rows),
-            refresh=True,
-        )["job_id"]
+    started = fills.detect_drum_fills(
+        stems,
+        master,
+        transcriber=_played(rows),
+        detector=_detector_for(rows),
+        refresh=True,
     )
+    record = wait_for(started["job_id"])
 
     assert record.cached is False
     assert _finished(record)["count"] == 1
 
 
-def test_a_different_floor_is_a_different_key(tmp_path: Path) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-    rows = grid()
-    stems = stems_on_disk(tmp_path)
-    wait_for(
-        fills.detect_drum_fills(
-            stems, audio, transcriber=played(rows), detector=detector_for(rows)
-        )["job_id"]
-    )
+def test_a_different_floor_is_a_different_key(master: Path, stems: dict[str, Path]) -> None:
+    rows = _grid()
+    _ran(stems, master, rows)
 
     started = fills.detect_drum_fills(
         stems,
-        audio,
+        master,
         minimum_confidence=0.9,
-        transcriber=played(rows),
-        detector=detector_for(rows),
+        transcriber=_played(rows),
+        detector=_detector_for(rows),
     )
 
     assert started.get("cached") is not True
 
 
-def test_the_beat_grid_is_the_one_analyze_music_already_paid_for(tmp_path: Path) -> None:
+def test_the_beat_grid_is_the_one_analyze_music_already_paid_for(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
     """The two jobs share the beats cache entry, so the model runs once per master."""
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-    rows = grid()
-    wait_for(music.analyze_music(audio, energy=False, detector=detector_for(rows))["job_id"])
+    rows = _grid()
+    wait_for(music.analyze_music(master, energy=False, detector=_detector_for(rows))["job_id"])
 
     def detector_that_must_not_run(path: Path) -> BeatGrid:
         raise AssertionError("beats were already detected for this audio")
 
-    result = _finished(
-        wait_for(
-            fills.detect_drum_fills(
-                stems_on_disk(tmp_path),
-                audio,
-                transcriber=played(rows),
-                detector=detector_that_must_not_run,
-            )["job_id"]
-        )
+    started = fills.detect_drum_fills(
+        stems,
+        master,
+        transcriber=_played(rows),
+        detector=detector_that_must_not_run,
     )
 
-    assert result["count"] == 1
+    assert _finished(wait_for(started["job_id"]))["count"] == 1
 
 
 # --- what the starter refuses -------------------------------------------------------
 
 
-def test_a_missing_master_is_refused_before_a_job_exists(tmp_path: Path) -> None:
+def test_a_missing_master_is_refused_before_a_job_exists(
+    tmp_path: Path,
+    stems: dict[str, Path],
+) -> None:
     with pytest.raises(InvalidRequestError) as raised:
-        fills.detect_drum_fills(stems_on_disk(tmp_path), tmp_path / "nothing.wav")
+        fills.detect_drum_fills(stems, tmp_path / "nothing.wav")
 
     assert "nothing.wav" in raised.value.cause
 
 
-def test_a_stems_directory_holding_no_drum_stems_is_refused(tmp_path: Path) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
+def test_a_stems_directory_holding_no_drum_stems_is_refused(
+    tmp_path: Path,
+    master: Path,
+) -> None:
     empty = tmp_path / "stems" / "nothing"
     write_hits(empty / "concert_(Vocals)_model.wav", times=(), seconds=1.0)
 
     with pytest.raises(InvalidRequestError) as raised:
-        fills.detect_drum_fills(empty, audio)
+        fills.detect_drum_fills(empty, master)
 
     assert raised.value.detail["wanted"] == list(DRUM_STEMS)
 
 
-def test_a_named_stem_that_is_not_on_disk_is_refused(tmp_path: Path) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-
+def test_a_directory_that_is_not_there_is_refused(tmp_path: Path, master: Path) -> None:
     with pytest.raises(InvalidRequestError) as raised:
-        fills.detect_drum_fills({"toms": tmp_path / "gone.wav"}, audio)
+        fills.detect_drum_fills(tmp_path / "gone", master)
+
+    assert "gone" in raised.value.cause
+
+
+def test_a_named_stem_that_is_not_on_disk_is_refused(tmp_path: Path, master: Path) -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        fills.detect_drum_fills({"toms": tmp_path / "gone.wav"}, master)
 
     assert "toms" in raised.value.cause
 
 
 @pytest.mark.parametrize("floor", [-0.1, 1.1])
-def test_a_confidence_floor_outside_zero_to_one_is_refused(tmp_path: Path, floor: float) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-
+def test_a_confidence_floor_outside_zero_to_one_is_refused(
+    master: Path,
+    stems: dict[str, Path],
+    floor: float,
+) -> None:
     with pytest.raises(InvalidRequestError) as raised:
-        fills.detect_drum_fills(stems_on_disk(tmp_path), audio, minimum_confidence=floor)
+        fills.detect_drum_fills(stems, master, minimum_confidence=floor)
 
     assert raised.value.detail["minimum_confidence"] == floor
 
@@ -430,18 +465,20 @@ def test_a_confidence_floor_outside_zero_to_one_is_refused(tmp_path: Path, floor
 # --- progress and the tool seam -----------------------------------------------------
 
 
-def test_progress_only_climbs_and_the_document_is_the_job_artifact(tmp_path: Path) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-    rows = grid()
+def test_progress_only_climbs_and_the_document_is_the_job_artifact(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    rows = _grid()
     steps: list[tuple[float, str]] = []
 
-    output = fills.detect(
-        audio,
-        stems_on_disk(tmp_path),
+    output: JobOutput = fills.detect(
+        master,
+        stems,
         {"minimum_confidence": fills.DEFAULT_MINIMUM_CONFIDENCE},
         lambda fraction, step: steps.append((fraction, step)),
-        transcriber=played(rows),
-        detector=detector_for(rows),
+        transcriber=_played(rows),
+        detector=_detector_for(rows),
     )
 
     fractions = [fraction for fraction, _ in steps]
@@ -450,11 +487,11 @@ def test_progress_only_climbs_and_the_document_is_the_job_artifact(tmp_path: Pat
     assert output.artifacts == (Path(output.result["path"]),)
 
 
-def test_the_tool_returns_a_job_to_poll_inside_an_ok_envelope(tmp_path: Path) -> None:
-    audio = write_clicks(tmp_path / "media" / "concert.wav", seconds=4.0)
-    directory = next(iter(stems_on_disk(tmp_path).values())).parent
-
-    envelope = analysis_tools.detect_drum_fills(str(directory), str(audio))
+def test_the_tool_returns_a_job_to_poll_inside_an_ok_envelope(
+    master: Path,
+    separation: Path,
+) -> None:
+    envelope = analysis_tools.detect_drum_fills(str(separation), str(master))
 
     assert envelope["ok"] is True
     assert "job_id" in envelope["job"]

--- a/tests/test_drum_fills.py
+++ b/tests/test_drum_fills.py
@@ -21,7 +21,7 @@ import pytest
 from resolve_mcp.analysis import drums, fills, music
 from resolve_mcp.analysis.beats import BeatGrid, Detector, numbered
 from resolve_mcp.analysis.drums import Hit
-from resolve_mcp.audio.stems import DRUM_PASS, DRUM_STEMS
+from resolve_mcp.audio.stems import DRUM_PASS, DRUM_STEMS, MIX_PASS
 from resolve_mcp.config import get_config
 from resolve_mcp.errors import AnalysisFailedError, InvalidRequestError
 from resolve_mcp.jobs.runner import JobOutput, wait_for
@@ -41,7 +41,7 @@ def master(tmp_path: Path) -> Path:
 def separation(tmp_path: Path) -> Path:
     """A separation directory as ``separate_stems`` leaves it: two passes, one parent."""
     directory = tmp_path / "stems" / "concert-abc123def456"
-    write_hits(directory / "mix" / "concert_(Drums)_model.wav", times=(), seconds=4.0)
+    write_hits(directory / MIX_PASS / "concert_(Drums)_model.wav", times=(), seconds=4.0)
     for label in DRUM_STEMS:
         write_hits(
             directory / DRUM_PASS / f"concert_({label.title()})_model.wav",
@@ -327,9 +327,34 @@ def test_the_four_stem_pass_is_not_mistaken_for_the_drum_stems(
     separation: Path,
 ) -> None:
     with pytest.raises(InvalidRequestError) as raised:
-        fills.detect_drum_fills(separation / "mix", master)
+        fills.detect_drum_fills(separation / MIX_PASS, master)
 
     assert raised.value.detail["wanted"] == list(DRUM_STEMS)
+
+
+def test_a_drum_pass_holding_nothing_labelled_falls_back_to_the_directory(
+    master: Path,
+    tmp_path: Path,
+) -> None:
+    """The drum pass is looked in first, but an empty one must not end the search."""
+    directory = tmp_path / "stems" / "hand-copied"
+    write_hits(directory / DRUM_PASS / "unlabelled.wav", times=(), seconds=1.0)
+    for label in DRUM_STEMS:
+        write_hits(directory / f"concert_({label.title()})_model.wav", times=(), seconds=4.0)
+
+    result = _ran(directory, master, _grid())
+
+    assert result["stems"] == list(DRUM_STEMS)
+
+
+def test_a_kit_missing_a_stem_is_read_rather_than_refused(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    """Some stems beat none — the gist names what was read, so a timid score is explainable."""
+    result = _ran({"kick": stems["kick"], "snare": stems["snare"]}, master, _grid())
+
+    assert result["stems"] == ["kick", "snare"]
 
 
 # --- the cache ----------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -46,6 +46,7 @@ def test_registers_the_p1_session_media_timeline_cut_titling_render_and_job_tool
         "detect_scene_cuts",
         "transcribe_audio",
         "analyze_music",
+        "detect_drum_fills",
         "separate_stems",
         "list_render_presets",
         "render_timeline",


### PR DESCRIPTION
Closes #39.

Drum-fill candidates from drum-stem hits and the beat grid, written as
timestamped JSON with confidence, cached, with the gist returned inline.

## What landed

**`analysis/drums.py`** — the transcription seam. Separation (#36) already did
the hard part: once kick, snare and toms are three files, a transient in the
toms file *is* a tom, so the default transcriber is the spectral-flux onset
detector the energy curve already uses, run per stem and labelled by it. No new
model and no new dependency. The `Transcriber` seam is kept anyway (ADR 0002
shape) — a real drum transcriber is a plausible upgrade, and the seam is what
lets the rule layer be tested on exact hits rather than on synthesized audio.

**`analysis/fills.py`** — the rule layer and the job. Everything is measured
against the median beat of this performance, because a brushed ballad and a
burning up-tempo differ by an order of magnitude and neither is filling all the
time. Toms nominate a beat on their own and carry a quarter of the confidence.
Candidates start and end on the grid, because the resolution point is what a
cut is placed against. A run longer than two bars is counted and dropped rather
than reported unsure: that is a drum solo (#38's question), and calling it a
long fill would be a wrong answer rather than a hesitant one.

**Shared beat grid.** The grid comes from the half `analyze_music` already
writes, under that half's own key, so a master that has had music analysis run
over it does not pay for the beat model twice (#22, story 26). That needed
`music.beats_half` / `music.numbered_beats` extracted with the cache key
unchanged, and the hash-or-fingerprint rule promoted to `cache.identity`.

**ADR 0003** records the one deviation from "hash what the server wrote": stems
are fingerprinted, because a separation directory is named after a key derived
from the content hash of the audio it separated — the path already *is* the
identity, and hashing three concert-length WAVs in a starter whose contract is
to return an id at once is precisely the stall the rule's other half exists to
avoid.

## Seam

**Fake tier**, worker seam — which is what #22's testing decision names for
analysis workers ("small fixture audio … output JSON shape, timestamps, and
cache behavior; model quality is not under test"). The rules are plain
functions over hits and a numbered grid; the default transcriber is checked on
fixture audio (`fakes.write_hits`); the job is checked for what lands on disk,
the shared beats entry, refresh, and the floor varying the key. 32 tests.

**No live ACs on this ticket.** What no seam covers is whether the thresholds
fire correctly on a real jazz drummer — that is a tuning question a test cannot
settle, and it is called out on the ticket.

## Review

`/code-review` — two-axis, Standards and Spec as parallel sub-agents, plus a
focused pass over the fix diff.

**Spec axis — 4 findings.**

1. **Real bug, fixed.** `separate_stems` writes `<directory>/mix/` and
   `<directory>/drums/` and reports the *parent*; `separator.collect` globs
   non-recursively. So the directory the tool documented as its input found
   nothing — and the stem fixture wrote three files flat into one folder, which
   hid it. `_collected` now looks in the drum pass first and the directory
   itself second; the fixture mimics the real two-pass layout (CLAUDE.md: the
   fakes mimic the real API's quirks); four tests cover the parent, the drum
   pass alone, the fall-through when the drum pass holds nothing labelled, and
   the four-stem pass being refused rather than mistaken for the kit.
2. **Fingerprint-not-hash deviation from #22 story 26** was documented only in
   a module docstring. Now ADR 0003, referenced from `fills._key`.
3. **Fix hints pointed at a mapping the MCP surface cannot pass.** They lead
   with the directory now.
4. **Tool-catalog budget** — #22 says "~32 coarse workflow tools", and this
   makes 33 with `correlate_timeline` (#40) still to come. Not changed:
   folding fills into `analyze_music` is wrong, because that job runs on the
   master mix and this one needs stems that may not exist yet. Flagged on the
   ticket as a decision for the human, not resolved here.

**Standards axis — no hard violations; 7 judgement calls, 6 applied.**
`music.numbered_beats` so `fills` no longer decodes another module's document
layout; one shared `readable_audio` instead of two near-copies; `beats_half`'s
unreachable `None` fallbacks made required; one `_key` both the starter and the
worker call, so they cannot drift into a silent cache miss; a `Reading` tuple
in place of a five-value data clump; `resolves_at` dropped as always equal to
`end`; test fixtures and private helper names to the house pattern.

**Held:** `music.readable_audio` was flagged as a generic file check living in
a job module. Left there — both callers are analysis starters, and `fills`
already imports `music` for the beats half it shares, so moving it to `wav.py`
would trade a coupling that exists for one that does not.

**Third round** (focused pass over the fix diff) confirmed all ten fixes and
found the `_collected` fall-through untested, plus a kit missing a stem reading
silently — a kit with no toms scores every candidate with a tom factor of zero.
Not refused (some stems beat none), but it logs what is missing now, and the
gist already names what was read.

CI: 848 tests pass, mypy strict clean, ruff clean.

Review: clean — two-axis review, 11 findings, 10 applied and 1 held with reason; fix diff re-checked twice.

## Merge with main (post-open)

Main gained #38 (structure analysis and the `halves` module) after this PR
opened; four files conflicted. Resolution kept main's structure: the shared
cached beats entry is `music.beats_of` (this branch's cached `beats_half`
wrapper is gone; main's `beats_half` writer stays), `numbered_beats` now reads
through `beats_of` with the cache key unchanged, `music.readable_audio` folded
into `halves.readable` via an optional per-job `fix` message, and
`halves.identity` delegates to this branch's `cache.identity` so the
hash-or-fingerprint rule lives once. Union of tools and fixtures elsewhere.

Reviewed as a focused pass over the resolution diff: cache-key consistency,
signatures, no orphaned helpers, tool/test alignment — no findings.
910 tests pass, mypy strict clean, ruff clean.

Review: clean — merge resolution re-reviewed, no findings
