### PR TITLE
P1: correlate_timeline — measure a cut against its music (#40)

### DIFF
--- a/src/resolve_mcp/analysis/beats.py
+++ b/src/resolve_mcp/analysis/beats.py
@@ -115,13 +115,14 @@ def _downbeat_flags(grid: BeatGrid) -> tuple[bool, ...]:
     """Match each downbeat to the nearest beat rather than trusting float equality."""
     flags = [False] * len(grid.beats)
     for downbeat in grid.downbeats:
-        nearest = _nearest(grid.beats, downbeat)
-        if nearest is not None and abs(grid.beats[nearest] - downbeat) <= DOWNBEAT_TOLERANCE:
-            flags[nearest] = True
+        closest = nearest(grid.beats, downbeat)
+        if closest is not None and abs(grid.beats[closest] - downbeat) <= DOWNBEAT_TOLERANCE:
+            flags[closest] = True
     return tuple(flags)
 
 
-def _nearest(beats: Sequence[float], seconds: float) -> int | None:
+def nearest(beats: Sequence[float], seconds: float) -> int | None:
+    """Which of ``beats`` sits closest to ``seconds`` — the lookup every correlation makes."""
     if not beats:
         return None
     after = bisect.bisect_left(beats, seconds)

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -1,0 +1,616 @@
+"""Measuring a cut against the music it was cut to.
+
+This is the instrument style is learned with (#22, story 32) and the one a build is reviewed
+with (story 47). Both directions need the same numbers: for every shot, how far its start
+sits from the nearest beat and from the nearest transient, where in the bar that is, which
+tune it happens in, who was out front, how long the shot runs and which angle it came from.
+
+Two rules shape everything here.
+
+*Nothing is decided.* An offset of two frames late is reported as two frames late, never as
+"good" or "loose": what counts as musical is the style profile's business, and that is a
+Markdown document Claude writes, never server code (#21). The same goes for the roles: the
+angle sidecar is the agent's own document and no server path touches it (#45), so the labels
+arrive here as a mapping the caller already lifted out of it.
+
+*Measurement, not analysis.* The beat grid, the tunes and the solo changes are files another
+job already wrote; this joins them to the shots. The one thing it computes is the transient
+list, because onsets are the fourth-wall risk (#21: transients, not the beat grid) and no
+job persists them. That decode is why this is a job at all, and why the detector is
+injectable per ADR 0002 — the arithmetic is testable without a model or a concert.
+
+The cut's clock is not the timeline's. Analysis times count from the start of the master
+mix, so a shot's time is read through whatever the audio track says about where that mix
+sits — and when a timeline has no audio to say, the reading falls back to counting from the
+timeline's own first frame and *says which it did*, because a whole file of times measured
+against the wrong zero looks exactly like a whole file of times measured against the right
+one.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from ..config import Config, get_config
+from ..errors import InvalidRequestError
+from ..jobs import cache
+from ..jobs.runner import JobOutput, Progress, start_job
+from ..logging_config import get_logger
+from ..naming import keyed_name
+from ..resolve.connection import ResolveConnection
+from ..resolve.session import frame_rate
+from ..resolve.timeline import (
+    FIRST_TRACK,
+    Reader,
+    clip_name,
+    find_timeline,
+    fingerprint,
+    items_in_track,
+    name_of,
+    open_project,
+    read_frames,
+    source_bounds,
+    start_frame,
+)
+from ..timing import SECONDS_PRECISION
+from . import decode, energy, records
+from .beats import nearest
+
+log = get_logger("analysis")
+
+KIND = "correlate_timeline"
+
+INLINE_CUTS = 12
+"""How many records the gist carries: enough to see the shape of the cut, not the concert."""
+
+UNLABELLED = "unlabelled"
+"""Where shots from a clip the angle sidecar does not name are counted."""
+
+Onsets = Callable[[Path], tuple[float, ...]]
+"""The transient seam: a WAV in, onset times in seconds out."""
+
+
+class Shot(NamedTuple):
+    """One shot as the measurement needs it: what it is and where it sits."""
+
+    clip: str
+    record_in: int
+    duration: int
+
+    @property
+    def record_out(self) -> int:
+        return self.record_in + self.duration
+
+
+class Clock(NamedTuple):
+    """How a timeline frame becomes a second in the analysed mix."""
+
+    zero_frame: int
+    fps: float
+    mode: str
+    audio: str | None
+
+    def seconds(self, frame: int) -> float:
+        """Where ``frame`` falls in the analysis, unrounded — the callers round."""
+        return (frame - self.zero_frame) / self.fps
+
+    def reading(self) -> dict[str, Any]:
+        return {"mode": self.mode, "audio": self.audio, "zero_frame": self.zero_frame}
+
+
+class Music(NamedTuple):
+    """Everything read off disk: the grid, the transients' source, and the optional shape."""
+
+    beats: tuple[dict[str, Any], ...]
+    tunes: tuple[dict[str, Any], ...] | None
+    solos: tuple[dict[str, Any], ...] | None
+    roles: dict[str, str] | None
+    audio: Path | None
+
+
+def correlate_timeline(
+    connection: ResolveConnection,
+    beats: str,
+    timeline: str | None = None,
+    audio: str | None = None,
+    tunes: str | None = None,
+    solos: str | None = None,
+    angles: Mapping[str, Any] | None = None,
+    track: int = FIRST_TRACK,
+    refresh: bool = False,
+    onsets: Onsets | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Start a job measuring a timeline against its music analysis. Returns the job record.
+
+    Every input is read and checked here, before the job exists: a path that is not there
+    and a file that is not what it claims are wrong *calls*, and a wrong call should come
+    back from the tool rather than from a poll two seconds later.
+
+    ``angles`` is a mapping the caller passes, not a file this reads: the angle sidecar is
+    the agent's document (#45 — no server path reads or writes it), so the labels arrive
+    already lifted out of it.
+
+    ``onsets`` is the transient seam; the default decodes the audio for real.
+    """
+    config = config or get_config()
+    roles = _roles(angles)
+    music = _music(beats, audio, tunes, solos, roles)
+    shots, clock, print_, name = _read_cut(connection, timeline, track)
+
+    params: dict[str, Any] = {
+        "timeline": name,
+        "track": int(track),
+        "beats": _named(beats),
+        "audio": _named(audio),
+        "tunes": _named(tunes),
+        "solos": _named(solos),
+        "angles": dict(sorted(roles.items())) if roles is not None else None,
+    }
+    watched = [print_, *_fingerprints(beats, audio, tunes, solos)]
+    key = cache.cache_key(KIND, watched, params)
+
+    def work(progress: Progress) -> JobOutput:
+        return correlate(shots, clock, name, music, key, params, progress, onsets, config)
+
+    return start_job(KIND, params, work, cache_key=key, refresh=refresh, config=config)
+
+
+def correlate(
+    shots: Sequence[Shot],
+    clock: Clock,
+    name: str,
+    music: Music,
+    key: str,
+    params: dict[str, Any],
+    progress: Progress,
+    onsets: Onsets | None = None,
+    config: Config | None = None,
+) -> JobOutput:
+    """The worker: transients, then one record per shot on disk and the stats inline."""
+    config = config or get_config()
+
+    progress(0.1, "reading the transients")
+    transients = _transients(music.audio, onsets)
+
+    progress(0.7, "measuring the cut against the music")
+    rows = measure(shots, clock, music, transients)
+    summary = _summary(rows, clock, transients)
+
+    target = config.analysis_dir / keyed_name(name, key, ".correlate.json", "correlate")
+    # "count", not "cuts": the records themselves are the file's ``cuts`` field, and a header
+    # key of the same name would be a second one that only the last reader of the two sees.
+    header: dict[str, Any] = {
+        "kind": KIND,
+        "timeline": name,
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "inputs": {named: value for named, value in params.items() if named != "timeline"},
+        **{named: value for named, value in summary.items() if named != "cuts"},
+        "count": summary["cuts"],
+    }
+    records.write(target, header, "cuts", rows)
+
+    log.info("Measured %d shot(s) of %s against its music into %s", len(rows), name, target)
+    return JobOutput({"path": str(target), **summary, "first_cuts": rows[:INLINE_CUTS]}, (target,))
+
+
+# --- reading the cut --------------------------------------------------------------------------
+
+
+def _read_cut(
+    connection: ResolveConnection,
+    name: str | None,
+    track: int,
+) -> tuple[list[Shot], Clock, dict[str, Any], str]:
+    """Everything Resolve has to answer for, taken before the job starts.
+
+    A job that reached back into Resolve would be measuring a timeline the director may
+    have moved on from, and would need the Resolve lock to do it. One reading up front,
+    then arithmetic — and a handle that dies during it fails the *call*, which is the one
+    failure the tool layer's single reconnect can still fix.
+    """
+    project = open_project(connection)
+    timeline = find_timeline(project, name)
+    reader = Reader(connection)
+    found = name_of(timeline)
+
+    fps = frame_rate(project, timeline)
+    if not fps:
+        raise InvalidRequestError(
+            cause=f"Resolve reported no frame rate for {found!r}, so no shot has a time.",
+            fix="Open the timeline in Resolve and check its frame rate, then measure again.",
+            detail={"timeline": found},
+        )
+
+    shots = _shots(reader, timeline, track)
+    if not shots:
+        raise InvalidRequestError(
+            cause=f"Video track {track} of {found!r} holds no shots to measure.",
+            fix=(
+                "Name the timeline with timeline= and the track the cut sits on with track= "
+                "— inspect_timeline shows which tracks hold what."
+            ),
+            detail={"timeline": found, "track": int(track)},
+        )
+    return shots, _clock(reader, timeline, fps), fingerprint(reader, timeline), found
+
+
+def _shots(reader: Reader, timeline: Any, track: int) -> list[Shot]:
+    """The shots on one video track, in the order they play.
+
+    A shot whose position will not read is dropped rather than guessed at: a measurement
+    with an invented time in it is worse than one shot short, and the log says which.
+    """
+    found: list[Shot] = []
+    for item in items_in_track(timeline, "video", int(track)):
+        record_in = read_frames(item.GetStart())
+        duration = read_frames(item.GetDuration())
+        if record_in is None or duration is None:
+            log.warning("Skipped a shot on video track %d: Resolve gave no position", track)
+            continue
+        name = clip_name(reader, item) or str(item.GetName() or "")
+        found.append(Shot(clip=name, record_in=record_in, duration=duration))
+    return sorted(found, key=lambda shot: shot.record_in)
+
+
+def _clock(reader: Reader, timeline: Any, fps: float) -> Clock:
+    """Where the analysed mix sits under the cut, read off the first audio shot there is.
+
+    The mix is one continuous clip under the whole cut (#22: the cutting substrate), so its
+    record position and its own in point together say which second of the analysis any
+    timeline frame is.
+    """
+    count = int(read_frames(reader.optional(timeline, "GetTrackCount", 0, "audio")) or 0)
+    for index in range(1, count + 1):
+        for item in items_in_track(timeline, "audio", index):
+            record_in = read_frames(item.GetStart())
+            source_in, _ = source_bounds(reader, item, read_frames(item.GetDuration()))
+            if record_in is None or source_in is None:
+                continue
+            name = clip_name(reader, item) or str(item.GetName() or "")
+            return Clock(record_in - source_in, fps, "audio_clip", name)
+    return Clock(start_frame(timeline), fps, "timeline_start", None)
+
+
+# --- reading the analysis ---------------------------------------------------------------------
+
+
+def _music(
+    beats: str,
+    audio: str | None,
+    tunes: str | None,
+    solos: str | None,
+    roles: dict[str, str] | None,
+) -> Music:
+    """Every file the measurement joins — or a refusal naming the one that is not there."""
+    return Music(
+        beats=_rows(_path(beats, "beat grid", "analyze_music writes it"), "beats"),
+        tunes=_optional_rows(tunes, "tune list", "tunes"),
+        solos=_optional_rows(solos, "solo changes", "solos"),
+        roles=roles,
+        audio=_path(audio, "master mix", "it is the file the analysis ran on") if audio else None,
+    )
+
+
+def _optional_rows(file: str | None, what: str, field: str) -> tuple[dict[str, Any], ...] | None:
+    if file is None:
+        return None
+    return _rows(_path(file, what, "the structure analysis writes it"), field)
+
+
+def _path(file: str, what: str, provenance: str) -> Path:
+    path = Path(file).expanduser()
+    if not path.is_file():
+        raise InvalidRequestError(
+            cause=f"There is no {what} at {str(path)!r}.",
+            fix=(
+                f"Pass the path a finished analysis job returned — {provenance}. "
+                "analyze_music names the beats file in its result; get_job has it too."
+            ),
+            detail={"file": str(path)},
+        )
+    return path
+
+
+def _rows(path: Path, field: str) -> tuple[dict[str, Any], ...]:
+    """One analysis file's records, in time order — the shape ``records.write`` leaves."""
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise InvalidRequestError(
+            cause=f"Could not read {path.name} as analysis JSON: {exc}.",
+            fix="Pass the path an analysis job returned, unedited.",
+            detail={"file": str(path), "field": field},
+        ) from exc
+
+    held = doc.get(field) if isinstance(doc, Mapping) else None
+    if not isinstance(held, list):
+        raise InvalidRequestError(
+            cause=f"{path.name} holds no {field!r} records.",
+            fix=f"That file is not the {field} analysis; pass the one whose kind is {field!r}.",
+            detail={"file": str(path), "field": field},
+        )
+    rows = [
+        dict(row)
+        for row in held
+        if isinstance(row, Mapping) and isinstance(row.get("t"), int | float)
+    ]
+    return tuple(sorted(rows, key=lambda row: float(row["t"])))
+
+
+def _roles(angles: Mapping[str, Any] | None) -> dict[str, str] | None:
+    """Clip name to angle role, as the agent lifted it out of its own sidecar.
+
+    Two shapes read the same, because what the agent has to hand is whatever it wrote in
+    that sidecar: a bare string is the role, and an object is a labelling with a ``role`` in
+    it alongside whatever else was recorded about that angle. An entry with no role in it is
+    dropped rather than refused — a sidecar that labels a camera by subject alone is a
+    half-labelled corpus, not a wrong call.
+    """
+    if angles is None:
+        return None
+    if not isinstance(angles, Mapping):
+        raise InvalidRequestError(
+            cause="angles is not a mapping of clip name to angle.",
+            fix='Pass {"C0012.mp4": {"role": "drums"}} — the role may also be a bare string.',
+            detail={"angles": repr(angles)},
+        )
+    return {str(clip): role for clip, entry in angles.items() if (role := _role(entry)) is not None}
+
+
+def _role(entry: Any) -> str | None:
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, Mapping) and isinstance(entry.get("role"), str):
+        return str(entry["role"])
+    return None
+
+
+def _transients(audio: Path | None, onsets: Onsets | None) -> tuple[float, ...] | None:
+    """Onset times for the mix, or ``None`` when no mix was named.
+
+    Not measuring is a different answer from measuring nothing, and the difference decides
+    whether the file's transient column means "the cut is nowhere near a hit" or "nobody
+    looked" — so it stays ``None`` all the way to the gist.
+    """
+    if audio is None:
+        return None
+    detect = onsets or measured_onsets
+    return tuple(sorted(detect(audio)))
+
+
+def measured_onsets(path: Path) -> tuple[float, ...]:
+    """The default detector: decode the mix and take its onsets."""
+    return tuple(float(seconds) for seconds in energy.onsets(decode.read(path)))
+
+
+def _fingerprints(*files: str | None) -> list[dict[str, Any]]:
+    """What the cache watches besides the cut: the analysis the measurement is made against."""
+    return [cache.fingerprint(Path(file).expanduser()) for file in files if file is not None]
+
+
+def _named(file: str | None) -> str | None:
+    return None if file is None else str(Path(file).expanduser())
+
+
+# --- the measurement --------------------------------------------------------------------------
+
+
+def measure(
+    shots: Sequence[Shot],
+    clock: Clock,
+    music: Music,
+    transients: Sequence[float] | None,
+) -> list[dict[str, Any]]:
+    """One record per shot: where it starts in the music, and how far off everything it is.
+
+    Offsets are signed from the cut to the thing it is measured against, so a negative
+    number is a cut that arrives early and a positive one is a cut that arrives late. That
+    sign is the whole point: cutting just before a hit and just after it are opposite
+    edits, and an absolute value would call them the same.
+    """
+    times = [float(row["t"]) for row in music.beats]
+    tune_times = [float(row["t"]) for row in (music.tunes or ())]
+    solo_times = [float(row["t"]) for row in (music.solos or ())]
+    roles = music.roles or {}
+
+    rows: list[dict[str, Any]] = []
+    for index, shot in enumerate(shots, start=1):
+        seconds = clock.seconds(shot.record_in)
+        beat = _beat_at(music.beats, times, seconds)
+        rows.append(
+            {
+                "cut": index,
+                "clip": shot.clip,
+                "role": roles.get(shot.clip),
+                # The first shot starts where the timeline does; nothing was cut *to* the
+                # music there, so it is marked and left out of the offset statistics.
+                "opening": index == 1,
+                "t": _rounded(seconds),
+                "in": shot.record_in,
+                "out": shot.record_out,
+                "seconds": _rounded(shot.duration / clock.fps),
+                "beat_offset": None if beat is None else _rounded(seconds - float(beat["t"])),
+                "beat": None if beat is None else beat.get("beat"),
+                "bar": None if beat is None else beat.get("bar"),
+                "in_bar": None if beat is None else beat.get("in_bar"),
+                "transient_offset": _offset(transients, seconds),
+                "tune": _tune_at(music.tunes, tune_times, seconds),
+                "front": _front_at(music.solos, solo_times, seconds),
+            }
+        )
+    return rows
+
+
+def _beat_at(
+    rows: Sequence[dict[str, Any]],
+    times: Sequence[float],
+    seconds: float,
+) -> dict[str, Any] | None:
+    found = nearest(times, seconds)
+    return None if found is None else rows[found]
+
+
+def _offset(times: Sequence[float] | None, seconds: float) -> float | None:
+    if times is None:
+        return None
+    found = nearest(times, seconds)
+    return None if found is None else _rounded(seconds - times[found])
+
+
+def _tune_at(
+    rows: Sequence[dict[str, Any]] | None,
+    times: Sequence[float],
+    seconds: float,
+) -> int | None:
+    """Which tune a cut happens in — nothing at all when it lands in the applause between two."""
+    if not rows:
+        return None
+    for row, start in zip(rows, times, strict=False):
+        end = row.get("end")
+        if start <= seconds and isinstance(end, int | float) and seconds < float(end):
+            return int(row["tune"]) if isinstance(row.get("tune"), int | float) else None
+    return None
+
+
+def _front_at(
+    rows: Sequence[dict[str, Any]] | None,
+    times: Sequence[float],
+    seconds: float,
+) -> str | None:
+    """Who was out front when the cut happened: the last change at or before it."""
+    if not rows:
+        return None
+    held: str | None = None
+    for row, start in zip(rows, times, strict=False):
+        if start > seconds:
+            break
+        entered = row.get("to")
+        held = str(entered) if isinstance(entered, str) else held
+    return held
+
+
+# --- the stats --------------------------------------------------------------------------------
+
+
+def _summary(
+    rows: Sequence[dict[str, Any]],
+    clock: Clock,
+    transients: Sequence[float] | None,
+) -> dict[str, Any]:
+    """The list-free reading: what a style profile is written from, and a self-review read.
+
+    Every stat is taken over the records as they were written, not over the unrounded
+    arithmetic behind them, so the gist and the file never disagree: an agent that greps the
+    file and averages the column gets the number it was already told.
+    """
+    cut_to_music = [row for row in rows if not row["opening"]]
+    transient_offsets = (
+        None if transients is None else _offsets([row["transient_offset"] for row in cut_to_music])
+    )
+    return {
+        "timeline_fps": clock.fps,
+        "alignment": clock.reading(),
+        "cuts": len(rows),
+        "openings": sum(1 for row in rows if row["opening"]),
+        "beat_offsets": _offsets([row["beat_offset"] for row in cut_to_music]),
+        "transient_offsets": transient_offsets,
+        "bars": _histogram(row["in_bar"] for row in cut_to_music),
+        "tunes": _spread("tune", cut_to_music) if _measured("tune", rows) else None,
+        "solos": _spread("front", cut_to_music) if _measured("front", rows) else None,
+        "shot_seconds": _lengths([row["seconds"] for row in rows]),
+        "clips": _usage(rows, "clip"),
+        "roles": _usage(rows, "role") if _measured("role", rows) else {},
+    }
+
+
+def _measured(field: str, rows: Sequence[dict[str, Any]]) -> bool:
+    """Whether a column was measured at all — an input nobody named reads as nothing, not zero."""
+    return any(row[field] is not None for row in rows)
+
+
+def _offsets(found: Sequence[float | None]) -> dict[str, Any] | None:
+    """How far off the cuts are, and which way — early and late counted apart."""
+    measured = [value for value in found if value is not None]
+    if not measured:
+        return None
+    sizes = [abs(value) for value in measured]
+    return {
+        "measured": len(measured),
+        "mean_abs": _rounded(statistics.fmean(sizes)),
+        "median_abs": _rounded(statistics.median(sizes)),
+        "max_abs": _rounded(max(sizes)),
+        "early": sum(1 for value in measured if value < 0),
+        "late": sum(1 for value in measured if value > 0),
+        "on": sum(1 for value in measured if value == 0),
+    }
+
+
+def _lengths(seconds: Sequence[float]) -> dict[str, Any]:
+    if not seconds:
+        return {"mean": None, "median": None, "min": None, "max": None}
+    return {
+        "mean": _rounded(statistics.fmean(seconds)),
+        "median": _rounded(statistics.median(seconds)),
+        "min": _rounded(min(seconds)),
+        "max": _rounded(max(seconds)),
+    }
+
+
+def _usage(rows: Sequence[dict[str, Any]], field: str) -> dict[str, dict[str, Any]]:
+    """How much of the cut each angle — or each role — actually holds.
+
+    Counted in both shots and seconds because they answer different questions: a role can
+    take a third of the cuts and a tenth of the screen time, and which of those a style
+    profile should say is the director's call, not this tool's.
+    """
+    total = sum(float(row["seconds"]) for row in rows) or 1.0
+    usage: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        held = row[field]
+        key = UNLABELLED if held is None else str(held)
+        entry = usage.setdefault(key, {"cuts": 0, "seconds": 0.0, "share": 0.0})
+        entry["cuts"] += 1
+        entry["seconds"] += float(row["seconds"])
+    for entry in usage.values():
+        entry["share"] = _rounded(entry["seconds"] / total)
+        entry["seconds"] = _rounded(entry["seconds"])
+    return usage
+
+
+def _spread(field: str, rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """How the cuts fall across the tunes, or across who was in front."""
+    placed = [row[field] for row in rows if row[field] is not None]
+    return {
+        "covered": len(set(placed)),
+        "outside": len(rows) - len(placed),
+        "cuts": _histogram(iter(placed)),
+    }
+
+
+def _histogram(values: Any) -> dict[str, int]:
+    """Counts keyed by value as a string — JSON has no integer keys to speak of."""
+    counted = Counter(value for value in values if value is not None)
+    return {str(key): count for key, count in sorted(counted.items(), key=lambda one: str(one[0]))}
+
+
+def _rounded(seconds: float) -> float:
+    return round(seconds, SECONDS_PRECISION)
+
+
+__all__ = [
+    "INLINE_CUTS",
+    "KIND",
+    "Clock",
+    "Music",
+    "Onsets",
+    "Shot",
+    "correlate_timeline",
+    "measure",
+]

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -58,7 +58,7 @@ from ..resolve.timeline import (
     source_bounds,
     start_frame,
 )
-from ..timing import SECONDS_PRECISION
+from ..timing import SECONDS_PRECISION, dual_time
 from . import decode, energy, records
 from .beats import nearest
 
@@ -95,13 +95,20 @@ class Clock(NamedTuple):
     fps: float
     mode: str
     audio: str | None
+    matched: bool
 
     def seconds(self, frame: int) -> float:
         """Where ``frame`` falls in the analysis, unrounded — the callers round."""
         return (frame - self.zero_frame) / self.fps
 
     def reading(self) -> dict[str, Any]:
-        return {"mode": self.mode, "audio": self.audio, "zero_frame": self.zero_frame}
+        """How the times were arrived at — the first thing to check when they look wrong."""
+        return {
+            "mode": self.mode,
+            "audio": self.audio,
+            "matched": self.matched,
+            "zero_frame": self.zero_frame,
+        }
 
 
 class Music(NamedTuple):
@@ -142,7 +149,7 @@ def correlate_timeline(
     config = config or get_config()
     roles = _roles(angles)
     music = _music(beats, audio, tunes, solos, roles)
-    shots, clock, print_, name = _read_cut(connection, timeline, track)
+    shots, clock, print_, name = _read_cut(connection, timeline, track, music.audio)
 
     params: dict[str, Any] = {
         "timeline": name,
@@ -181,7 +188,7 @@ def correlate(
 
     progress(0.7, "measuring the cut against the music")
     rows = measure(shots, clock, music, transients)
-    summary = _summary(rows, clock, transients)
+    summary = _summary(rows, clock, transients, [float(one["t"]) for one in music.beats])
 
     target = config.analysis_dir / keyed_name(name, key, ".correlate.json", "correlate")
     # "count", not "cuts": the records themselves are the file's ``cuts`` field, and a header
@@ -207,6 +214,7 @@ def _read_cut(
     connection: ResolveConnection,
     name: str | None,
     track: int,
+    mix: Path | None = None,
 ) -> tuple[list[Shot], Clock, dict[str, Any], str]:
     """Everything Resolve has to answer for, taken before the job starts.
 
@@ -238,7 +246,8 @@ def _read_cut(
             ),
             detail={"timeline": found, "track": int(track)},
         )
-    return shots, _clock(reader, timeline, fps), fingerprint(reader, timeline), found
+    clock = _clock(reader, timeline, fps, mix)
+    return shots, clock, fingerprint(reader, timeline), found
 
 
 def _shots(reader: Reader, timeline: Any, track: int) -> list[Shot]:
@@ -259,14 +268,38 @@ def _shots(reader: Reader, timeline: Any, track: int) -> list[Shot]:
     return sorted(found, key=lambda shot: shot.record_in)
 
 
-def _clock(reader: Reader, timeline: Any, fps: float) -> Clock:
-    """Where the analysed mix sits under the cut, read off the first audio shot there is.
+def _clock(reader: Reader, timeline: Any, fps: float, mix: Path | None) -> Clock:
+    """Where the analysed mix sits under the cut, read off the audio shot that holds it.
 
     The mix is one continuous clip under the whole cut (#22: the cutting substrate), so its
     record position and its own in point together say which second of the analysis any
     timeline frame is.
+
+    *Which* audio clip is the question. On a cut this server built, A1 is the mix; on a
+    hand-edited concert it is routinely camera scratch, and anchoring to that would shift
+    every time in the file by however far apart the two recordings start. So when the caller
+    named the audio, the clip carrying that file wins, and ``matched`` says whether the mix
+    was recognised or merely assumed — which is the difference between a reading to trust
+    and one to check before writing a style profile from it.
+    """
+    found = _audio_shots(reader, timeline)
+    wanted = _matching(found, mix)
+    chosen = wanted or (found[0] if found else None)
+    if chosen is None:
+        return Clock(start_frame(timeline), fps, "timeline_start", None, False)
+    name, record_in, source_in = chosen
+    return Clock(record_in - source_in, fps, "audio_clip", name, wanted is not None)
+
+
+def _audio_shots(reader: Reader, timeline: Any) -> list[tuple[str, int, int]]:
+    """Every audio shot that will say where it sits: its clip name, record in and mix in.
+
+    The mix in is counted from the *start of the file*, not from the clip's own start
+    timecode: a WAV stamped 01:00:00:00 reports source frames an hour in, and subtracting
+    that stamp is the difference between a correct reading and one shifted by an hour.
     """
     count = int(read_frames(reader.optional(timeline, "GetTrackCount", 0, "audio")) or 0)
+    found: list[tuple[str, int, int]] = []
     for index in range(1, count + 1):
         for item in items_in_track(timeline, "audio", index):
             record_in = read_frames(item.GetStart())
@@ -274,8 +307,30 @@ def _clock(reader: Reader, timeline: Any, fps: float) -> Clock:
             if record_in is None or source_in is None:
                 continue
             name = clip_name(reader, item) or str(item.GetName() or "")
-            return Clock(record_in - source_in, fps, "audio_clip", name)
-    return Clock(start_frame(timeline), fps, "timeline_start", None)
+            found.append((name, record_in, source_in - _media_start(reader, item)))
+    return found
+
+
+def _media_start(reader: Reader, item: Any) -> int:
+    """The first frame of the media itself, which is not zero on anything with a start stamp."""
+    clip = reader.optional(item, "GetMediaPoolItem", None)
+    if clip is None:
+        return 0
+    return read_frames(reader.optional(clip, "GetClipProperty", None, "Start")) or 0
+
+
+def _matching(
+    found: Sequence[tuple[str, int, int]],
+    mix: Path | None,
+) -> tuple[str, int, int] | None:
+    """The audio shot holding the file the analysis ran on, by name or by stem."""
+    if mix is None:
+        return None
+    names = {mix.name.casefold(), mix.stem.casefold()}
+    for shot in found:
+        if shot[0].casefold() in names or Path(shot[0]).stem.casefold() in names:
+            return shot
+    return None
 
 
 # --- reading the analysis ---------------------------------------------------------------------
@@ -341,6 +396,18 @@ def _rows(path: Path, field: str) -> tuple[dict[str, Any], ...]:
         for row in held
         if isinstance(row, Mapping) and isinstance(row.get("t"), int | float)
     ]
+    if not rows:
+        # A file that was named but says nothing must not read like a file nobody named:
+        # both would leave the column null, and only one of them is what the caller meant.
+        raise InvalidRequestError(
+            cause=f"{path.name} holds no {field} record with a time in it.",
+            fix=(
+                f"Pass the {field} file a finished analysis job wrote — its records each "
+                'carry a "t" in seconds. An analysis that found nothing is worth rerunning '
+                "rather than measuring against."
+            ),
+            detail={"file": str(path), "field": field},
+        )
     return tuple(sorted(rows, key=lambda row: float(row["t"])))
 
 
@@ -429,12 +496,13 @@ def measure(
                 "cut": index,
                 "clip": shot.clip,
                 "role": roles.get(shot.clip),
-                # The first shot starts where the timeline does; nothing was cut *to* the
-                # music there, so it is marked and left out of the offset statistics.
-                "opening": index == 1,
+                "opening": _opens(index, shot, shots),
                 "t": _rounded(seconds),
-                "in": shot.record_in,
-                "out": shot.record_out,
+                # Dual time for the two timeline positions, because an outlier the agent
+                # flags is one the director then has to find in Resolve, and a bare frame
+                # number is the one form nobody can scrub to.
+                "in": dual_time(shot.record_in, clock.fps),
+                "out": dual_time(shot.record_out, clock.fps),
                 "seconds": _rounded(shot.duration / clock.fps),
                 "beat_offset": None if beat is None else _rounded(seconds - float(beat["t"])),
                 "beat": None if beat is None else beat.get("beat"),
@@ -446,6 +514,18 @@ def measure(
             }
         )
     return rows
+
+
+def _opens(index: int, shot: Shot, shots: Sequence[Shot]) -> bool:
+    """Whether this shot starts something rather than cutting away from something.
+
+    The first shot is one. So is a shot that begins after a gap: there is no outgoing angle
+    at that frame, so its distance from the nearest beat says nothing about how the director
+    cuts, and averaging it in would quietly describe a style nobody has. Both are marked
+    rather than dropped — a hand-edited timeline with three gaps in it is still a
+    measurement, and the records say which shots were left out of the statistics.
+    """
+    return index == 1 or shot.record_in != shots[index - 2].record_out
 
 
 def _beat_at(
@@ -484,10 +564,16 @@ def _front_at(
     times: Sequence[float],
     seconds: float,
 ) -> str | None:
-    """Who was out front when the cut happened: the last change at or before it."""
+    """Who was out front when the cut happened: the last change at or before it.
+
+    Before the first change there is still someone out front — the change records who it
+    was, as the voice it took over *from* — so a cut in the opening head reads as that
+    player rather than as nobody.
+    """
     if not rows:
         return None
-    held: str | None = None
+    first = rows[0].get("from")
+    held: str | None = str(first) if isinstance(first, str) else None
     for row, start in zip(rows, times, strict=False):
         if start > seconds:
             break
@@ -503,6 +589,7 @@ def _summary(
     rows: Sequence[dict[str, Any]],
     clock: Clock,
     transients: Sequence[float] | None,
+    grid: Sequence[float],
 ) -> dict[str, Any]:
     """The list-free reading: what a style profile is written from, and a self-review read.
 
@@ -519,6 +606,7 @@ def _summary(
         "alignment": clock.reading(),
         "cuts": len(rows),
         "openings": sum(1 for row in rows if row["opening"]),
+        "outside_grid": _outside(rows, grid),
         "beat_offsets": _offsets([row["beat_offset"] for row in cut_to_music]),
         "transient_offsets": transient_offsets,
         "bars": _histogram(row["in_bar"] for row in cut_to_music),
@@ -526,8 +614,21 @@ def _summary(
         "solos": _spread("front", cut_to_music) if _measured("front", rows) else None,
         "shot_seconds": _lengths([row["seconds"] for row in rows]),
         "clips": _usage(rows, "clip"),
-        "roles": _usage(rows, "role") if _measured("role", rows) else {},
+        "roles": _usage(rows, "role") if _measured("role", rows) else None,
     }
+
+
+def _outside(rows: Sequence[dict[str, Any]], grid: Sequence[float]) -> int:
+    """How many cuts fall outside the analysed span — the tell for a misaligned clock.
+
+    The nearest-beat lookup clamps: a cut an hour past the end of the grid still reports a
+    small-looking offset against the last beat, so a whole file measured against the wrong
+    audio looks well-formed. Anything above zero here means the times and the analysis are
+    not describing the same recording, and the alignment is what to check first.
+    """
+    if not grid:
+        return len(rows)
+    return sum(1 for row in rows if not grid[0] <= float(row["t"]) <= grid[-1])
 
 
 def _measured(field: str, rows: Sequence[dict[str, Any]]) -> bool:
@@ -604,13 +705,3 @@ def _rounded(seconds: float) -> float:
     return round(seconds, SECONDS_PRECISION)
 
 
-__all__ = [
-    "INLINE_CUTS",
-    "KIND",
-    "Clock",
-    "Music",
-    "Onsets",
-    "Shot",
-    "correlate_timeline",
-    "measure",
-]

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -511,7 +511,7 @@ def _read_track(
     in_range = [
         (item, placement)
         for item, placement in (
-            (item, _placement(item)) for item in _items_in_track(timeline, track_type, index)
+            (item, _placement(item)) for item in items_in_track(timeline, track_type, index)
         )
         if _touches(placement, window)
     ]
@@ -570,7 +570,7 @@ def _touches(placement: Placement, window: tuple[int, int]) -> bool:
     return overlaps(placement.start, placement.end, window)
 
 
-def _items_in_track(timeline: Timeline, track_type: str, index: int) -> list[TimelineItem]:
+def items_in_track(timeline: Timeline, track_type: str, index: int) -> list[TimelineItem]:
     """The shots on one track. An empty track answers ``None`` rather than an empty list."""
     return list(timeline.GetItemListInTrack(track_type, index) or [])
 
@@ -596,7 +596,7 @@ def read_item(
     """One shot: where it sits, where it came from, and the offset between the two."""
     record_in, duration = placement.start, placement.duration
     record_out = placement.end
-    source_in, source_out = _source_bounds(reader, item, duration)
+    source_in, source_out = source_bounds(reader, item, duration)
     offset = record_in - source_in if record_in is not None and source_in is not None else None
     return {
         "name": str(item.GetName() or ""),
@@ -608,7 +608,7 @@ def read_item(
         },
         "source": {"in": dual_time(source_in, fps), "out": dual_time(source_out, fps)},
         "sync_offset": dual_time(offset, fps),
-        "clip": _clip_name(reader, item),
+        "clip": clip_name(reader, item),
         "enabled": bool(reader.optional(item, "GetClipEnabled", True)),
         # ``GetTakesCount``, not ``GetTakeCount``: the plural is the method the scripting
         # README actually declares (line 523), and fusionscript answers an unknown name
@@ -617,7 +617,7 @@ def read_item(
     }
 
 
-def _source_bounds(
+def source_bounds(
     reader: Reader,
     item: TimelineItem,
     duration: int | None,
@@ -647,7 +647,7 @@ def _source_bounds(
     return offset, (offset + duration if duration is not None else None)
 
 
-def _clip_name(reader: Reader, item: TimelineItem) -> str | None:
+def clip_name(reader: Reader, item: TimelineItem) -> str | None:
     """The media pool clip a shot came from — a generator or title has none."""
     clip = reader.optional(item, "GetMediaPoolItem", None)
     if clip is None:

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..analysis import music, silence, transcribe, transcript, whisper
+from ..analysis import correlate, music, silence, transcribe, transcript, whisper
 from ..resolve.connection import get_connection
+from ..resolve.timeline import FIRST_TRACK
 from .envelope import tool
 
 
@@ -97,6 +98,58 @@ def transcribe_audio(
     }
 
 
-TOOLS: tuple[Any, ...] = (transcribe_audio, analyze_music)
+@tool
+def correlate_timeline(
+    beats: str,
+    timeline: str | None = None,
+    audio: str | None = None,
+    tunes: str | None = None,
+    solos: str | None = None,
+    angles: dict[str, Any] | None = None,
+    track: int = FIRST_TRACK,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    """Measure a cut against the music it was cut to. Returns a job to poll, not the measurement.
 
-__all__ = ["TOOLS", "analyze_music", "transcribe_audio"]
+    This is how style is learned from your own past edits, and how a cut you just built gets
+    reviewed before anyone watches it: for every shot, how far its start sits from the
+    nearest beat and from the nearest transient (signed — negative is early, positive is
+    late), where in the bar that lands, which tune it happens in, who was out front, how
+    long the shot runs and which angle it came from.
+
+    beats is the beats file analyze_music wrote. audio is the same master mix it analysed,
+    and naming it is what makes the transient column real — onsets are not stored by any
+    other job, so they are measured here. tunes and solos are the structure job's files.
+    angles is the angle labels themselves, not a path: {"C0012.mp4": {"role": "drums"}}, or
+    just {"C0012.mp4": "drums"} — you keep the sidecar, you read it, you pass what it says.
+    Each of these is optional, and each one absent means that column reads null rather than
+    a guess.
+
+    timeline names the cut, defaulting to the open one; track is the video track it sits on.
+    The result names a JSON file of one record per shot — grep it, or read a slice with sed
+    — and returns the reading inline: offset statistics with early and late counted apart, a
+    histogram of where in the bar the cuts land, shot-duration stats, and how much of the
+    cut each angle and role holds.
+
+    Nothing here judges the edit. Two frames late is reported as two frames late; what
+    counts as musical belongs in your style profile, not in this server.
+    """
+    connection = get_connection()
+    return {
+        "job": correlate.correlate_timeline(
+            connection,
+            beats=beats,
+            timeline=timeline,
+            audio=audio,
+            tunes=tunes,
+            solos=solos,
+            angles=angles,
+            track=track,
+            refresh=refresh,
+        )
+    }
+
+
+TOOLS: tuple[Any, ...] = (transcribe_audio, analyze_music, correlate_timeline)
+
+__all__ = ["TOOLS", "analyze_music", "correlate_timeline", "transcribe_audio"]

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -1,0 +1,428 @@
+"""Measuring a cut against its music: what lands on disk, and what comes back inline.
+
+The seam is the fake Resolve singleton for the shots and real files on disk for the
+analysis, because that is exactly what this tool joins: shots read out of Resolve, times
+read out of the files another job wrote. The transient detector is injected (ADR 0002), so
+the arithmetic under test never waits for a decode.
+
+The fixture cut is deliberately off the grid in both directions — one shot lands two frames
+late, the next one frame early — because a measurement that cannot tell early from late is
+no use to a style profile.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.analysis import beats as beats_module
+from resolve_mcp.analysis import correlate, records
+from resolve_mcp.analysis.beats import BeatGrid
+from resolve_mcp.jobs.runner import wait_for
+from resolve_mcp.resolve.connection import get_connection
+from resolve_mcp.tools import analysis as analysis_tools
+
+from .conftest import Attach
+from .fakes import FakeMediaPoolItem, FakeTimeline, FakeTimelineItem, FakeTrack, studio
+
+FPS = "60"
+
+BEAT_SECONDS = tuple(index * 0.5 for index in range(13))
+"""Half-second beats from zero: 120bpm, four to the bar, six seconds of concert."""
+
+ONSETS = (1.05, 2.48)
+"""Two transients, one either side of the beat the cuts near them are measured against."""
+
+SHOTS = (
+    ("C0012.mp4", 100, 62, 1000),
+    ("C0031.mp4", 162, 87, 4200),
+    ("C0012.mp4", 249, 50, 1400),
+)
+"""name, record in, duration, source in — a cut at 1.033s and another at 2.483s."""
+
+
+def a_cut(
+    name: str = "sunset-set v3",
+    shots: Sequence[tuple[str, int, int, int]] = SHOTS,
+    audio_source: int | None = 0,
+) -> FakeTimeline:
+    """Shots over one continuous master mix — the shape build_timeline materializes."""
+    audio = (
+        [FakeTrack("Master", [_shot("master_mix.wav", 100, 200, audio_source)])]
+        if audio_source is not None
+        else []
+    )
+    return FakeTimeline(
+        name,
+        FPS,
+        start_frame=100,
+        video=[FakeTrack("Video 1", [_shot(*shot) for shot in shots])],
+        audio=audio,
+    )
+
+
+def _shot(name: str, start: int, duration: int, source_start: int) -> FakeTimelineItem:
+    return FakeTimelineItem(
+        name,
+        start,
+        duration,
+        source_start=source_start,
+        media_item=FakeMediaPoolItem(name),
+    )
+
+
+def beats_file(tmp_path: Path, seconds: Sequence[float] = BEAT_SECONDS) -> Path:
+    """A beats file in the shape analyze_music writes: header, then one record per line.
+
+    Written once per test: the cache keys off the file's mtime, so a second identical write
+    would look like new analysis and no rerun would ever be answered from cache.
+    """
+    target = tmp_path / "concert-beats.json"
+    if target.exists():
+        return target
+    grid = BeatGrid(tuple(seconds), tuple(seconds[::4]))
+    return records.write(
+        target,
+        {"kind": "beats", "audio": "concert.wav", "duration_seconds": 6.0},
+        "beats",
+        beats_module.numbered(grid),
+    )
+
+
+def tunes_file(tmp_path: Path) -> Path:
+    """Two tunes with an applause gap between them, as the structure job writes them."""
+    return records.write(
+        tmp_path / "concert-tunes.json",
+        {"kind": "tunes", "audio": "concert.wav", "count": 2},
+        "tunes",
+        [
+            {"tune": 1, "t": 0.0, "end": 2.0, "seconds": 2.0},
+            {"tune": 2, "t": 2.2, "end": 6.0, "seconds": 3.8},
+        ],
+    )
+
+
+def solos_file(tmp_path: Path) -> Path:
+    return records.write(
+        tmp_path / "concert-solos.json",
+        {"kind": "solos", "audio": "concert.wav", "count": 2},
+        "solos",
+        [
+            {"change": 1, "t": 0.0, "to": "drums", "from": None, "signal": "prominence"},
+            {"change": 2, "t": 2.0, "to": "other", "from": "drums", "signal": "timbre"},
+        ],
+    )
+
+
+
+
+def _onsets(times: Sequence[float] = ONSETS) -> correlate.Onsets:
+    def detect(path: Path) -> tuple[float, ...]:
+        return tuple(times)
+
+    return detect
+
+
+def _audio(tmp_path: Path) -> Path:
+    """A stand-in master mix: the injected detector never opens it, the cache only stats it."""
+    target = tmp_path / "master_mix.wav"
+    if not target.exists():
+        target.write_bytes(b"RIFF----WAVE")
+    return target
+
+
+def _started(tmp_path: Path, **overrides: Any) -> dict[str, Any]:
+    call: dict[str, Any] = {
+        "beats": str(beats_file(tmp_path)),
+        "audio": str(_audio(tmp_path)),
+        "onsets": _onsets(),
+    }
+    call.update(overrides)
+    return correlate.correlate_timeline(get_connection(), **call)
+
+
+def _measured(tmp_path: Path, **overrides: Any) -> dict[str, Any]:
+    """Start the job the way the tool does and hand back its completed result."""
+    return _result(_started(tmp_path, **overrides))
+
+
+def _result(started: dict[str, Any]) -> dict[str, Any]:
+    record = wait_for(started["job_id"])
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    return record.result
+
+
+def _rows(result: dict[str, Any]) -> list[dict[str, Any]]:
+    written = json.loads(Path(result["path"]).read_text(encoding="utf-8"))
+    return list(written["cuts"])
+
+
+def test_every_shot_lands_on_disk_with_its_offsets_bar_and_section(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, tunes=str(tunes_file(tmp_path)), solos=str(solos_file(tmp_path)))
+
+    cuts = _rows(result)
+    assert [one["clip"] for one in cuts] == ["C0012.mp4", "C0031.mp4", "C0012.mp4"]
+    assert cuts[1] == {
+        "cut": 2,
+        "clip": "C0031.mp4",
+        "role": None,
+        "opening": False,
+        "t": 1.033,
+        "in": 162,
+        "out": 249,
+        "seconds": 1.45,
+        "beat_offset": 0.033,
+        "beat": 3,
+        "bar": 1,
+        "in_bar": 3,
+        "transient_offset": -0.017,
+        "tune": 1,
+        "front": "drums",
+    }
+    assert cuts[2]["tune"] == 2
+    assert cuts[2]["front"] == "other"
+
+
+def test_the_offset_is_signed_from_the_cut_to_the_nearest_beat(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Early and late are different edits, so the sign has to survive to the file."""
+    attach(studio(timeline=a_cut()))
+
+    cuts = _rows(_measured(tmp_path))
+
+    late, early = cuts[1], cuts[2]
+    assert late["beat_offset"] == 0.033  # 1.033s against a beat at 1.0: two frames late
+    assert late["transient_offset"] == -0.017  # a transient at 1.05: one frame ahead of the hit
+    assert early["beat_offset"] == -0.017  # 2.483s against a beat at 2.5: one frame early
+    assert early["transient_offset"] == 0.003
+
+
+def test_the_opening_shot_is_marked_and_left_out_of_the_offset_statistics(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Where the timeline begins is not an edit decision; averaging it in would flatter it."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path)
+
+    assert _rows(result)[0]["opening"] is True
+    assert result["cuts"] == 3
+    assert result["openings"] == 1
+    assert result["beat_offsets"]["measured"] == 2
+
+
+def test_the_gist_carries_statistics_inline_and_the_records_stay_on_disk(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path)
+
+    assert result["beat_offsets"] == {
+        "measured": 2,
+        "mean_abs": 0.025,
+        "median_abs": 0.025,
+        "max_abs": 0.033,
+        "early": 1,
+        "late": 1,
+        "on": 0,
+    }
+    assert result["transient_offsets"]["mean_abs"] == 0.01
+    # Every stat is taken over the records as written, so the gist agrees to the last decimal
+    # with anything the agent computes from the file itself.
+    assert result["shot_seconds"] == {
+        "mean": 1.105,
+        "median": 1.033,
+        "min": 0.833,
+        "max": 1.45,
+    }
+    assert result["bars"] == {"2": 1, "3": 1}
+    assert len(result["first_cuts"]) == 3
+
+
+def test_roles_come_from_the_angle_sidecar_and_unlabelled_shots_say_so(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, angles={"C0031.mp4": {"role": "drums"}})
+
+    assert result["roles"]["drums"] == {"cuts": 1, "seconds": 1.45, "share": 0.437}
+    assert result["roles"]["unlabelled"]["cuts"] == 2
+    assert [one["role"] for one in _rows(result)] == [None, "drums", None]
+
+
+def test_a_role_may_be_written_as_a_bare_string(attach: Attach, tmp_path: Path) -> None:
+    """The sidecar is the agent's document; both shapes of entry it holds read the same."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, angles={"C0012.mp4": "wide"})
+
+    assert result["roles"]["wide"]["cuts"] == 2
+
+
+def test_an_entry_with_no_role_in_it_is_dropped_rather_than_refused(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Half a labelled corpus is still a measurement; a wrong call would cost the whole run."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, angles={"C0012.mp4": {"subject": "the room"}})
+
+    assert result["roles"] == {}
+
+
+def test_shots_are_counted_per_clip_even_without_a_sidecar(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Angle labels are the director's to author; the measurement stands without them."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path)
+
+    assert result["clips"]["C0012.mp4"]["cuts"] == 2
+    assert result["clips"]["C0031.mp4"]["cuts"] == 1
+    assert result["roles"] == {}
+
+
+def test_the_analysis_clock_is_read_off_the_master_audio_clip(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A cut's time is its position in the *mix*, not on the timeline: the audio says where."""
+    attach(studio(timeline=a_cut(audio_source=120)))  # the mix starts two seconds in
+
+    result = _measured(tmp_path)
+
+    assert result["alignment"] == {
+        "mode": "audio_clip",
+        "audio": "master_mix.wav",
+        "zero_frame": -20,
+    }
+    assert _rows(result)[1]["t"] == 3.033
+
+
+def test_a_timeline_without_audio_counts_from_its_own_first_frame(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timeline=a_cut(audio_source=None)))
+
+    result = _measured(tmp_path)
+
+    assert result["alignment"] == {"mode": "timeline_start", "audio": None, "zero_frame": 100}
+
+
+def test_sections_are_absent_rather_than_guessed_when_no_structure_file_is_given(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Tunes and solos are optional input; a cut still measures against the grid without them."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path)
+
+    assert result["tunes"] is None
+    assert result["solos"] is None
+    assert all(one["tune"] is None and one["front"] is None for one in _rows(result))
+
+
+def test_transients_are_not_measured_when_no_audio_is_named(
+    attach: Attach, tmp_path: Path
+) -> None:
+    def refuse(path: Path) -> tuple[float, ...]:
+        raise AssertionError("the detector must not run without audio")
+
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, audio=None, onsets=refuse)
+
+    assert result["transient_offsets"] is None
+    assert all(one["transient_offset"] is None for one in _rows(result))
+
+
+def test_an_empty_video_track_is_a_refusal_not_an_empty_measurement(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timeline=FakeTimeline("empty v1", FPS, start_frame=100)))
+
+    envelope = analysis_tools.correlate_timeline(beats=str(beats_file(tmp_path)))
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["code"] == "invalid_request"
+    assert "track" in envelope["error"]["fix"]
+    assert "context" in envelope
+
+
+def test_a_missing_analysis_file_is_refused_before_the_job_starts(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timeline=a_cut()))
+
+    envelope = analysis_tools.correlate_timeline(beats=str(tmp_path / "nothing-here.json"))
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["code"] == "invalid_request"
+    assert "analyze_music" in envelope["error"]["fix"]
+
+
+def test_a_beats_file_that_is_not_a_beats_file_names_the_field_it_wanted(
+    attach: Attach, tmp_path: Path
+) -> None:
+    wrong = tmp_path / "energy.json"
+    wrong.write_text(json.dumps({"kind": "energy", "energy": []}), encoding="utf-8")
+    attach(studio(timeline=a_cut()))
+
+    envelope = analysis_tools.correlate_timeline(beats=str(wrong))
+
+    assert envelope["ok"] is False
+    assert "beats" in envelope["error"]["cause"]
+
+
+def test_the_second_run_over_an_unchanged_cut_comes_back_from_cache(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timeline=a_cut()))
+    first = _measured(tmp_path)
+
+    started = _started(tmp_path)
+
+    assert started["cached"] is True
+    assert _result(started)["path"] == first["path"]
+
+
+def test_a_recut_is_a_different_measurement(attach: Attach, tmp_path: Path) -> None:
+    """The cache is keyed on the shots themselves, so a re-cut is never answered by an old file."""
+    attach(studio(timeline=a_cut()))
+    first = _measured(tmp_path)
+
+    swapped = (SHOTS[0], ("C0044.mp4", 162, 87, 900), SHOTS[2])
+    attach(studio(timeline=a_cut(shots=swapped)))
+    second = _measured(tmp_path)
+
+    assert second["path"] != first["path"]
+    assert _rows(second)[1]["clip"] == "C0044.mp4"
+
+
+@pytest.mark.parametrize("survives", range(1, 12))
+def test_a_handle_that_dies_mid_read_never_measures_half_a_cut(
+    attach: Attach, tmp_path: Path, survives: int
+) -> None:
+    """Every reading is taken before the job starts, so a death is a refusal, not a short file."""
+    dying = studio(timeline=a_cut())
+    dying.die_after(survives)
+    attach(dying, studio(timeline=a_cut()))
+
+    envelope = analysis_tools.correlate_timeline(beats=str(beats_file(tmp_path)))
+
+    if envelope["ok"]:
+        assert _result(envelope["job"])["cuts"] == 3
+    else:
+        assert envelope["error"]["code"] in {"resolve_unavailable", "internal_error"}

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -106,13 +106,13 @@ def tunes_file(tmp_path: Path) -> Path:
     )
 
 
-def solos_file(tmp_path: Path) -> Path:
+def solos_file(tmp_path: Path, first_from: str | None = None, first_t: float = 0.0) -> Path:
     return records.write(
-        tmp_path / "concert-solos.json",
+        tmp_path / f"concert-solos-{first_from or 'nobody'}-{first_t}.json",
         {"kind": "solos", "audio": "concert.wav", "count": 2},
         "solos",
         [
-            {"change": 1, "t": 0.0, "to": "drums", "from": None, "signal": "prominence"},
+            {"change": 1, "t": first_t, "to": "drums", "from": first_from, "signal": "prominence"},
             {"change": 2, "t": 2.0, "to": "other", "from": "drums", "signal": "timbre"},
         ],
     )
@@ -177,8 +177,8 @@ def test_every_shot_lands_on_disk_with_its_offsets_bar_and_section(
         "role": None,
         "opening": False,
         "t": 1.033,
-        "in": 162,
-        "out": 249,
+        "in": {"frames": 162, "seconds": 2.7, "timecode": "00:00:02:42", "fps": 60.0},
+        "out": {"frames": 249, "seconds": 4.15, "timecode": "00:00:04:09", "fps": 60.0},
         "seconds": 1.45,
         "beat_offset": 0.033,
         "beat": 3,
@@ -279,7 +279,7 @@ def test_an_entry_with_no_role_in_it_is_dropped_rather_than_refused(
 
     result = _measured(tmp_path, angles={"C0012.mp4": {"subject": "the room"}})
 
-    assert result["roles"] == {}
+    assert result["roles"] is None
 
 
 def test_shots_are_counted_per_clip_even_without_a_sidecar(
@@ -292,7 +292,7 @@ def test_shots_are_counted_per_clip_even_without_a_sidecar(
 
     assert result["clips"]["C0012.mp4"]["cuts"] == 2
     assert result["clips"]["C0031.mp4"]["cuts"] == 1
-    assert result["roles"] == {}
+    assert result["roles"] is None
 
 
 def test_the_analysis_clock_is_read_off_the_master_audio_clip(
@@ -306,6 +306,7 @@ def test_the_analysis_clock_is_read_off_the_master_audio_clip(
     assert result["alignment"] == {
         "mode": "audio_clip",
         "audio": "master_mix.wav",
+        "matched": True,
         "zero_frame": -20,
     }
     assert _rows(result)[1]["t"] == 3.033
@@ -318,7 +319,140 @@ def test_a_timeline_without_audio_counts_from_its_own_first_frame(
 
     result = _measured(tmp_path)
 
-    assert result["alignment"] == {"mode": "timeline_start", "audio": None, "zero_frame": 100}
+    assert result["alignment"] == {
+        "mode": "timeline_start",
+        "audio": None,
+        "matched": False,
+        "zero_frame": 100,
+    }
+
+
+def test_the_clip_holding_the_analysed_mix_wins_over_the_scratch_track(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """On a hand-edited cut A1 is routinely camera scratch; anchoring to it shifts everything."""
+    attach(
+        studio(
+            timeline=FakeTimeline(
+                "hand-edited",
+                FPS,
+                start_frame=100,
+                video=[FakeTrack("Video 1", [_shot(*shot) for shot in SHOTS])],
+                audio=[
+                    FakeTrack("Scratch", [_shot("camera_scratch.wav", 100, 200, 0)]),
+                    FakeTrack("Master", [_shot("master_mix.wav", 100, 200, 120)]),
+                ],
+            )
+        )
+    )
+
+    result = _measured(tmp_path)
+
+    assert result["alignment"]["audio"] == "master_mix.wav"
+    assert result["alignment"]["matched"] is True
+    assert _rows(result)[1]["t"] == 3.033
+
+
+def test_an_unrecognised_mix_still_measures_but_says_the_clock_was_assumed(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A reading taken off a clip nobody vouched for is the one to check before trusting it."""
+    attach(studio(timeline=a_cut()))
+
+    other = tmp_path / "some-other-mix.wav"
+    other.write_bytes(b"RIFF----WAVE")
+    result = _measured(tmp_path, audio=str(other))
+
+    assert result["alignment"]["audio"] == "master_mix.wav"
+    assert result["alignment"]["matched"] is False
+
+
+def test_a_mix_with_a_start_timecode_is_not_read_an_hour_late(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Source frames are absolute: a WAV stamped 01:00:00:00 calls its first frame 216000."""
+    stamped = FakeTimelineItem(
+        "master_mix.wav",
+        100,
+        200,
+        source_start=216000,
+        media_item=FakeMediaPoolItem("master_mix.wav", properties={"Start": "216000"}),
+    )
+    attach(
+        studio(
+            timeline=FakeTimeline(
+                "stamped",
+                FPS,
+                start_frame=100,
+                video=[FakeTrack("Video 1", [_shot(*shot) for shot in SHOTS])],
+                audio=[FakeTrack("Master", [stamped])],
+            )
+        )
+    )
+
+    result = _measured(tmp_path)
+
+    assert result["alignment"]["zero_frame"] == 100
+    assert _rows(result)[1]["t"] == 1.033
+
+
+def test_a_shot_that_starts_after_a_gap_opens_rather_than_cuts(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """There is no outgoing angle at that frame, so its distance from the beat says nothing."""
+    gapped = (SHOTS[0], ("C0031.mp4", 200, 87, 4200))
+    attach(studio(timeline=a_cut(shots=gapped)))
+
+    result = _measured(tmp_path)
+
+    assert [one["opening"] for one in _rows(result)] == [True, True]
+    assert result["openings"] == 2
+    assert result["beat_offsets"] is None
+
+
+def test_cuts_past_the_end_of_the_grid_are_counted_rather_than_pinned_quietly(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The nearest-beat lookup clamps, so a wrong clock otherwise produces well-formed nonsense."""
+    far = (*SHOTS, ("C0031.mp4", 700, 60, 5000))  # 10s in, against six seconds of analysis
+    attach(studio(timeline=a_cut(shots=far)))
+
+    result = _measured(tmp_path)
+
+    assert result["outside_grid"] == 1
+    assert result["cuts"] == 4
+
+
+def test_the_head_reads_as_whoever_the_first_change_took_over_from(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(
+        tmp_path, solos=str(solos_file(tmp_path, first_from="piano", first_t=1.5))
+    )
+
+    assert _rows(result)[1]["front"] == "piano"
+
+
+def test_a_named_analysis_file_that_says_nothing_is_refused_not_read_as_absent(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Otherwise a tunes file whose records the reader cannot use looks like no tunes file."""
+    empty = records.write(
+        tmp_path / "empty-tunes.json",
+        {"kind": "tunes", "audio": "concert.wav", "count": 0},
+        "tunes",
+        [{"note": "nothing found"}],
+    )
+    attach(studio(timeline=a_cut()))
+
+    envelope = analysis_tools.correlate_timeline(
+        beats=str(beats_file(tmp_path)), tunes=str(empty)
+    )
+
+    assert envelope["ok"] is False
+    assert "tunes" in envelope["error"]["cause"]
 
 
 def test_sections_are_absent_rather_than_guessed_when_no_structure_file_is_given(

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -37,6 +37,7 @@ from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.naming import timestamped_name
 from resolve_mcp.resolve.connection import get_connection
 from resolve_mcp.resolve.media import find_clip, media_pool
+from resolve_mcp.tools.analysis import correlate_timeline
 from resolve_mcp.tools.cut import build_timeline, swap_take, validate_cut
 from resolve_mcp.tools.escape_hatch import run_python
 from resolve_mcp.tools.jobs import get_job, list_jobs
@@ -58,6 +59,11 @@ from .fakes import write_wav
 from .text_plus_probe import TEMPLATE_ENV, probe_template_append
 
 pytestmark = pytest.mark.live
+
+CORRELATE_BEATS_ENV = "RESOLVE_MCP_CORRELATE_BEATS"
+CORRELATE_TIMELINE_ENV = "RESOLVE_MCP_CORRELATE_TIMELINE"
+CORRELATE_AUDIO_ENV = "RESOLVE_MCP_CORRELATE_AUDIO"
+"""Opt-in for #40's live AC: a real beats file, and the hand-edited cut to measure with it."""
 
 SMOKE_CUT = "resolve-mcp-smoke"
 """Every build here materialises a new version of this name; delete them when you are done."""
@@ -898,6 +904,65 @@ def test_apply_titles_places_text_plus_instances_with_their_own_text_and_fades(
         if was_on is not None:
             project.SetCurrentTimeline(was_on)
         pool.DeleteTimelines([scratch])
+
+
+def test_correlate_measures_a_real_hand_edited_timeline() -> None:
+    """#40's live AC: the measurement survives a cut a person made, not one a build made.
+
+    A hand-edited concert timeline is where the reading is actually hard — titles and
+    generators with no media pool item, shots that were trimmed rather than placed, an audio
+    track that may or may not be the mix the analysis ran on. Opt in by pointing the two
+    variables at a real cut and a real beats file, in PowerShell on the Resolve machine:
+
+        $env:RESOLVE_MCP_CORRELATE_BEATS = 'C:\\cache\\analysis\\gig-beats.json'
+        $env:RESOLVE_MCP_CORRELATE_TIMELINE = 'Sunset set 2024'   # optional; open one by default
+        $env:RESOLVE_MCP_CORRELATE_AUDIO = 'C:\\audio\\gig.wav'   # optional; adds transients
+        uv run pytest -m live -k correlate -s
+    """
+    beats = os.environ.get(CORRELATE_BEATS_ENV)
+    if not beats:
+        pytest.skip(f"Set {CORRELATE_BEATS_ENV} to a beats file from a real analysis")
+
+    named = os.environ.get(CORRELATE_TIMELINE_ENV)
+    envelope = correlate_timeline(
+        beats=beats,
+        timeline=named,
+        audio=os.environ.get(CORRELATE_AUDIO_ENV),
+        refresh=True,
+    )
+    assert envelope["ok"] is True, envelope.get("error")
+
+    record = wait_for(envelope["job"]["job_id"], timeout=300.0)
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    result = record.result
+
+    written = json.loads(Path(result["path"]).read_text(encoding="utf-8"))
+    tracks = inspect_timeline(timeline=named, detail="clips")["tracks"]
+    on_video_one = next(
+        track for track in tracks if track["type"] == "video" and track["index"] == 1
+    )
+
+    assert len(written["cuts"]) == on_video_one["item_count"]
+    assert [one["t"] for one in written["cuts"]] == sorted(one["t"] for one in written["cuts"])
+    assert result["beat_offsets"] is not None, "no cut measured against the grid"
+    print(_render_correlation(result))
+
+
+def _render_correlation(result: dict[str, Any]) -> str:
+    """The reading a human puts on the ticket: is this cut on the grid, and how far off?"""
+    return "\n".join(
+        [
+            f"file:      {result['path']}",
+            f"alignment: {result['alignment']}",
+            f"cuts:      {result['cuts']} ({result['openings']} opening)",
+            f"beats:     {result['beat_offsets']}",
+            f"transients:{result['transient_offsets']}",
+            f"bars:      {result['bars']}",
+            f"shots:     {result['shot_seconds']}",
+            f"clips:     {result['clips']}",
+        ]
+    )
 
 
 def _smoke_titles(timeline: str, template: str) -> dict[str, Any]:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -46,6 +46,7 @@ def test_registers_the_p1_session_media_timeline_cut_titling_render_and_job_tool
         "detect_scene_cuts",
         "transcribe_audio",
         "analyze_music",
+        "correlate_timeline",
         "separate_stems",
         "list_render_presets",
         "render_timeline",


### PR DESCRIPTION
Closes #40.

`correlate_timeline` measures an existing timeline against its music analysis: per shot, the signed offset to the nearest beat and the nearest transient, the bar position, the tune it happens in and who was out front, its duration, and its angle role. One record per line on disk, list-free stats inline. This is both the corpus-learning instrument (#45) and the mandatory post-build self-review instrument (#22, story 47).

**Test seam: the fake tier** (`tests/test_correlate_timeline.py`) — the fake Resolve singleton supplies the shots, real analysis files on disk supply the music, and the transient detector is injected per ADR 0002, so all the arithmetic verifies without a model or a concert. The live AC has its own opt-in test (below).

## Decisions worth knowing

- **The clock is the mix's, not the timeline's.** A shot's time is read through the audio clip carrying the file `audio=` names — by clip name or stem — falling back to the first audio shot and then to the timeline's first frame, and the alignment reading says which route it took and whether the mix was *recognised* or merely assumed. On a hand-edited concert A1 is routinely camera scratch, and a whole file measured against the wrong zero looks exactly like one measured against the right one.
- **Transients are measured here**, because no job persists onsets and #21 names transients (not the beat grid) as the fourth-wall risk. Behind an injectable detector per ADR 0002; the decode is why this is a job.
- **Sections are optional input, not a dependency.** #38's tunes and solos files are consumed by their record shape, so this lands on `main` without waiting for PR #82 and lights up when it merges. A file that is named but yields no usable record is refused rather than reading like a file nobody named.
- **Angle roles arrive as an inline mapping**, lifted by the agent out of its own sidecar — no server path reads or writes that file (#45's AC).
- **Nothing is judged.** Two frames late is reported as two frames late; what counts as musical belongs in the style profile.
- Two helpers in `resolve/timeline.py` (`items_in_track`, `source_bounds`, `clip_name`) and `beats.nearest` became public rather than being reimplemented — the source-clock rule keeps one home.

## Review record

Two-axis review (`/code-review`, Standards and Spec as parallel sub-agents) since `origin/main`, run on the branch before this PR existed.

**Standards findings — 2 hard, 4 judgement calls.**

1. *Records on disk were not dual time* (hard; `timing.py`'s rule, echoed by `video/scenes.py`). **Fixed** — `in`/`out` carry frames + seconds + timecode + fps. A self-review that flags cut 47 has to give the director something to scrub to.
2. *"Not measured" was signalled two ways* — `roles` came back `{}` while every other unmeasured column came back `null`, contradicting a decision documented in the same file (hard). **Fixed** — `null`.
3. *`__all__` is convention drift* — no sibling analysis module has one. **Fixed** — removed.
4. *Duplicated `_rounded` / `INLINE_CUTS` / shot-length stats with `video/scenes.py`* (judgement). **Held.** The duplication is deliberate mimicry of the neighbouring module; a shared stats home is worth doing across both, not as a side effect of this ticket.
5. *Data clump: the four analysis paths travel together* (judgement). **Held** — they are four separate MCP parameters at the tool boundary, and `Music` already bundles the loaded form.
6. *Primitive obsession: `Clock.mode` is a bare string* (judgement). **Held** — it is a JSON value the agent reads.

**Spec findings — 7, all resolved or held with reasons.** Verified clean by the reviewer: the sign convention (negative = early, tested both directions), the bisect nearest-lookup, the bar-position read, and #45's no-sidecar-in-server-code AC.

1. *Dual time* — same as Standards 1. **Fixed.**
2. *A named tunes file whose records the reader cannot use read identically to no tunes file.* **Fixed** — that is now a refusal naming the file and field.
3. *The opening-shot exclusion asserted, but never checked, that the first shot starts where the timeline does.* **Fixed** — a shot that starts after a gap is an opening too, so a hand-edited timeline with gaps no longer averages non-cuts into the style.
4. *The clock could anchor to camera scratch.* **Fixed** — see above.
5. *`source_in` is absolute, so a mix with a start timecode would shift every cut by an hour.* **Fixed** — the media item's start frame comes off it.
6. *Nothing detected 4 or 5, because the nearest lookup clamps.* **Fixed** — `outside_grid` counts cuts past the analysed span.
7. *`_front_at` ignored the first solo change's `from`.* **Fixed** — a cut in the head reads as whoever the change took over from.

Fixes re-checked as a focused pass over the fix diff (off-by-one in the gap rule, whether the mix match can pick the wrong clip, whether the start-frame subtraction can wrongly fire, whether the gist/file agreement still holds): no issues.

`uv run pytest -m 'not live'`, `mypy --strict` and `ruff check` all clean.

## Unrun

AC 4 — "runs on a real hand-edited past timeline" — is live smoke and unrun: it needs Resolve Studio on the Windows box, a real beats file, and a real past cut. `tests/test_live_smoke.py::test_correlate_measures_a_real_hand_edited_timeline` is written and skips until opted in with `RESOLVE_MCP_CORRELATE_BEATS` (plus optional `RESOLVE_MCP_CORRELATE_TIMELINE` / `RESOLVE_MCP_CORRELATE_AUDIO`); it prints the reading for the ticket.

Review: clean — 2 hard standards findings and 6 spec/quality findings fixed, 3 judgement calls held with reasons, fix diff re-checked clean.

## Merge with main (post-open)

Main gained #38 (structure analysis and the `halves` module) after this PR
opened; three files conflicted, all shallow. Both branches had independently
made `beats.nearest` public — kept main's variable naming and merged the two
docstrings so both callers (#38 snapping, #40 correlation) are named. The
tools file is the union: `analyze_structure` and `correlate_timeline` both
import and register, and the server test lists both. `correlate.py` itself
touches nothing the halves refactor moved, so no adaptation was needed there.

Reviewed as a focused pass over the resolution diff: no lost behaviour,
no dangling references, tool/test alignment — no findings.
913 tests pass, mypy strict clean, ruff clean.

Review: clean — merge resolution re-reviewed, no findings

## Second merge with main (post-#83)

PR #83 (drum fills) merged and re-conflicted the same two additive spots:
the analysis tools file and the server test's tool list. Resolution is the
predicted union — `detect_drum_fills` and `correlate_timeline` both import,
register in `TOOLS`, and appear in the test's expected set; nothing else
changed hands. Reviewed inline as a focused pass over the two hunks.
945 tests pass, mypy strict clean, ruff clean.

Review: clean — additive re-merge after #83, union verified, checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

