### PR TITLE
fix: what the #79 live pass found

### DIFF
--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -63,6 +63,8 @@ SCOPES = (TIMELINE_SCOPE, CLIP_SCOPE)
 
 RENDER_FORMAT = "wav"
 RENDER_CODEC = "lpcm"
+#: Stock Resolve preset, and the only route to a WAV on a build that refuses the pair above.
+AUDIO_ONLY_PRESET = "Audio Only"
 
 EXPORT_FLOOR = 0.1
 EXPORT_CEILING = 0.9
@@ -135,7 +137,12 @@ def export_timeline_mix(
             "AudioSampleRate": int(params["sample_rate"]),
         }
         try:
-            job_id = render.submit(project, settings, (RENDER_FORMAT, RENDER_CODEC))
+            job_id = render.submit(
+                project,
+                settings,
+                (RENDER_FORMAT, RENDER_CODEC),
+                fallback_preset=AUDIO_ONLY_PRESET,
+            )
             render.render(
                 project,
                 job_id,

--- a/src/resolve_mcp/resolve/connection.py
+++ b/src/resolve_mcp/resolve/connection.py
@@ -36,6 +36,19 @@ class ResolveConnection:
         # stale handle is left to observe.
         self._ever_attached = False
         self._lock = threading.RLock()
+        self._build_notes: dict[str, Any] = {}
+
+    @property
+    def build_notes(self) -> dict[str, Any]:
+        """Facts about the attached build that cost a real call to learn.
+
+        Emptied whenever a handle is attached, so nothing learned about one Resolve is
+        believed about the next. What goes here is what cannot change while the same
+        Resolve is attached and is expensive to ask twice — the interchange layer keeps
+        the export type this build actually writes through, which costs a whole export
+        to discover (#26).
+        """
+        return self._build_notes
 
     @property
     def connected(self) -> bool:
@@ -70,6 +83,9 @@ class ResolveConnection:
             handle, failure = self._connect_once()
             if handle is not None and self._probe(handle):
                 self._handle = handle
+                # A new handle may be a different Resolve; nothing learned about the last
+                # one survives into it.
+                self._build_notes.clear()
                 log.info("Resolve %s", "reconnected" if self._ever_attached else "attached")
                 self._ever_attached = True
                 return handle

--- a/src/resolve_mcp/resolve/connection.py
+++ b/src/resolve_mcp/resolve/connection.py
@@ -42,11 +42,19 @@ class ResolveConnection:
     def build_notes(self) -> dict[str, Any]:
         """Facts about the attached build that cost a real call to learn.
 
-        Emptied whenever a handle is attached, so nothing learned about one Resolve is
-        believed about the next. What goes here is what cannot change while the same
-        Resolve is attached and is expensive to ask twice — the interchange layer keeps
-        the export type this build actually writes through, which costs a whole export
-        to discover (#26).
+        Replaced with an empty dict whenever a handle is attached, so nothing learned
+        about one Resolve is believed about the next. What goes here is what cannot change
+        while the same Resolve is attached and is expensive to ask twice — the interchange
+        layer keeps the export type this build actually writes through, which costs a
+        whole export to discover (#26).
+
+        Replaced rather than emptied, and that is the whole safety property. Learning a
+        fact can take seconds (an export is a real one), so a caller holds this dict
+        across a window in which the handle can die and reattach. Clearing in place would
+        let that caller write what it learned about the old build into the notes now
+        belonging to the new one — the exact belief this is meant to rule out. Writing
+        into a dict that has been swapped out is harmless: it is unreachable, and the new
+        build starts empty and learns for itself.
         """
         return self._build_notes
 
@@ -84,8 +92,9 @@ class ResolveConnection:
             if handle is not None and self._probe(handle):
                 self._handle = handle
                 # A new handle may be a different Resolve; nothing learned about the last
-                # one survives into it.
-                self._build_notes.clear()
+                # one survives into it. Swapped, not cleared, so a probe still running
+                # against the old handle cannot write its answer in here (see build_notes).
+                self._build_notes = {}
                 log.info("Resolve %s", "reconnected" if self._ever_attached else "attached")
                 self._ever_attached = True
                 return handle

--- a/src/resolve_mcp/resolve/interchange.py
+++ b/src/resolve_mcp/resolve/interchange.py
@@ -16,9 +16,10 @@ Five things are decisions rather than API calls:
   21.0.3 defines ``EXPORT_FCPXML_1_10``, answers True for it, writes a zero-byte file, and
   then holds that file open — so the path it touched can never be exported to or deleted
   again (#26, live). Picking on definedness alone therefore fails *and* destroys the
-  caller's target. A format with more than one candidate is settled on a scratch file
-  first and only the winner is aimed at the target; the answer is remembered for the life
-  of the attach, because a probe that walks past a broken constant strands a file.
+  caller's target. A format whose ladder holds more than one constant is settled on a
+  scratch file first and only the winner is aimed at the target; the answer — including
+  "nothing here writes" — is remembered for the life of the attach, because settling walks
+  past broken constants and each one it walks past strands a file.
 * **The export is confirmed on disk, not by the return value.** ``Export`` answers a bool,
   and a path in a successful reply that has nothing behind it is worse than a failure: the
   agent's next move is to open that file.
@@ -143,8 +144,10 @@ def export_timeline(
                 f"nothing to {target}."
             ),
             fix=(
-                "Check the path is writable from the machine Resolve runs on, and that no "
-                "dialog in the Resolve GUI is holding the export. Then retry."
+                "Retry to a different path, not this one: Resolve holds a file it wrote "
+                "nothing to open for the life of the process, so this path will keep "
+                "failing until Resolve restarts. Check too that no dialog in the Resolve "
+                "GUI is holding the export."
             ),
             detail={"timeline": timeline_name, "format": spec.key, "path": str(target)},
         )
@@ -189,6 +192,18 @@ def _defined_types(resolve: Any, spec: Format) -> list[tuple[Any, str]]:
     return defined
 
 
+class _Probed(NamedTuple):
+    """What settling found for one format on one attach.
+
+    ``constant`` is the name of the export type that wrote, or ``None`` when every
+    candidate was walked past — a failure worth remembering, because finding it out again
+    costs another stranded file per broken constant.
+    """
+
+    constant: str | None
+    attempts: list[dict[str, Any]]
+
+
 def _export_type(
     resolve: Any, spec: Format, timeline: Any, notes: dict[str, Any]
 ) -> tuple[Any, str]:
@@ -200,67 +215,111 @@ def _export_type(
     ladder that picks on definedness alone therefore both fails and takes the caller's
     target down with it.
 
-    So a format with more than one candidate is settled on a scratch file first, and only
-    the winner is ever pointed at the target. Two consequences worth stating:
+    So a format whose ladder holds more than one constant is settled on a scratch file
+    first, and only the winner is ever pointed at the target. Three consequences worth
+    stating:
 
-    * **A single-candidate format is not probed.** otio and drt each define one constant,
-      and a probe could only confirm what there is no alternative to. They go straight at
-      the target, and a build that cannot write them fails on the post-export byte check
-      as before.
-    * **The answer is remembered for the attach, not the call.** A probe that has to walk
-      past a broken constant strands a file Resolve will not release, so probing per export
-      would leak one directory per export. ``notes`` is emptied whenever a handle is
-      attached, so a reconnect re-probes rather than trusting the last build's answer.
+    * **The test is on the ladder, not on what this build happens to define.** A build
+      that defines exactly one FCPXML constant still gets settled, because one candidate
+      is no evidence that candidate writes — and fcpxml is the format the destructive
+      failure was found on. Only otio and drt skip it: their ladders hold a single
+      constant, so there is no choice to make, and a build that cannot write them fails on
+      the post-export byte check with the caller's target spent. That is the residual
+      exposure, and it is accepted only because no build has ever failed those two.
+    * **The answer is remembered for the attach, not the call** — and that includes the
+      answer "nothing here writes". Settling walks past broken constants, and each one it
+      walks past strands a file Resolve will not release, so a build where every candidate
+      is broken would leak a directory per call if only successes were remembered.
+      ``notes`` is emptied whenever a handle is attached, so a reconnect settles afresh
+      rather than trusting the last build's answer.
+    * **A remembered constant is not re-validated.** Notes are cleared on attach, so a
+      constant that has stopped existing means the notes outlived their handle; that is a
+      bug in the caching, not a build quirk, and it says so rather than quietly settling
+      again.
     """
     candidates = _defined_types(resolve, spec)
-    if len(candidates) == 1:
+    if len(spec.export_types) == 1:
         return candidates[0]
 
     note = f"export_type:{spec.key}"
-    remembered = notes.get(note)
-    if remembered is not None:
-        value = getattr(resolve, remembered, None)
-        if value is not None:
-            return value, str(remembered)
+    settled = notes.get(note)
+    if not isinstance(settled, _Probed):
+        settled = _first_writable_type(timeline, spec, candidates)
+        notes[note] = settled
 
-    winner, attempts = _probe(timeline, spec, candidates)
-    if winner is None:
+    if settled.constant is None:
         raise TimelineExportFailedError(
             cause=f"No export type this Resolve defines for {spec.key} writes a file.",
             fix=(
                 "Export in another format — otio and drt are written by every build this "
                 "server attaches to — or update Resolve."
             ),
-            detail={"format": spec.key, "attempts": attempts},
+            detail={"format": spec.key, "attempts": settled.attempts},
         )
-    notes[note] = winner[1]
-    return winner
+
+    value = getattr(resolve, settled.constant, None)
+    if value is None:
+        raise TimelineExportFailedError(
+            cause=(
+                f"This Resolve no longer defines {settled.constant}, which it wrote "
+                f"{spec.key} through earlier on this connection."
+            ),
+            fix="Reconnect: what a build was found to write through is dropped on attach.",
+            detail={"format": spec.key, "export_type": settled.constant},
+        )
+    return value, settled.constant
 
 
-def _probe(
+def _first_writable_type(
     timeline: Any, spec: Format, candidates: list[tuple[Any, str]]
-) -> tuple[tuple[Any, str] | None, list[dict[str, Any]]]:
+) -> _Probed:
     """Export to a throwaway file per candidate, newest first, and report the first that lands.
 
-    One file per candidate, never reused: a constant that fails leaves its path unusable.
-    Removing the directory afterwards is best effort and *expected to fail whenever a
-    candidate was walked past* — Resolve holds the zero-byte file it wrote open for the
-    life of the process, so that scratch directory outlives the server. It is a few KB of
-    XML, and the caller remembers the answer so this happens once per attach.
+    One file per candidate, never reused: a constant that fails leaves its path unusable,
+    so aiming the next candidate at the same name would test the poisoning rather than the
+    constant. Removing the directory afterwards is best effort and *expected to fail
+    whenever a candidate was walked past* — Resolve holds the zero-byte file it wrote open
+    for the life of the process, so that scratch directory outlives the server. What is
+    stranded is one empty file per broken constant; the caller remembers the answer, so it
+    happens once per attach rather than once per export.
+
+    The directory is logged before anything is written to it. It is the only record of
+    where those files went, and on the machine this runs on nobody is watching the screen.
     """
     attempts: list[dict[str, Any]] = []
-    scratch = Path(tempfile.mkdtemp(prefix="resolve-mcp-export-probe-"))
-    for export_type, constant in candidates:
-        scratch_target = scratch / f"{constant}{spec.suffix}"
-        returned, written = _export_once(timeline, scratch_target, export_type)
-        if returned and written:
-            log.info("This build writes %s through %s", spec.key, constant)
-            _discard(scratch)
-            return (export_type, constant), attempts
-        attempts.append({"export_type": constant, "returned": returned, "bytes": written})
-        log.warning("This build defines %s but writes nothing through it", constant)
-    _discard(scratch)
-    return None, attempts
+    try:
+        scratch = Path(tempfile.mkdtemp(prefix="resolve-mcp-export-probe-"))
+    except OSError as exc:
+        raise TimelineExportFailedError(
+            cause=f"Could not make a scratch directory to settle {spec.key} on: {exc}",
+            fix=(
+                "Free space in the system temp directory, or point TEMP at somewhere "
+                "writable from the account Resolve runs under."
+            ),
+            detail={"format": spec.key},
+        ) from exc
+
+    log.info("Settling which export type writes %s, on %s", spec.key, scratch)
+    try:
+        for export_type, constant in candidates:
+            scratch_target = scratch / f"{constant}{spec.suffix}"
+            returned, written = _export_once(timeline, scratch_target, export_type)
+            if returned and written:
+                log.info("This build writes %s through %s", spec.key, constant)
+                return _Probed(constant, attempts)
+            attempts.append({"export_type": constant, "returned": returned, "bytes": written})
+            if returned:
+                log.warning(
+                    "This build defines %s and answers True for it but wrote nothing; "
+                    "%s is now held open and cannot be reused",
+                    constant,
+                    scratch_target,
+                )
+            else:
+                log.warning("This build defines %s but refused to export through it", constant)
+    finally:
+        _discard(scratch)
+    return _Probed(None, attempts)
 
 
 def _export_once(timeline: Any, target: Path, export_type: Any) -> tuple[bool, int]:

--- a/src/resolve_mcp/resolve/interchange.py
+++ b/src/resolve_mcp/resolve/interchange.py
@@ -32,6 +32,9 @@ Four things are decisions rather than API calls:
 
 from __future__ import annotations
 
+import shutil
+import tempfile
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -112,7 +115,7 @@ def export_timeline(
     timeline = find_timeline(project, name)
     timeline_name = name_of(timeline)
 
-    export_type, constant = _export_type(resolve, spec)
+    export_type, constant = _export_type(resolve, spec, timeline)
     target = write_target(
         path, timeline_name, spec.suffix, (config or get_config()).interchange_dir, "timeline"
     )
@@ -168,20 +171,86 @@ def _format(export_format: str) -> Format:
     return spec
 
 
-def _export_type(resolve: Any, spec: Format) -> tuple[Any, str]:
-    """The newest constant for this format that the attached Resolve actually defines."""
-    for constant in spec.export_types:
-        value = getattr(resolve, constant, None)
-        if value is not None:
-            return value, constant
-    raise TimelineExportFailedError(
-        cause=f"This Resolve build defines no export type for {spec.key}.",
-        fix=(
-            "Update Resolve, or export in another format — otio and drt are supported on "
-            "every build this server attaches to."
-        ),
-        detail={"format": spec.key, "tried": list(spec.export_types)},
-    )
+def _export_types(resolve: Any, spec: Format) -> list[tuple[Any, str]]:
+    """Every constant for this format the attached Resolve defines, newest first."""
+    defined = [
+        (getattr(resolve, constant, None), constant)
+        for constant in spec.export_types
+        if getattr(resolve, constant, None) is not None
+    ]
+    if not defined:
+        raise TimelineExportFailedError(
+            cause=f"This Resolve build defines no export type for {spec.key}.",
+            fix=(
+                "Update Resolve, or export in another format — otio and drt are supported on "
+                "every build this server attaches to."
+            ),
+            detail={"format": spec.key, "tried": list(spec.export_types)},
+        )
+    return defined
+
+
+def _export_type(resolve: Any, spec: Format, timeline: Any) -> tuple[Any, str]:
+    """The newest constant for this format that this build can actually write through.
+
+    Defining a constant is not the same as exporting through it. Resolve 21.0.3 defines
+    EXPORT_FCPXML_1_10, answers True for it, and writes a zero-byte file — and then keeps
+    the handle, so that path can never be exported to or deleted again (#26, live). A
+    ladder that picks on definedness alone therefore both fails and takes the caller's
+    target down with it.
+
+    So a format with more than one candidate is settled on a scratch file first, and only
+    the winner is ever pointed at the target. That costs one extra export, on fcpxml alone
+    — otio and drt have a single candidate each and go straight out. Nothing is cached
+    between calls: a memo keyed on the build would be one more thing to be wrong about
+    after a reconnect, and the probe is cheap next to the render it usually precedes.
+    """
+    candidates = _export_types(resolve, spec)
+    if len(candidates) == 1:
+        return candidates[0]
+
+    winner, attempts = _probe(timeline, spec, candidates)
+    if winner is None:
+        raise TimelineExportFailedError(
+            cause=f"No export type this Resolve defines for {spec.key} writes a file.",
+            fix=(
+                "Export in another format — otio and drt are written by every build this "
+                "server attaches to — or update Resolve."
+            ),
+            detail={"format": spec.key, "attempts": attempts},
+        )
+    return winner
+
+
+def _probe(
+    timeline: Any, spec: Format, candidates: list[tuple[Any, str]]
+) -> tuple[tuple[Any, str] | None, list[dict[str, Any]]]:
+    """Export to a throwaway file per candidate, newest first, and report the first that lands.
+
+    One file per candidate, never reused: a constant that fails leaves its path unusable.
+    The directory is left to the OS to clean — the files Resolve holds open cannot be
+    deleted from here, and they are a few KB of XML.
+    """
+    attempts: list[dict[str, Any]] = []
+    scratch = Path(tempfile.mkdtemp(prefix="resolve-mcp-export-probe-"))
+    for export_type, constant in candidates:
+        target = scratch / f"{constant}{spec.suffix}"
+        returned = bool(timeline.Export(str(target), export_type))
+        written = _written_bytes(target)
+        if returned and written:
+            log.info("This build writes %s through %s", spec.key, constant)
+            _discard(scratch)
+            return (export_type, constant), attempts
+        attempts.append({"export_type": constant, "returned": returned, "bytes": written})
+        log.warning("This build defines %s but writes nothing through it", constant)
+    _discard(scratch)
+    return None, attempts
+
+
+def _discard(scratch: Path) -> None:
+    """Best effort: Resolve keeps a handle on what it exported, and that is not an error."""
+    with suppress(OSError):
+        shutil.rmtree(scratch, ignore_errors=True)
 
 
 def _written_bytes(target: Path) -> int:

--- a/src/resolve_mcp/resolve/interchange.py
+++ b/src/resolve_mcp/resolve/interchange.py
@@ -4,15 +4,21 @@ This is the structural escape hatch. The scripting API cannot cut a transition, 
 route around that wall is: export the cut, hand-edit a dissolve into the document, import
 it back. Everything here exists to make that round trip safe to take.
 
-Four things are decisions rather than API calls:
+Five things are decisions rather than API calls:
 
 * **A format name is not an export constant.** ``Timeline.Export`` takes a number that
   lives on the Resolve app object, and which numbers exist depends on the build — FCPXML
   has gained a constant per version of the format. So a format maps to an ordered list of
-  constant names and the newest one this build has wins; a build with none of them fails
-  naming what it looked for, not with an ``AttributeError`` from inside a wrapper. The lookup
-  tests against ``None`` and never against truthiness, because the first constant Resolve
-  defines has the value 0.
+  constant names, newest first; a build with none of them fails naming what it looked for,
+  not with an ``AttributeError`` from inside a wrapper. The lookup tests against ``None``
+  and never against truthiness, because the first constant Resolve defines has the value 0.
+* **Defined is not the same as writable, so the newest one that *works* wins.** Resolve
+  21.0.3 defines ``EXPORT_FCPXML_1_10``, answers True for it, writes a zero-byte file, and
+  then holds that file open — so the path it touched can never be exported to or deleted
+  again (#26, live). Picking on definedness alone therefore fails *and* destroys the
+  caller's target. A format with more than one candidate is settled on a scratch file
+  first and only the winner is aimed at the target; the answer is remembered for the life
+  of the attach, because a probe that walks past a broken constant strands a file.
 * **The export is confirmed on disk, not by the return value.** ``Export`` answers a bool,
   and a path in a successful reply that has nothing behind it is worse than a failure: the
   agent's next move is to open that file.
@@ -34,7 +40,6 @@ from __future__ import annotations
 
 import shutil
 import tempfile
-from contextlib import suppress
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -115,7 +120,7 @@ def export_timeline(
     timeline = find_timeline(project, name)
     timeline_name = name_of(timeline)
 
-    export_type, constant = _export_type(resolve, spec, timeline)
+    export_type, constant = _export_type(resolve, spec, timeline, connection.build_notes)
     target = write_target(
         path, timeline_name, spec.suffix, (config or get_config()).interchange_dir, "timeline"
     )
@@ -124,16 +129,13 @@ def export_timeline(
     except OSError as exc:
         raise TimelineExportFailedError(cause=f"Could not create {target.parent}: {exc}") from exc
 
-    # Two arguments, not three: the subtype is Resolve's own optional argument and none of
-    # these three formats has one. Passing a subtype constant borrowed from AAF or EDL
-    # would be a guess at what the export means.
-    if not timeline.Export(str(target), export_type):
+    returned, written = _export_once(timeline, target, export_type)
+    if not returned:
         raise TimelineExportFailedError(
             cause=f"Resolve refused to export {timeline_name!r} as {spec.key} to {target}.",
             detail={"timeline": timeline_name, "format": spec.key, "export_type": constant},
         )
 
-    written = _written_bytes(target)
     if not written:
         raise TimelineExportFailedError(
             cause=(
@@ -171,13 +173,10 @@ def _format(export_format: str) -> Format:
     return spec
 
 
-def _export_types(resolve: Any, spec: Format) -> list[tuple[Any, str]]:
+def _defined_types(resolve: Any, spec: Format) -> list[tuple[Any, str]]:
     """Every constant for this format the attached Resolve defines, newest first."""
-    defined = [
-        (getattr(resolve, constant, None), constant)
-        for constant in spec.export_types
-        if getattr(resolve, constant, None) is not None
-    ]
+    values = ((getattr(resolve, constant, None), constant) for constant in spec.export_types)
+    defined = [(value, constant) for value, constant in values if value is not None]
     if not defined:
         raise TimelineExportFailedError(
             cause=f"This Resolve build defines no export type for {spec.key}.",
@@ -190,7 +189,9 @@ def _export_types(resolve: Any, spec: Format) -> list[tuple[Any, str]]:
     return defined
 
 
-def _export_type(resolve: Any, spec: Format, timeline: Any) -> tuple[Any, str]:
+def _export_type(
+    resolve: Any, spec: Format, timeline: Any, notes: dict[str, Any]
+) -> tuple[Any, str]:
     """The newest constant for this format that this build can actually write through.
 
     Defining a constant is not the same as exporting through it. Resolve 21.0.3 defines
@@ -200,14 +201,27 @@ def _export_type(resolve: Any, spec: Format, timeline: Any) -> tuple[Any, str]:
     target down with it.
 
     So a format with more than one candidate is settled on a scratch file first, and only
-    the winner is ever pointed at the target. That costs one extra export, on fcpxml alone
-    — otio and drt have a single candidate each and go straight out. Nothing is cached
-    between calls: a memo keyed on the build would be one more thing to be wrong about
-    after a reconnect, and the probe is cheap next to the render it usually precedes.
+    the winner is ever pointed at the target. Two consequences worth stating:
+
+    * **A single-candidate format is not probed.** otio and drt each define one constant,
+      and a probe could only confirm what there is no alternative to. They go straight at
+      the target, and a build that cannot write them fails on the post-export byte check
+      as before.
+    * **The answer is remembered for the attach, not the call.** A probe that has to walk
+      past a broken constant strands a file Resolve will not release, so probing per export
+      would leak one directory per export. ``notes`` is emptied whenever a handle is
+      attached, so a reconnect re-probes rather than trusting the last build's answer.
     """
-    candidates = _export_types(resolve, spec)
+    candidates = _defined_types(resolve, spec)
     if len(candidates) == 1:
         return candidates[0]
+
+    note = f"export_type:{spec.key}"
+    remembered = notes.get(note)
+    if remembered is not None:
+        value = getattr(resolve, remembered, None)
+        if value is not None:
+            return value, str(remembered)
 
     winner, attempts = _probe(timeline, spec, candidates)
     if winner is None:
@@ -219,6 +233,7 @@ def _export_type(resolve: Any, spec: Format, timeline: Any) -> tuple[Any, str]:
             ),
             detail={"format": spec.key, "attempts": attempts},
         )
+    notes[note] = winner[1]
     return winner
 
 
@@ -228,15 +243,16 @@ def _probe(
     """Export to a throwaway file per candidate, newest first, and report the first that lands.
 
     One file per candidate, never reused: a constant that fails leaves its path unusable.
-    The directory is left to the OS to clean — the files Resolve holds open cannot be
-    deleted from here, and they are a few KB of XML.
+    Removing the directory afterwards is best effort and *expected to fail whenever a
+    candidate was walked past* — Resolve holds the zero-byte file it wrote open for the
+    life of the process, so that scratch directory outlives the server. It is a few KB of
+    XML, and the caller remembers the answer so this happens once per attach.
     """
     attempts: list[dict[str, Any]] = []
     scratch = Path(tempfile.mkdtemp(prefix="resolve-mcp-export-probe-"))
     for export_type, constant in candidates:
-        target = scratch / f"{constant}{spec.suffix}"
-        returned = bool(timeline.Export(str(target), export_type))
-        written = _written_bytes(target)
+        scratch_target = scratch / f"{constant}{spec.suffix}"
+        returned, written = _export_once(timeline, scratch_target, export_type)
         if returned and written:
             log.info("This build writes %s through %s", spec.key, constant)
             _discard(scratch)
@@ -247,10 +263,22 @@ def _probe(
     return None, attempts
 
 
+def _export_once(timeline: Any, target: Path, export_type: Any) -> tuple[bool, int]:
+    """One ``Export`` call: what Resolve said, and what actually landed on disk.
+
+    The two are separate answers because Resolve gives a True that means nothing — the
+    whole reason this module never trusts the return value alone.
+    """
+    # Two arguments, not three: the subtype is Resolve's own optional argument and none of
+    # these three formats has one. Passing a subtype constant borrowed from AAF or EDL
+    # would be a guess at what the export means.
+    returned = bool(timeline.Export(str(target), export_type))
+    return returned, _written_bytes(target)
+
+
 def _discard(scratch: Path) -> None:
     """Best effort: Resolve keeps a handle on what it exported, and that is not an error."""
-    with suppress(OSError):
-        shutil.rmtree(scratch, ignore_errors=True)
+    shutil.rmtree(scratch, ignore_errors=True)
 
 
 def _written_bytes(target: Path) -> int:

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from ..errors import RenderPresetNotFoundError, RenderQueueError
+from ..errors import RenderPresetNotFoundError, RenderQueueError, ResolveMcpError
 from ..logging_config import get_logger
 
 log = get_logger("render")
@@ -109,15 +109,35 @@ def submit(
     refuses every ("wav", …) pair, so audio can only be reached through the stock preset
     that already selects it (#32, live). The settings are applied after the preset either
     way, so the caller's target directory and name still win.
+
+    What the fallback deliberately does *not* do is confirm the preset selected the format
+    that was asked for. On the build this exists for, ``GetCurrentRenderFormatAndCodec``
+    answers ``{"format": "unknown"}`` after ``Audio Only`` loads and still renders a WAV —
+    so a check against the requested format would reject the one route that works. The
+    file the job writes is what settles it, and ``render`` already refuses a job that
+    produced nothing.
     """
     if format_and_codec is not None:
         format_, codec = format_and_codec
         if not project.SetCurrentRenderFormatAndCodec(format_, codec):
-            if fallback_preset is None or not project.LoadRenderPreset(fallback_preset):
+            if fallback_preset is None:
                 raise RenderQueueError(
                     cause=f"Resolve would not render {format_}/{codec}.",
-                    detail={"format": format_, "codec": codec, "preset": fallback_preset},
+                    detail={"format": format_, "codec": codec, "preset": None},
                 )
+            # load_preset, not LoadRenderPreset: a bare False means both "no such preset"
+            # and "will not load", and the two want different answers from the caller.
+            try:
+                load_preset(project, fallback_preset)
+            except ResolveMcpError as exc:
+                raise RenderQueueError(
+                    cause=(
+                        f"Resolve would not render {format_}/{codec}, and the "
+                        f"{fallback_preset!r} preset it falls back on is unusable: {exc.cause}"
+                    ),
+                    fix=exc.fix,
+                    detail={"format": format_, "codec": codec, "preset": fallback_preset},
+                ) from exc
             log.info(
                 "Resolve refused %s/%s — rendering through the %r preset instead",
                 format_,

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -135,8 +135,22 @@ def submit(
                         f"Resolve would not render {format_}/{codec}, and the "
                         f"{fallback_preset!r} preset it falls back on is unusable: {exc.cause}"
                     ),
-                    fix=exc.fix,
-                    detail={"format": format_, "codec": codec, "preset": fallback_preset},
+                    # Not exc.fix: that one tells the caller to re-spell the preset, and
+                    # the caller never chose this name — the worker hardcodes it. What is
+                    # actually wrong is the install.
+                    fix=(
+                        f"Restore the stock {fallback_preset!r} preset in this Resolve — "
+                        "it is the only route to this format on builds that refuse the "
+                        "format/codec pair directly."
+                    ),
+                    # exc.detail carries what presets do exist, which is the one fact that
+                    # identifies a renamed or localised install.
+                    detail={
+                        **exc.detail,
+                        "format": format_,
+                        "codec": codec,
+                        "preset": fallback_preset,
+                    },
                 ) from exc
             log.info(
                 "Resolve refused %s/%s — rendering through the %r preset instead",

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -95,6 +95,7 @@ def submit(
     project: Project,
     settings: dict[str, Any],
     format_and_codec: tuple[str, str] | None = None,
+    fallback_preset: str | None = None,
 ) -> str:
     """Push one job onto the queue and return its id.
 
@@ -102,13 +103,26 @@ def submit(
     immediately before the job is added so that the job captures them. The pair travels as
     one because Resolve takes it as one, and it is optional because a loaded preset has
     already set both — setting them again would overwrite the rest of what the preset chose.
+
+    ``fallback_preset`` is the way past a build that refuses the pair outright: Resolve
+    21.0.3 lists Wave among its render formats, returns an empty codec map for it, and
+    refuses every ("wav", …) pair, so audio can only be reached through the stock preset
+    that already selects it (#32, live). The settings are applied after the preset either
+    way, so the caller's target directory and name still win.
     """
     if format_and_codec is not None:
         format_, codec = format_and_codec
         if not project.SetCurrentRenderFormatAndCodec(format_, codec):
-            raise RenderQueueError(
-                cause=f"Resolve would not render {format_}/{codec}.",
-                detail={"format": format_, "codec": codec},
+            if fallback_preset is None or not project.LoadRenderPreset(fallback_preset):
+                raise RenderQueueError(
+                    cause=f"Resolve would not render {format_}/{codec}.",
+                    detail={"format": format_, "codec": codec, "preset": fallback_preset},
+                )
+            log.info(
+                "Resolve refused %s/%s — rendering through the %r preset instead",
+                format_,
+                codec,
+                fallback_preset,
             )
     if not project.SetRenderSettings(settings):
         raise RenderQueueError(

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -523,6 +523,9 @@ class FakeTimeline(AnswersNone):
         self.exports: list[tuple[str, Any, tuple[Any, ...]]] = []
         self.export_result = True
         self.export_writes_the_file = True
+        # Export type *values* that answer True and write a zero-byte file — Resolve 21.0.3
+        # does exactly this for EXPORT_FCPXML_1_10 (#26, live).
+        self.export_types_that_write_nothing: set[Any] = set()
         self.add_track_result = True
         self.set_track_name_result = True
         # A clear that answers True and leaves the clips standing is the failure a caller
@@ -662,12 +665,15 @@ class FakeTimeline(AnswersNone):
         """Write an interchange file. The subtype is variadic because Resolve's is optional.
 
         ``export_writes_the_file=False`` models the failure the return value hides: Resolve
-        answers True and nothing lands on disk.
+        answers True and nothing lands on disk. ``export_types_that_write_nothing`` models
+        the same failure for one export type only, which is the real shape of it.
         """
         self._check()
         self.exports.append((file_name, export_type, subtype))
         if not self.export_result:
             return False
+        if export_type in self.export_types_that_write_nothing:
+            return True
         if self.export_writes_the_file:
             target = Path(file_name)
             target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -526,6 +526,9 @@ class FakeTimeline(AnswersNone):
         # Export type *values* that answer True and write a zero-byte file — Resolve 21.0.3
         # does exactly this for EXPORT_FCPXML_1_10 (#26, live).
         self.export_types_that_write_nothing: set[Any] = set()
+        # Paths one of those types has touched. Resolve keeps the handle for the life of
+        # the process, so the name is spent whatever type asks for it next (#26, live).
+        self.export_paths_held_open: set[str] = set()
         self.add_track_result = True
         self.set_track_name_result = True
         # A clear that answers True and leaves the clips standing is the failure a caller
@@ -667,12 +670,21 @@ class FakeTimeline(AnswersNone):
         ``export_writes_the_file=False`` models the failure the return value hides: Resolve
         answers True and nothing lands on disk. ``export_types_that_write_nothing`` models
         the same failure for one export type only, which is the real shape of it.
+
+        A type that writes nothing also *poisons the path it touched*, exactly as the real
+        one does: Resolve holds that zero-byte file open for the life of the process, so
+        every later export to the same name fails no matter which type is asked for. That
+        is why the real ladder never reuses a scratch filename, and modelling it here is
+        what makes reuse fail a test instead of only failing on the machine.
         """
         self._check()
         self.exports.append((file_name, export_type, subtype))
         if not self.export_result:
             return False
+        if file_name in self.export_paths_held_open:
+            return False
         if export_type in self.export_types_that_write_nothing:
+            self.export_paths_held_open.add(file_name)
             return True
         if self.export_writes_the_file:
             target = Path(file_name)
@@ -1373,11 +1385,18 @@ class FakeProject:
         return list(self.render_presets)
 
     def LoadRenderPreset(self, name: str) -> bool:  # noqa: N802
-        """Resolve answers a bare ``False`` for a preset it does not have, and for a refusal."""
+        """Resolve answers a bare ``False`` for a preset it does not have, and for a refusal.
+
+        Loading a preset also **replaces the render settings**, which is why the caller
+        applies its own after this and not before. Modelling the clobber is what makes
+        that ordering testable: get it backwards and the caller's target directory is the
+        preset's, not the one that was asked for.
+        """
         if not self.accepts_preset or name not in self.render_presets:
             return False
         self.loaded_presets.append(name)
         self.render_format = self.render_presets[name]
+        self.render_settings = {"TargetDir": "C:/preset-default", "CustomName": "preset-default"}
         return True
 
     def GetCurrentRenderFormatAndCodec(self) -> dict[str, str]:  # noqa: N802

--- a/tests/test_audio_acquisition.py
+++ b/tests/test_audio_acquisition.py
@@ -155,6 +155,45 @@ def test_the_export_renders_one_file_for_the_whole_timeline(attach: Attach) -> N
     assert _project(resolve).render_mode == 1
 
 
+def test_the_mix_still_exports_on_a_build_that_refuses_the_wav_pair(attach: Attach) -> None:
+    """Resolve 21.0.3 refuses every ("wav", …) pair, and the mix has to come out anyway.
+
+    The stock ``Audio Only`` preset is the only route to a WAV on that build (#32, live),
+    so the worker names it as the fallback. Without this test the worker could stop passing
+    it and every other test here would stay green.
+    """
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    project = _project(resolve)
+    project.accepts_format = False
+    project.render_presets["Audio Only"] = ("wav", "lpcm")
+    attach(resolve)
+
+    record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert Path(record.result["path"]).exists()
+    assert project.loaded_presets == ["Audio Only"]
+    # The preset chose the format; the caller still chose where it lands.
+    assert project.render_settings["TargetDir"] == str(get_config().audio_dir)
+    assert project.render_settings["ExportVideo"] is False
+
+
+def test_a_build_with_no_wav_route_at_all_fails_the_job_naming_both(attach: Attach) -> None:
+    """The pair refused and no usable fallback: the reply has to name the preset too,
+    or the machine that cannot render audio looks identical to one missing a codec."""
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    _project(resolve).accepts_format = False  # and no "Audio Only" among the presets
+    attach(resolve)
+
+    record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "audio_export_failed"
+    assert "Audio Only" in record.error["cause"]
+
+
 def test_a_queue_that_refuses_the_job_fails_the_job_not_the_server(attach: Attach) -> None:
     resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
     _project(resolve).accepts_job = False

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -122,11 +122,19 @@ def test_lists_the_real_media_pool() -> None:
 
 
 def test_inspects_a_real_clip_with_the_property_keys_the_wrappers_assume() -> None:
-    """The one live check the fakes cannot make: that these key names exist at all."""
+    """The one live check the fakes cannot make: that these key names exist at all.
+
+    Filtered, because the assertions below are about a clip with a file behind it, and the
+    first pool entry is a build timeline on any project this suite has run once — which
+    has no ``File Path`` and would fail this for a reason that is not the one it tests.
+    """
     listing = list_media()
-    if not listing["ok"] or not listing["clips"]:
-        pytest.skip("No clips in the media pool")
-    first = listing["clips"][0]
+    if not listing["ok"]:
+        pytest.skip("No media pool")
+    decodable = _decodable(listing["clips"])
+    if not decodable:
+        pytest.skip("No clips with media behind them in the media pool")
+    first = decodable[0]
 
     result = inspect_clip(first["name"], bin=first["bin"] or None)
 
@@ -331,11 +339,22 @@ def _decodable(clips: list[dict[str, Any]]) -> list[dict[str, Any]]:
     offline — and every build test here leaves one behind, so on a project the suite has
     run once the shortest "clip" in the pool is a timeline with no file on disk (#34,
     live).
+
+    The test that matters is therefore **a file path**, not the type name. Compound clips,
+    multicams, Fusion compositions and generators are all pathless in exactly the same
+    way, all report a rate and a frame count, and none of them is typed ``Timeline``; and
+    a pathless entry is reported as *pathless rather than offline*, so the offline flag
+    does not catch them either. Requiring a path covers every one of them, and covers
+    timelines as a side effect rather than by naming a string this build happens to use.
     """
     return [
         one
         for one in clips
-        if one["fps"] and one["frames"] and not one["offline"] and one["type"] != "Timeline"
+        if one["fps"]
+        and one["frames"]
+        and not one["offline"]
+        and one["file_path"]
+        and one["type"] != "Timeline"
     ]
 
 

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -324,12 +324,32 @@ def test_the_interchange_formats_all_write_a_file(tmp_path: Path) -> None:
 # --- build_timeline: the footgun wraps, on the only API that can confirm them --------------
 
 
+def _decodable(clips: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Pool entries with media behind them that ffmpeg can open.
+
+    A timeline is a pool clip too — it reports a frame count and a rate and is never
+    offline — and every build test here leaves one behind, so on a project the suite has
+    run once the shortest "clip" in the pool is a timeline with no file on disk (#34,
+    live).
+    """
+    return [
+        one
+        for one in clips
+        if one["fps"] and one["frames"] and not one["offline"] and one["type"] != "Timeline"
+    ]
+
+
 def a_source_clip() -> dict[str, Any]:
-    """A pool clip long enough to cut three shots out of, with a rate the cut can declare."""
+    """A pool clip long enough to cut three shots out of, with a rate the cut can declare.
+
+    Timelines are excluded for the same reason the video tests exclude them: every build
+    here leaves one in the pool, and a timeline reports a frame count and a rate while
+    having no media behind it to cut from (#34, live).
+    """
     listing = list_media()
     if not listing["ok"]:
         pytest.skip("No media pool")
-    for entry in listing["clips"]:
+    for entry in _decodable(listing["clips"]):
         clip = inspect_clip(entry["name"], bin=entry["bin"] or None)
         if not clip["ok"]:
             continue
@@ -649,20 +669,6 @@ def test_faster_whisper_reports_words_in_the_shape_the_worker_reads(tmp_path: Pa
         assert word.text
         assert 0.0 <= word.start <= word.end
         assert 0.0 <= word.confidence <= 1.0
-
-
-def _decodable(clips: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Pool entries ffmpeg can actually open.
-
-    A timeline is a pool clip too — it reports a frame count and a rate and is never
-    offline, and every build here leaves one behind, so the shortest "clip" in the pool is
-    usually a timeline with no file on disk (#34, live).
-    """
-    return [
-        one
-        for one in clips
-        if one["fps"] and one["frames"] and not one["offline"] and one.get("type") != "Timeline"
-    ]
 
 
 def test_a_real_frame_grab_lands_on_the_moment_resolve_numbers_it_at() -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -19,6 +19,7 @@ in PowerShell, which is the shell on the machine this runs on:
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import os
@@ -340,7 +341,8 @@ def a_source_clip() -> dict[str, Any]:
             "name": entry["name"],
             "bin": entry["bin"] or None,
             "fps": float(fps),
-            "start": media["start"]["frames"],
+            # inspect_clip reports media bounds as in/out/duration — there is no "start".
+            "start": media["in"]["frames"],
         }
     pytest.skip("No pool clip long enough to cut a smoke timeline from")
 
@@ -402,7 +404,7 @@ def test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it(tmp_path: 
     result = build_timeline(cut_file)
 
     assert result["ok"] is True, result.get("error")
-    assert result["placed"] == {"segments": 3, "audio": False, "selectors": 0}
+    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": False, "selectors": 0}
     built = inspect_timeline(result["timeline"]["name"], detail="clips")
     assert built["ok"] is True
     video = [track for track in built["tracks"] if track["type"] == "video"][0]
@@ -433,7 +435,7 @@ def test_a_real_take_selector_swaps_the_angle_without_moving_the_shot(tmp_path: 
     result = build_timeline(cut_file)
 
     assert result["ok"] is True, result.get("error")
-    assert result["placed"] == {"segments": 3, "audio": False, "selectors": 3}
+    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": False, "selectors": 3}
     name = result["timeline"]["name"]
     before = _video_items(name)
     assert [item["takes"] for item in before] == [2, 2, 2]
@@ -529,10 +531,12 @@ def test_the_locked_track_footgun_is_still_real(tmp_path: Path) -> None:
     )
 
     assert probe["ok"] is True, probe.get("error")
-    if not probe["result"]["found"]:
+    # run_python renders its value with repr, so the probe's dict comes back as source text.
+    reported = ast.literal_eval(probe["result"])
+    if not reported["found"]:
         pytest.skip("The chosen clip is not in the root folder, so the probe could not run")
-    assert probe["result"]["returned_truthy"] is True
-    assert probe["result"]["items_on_track"] == 0
+    assert reported["returned_truthy"] is True
+    assert reported["items_on_track"] == 0
 
 
 def test_an_invalid_cut_creates_no_timeline_on_a_real_project(tmp_path: Path) -> None:
@@ -647,6 +651,20 @@ def test_faster_whisper_reports_words_in_the_shape_the_worker_reads(tmp_path: Pa
         assert 0.0 <= word.confidence <= 1.0
 
 
+def _decodable(clips: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Pool entries ffmpeg can actually open.
+
+    A timeline is a pool clip too — it reports a frame count and a rate and is never
+    offline, and every build here leaves one behind, so the shortest "clip" in the pool is
+    usually a timeline with no file on disk (#34, live).
+    """
+    return [
+        one
+        for one in clips
+        if one["fps"] and one["frames"] and not one["offline"] and one.get("type") != "Timeline"
+    ]
+
+
 def test_a_real_frame_grab_lands_on_the_moment_resolve_numbers_it_at() -> None:
     """The AC no seam can check: that Start really is the offset between the two clocks.
 
@@ -657,10 +675,7 @@ def test_a_real_frame_grab_lands_on_the_moment_resolve_numbers_it_at() -> None:
     listing = list_media()
     if not listing["ok"]:
         pytest.skip("No project open in Resolve")
-    footage = next(
-        (one for one in listing["clips"] if one["fps"] and not one["offline"] and one["frames"]),
-        None,
-    )
+    footage = next(iter(_decodable(listing["clips"])), None)
     if footage is None:
         pytest.skip("No online clip with a frame rate in the media pool")
     bounds = inspect_clip(footage["name"], bin=footage["bin"] or None)["bounds"]["media"]
@@ -688,9 +703,7 @@ def test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock() -> None:
     listing = list_media()
     if not listing["ok"]:
         pytest.skip("No project open in Resolve")
-    footage = [
-        one for one in listing["clips"] if one["fps"] and not one["offline"] and one["frames"]
-    ]
+    footage = _decodable(listing["clips"])
     if not footage:
         pytest.skip("No online clip with a frame rate in the media pool")
     shortest = min(footage, key=lambda one: one["frames"])

--- a/tests/test_render_queue.py
+++ b/tests/test_render_queue.py
@@ -122,6 +122,62 @@ def test_every_way_the_queue_can_refuse_a_job_says_which(
     assert expected in raised.value.cause
 
 
+def test_a_build_that_refuses_the_pair_renders_through_the_fallback_preset(
+    tmp_path: Path,
+) -> None:
+    """Resolve 21.0.3 refuses every ("wav", …) pair, so the preset is the only way in (#32).
+
+    The settings are applied after the preset, so the caller's target directory survives it.
+    """
+    project = FakeProject("sunset-set")
+    project.accepts_format = False
+    project.render_presets["Audio Only"] = ("wav", "lpcm")
+
+    job_id = render.submit(
+        project,
+        {"TargetDir": str(tmp_path)},
+        ("wav", "lpcm"),
+        fallback_preset="Audio Only",
+    )
+
+    assert job_id
+    assert project.loaded_presets == ["Audio Only"]
+    assert project.render_settings["TargetDir"] == str(tmp_path)
+
+
+def test_the_fallback_preset_is_left_alone_when_the_pair_is_taken(tmp_path: Path) -> None:
+    """A preset carries a whole render config — loading one a build did not need would
+    overwrite settings the caller never asked to change."""
+    project = FakeProject("sunset-set")
+    project.render_presets["Audio Only"] = ("wav", "lpcm")
+
+    render.submit(
+        project,
+        {"TargetDir": str(tmp_path)},
+        ("wav", "lpcm"),
+        fallback_preset="Audio Only",
+    )
+
+    assert project.loaded_presets == []
+    assert project.render_format == ("wav", "lpcm")
+
+
+def test_a_refused_pair_with_no_preset_to_fall_back_on_says_both(tmp_path: Path) -> None:
+    project = FakeProject("sunset-set")
+    project.accepts_format = False
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.submit(
+            project,
+            {"TargetDir": str(tmp_path)},
+            ("wav", "lpcm"),
+            fallback_preset="Audio Only",
+        )
+
+    assert "would not render" in raised.value.cause
+    assert raised.value.detail["preset"] == "Audio Only"
+
+
 def test_a_queue_that_will_not_start_takes_its_job_back_off(tmp_path: Path) -> None:
     project = FakeProject("sunset-set")
     project.starts_rendering = False

--- a/tests/test_timeline_interchange.py
+++ b/tests/test_timeline_interchange.py
@@ -156,6 +156,47 @@ def test_the_broken_export_type_never_touches_the_file_the_caller_asked_for(
     assert written_to_target == [fake.EXPORT_FCPXML_1_9]  # type: ignore[attr-defined]
 
 
+def test_the_probe_happens_once_per_attach_and_not_once_per_export(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A probe that walks past a broken constant strands a file Resolve will not release,
+    so probing per export would leak one directory per export."""
+    cut = a_cut()
+    fake = studio(timeline=cut, export_types=("EXPORT_FCPXML_1_9", "EXPORT_FCPXML_1_10"))
+    cut.export_types_that_write_nothing = {fake.EXPORT_FCPXML_1_10}  # type: ignore[attr-defined]
+    attach(fake)
+
+    for index in range(3):
+        assert export_timeline(format="fcpxml", path=str(tmp_path / f"cut{index}"))["ok"] is True
+
+    walked_past = [
+        export_type
+        for _, export_type, _ in cut.exports
+        if export_type == fake.EXPORT_FCPXML_1_10  # type: ignore[attr-defined]
+    ]
+    assert len(walked_past) == 1, "the broken constant was tried again after it was settled"
+
+
+def test_a_reconnect_re_probes_rather_than_trusting_the_last_builds_answer(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The next handle may be a different Resolve, and what one build writes says nothing
+    about what the next one does."""
+    first = a_cut()
+    second = a_cut()
+    one = studio(timeline=first, export_types=("EXPORT_FCPXML_1_9", "EXPORT_FCPXML_1_10"))
+    two = studio(timeline=second, export_types=("EXPORT_FCPXML_1_9", "EXPORT_FCPXML_1_10"))
+    first.export_types_that_write_nothing = {one.EXPORT_FCPXML_1_10}  # type: ignore[attr-defined]
+    attach(one, two)
+
+    assert export_timeline(format="fcpxml", path=str(tmp_path / "one"))["ok"] is True
+    one.drop()  # Resolve quits; the next call reconnects to a build that writes 1_10
+    result = export_timeline(format="fcpxml", path=str(tmp_path / "two"))
+
+    assert result["ok"] is True
+    assert result["export_type"] == "EXPORT_FCPXML_1_10"
+
+
 def test_export_reports_every_type_it_tried_when_none_of_them_writes(
     attach: Attach, tmp_path: Path
 ) -> None:

--- a/tests/test_timeline_interchange.py
+++ b/tests/test_timeline_interchange.py
@@ -114,6 +114,73 @@ def test_export_falls_back_to_the_newest_fcpxml_this_build_has(attach: Attach) -
     assert result["export_type"] == "EXPORT_FCPXML_1_8"
 
 
+def test_export_walks_past_a_type_this_build_defines_but_cannot_write(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Defined is not the same as writable — Resolve 21.0.3 proves the two come apart.
+
+    It defines EXPORT_FCPXML_1_10, answers True for it, and writes a zero-byte file (#26,
+    live). Picking on definedness alone hands back a failure for a format the build can
+    still write one version down.
+    """
+    cut = a_cut()
+    fake = studio(timeline=cut, export_types=("EXPORT_FCPXML_1_9", "EXPORT_FCPXML_1_10"))
+    cut.export_types_that_write_nothing = {fake.EXPORT_FCPXML_1_10}  # type: ignore[attr-defined]
+    attach(fake)
+
+    result = export_timeline(format="fcpxml", path=str(tmp_path / "cut"))
+
+    assert result["ok"] is True
+    assert result["export_type"] == "EXPORT_FCPXML_1_9"
+    assert result["bytes"] > 0
+    assert Path(result["path"]).stat().st_size == result["bytes"]
+
+
+def test_the_broken_export_type_never_touches_the_file_the_caller_asked_for(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The zero-byte write is not the whole damage: Resolve keeps the handle, so the path it
+    touched can never be exported to or deleted again. The probe therefore happens on a
+    throwaway file, and the target sees exactly one export — the one that works."""
+    cut = a_cut()
+    fake = studio(timeline=cut, export_types=("EXPORT_FCPXML_1_9", "EXPORT_FCPXML_1_10"))
+    cut.export_types_that_write_nothing = {fake.EXPORT_FCPXML_1_10}  # type: ignore[attr-defined]
+    attach(fake)
+    target = tmp_path / "cut.fcpxml"
+
+    export_timeline(format="fcpxml", path=str(target))
+
+    written_to_target = [
+        export_type for file_name, export_type, _ in cut.exports if Path(file_name) == target
+    ]
+    assert written_to_target == [fake.EXPORT_FCPXML_1_9]  # type: ignore[attr-defined]
+
+
+def test_export_reports_every_type_it_tried_when_none_of_them_writes(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A build where the whole ladder is broken says so with the attempts, not a bare no."""
+    cut = a_cut()
+    fake = studio(timeline=cut, export_types=("EXPORT_FCPXML_1_9", "EXPORT_FCPXML_1_10"))
+    cut.export_types_that_write_nothing = {
+        fake.EXPORT_FCPXML_1_10,  # type: ignore[attr-defined]
+        fake.EXPORT_FCPXML_1_9,  # type: ignore[attr-defined]
+    }
+    attach(fake)
+    target = tmp_path / "cut.fcpxml"
+
+    result = export_timeline(format="fcpxml", path=str(target))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_export_failed"
+    assert [attempt["export_type"] for attempt in result["error"]["detail"]["attempts"]] == [
+        "EXPORT_FCPXML_1_10",
+        "EXPORT_FCPXML_1_9",
+    ]
+    # A failed probe leaves nothing where the caller was going to look.
+    assert not target.exists()
+
+
 def test_export_uses_a_type_whose_value_is_zero(attach: Attach) -> None:
     """The constants are plain numbers, and the first of them is 0.
 

--- a/tests/test_timeline_interchange.py
+++ b/tests/test_timeline_interchange.py
@@ -222,6 +222,71 @@ def test_export_reports_every_type_it_tried_when_none_of_them_writes(
     assert not target.exists()
 
 
+def test_settling_never_aims_two_candidates_at_the_same_scratch_name(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A candidate that fails poisons the path it touched, so reusing the name would test
+    the poisoning rather than the next constant — and would find the whole ladder broken on
+    a build that writes perfectly well one version down."""
+    cut = a_cut()
+    fake = studio(timeline=cut, export_types=("EXPORT_FCPXML_1_9", "EXPORT_FCPXML_1_10"))
+    cut.export_types_that_write_nothing = {fake.EXPORT_FCPXML_1_10}  # type: ignore[attr-defined]
+    attach(fake)
+    target = tmp_path / "cut.fcpxml"
+
+    result = export_timeline(format="fcpxml", path=str(target))
+
+    assert result["ok"] is True
+    scratch_paths = [file_name for file_name, _, _ in cut.exports if Path(file_name) != target]
+    assert len(scratch_paths) == len(set(scratch_paths)), "a scratch name was used twice"
+
+
+def test_a_build_where_nothing_writes_is_only_discovered_once_per_attach(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Failure is as expensive to learn as success and is remembered the same way.
+
+    Every candidate walked past strands a file Resolve will not release, so a build whose
+    whole ladder is broken would leak one scratch directory per call if only the successes
+    were kept.
+    """
+    cut = a_cut()
+    fake = studio(timeline=cut, export_types=("EXPORT_FCPXML_1_9", "EXPORT_FCPXML_1_10"))
+    cut.export_types_that_write_nothing = {
+        fake.EXPORT_FCPXML_1_10,  # type: ignore[attr-defined]
+        fake.EXPORT_FCPXML_1_9,  # type: ignore[attr-defined]
+    }
+    attach(fake)
+
+    for index in range(3):
+        assert export_timeline(format="fcpxml", path=str(tmp_path / f"cut{index}"))["ok"] is False
+
+    assert len(cut.exports) == 2, "the dead ladder was walked again after it was settled"
+
+
+def test_a_single_candidate_fcpxml_build_is_still_settled_on_a_scratch_file(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """One candidate is not evidence that candidate writes.
+
+    fcpxml is the format the destructive failure was found on, so a build defining exactly
+    one FCPXML constant is settled like any other — otherwise the one constant goes
+    straight at the caller's target and spends that path for the life of the process.
+    """
+    cut = a_cut()
+    fake = studio(timeline=cut, export_types=("EXPORT_FCPXML_1_9",))
+    cut.export_types_that_write_nothing = {fake.EXPORT_FCPXML_1_9}  # type: ignore[attr-defined]
+    attach(fake)
+    target = tmp_path / "cut.fcpxml"
+
+    result = export_timeline(format="fcpxml", path=str(target))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "timeline_export_failed"
+    assert [file_name for file_name, _, _ in cut.exports if Path(file_name) == target] == []
+    assert not target.exists()
+
+
 def test_export_uses_a_type_whose_value_is_zero(attach: Attach) -> None:
     """The constants are plain numbers, and the first of them is 0.
 


### PR DESCRIPTION
The #79 live pass against **DaVinci Resolve Studio 21.0.3.7** found two product failures no fake could reach, and five live tests that had never been runnable. This is the fix for all of it. Full results are on the source tickets (#26, #27, #28, #29, #31, #32, #33, #34, #35, #36, #37, #41, #42, #62, #68, #71); the index is on #79.

## What was broken

**FCPXML export was dead on this build (#26).** The ladder picked the newest constant Resolve *defines* — `EXPORT_FCPXML_1_10` — which returns `True` while writing a **zero-byte file**, and then keeps the handle, so the path it touched can never be exported to or deleted again (`WinError 5`, still true after a wait). `1_9` and `1_8` write fine; `1_11`+ are undefined, which answers #79's "bump the ladder if 1_12 is there" item in the negative. Because a failed constant poisons its path, falling back *on the target* destroys the caller's file — so a multi-candidate format is settled on a scratch file first and only the winner is ever aimed at the target. otio and drt have one candidate each and are untouched.

**The timeline mix export could not queue at all (#32).** `GetRenderCodecs('wav')` returns `{}` and `SetCurrentRenderFormatAndCodec` refuses **every** `("wav", …)` pair. The stock `Audio Only` preset works, so `render.submit` takes a `fallback_preset` and the audio worker names it; settings are applied after the preset so the caller's target still wins. The whole transcription/analysis chain sat behind this.

**Five live tests could not run.** `a_source_clip` read `bounds["media"]["start"]`, a key that has never existed; the build assertions predated the `overlays` key #30 added; the locked-track probe indexed `run_python`'s repr string as a dict; and the video tests took "the shortest clip in the pool", which is a **timeline** once any build test has run.

## Verification

Fake tier, mypy strict and ruff all clean. Live, on the machine: `interchange_formats`, `otio_round_trip`, `dissolve`, `real_build_places`, `take_selector`, `rebuild_makes`, `still_lands`, `locked_track`, `invalid_cut`, `real_frame_grab`, `real_scene_scan`, `preset_list`, `range_render` and `render_queue_exports` all pass.

The mix that proves #32 is real audio, measured rather than asserted: 69.533 s, 48 kHz, 24-bit, `mean_volume -17.0 dB`, `max_volume -2.9 dB`. That run used the **post-review** fallback — the version that goes through `load_preset` — so nothing in this diff is unverified against real Resolve.

Getting there cost two misdiagnoses, both retracted on #32 and #79, and one of them turned into a product finding. I read `GetIsTrackEnabled` off a *non-current* timeline, got `False` for every track, and reported the mix as silence from a muted timeline. It was neither: that getter answers only for the current timeline, exactly like `GetTakesCount` in #84, so #84 now carries two instances and a stronger brief. The other was a queue that appeared wedged; it was an audio-only render aimed at a build timeline with **zero audio items**, which queues and never starts. Both were caught by Daniel pushing back on the silence claim rather than by any check of mine — noted because the fake tier cannot reach either one.

## Review

`/code-review` against `origin/main`, two axes in parallel. Findings and what happened to them:

**Standards**
- *Module docstring states the disproved rule* (hard) — `interchange.py`'s header still said "the newest one this build has wins". **Fixed**: that decision is now documented, and the list is five items.
- *`LoadRenderPreset` called raw, bypassing the module's own contract* — collapses "no such preset" and "will not load" into one message. **Fixed**: goes through `load_preset` and names both facts.
- *Duplicated export-call shape between `_probe` and `export_timeline`* — **Fixed**: one `_export_once`.
- *`_export_types` vs `_export_type` differ by a character* — **Fixed**: renamed `_defined_types`.
- *`suppress(OSError)` around `rmtree(ignore_errors=True)`, and a docstring contradicting it* — **Fixed**: one mechanism, and the docstring now says the truth (the directory outlives us whenever a candidate was walked past).
- *`getattr` evaluated twice per constant* — **Fixed**.
- *Probe skipped for single-candidate formats, so the safety property is conditional* — **Kept, now stated**: otio and drt have no alternative to choose between, and the post-export byte check still catches a build that cannot write them.
- *Fallback never confirms the preset selected WAV* — **Kept, with evidence**: on this build `GetCurrentRenderFormatAndCodec` answers `{"format": "unknown"}` after `Audio Only` loads and renders a WAV anyway, so that check would reject the one route that works. The docstring explains why the file is what settles it.
- *`one.get("type")` beside `one["type"]`* — **Fixed**.

**Spec**
- *The probe leaked a scratch directory per export, not per attach* — the sharpest finding. A walk past `1_10` strands a file Resolve holds open for the life of the process. **Fixed**: the answer lives in `ResolveConnection.build_notes`, emptied whenever a handle is attached, so a reconnect re-probes. Two tests pin it, including the reconnect case.
- *The audio decision had no fake-tier test* — deleting `fallback_preset=AUDIO_ONLY_PRESET` from the worker left the suite green, which CLAUDE.md's seam rule forbids. **Fixed**: two tests in `test_audio_acquisition.py`.
- *`a_source_clip` still had no type filter* — the build tests kept the timeline-is-a-clip exposure the video tests were fixed for. **Fixed**.
- *Failures did not become tickets, as #79 asks* — **Fixed**: #84 (takes read 0 for any non-current timeline) and #85 (image-sequence offline flag; `was_offline` after a `ReplaceClip` relink). The #26 and #32 failures were fixed in place rather than ticketed, with the reasoning stated on #79.
- *The ladder-probe note belonged on #26* — **Done**.

Review: clean — both axes' findings fixed or answered with live evidence; re-reviewed the fix diff, fake tier, mypy and ruff green.

## Third review round

Three more reviews after the PR opened, run in parallel on separate axes — correctness, test quality, standards. Two of them independently found the same two defects, which is the part worth taking seriously. Fixed in `dd68c7b`:

**Product**
- *A build where every candidate is broken was never memoized* — each call re-settled and stranded another scratch directory, the exact leak the memo exists to prevent, in the case that leaks worst. The note now carries the failure as `_Probed(constant=None, attempts=…)`.
- *`build_notes` was cleared in place* — found independently by two reviewers. Settling takes seconds of real exports, so a caller holds that dict across a window in which the handle can die and reattach, and would then write what it learned about the old build into the new build's notes. Swapped, not cleared: a late write lands in an orphan.
- *fcpxml with one defined constant skipped settling* — and aimed that constant straight at the caller's target, the destructive path, on the format the destruction was found on. The test is now on the ladder, so only otio and drt skip it, and the docstring states the residual exposure rather than implying there is none.
- *The zero-byte failure said "retry"* — which can never work on the same path, since Resolve holds that file for the life of the process. It now says to use a different path, and why.
- *The render fallback discarded `exc.detail`* — throwing away the list of presets that exist, the one fact identifying a renamed or localised install, and forwarding a fix telling the caller to re-spell a name the caller never chose.
- *`mkdtemp` unguarded; scratch directory never logged though files are knowingly stranded in it; not discarded when `Export` raises; the walked-past log line claimed "writes nothing" even when Resolve refused outright.*

**Tests**
- *The fake modelled two thirds of the quirk* — True, zero bytes, but not the held handle. So "never reuse a scratch filename", a real decision, was invisible at the fake tier, which the seam rule forbids. `Export` now poisons the path it touched; three tests pin the consequences, and the existing walk-past test would now fail if the names collapsed.
- *"Settings applied after the preset" was asserted vacuously* — the fake's preset load never touched `render_settings`. It clobbers them now, so the wrong order fails.
- *`_decodable` filtered on `type == "Timeline"`* — but compound clips, multicams, Fusion comps and generators are pathless the same way, and `is_offline("")` is `False` by design. It filters on a file path now, covering timelines as a side effect rather than by matching a build-specific string.
- *`test_inspects_a_real_clip` took `clips[0]` unfiltered* and would fail on a build timeline for a reason unrelated to what it tests.

Re-checked the fix diff on its own: no new problems. Fake tier 828 passed, mypy strict and ruff clean; `interchange_formats` and `otio_round_trip` re-run green live against Resolve Studio 21.0.3.7 with the new settle path, which is what the behaviour change required.

Review: clean — three parallel axes, every finding fixed or answered; fix diff re-checked, fake tier 828 green, mypy and ruff clean, interchange re-verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
