### PR TITLE
fix: drum model name audio-separator 0.44.5 lists, live env overrides, scene-scan fixture knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Zero-config by default; every path has an environment override.
 | `RESOLVE_MCP_FFMPEG` | `ffmpeg` (found on PATH) | ffmpeg executable used for per-clip audio extraction, frame grabs and scene-cut detection |
 | `RESOLVE_MCP_AUDIO_SEPARATOR` | `audio-separator` (found on PATH) | python-audio-separator CLI used for stem separation |
 | `RESOLVE_MCP_STEM_MODEL` | `htdemucs_ft.yaml` | Pass one: the 4-stem model (vocals, drums, bass, other) |
-| `RESOLVE_MCP_DRUM_MODEL` | `MDX23C-DrumSep-6stem-FT.ckpt` | Pass two: the drum decomposition model (kick, snare, toms) |
+| `RESOLVE_MCP_DRUM_MODEL` | `MDX23C-DrumSep-aufr33-jarredou.ckpt` | Pass two: the drum decomposition model (kick, snare, toms) |
 | `RESOLVE_MCP_LOG_LEVEL` | `INFO` | Log level for the stderr logger |
 | `RESOLVE_MCP_ALLOW_ANY_PYTHON` | unset | Bypass the interpreter check (see ADR 0001) |
 

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -19,7 +19,9 @@ CACHE_DIR_NAME = "resolve-mcp"
 DEFAULT_FFMPEG = "ffmpeg"
 DEFAULT_AUDIO_SEPARATOR = "audio-separator"
 DEFAULT_STEM_MODEL = "htdemucs_ft.yaml"
-DEFAULT_DRUM_MODEL = "MDX23C-DrumSep-6stem-FT.ckpt"
+# The name audio-separator 0.44.5 lists for the six-stem MDX23C drum model; the
+# "MDX23C-DrumSep-6stem-FT.ckpt" spelling is not in its catalog and fails to load.
+DEFAULT_DRUM_MODEL = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
 
 
 TRUTHY = {"1", "true", "yes", "on"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Protocol
@@ -19,10 +20,21 @@ class Attach(Protocol):
 
 
 @pytest.fixture(autouse=True)
-def _clean_globals(tmp_path: Path) -> Iterator[None]:
-    """Keep the connection and config singletons from leaking between tests."""
+def _clean_globals(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[None]:
+    """Keep the connection and config singletons from leaking between tests.
+
+    The fake tier gets a hermetic config — machine-local ``RESOLVE_MCP_*`` variables
+    must not change what a unit test asserts. Live tests get the real process env:
+    the documented overrides (``RESOLVE_MCP_AUDIO_SEPARATOR``, ``RESOLVE_MCP_DRUM_MODEL``,
+    …) exist precisely so a live run can point at the machine's installs, and a
+    conftest that erased them made those knobs silently dead in the live tier.
+    Both tiers still get their cache redirected into ``tmp_path``.
+    """
     connection_module.reset_connection()
-    config_module.set_config(Config.from_env({"RESOLVE_MCP_CACHE": str(tmp_path / "cache")}))
+    base = dict(os.environ) if request.node.get_closest_marker("live") else {}
+    config_module.set_config(
+        Config.from_env({**base, "RESOLVE_MCP_CACHE": str(tmp_path / "cache")})
+    )
     yield
     connection_module.reset_connection()
     config_module.reset_config()

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -768,6 +768,11 @@ def test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock() -> None:
         )
     for cut in record.result["first_cuts"]:
         assert bounds["in"]["frames"] < cut["frames"] < bounds["out"]["frames"]
+    if not record.result["first_cuts"]:
+        pytest.skip(
+            f"scan completed but {chosen['name']!r} has no cuts — the mapping went "
+            f"unexercised; set {SCENE_SCAN_CLIP_ENV} to a pool clip with hard cuts"
+        )
 
 def test_the_preset_list_is_the_one_in_the_deliver_page() -> None:
     """#33: whether ``GetRenderPresetList`` answers at all, and with what spelling.

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -66,6 +66,9 @@ CORRELATE_TIMELINE_ENV = "RESOLVE_MCP_CORRELATE_TIMELINE"
 CORRELATE_AUDIO_ENV = "RESOLVE_MCP_CORRELATE_AUDIO"
 """Opt-in for #40's live AC: a real beats file, and the hand-edited cut to measure with it."""
 
+SCENE_SCAN_CLIP_ENV = "RESOLVE_MCP_SCENE_SCAN_CLIP"
+"""Opt-in for #34's live AC: a pool clip with hard cuts, so the scan has cuts to map."""
+
 SMOKE_CUT = "resolve-mcp-smoke"
 """Every build here materialises a new version of this name; delete them when you are done."""
 
@@ -730,6 +733,11 @@ def test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock() -> None:
     Slow — this decodes a whole clip, so it takes the shortest one in the pool. What it is
     for is the mapping the fakes replay rather than produce: that ffmpeg's reported times
     become frame numbers inside the bounds ``inspect_clip`` reports for the same clip.
+
+    The shortest pool clip is usually a continuous take (or a still), and a clip with no
+    cuts passes the mapping loop vacuously — the half of #34 this test exists for goes
+    unchecked. ``RESOLVE_MCP_SCENE_SCAN_CLIP`` names a pool clip known to contain hard
+    cuts; when set, that clip is scanned instead and the scan must find at least one cut.
     """
     listing = list_media()
     if not listing["ok"]:
@@ -737,16 +745,27 @@ def test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock() -> None:
     footage = _decodable(listing["clips"])
     if not footage:
         pytest.skip("No online clip with a frame rate in the media pool")
-    shortest = min(footage, key=lambda one: one["frames"])
-    bounds = inspect_clip(shortest["name"], bin=shortest["bin"] or None)["bounds"]["media"]
+    named = os.environ.get(SCENE_SCAN_CLIP_ENV, "").strip()
+    if named:
+        matches = [one for one in footage if one["name"] == named]
+        assert matches, f"{SCENE_SCAN_CLIP_ENV}={named!r} names no decodable pool clip"
+        chosen = matches[0]
+    else:
+        chosen = min(footage, key=lambda one: one["frames"])
+    bounds = inspect_clip(chosen["name"], bin=chosen["bin"] or None)["bounds"]["media"]
 
-    started = detect_scene_cuts(shortest["name"], bin=shortest["bin"] or None)
+    started = detect_scene_cuts(chosen["name"], bin=chosen["bin"] or None)
     record = wait_for(started["job_id"], timeout=1800.0)
 
     assert started["ok"] is True, started.get("error")
     assert record.state == "completed", record.error
     assert record.result is not None
     assert Path(record.result["path"]).exists()
+    if named:
+        assert record.result["first_cuts"], (
+            f"{named!r} was named as a clip with hard cuts, but the scan found none — "
+            "the clip-clock mapping went unexercised"
+        )
     for cut in record.result["first_cuts"]:
         assert bounds["in"]["frames"] < cut["frames"] < bounds["out"]["frames"]
 


### PR DESCRIPTION
Three findings from the #79 follow-up live run (source tickets #36 and #34), each verified against real Resolve Studio 21.0.3.7 on the live box:

- **`DEFAULT_DRUM_MODEL` named a model audio-separator 0.44.5 rejects** (`Model file MDX23C-DrumSep-6stem-FT.ckpt not found in supported model files`), so the second separation pass could never run with defaults. The catalog name is `MDX23C-DrumSep-aufr33-jarredou.ckpt`; with it the live two-pass test passes (2:16 including the DrumSep download).
- **`tests/conftest.py` erased the process env for config**, so every documented `RESOLVE_MCP_*` override was silently dead in test runs — including `RESOLVE_MCP_AUDIO_SEPARATOR`, which the live separator test's own skip logic documents. Live-marked tests now see the real env (cache still redirected to `tmp_path`); the fake tier stays hermetic.
- **The live scene scan picked the shortest file-backed pool clip** — on a real project a 1-frame still, so the cut-mapping loop passed vacuously. `RESOLVE_MCP_SCENE_SCAN_CLIP` names a clip with hard cuts; when set the scan must find at least one. Verified live: probe with joins at frames 72/145 detected at exactly 72/145.

## Review record

Two-axis /code-review (Standards + Spec, parallel sub-agents), diff vs `main`.

**Standards findings:**
- Hard: README.md:148 still documented the rejected model name as the default — **fixed** in e6ca445.
- Judgement (accepted, not changed): the conftest live/env branch itself has no fake-tier seam; the `os.environ.get(X, '').strip()` opt-in shape now appears three times in the live suite — both below the extraction threshold the reviewer set.

**Spec findings:**
- README stale default (same as Standards hard finding) — **fixed** in e6ca445.
- Hollow green: with the knob unset, a cut-less scan green-passed with the mapping unexercised — **fixed** in e6ca445: it now `pytest.skip`s with an actionable message; verified live (unset knob on this pool → `1 skipped`).
- Recording obligations on #36/#34/#79 — process items, being posted with this PR's link.
- Minor (accepted): clip match is by name only; duplicate names across bins take the first match.

Fix diff (e6ca445) got a focused re-check: README row now matches the code default; the skip lands after the named-clip assertion so it cannot mask the strengthened path.

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)