### PR TITLE
fix: refuse a mix export Resolve would queue and never run (#88)

### DIFF
--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -43,7 +43,7 @@ from ..naming import keyed_name
 from ..resolve import media, render
 from ..resolve.connection import ResolveConnection
 from ..resolve.session import current_project
-from ..resolve.timeline import Reader, current_timeline, find_timeline, fingerprint
+from ..resolve.timeline import Reader, current_timeline, find_timeline, fingerprint, read_frames
 from . import ffmpeg, wav
 
 log = get_logger("audio")
@@ -88,7 +88,7 @@ def acquire_timeline_audio(
     project = current_project(connection, "No project is open, so there is no timeline to export.")
     found = find_timeline(project, timeline)
     name = str(found.GetName() or "timeline")
-    refuse_a_silent_mix(found, name)
+    refuse_a_timeline_with_no_audio(found, name)
     params = _timeline_params(name, sample_rate, bit_depth)
     identity = fingerprint(Reader(connection), found)
     key = cache.cache_key(TIMELINE_KIND, [identity], params)
@@ -117,6 +117,10 @@ def export_timeline_mix(
 ) -> JobOutput:
     """The worker: queue an audio-only render of one timeline and wait for the WAV."""
     config = config or get_config()
+    # Checked in the starters too, so the refusal reaches the agent as a reply rather than a
+    # job it has to poll. This is the copy that holds the invariant: nothing this worker is
+    # handed reaches the queue unchecked, whichever route called it.
+    refuse_a_timeline_with_no_audio(timeline, str(params["timeline"]))
     target_dir = config.audio_dir
     target_dir.mkdir(parents=True, exist_ok=True)
     stem = keyed_name(str(params["timeline"]), key, "", "audio")
@@ -124,6 +128,10 @@ def export_timeline_mix(
 
     progress(0.05, "queuing the audio export")
     with current_timeline(project, timeline):
+        # Only here, with the timeline current, can a track's enabled state be believed
+        # (#84), so the second half of the precondition waits until the switch has happened
+        # and still runs before anything is queued.
+        refuse_a_timeline_with_every_audio_track_off(timeline, str(params["timeline"]))
         # One file for the whole timeline. The other mode renders a file per clip on it,
         # which for a concert cut is hundreds of fragments instead of the mix.
         project.SetCurrentRenderMode(render.SINGLE_CLIP)
@@ -157,39 +165,112 @@ def export_timeline_mix(
     return JobOutput(_result(expecting, params), (expecting,))
 
 
-def refuse_a_silent_mix(timeline: Timeline, name: str) -> None:
+def refuse_a_timeline_with_no_audio(timeline: Timeline, name: str) -> None:
     """Refuse to export a timeline with nothing on its audio tracks, before anything queues.
 
     Resolve takes such a render and never runs it: the job sits at "Ready for background
     render" at 0%, ``IsRenderingInProgress()`` reports ``True``, no dialog opens, and there
     is no error and no timeout — only ``DeleteAllRenderJobs()`` clears it, and the next one
     wedges the same way (#88, live on Studio 21.0.3.7). A hang is the one failure nothing
-    downstream can recover from or explain, so the precondition is checked here rather than
-    left to the queue.
+    downstream can recover from or explain, so the precondition is checked before the queue
+    can see the job.
 
-    The counts are read straight off the timeline rather than through ``Reader.optional``:
-    a getter that fails has to raise, because degrading it to an empty list would let a
-    dying handle read as "no audio" and refuse a timeline that has a mix on it. Reading
-    them off a timeline that is not the current one is sound — verified live on 21.0.3.7,
-    where ``GetItemListInTrack`` agreed exactly with the current-timeline reading, unlike
-    ``GetTakesCount`` and ``GetIsTrackEnabled`` (#84).
+    Only a reading that *succeeded* is allowed to refuse. A getter that answers ``None`` —
+    the way this API says "not on this build", and the way a dying handle reads — leaves
+    this silent rather than turning an unreadable count into "no audio": refusing a timeline
+    that has a mix on it is the failure this guard would otherwise trade the hang for, and
+    it is the worse of the two, because the hang at least announces itself by never
+    finishing. For the same reason the counts are not taken through the shared
+    ``timeline.items_in_track``, which folds ``None`` into an empty list.
+
+    Reading counts off a timeline that is not the current one is sound — verified live on
+    21.0.3.7, where ``GetItemListInTrack`` agreed exactly with the current-timeline reading,
+    unlike ``GetTakesCount`` and ``GetIsTrackEnabled`` (#84). That is why this half of the
+    precondition can run in a starter and
+    ``refuse_a_timeline_with_every_audio_track_off`` cannot.
     """
-    tracks = int(timeline.GetTrackCount("audio") or 0)
-    items = sum(
-        len(timeline.GetItemListInTrack("audio", index) or []) for index in range(1, tracks + 1)
-    )
-    if items:
+    counted = _audio_items(timeline, name, only_enabled=False)
+    if counted is None or counted.items:
         return
-    log.info("Refusing a mix export of %r: %d audio tracks, no items on them", name, tracks)
+    log.info("Refusing a mix export of %r: %d audio tracks, no items on them", name, counted.tracks)
     raise AudioExportError(
         cause=f"Timeline {name!r} has no audio items, so there is no mix to export.",
         fix=(
             "Check you targeted the timeline you meant — list_timelines names them, and "
             "inspect_timeline reports what sits on each track. Resolve queues an audio-only "
-            "render of a silent timeline and never runs it, so this refuses instead."
+            "render of a timeline with no audio on it and never runs it, so this refuses "
+            "instead."
         ),
-        detail={"timeline": name, "audio_tracks": tracks, "audio_items": 0},
+        detail={"timeline": name, "audio_tracks": counted.tracks, "audio_items": 0},
     )
+
+
+def refuse_a_timeline_with_every_audio_track_off(timeline: Timeline, name: str) -> None:
+    """Refuse when the only audio on the timeline sits on tracks that are switched off.
+
+    Resolve wedges on this exactly as it wedges on a timeline with no audio at all: one
+    clip on A1, A1 disabled, and the render sits at "Ready for background render" at 0%
+    with ``IsRenderingInProgress()`` True for as long as you care to watch (live on
+    21.0.3.7, while verifying #88). The hang is not "no items" — it is "nothing to render".
+
+    **This must only be called with ``timeline`` current.** ``GetIsTrackEnabled`` answers
+    ``False`` for every track of a timeline that is not the current one (#84), so run
+    anywhere else it would refuse every timeline it was handed.
+    """
+    counted = _audio_items(timeline, name, only_enabled=True)
+    if counted is None or counted.items:
+        return
+    log.info(
+        "Refusing a mix export of %r: audio on %d tracks, all of them off", name, counted.tracks
+    )
+    raise AudioExportError(
+        cause=(
+            f"Every audio track on timeline {name!r} is switched off, so the mix would be "
+            f"silent."
+        ),
+        fix=(
+            "Enable the audio track the mix should come from in Resolve's timeline, or "
+            "target the timeline you meant — inspect_timeline reports each track. Resolve "
+            "queues a render with nothing to render and never runs it, so this refuses "
+            "instead."
+        ),
+        detail={"timeline": name, "audio_tracks": counted.tracks, "audio_items_enabled": 0},
+    )
+
+
+class _AudioItems(NamedTuple):
+    """What the audio tracks hold: how many tracks were read, and how many items were on them."""
+
+    tracks: int
+    items: int
+
+
+def _audio_items(timeline: Timeline, name: str, only_enabled: bool) -> _AudioItems | None:
+    """Count the items on the timeline's audio tracks, or ``None`` if any reading failed.
+
+    ``None`` is the whole point: it is what keeps an unreadable timeline from being refused
+    as an empty one. Every getter here answers ``None`` rather than raising on a build that
+    lacks it, and a caller that cannot tell "no audio" from "no answer" must not refuse.
+    """
+    tracks = read_frames(timeline.GetTrackCount("audio"))
+    if tracks is None:
+        log.info("Not checking %r for audio: its audio track count did not read", name)
+        return None
+    items = 0
+    for index in range(1, tracks + 1):
+        if only_enabled:
+            enabled = timeline.GetIsTrackEnabled("audio", index)
+            if enabled is None:
+                log.info("Not checking %r for audio: audio track %d did not report on", name, index)
+                return None
+            if not enabled:
+                continue
+        listed = timeline.GetItemListInTrack("audio", index)
+        if listed is None:
+            log.info("Not checking %r for audio: audio track %d did not read", name, index)
+            return None
+        items += len(listed)
+    return _AudioItems(tracks, items)
 
 
 def _as_export_failure(exc: RenderQueueError) -> AudioExportError:
@@ -352,7 +433,7 @@ def audio_source(
         project = current_project(connection, "No project is open, so there is no timeline.")
         found = find_timeline(project, timeline)
         name = str(found.GetName() or "timeline")
-        refuse_a_silent_mix(found, name)
+        refuse_a_timeline_with_no_audio(found, name)
         return Source(
             fingerprint(Reader(connection), found),
             _timeline_params(name, sample_rate, bit_depth),

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -131,7 +131,7 @@ def export_timeline_mix(
         # Only here, with the timeline current, can a track's enabled state be believed
         # (#84), so the second half of the precondition waits until the switch has happened
         # and still runs before anything is queued.
-        refuse_a_timeline_with_every_audio_track_off(timeline, str(params["timeline"]))
+        refuse_a_timeline_with_no_audio_switched_on(timeline, str(params["timeline"]))
         # One file for the whole timeline. The other mode renders a file per clip on it,
         # which for a concert cut is hundreds of fragments instead of the mix.
         project.SetCurrentRenderMode(render.SINGLE_CLIP)
@@ -186,8 +186,8 @@ def refuse_a_timeline_with_no_audio(timeline: Timeline, name: str) -> None:
     Reading counts off a timeline that is not the current one is sound — verified live on
     21.0.3.7, where ``GetItemListInTrack`` agreed exactly with the current-timeline reading,
     unlike ``GetTakesCount`` and ``GetIsTrackEnabled`` (#84). That is why this half of the
-    precondition can run in a starter and
-    ``refuse_a_timeline_with_every_audio_track_off`` cannot.
+    precondition can run in a starter and ``refuse_a_timeline_with_no_audio_switched_on``
+    cannot.
     """
     counted = _audio_items(timeline, name, only_enabled=False)
     if counted is None or counted.items:
@@ -205,13 +205,14 @@ def refuse_a_timeline_with_no_audio(timeline: Timeline, name: str) -> None:
     )
 
 
-def refuse_a_timeline_with_every_audio_track_off(timeline: Timeline, name: str) -> None:
-    """Refuse when the only audio on the timeline sits on tracks that are switched off.
+def refuse_a_timeline_with_no_audio_switched_on(timeline: Timeline, name: str) -> None:
+    """Refuse when no audio track that is switched on has anything on it.
 
     Resolve wedges on this exactly as it wedges on a timeline with no audio at all: one
     clip on A1, A1 disabled, and the render sits at "Ready for background render" at 0%
     with ``IsRenderingInProgress()`` True for as long as you care to watch (live on
-    21.0.3.7, while verifying #88). The hang is not "no items" — it is "nothing to render".
+    21.0.3.7, while verifying #88). The hang is not "no items" — it is "nothing to render",
+    which is why the count that matters here is per *live* track and not per track.
 
     **This must only be called with ``timeline`` current.** ``GetIsTrackEnabled`` answers
     ``False`` for every track of a timeline that is not the current one (#84), so run
@@ -220,21 +221,19 @@ def refuse_a_timeline_with_every_audio_track_off(timeline: Timeline, name: str) 
     counted = _audio_items(timeline, name, only_enabled=True)
     if counted is None or counted.items:
         return
-    log.info(
-        "Refusing a mix export of %r: audio on %d tracks, all of them off", name, counted.tracks
-    )
+    log.info("Refusing a mix export of %r: nothing on any audio track that is on", name)
     raise AudioExportError(
         cause=(
-            f"Every audio track on timeline {name!r} is switched off, so the mix would be "
-            f"silent."
+            f"No audio track on timeline {name!r} is both switched on and carrying audio, "
+            f"so the mix would be silent."
         ),
         fix=(
-            "Enable the audio track the mix should come from in Resolve's timeline, or "
-            "target the timeline you meant — inspect_timeline reports each track. Resolve "
-            "queues a render with nothing to render and never runs it, so this refuses "
-            "instead."
+            "Switch on the audio track the mix should come from in Resolve's timeline, or "
+            "target the timeline you meant — inspect_timeline reports each track and "
+            "whether it is on. Resolve queues a render with nothing to render and never "
+            "runs it, so this refuses instead."
         ),
-        detail={"timeline": name, "audio_tracks": counted.tracks, "audio_items_enabled": 0},
+        detail={"timeline": name, "audio_tracks": counted.tracks, "audio_items_switched_on": 0},
     )
 
 
@@ -249,8 +248,14 @@ def _audio_items(timeline: Timeline, name: str, only_enabled: bool) -> _AudioIte
     """Count the items on the timeline's audio tracks, or ``None`` if any reading failed.
 
     ``None`` is the whole point: it is what keeps an unreadable timeline from being refused
-    as an empty one. Every getter here answers ``None`` rather than raising on a build that
-    lacks it, and a caller that cannot tell "no audio" from "no answer" must not refuse.
+    as an empty one, because a caller that cannot tell "no audio" from "no answer" must not
+    refuse. It covers the getter that *answers* nothing — a handle on its way out.
+
+    A build that lacks one of these getters outright is a different failure and is left to
+    raise: fusionscript answers every attribute name, so the missing method reads as ``None``
+    and the *call* dies with ``NoneType is not callable`` (#41, live on 21.0.3.7). That is
+    loud, lands as a failed job, and is honest; these three getters are old enough that a
+    build without them is not a case worth degrading a precondition for.
     """
     tracks = read_frames(timeline.GetTrackCount("audio"))
     if tracks is None:

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -88,6 +88,7 @@ def acquire_timeline_audio(
     project = current_project(connection, "No project is open, so there is no timeline to export.")
     found = find_timeline(project, timeline)
     name = str(found.GetName() or "timeline")
+    refuse_a_silent_mix(found, name)
     params = _timeline_params(name, sample_rate, bit_depth)
     identity = fingerprint(Reader(connection), found)
     key = cache.cache_key(TIMELINE_KIND, [identity], params)
@@ -154,6 +155,41 @@ def export_timeline_mix(
 
     progress(0.95, "hashing the export")
     return JobOutput(_result(expecting, params), (expecting,))
+
+
+def refuse_a_silent_mix(timeline: Timeline, name: str) -> None:
+    """Refuse to export a timeline with nothing on its audio tracks, before anything queues.
+
+    Resolve takes such a render and never runs it: the job sits at "Ready for background
+    render" at 0%, ``IsRenderingInProgress()`` reports ``True``, no dialog opens, and there
+    is no error and no timeout — only ``DeleteAllRenderJobs()`` clears it, and the next one
+    wedges the same way (#88, live on Studio 21.0.3.7). A hang is the one failure nothing
+    downstream can recover from or explain, so the precondition is checked here rather than
+    left to the queue.
+
+    The counts are read straight off the timeline rather than through ``Reader.optional``:
+    a getter that fails has to raise, because degrading it to an empty list would let a
+    dying handle read as "no audio" and refuse a timeline that has a mix on it. Reading
+    them off a timeline that is not the current one is sound — verified live on 21.0.3.7,
+    where ``GetItemListInTrack`` agreed exactly with the current-timeline reading, unlike
+    ``GetTakesCount`` and ``GetIsTrackEnabled`` (#84).
+    """
+    tracks = int(timeline.GetTrackCount("audio") or 0)
+    items = sum(
+        len(timeline.GetItemListInTrack("audio", index) or []) for index in range(1, tracks + 1)
+    )
+    if items:
+        return
+    log.info("Refusing a mix export of %r: %d audio tracks, no items on them", name, tracks)
+    raise AudioExportError(
+        cause=f"Timeline {name!r} has no audio items, so there is no mix to export.",
+        fix=(
+            "Check you targeted the timeline you meant — list_timelines names them, and "
+            "inspect_timeline reports what sits on each track. Resolve queues an audio-only "
+            "render of a silent timeline and never runs it, so this refuses instead."
+        ),
+        detail={"timeline": name, "audio_tracks": tracks, "audio_items": 0},
+    )
 
 
 def _as_export_failure(exc: RenderQueueError) -> AudioExportError:
@@ -316,6 +352,7 @@ def audio_source(
         project = current_project(connection, "No project is open, so there is no timeline.")
         found = find_timeline(project, timeline)
         name = str(found.GetName() or "timeline")
+        refuse_a_silent_mix(found, name)
         return Source(
             fingerprint(Reader(connection), found),
             _timeline_params(name, sample_rate, bit_depth),

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -515,6 +515,8 @@ class FakeTimeline(AnswersNone):
         }
         self._markers = dict(markers or {})
         self._owner = owner
+        #: #84's defect, opt-in: track flags read as off unless this timeline is current.
+        self.track_flags_need_current = False
         self.marker_writes: list[dict[str, Any]] = []
         self.refuse_markers = False
         # Refusing one marker by name is how a failed *replacement* is staged: Resolve
@@ -613,9 +615,25 @@ class FakeTimeline(AnswersNone):
         return list(track.items) if track else None
 
     def GetIsTrackEnabled(self, track_type: str, index: int) -> bool:  # noqa: N802
+        """Whether the track is on — and, opted into, the lie Resolve tells about that.
+
+        ``track_flags_need_current`` models #84: on Studio 21.0.3.7 this getter answers
+        ``False`` for *every* track of a timeline that is not the project's current one,
+        with no error and no ``None`` to distinguish "off" from "you did not ask the
+        current timeline". It is off by default because the read path documents the
+        defect rather than working around it; a caller whose correctness depends on
+        having switched first turns it on, and then a check that runs before the switch
+        reads every track as off.
+        """
         self._check()
+        if self.track_flags_need_current and not self._is_current():
+            return False
         track = self._track(track_type, index)
         return bool(track and track.enabled)
+
+    def _is_current(self) -> bool:
+        project = self._owner.current_project if self._owner is not None else None
+        return project is not None and project.GetCurrentTimeline() is self
 
     def GetIsTrackLocked(self, track_type: str, index: int) -> bool:  # noqa: N802
         self._check()

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1924,6 +1924,25 @@ def sync_reference(
     return FakeTimeline(name, fps, start_frame=start_frame, video=video)
 
 
+def with_a_mix(
+    timeline: FakeTimeline,
+    name: str = "Board mix.wav",
+    duration: int = 500,
+) -> FakeTimeline:
+    """Put a board recording on the timeline's first audio track, and hand it back.
+
+    A ``FakeTimeline`` is built with no tracks at all, which is the one timeline Resolve
+    will not export: an audio-only render of a cut with nothing on its audio tracks is
+    queued and then never run (#88). Any fake standing in for a timeline whose mix comes
+    off the render queue therefore has to carry audio, or the test is exercising the
+    refusal rather than the export it means to.
+    """
+    timeline._tracks["audio"].append(
+        FakeTrack("Audio 1", [FakeTimelineItem(name, timeline.GetStartFrame(), duration)])
+    )
+    return timeline
+
+
 def studio(
     project: str | None = "sunset-set",
     timeline: str | FakeTimeline | None = "sunset-set v3",

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1924,11 +1924,7 @@ def sync_reference(
     return FakeTimeline(name, fps, start_frame=start_frame, video=video)
 
 
-def with_a_mix(
-    timeline: FakeTimeline,
-    name: str = "Board mix.wav",
-    duration: int = 500,
-) -> FakeTimeline:
+def with_a_mix(timeline: FakeTimeline) -> FakeTimeline:
     """Put a board recording on the timeline's first audio track, and hand it back.
 
     A ``FakeTimeline`` is built with no tracks at all, which is the one timeline Resolve
@@ -1936,10 +1932,15 @@ def with_a_mix(
     queued and then never run (#88). Any fake standing in for a timeline whose mix comes
     off the render queue therefore has to carry audio, or the test is exercising the
     refusal rather than the export it means to.
+
+    Kept as a wrapper rather than a default on the fake, because a timeline that carries
+    audio is not the default a *Resolve* timeline has, and the tests that assert on track
+    counts read the fake's tracks as given.
     """
-    timeline._tracks["audio"].append(
-        FakeTrack("Audio 1", [FakeTimelineItem(name, timeline.GetStartFrame(), duration)])
-    )
+    item = FakeTimelineItem("Board mix.wav", timeline._start_frame, 500)
+    if timeline._owner is not None:
+        item.adopt(timeline._owner)
+    timeline._tracks["audio"].append(FakeTrack("Audio 1", [item]))
     return timeline
 
 

--- a/tests/test_audio_acquisition.py
+++ b/tests/test_audio_acquisition.py
@@ -19,10 +19,16 @@ from resolve_mcp.audio.acquire import (
     _as_export_failure,
     acquire_clip_audio,
     acquire_timeline_audio,
+    audio_source,
     mapping_conflict,
 )
 from resolve_mcp.config import get_config
-from resolve_mcp.errors import AudioExtractionError, AudioMappingError, RenderQueueError
+from resolve_mcp.errors import (
+    AudioExportError,
+    AudioExtractionError,
+    AudioMappingError,
+    RenderQueueError,
+)
 from resolve_mcp.ffmpeg import Completed, Runner
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.resolve.connection import get_connection
@@ -33,11 +39,13 @@ from .fakes import (
     FakeProject,
     FakeResolve,
     FakeTimeline,
+    FakeTimelineItem,
     ffmpeg_absent,
     ffmpeg_refusing,
     media_pool,
     studio,
     sync_reference,
+    with_a_mix,
     write_wav,
 )
 
@@ -55,7 +63,7 @@ def fixture_audio(tmp_path: Path) -> Path:
 
 
 def test_the_timeline_mix_comes_off_the_render_queue_as_a_48k_24bit_wav(attach: Attach) -> None:
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     attach(resolve)
 
     record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
@@ -77,8 +85,8 @@ def test_the_timeline_mix_comes_off_the_render_queue_as_a_48k_24bit_wav(attach: 
 
 
 def test_exporting_another_timeline_puts_the_directors_timeline_back(attach: Attach) -> None:
-    open_now = FakeTimeline("sunset-set v3", "59.94")
-    other = FakeTimeline("sunset-set v2", "59.94")
+    open_now = with_a_mix(FakeTimeline("sunset-set v3", "59.94"))
+    other = with_a_mix(FakeTimeline("sunset-set v2", "59.94"))
     resolve = studio(timeline=open_now, timelines=[open_now, other])
     attach(resolve)
 
@@ -88,7 +96,7 @@ def test_exporting_another_timeline_puts_the_directors_timeline_back(attach: Att
 
 
 def test_a_rerun_with_an_unchanged_timeline_is_an_instant_cache_hit(attach: Attach) -> None:
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     attach(resolve)
     first = wait_for(acquire_timeline_audio(get_connection())["job_id"])
 
@@ -101,7 +109,7 @@ def test_a_rerun_with_an_unchanged_timeline_is_an_instant_cache_hit(attach: Atta
 
 
 def test_refresh_exports_again_even_when_the_timeline_looks_unchanged(attach: Attach) -> None:
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     attach(resolve)
     wait_for(acquire_timeline_audio(get_connection())["job_id"])
 
@@ -114,7 +122,7 @@ def test_refresh_exports_again_even_when_the_timeline_looks_unchanged(attach: At
 
 def test_an_edited_timeline_is_a_different_key_and_exports_again(attach: Attach) -> None:
     """The fingerprint has to move when the cut does, or analysis reads yesterday's mix."""
-    timeline = FakeTimeline("sunset-set v3", "59.94")
+    timeline = with_a_mix(FakeTimeline("sunset-set v3", "59.94"))
     resolve = studio(timeline=timeline)
     attach(resolve)
     first = wait_for(acquire_timeline_audio(get_connection())["job_id"])
@@ -130,7 +138,7 @@ def test_an_edited_timeline_is_a_different_key_and_exports_again(attach: Attach)
 
 def test_a_take_swap_that_keeps_the_duration_still_exports_again(attach: Attach) -> None:
     """Bounds and track counts alone would call a recut timeline unchanged."""
-    timeline = sync_reference()
+    timeline = with_a_mix(sync_reference())
     resolve = studio(timeline=timeline)
     attach(resolve)
     first = wait_for(acquire_timeline_audio(get_connection())["job_id"])
@@ -147,7 +155,7 @@ def test_a_take_swap_that_keeps_the_duration_still_exports_again(attach: Attach)
 
 def test_the_export_renders_one_file_for_the_whole_timeline(attach: Attach) -> None:
     """The other render mode writes a file per clip — hundreds of fragments, not the mix."""
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     attach(resolve)
 
     wait_for(acquire_timeline_audio(get_connection())["job_id"])
@@ -162,7 +170,7 @@ def test_the_mix_still_exports_on_a_build_that_refuses_the_wav_pair(attach: Atta
     so the worker names it as the fallback. Without this test the worker could stop passing
     it and every other test here would stay green.
     """
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     project = _project(resolve)
     project.accepts_format = False
     project.render_presets["Audio Only"] = ("wav", "lpcm")
@@ -182,7 +190,7 @@ def test_the_mix_still_exports_on_a_build_that_refuses_the_wav_pair(attach: Atta
 def test_a_build_with_no_wav_route_at_all_fails_the_job_naming_both(attach: Attach) -> None:
     """The pair refused and no usable fallback: the reply has to name the preset too,
     or the machine that cannot render audio looks identical to one missing a codec."""
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     _project(resolve).accepts_format = False  # and no "Audio Only" among the presets
     attach(resolve)
 
@@ -195,7 +203,7 @@ def test_a_build_with_no_wav_route_at_all_fails_the_job_naming_both(attach: Atta
 
 
 def test_a_queue_that_refuses_the_job_fails_the_job_not_the_server(attach: Attach) -> None:
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     _project(resolve).accepts_job = False
     attach(resolve)
 
@@ -205,6 +213,54 @@ def test_a_queue_that_refuses_the_job_fails_the_job_not_the_server(attach: Attac
     assert record.error is not None
     assert record.error["code"] == "audio_export_failed"
     assert "audio on it" in record.error["fix"]
+
+
+def test_a_timeline_with_no_audio_items_is_refused_before_anything_is_queued(
+    attach: Attach,
+) -> None:
+    """#88, live on 21.0.3.7: Resolve queues this render and never runs it.
+
+    The job sits at "Ready for background render" at 0% with ``IsRenderingInProgress()``
+    reporting True and no dialog open, and the caller's wait blocks until its own timeout.
+    Nothing downstream can recover from that or explain it, so the queue must never see it.
+    """
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94", video=[[_shot()]]))
+    attach(resolve)
+
+    with pytest.raises(AudioExportError) as raised:
+        acquire_timeline_audio(get_connection())
+
+    assert "no audio items" in raised.value.cause
+    assert "sunset-set v3" in raised.value.cause
+    assert _project(resolve).render_jobs == []
+
+
+def test_an_analysis_of_a_timeline_with_no_audio_declines_up_front_too(attach: Attach) -> None:
+    """``audio_source`` promises the route's refusals before a job starts, not inside one."""
+    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94", video=[[_shot()]])))
+
+    with pytest.raises(AudioExportError):
+        audio_source(get_connection())
+
+
+def test_a_timeline_with_audio_on_a_later_track_is_still_exportable(attach: Attach) -> None:
+    """The count is across every audio track: an empty A1 says nothing about the mix."""
+    timeline = FakeTimeline(
+        "sunset-set v3",
+        "59.94",
+        video=[[_shot()]],
+        audio=[[], [FakeTimelineItem("Board mix.wav", 0, 500)]],
+    )
+    attach(studio(timeline=timeline))
+
+    record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert record.state == "completed", record.error
+
+
+def _shot() -> FakeTimelineItem:
+    """One video item, so the refusal is about the audio and not about an empty timeline."""
+    return FakeTimelineItem("Cam A.mp4", 0, 500)
 
 
 # --- clip scope --------------------------------------------------------------------------

--- a/tests/test_audio_acquisition.py
+++ b/tests/test_audio_acquisition.py
@@ -277,7 +277,7 @@ def test_audio_that_sits_only_on_switched_off_tracks_is_refused_too(attach: Atta
     assert record.state == "failed"
     assert record.error is not None
     assert record.error["code"] == "audio_export_failed"
-    assert "switched off" in record.error["cause"]
+    assert "switched on and carrying audio" in record.error["cause"]
     assert _project(resolve).render_jobs == []
 
 
@@ -297,6 +297,48 @@ def test_one_live_audio_track_is_enough_even_beside_switched_off_ones(attach: At
     record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
 
     assert record.state == "completed", record.error
+
+
+def test_the_track_check_runs_after_the_switch_not_before_it(attach: Attach) -> None:
+    """#84: track flags read as off on any timeline that is not current.
+
+    So the switched-on check is only truthful once the export has made its timeline
+    current. Run it a moment earlier — in the starter, where the cheaper check lives — and
+    it refuses every timeline the agent did not already have open. The fake tells that lie
+    here on purpose, so moving the check turns this red rather than the live machine.
+    """
+    open_now = with_a_mix(FakeTimeline("sunset-set v3", "59.94"))
+    other = with_a_mix(FakeTimeline("sunset-set v2", "59.94"))
+    other.track_flags_need_current = True
+    attach(studio(timeline=open_now, timelines=[open_now, other]))
+
+    record = wait_for(acquire_timeline_audio(get_connection(), timeline="sunset-set v2")["job_id"])
+
+    assert record.state == "completed", record.error
+
+
+def test_a_track_that_will_not_say_whether_it_is_on_exports_rather_than_refuses(
+    attach: Attach,
+) -> None:
+    """Same trade as the unreadable count: silence about a track is not "the track is off"."""
+    timeline = _TimelineThatWillNotSayIfTracksAreOn(
+        "sunset-set v3",
+        "59.94",
+        video=[[_shot()]],
+        audio=[[FakeTimelineItem("Board mix.wav", 0, 500)]],
+    )
+    attach(studio(timeline=timeline))
+
+    record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert record.state == "completed", record.error
+
+
+class _TimelineThatWillNotSayIfTracksAreOn(FakeTimeline):
+    """A build whose ``GetIsTrackEnabled`` answers nothing at all."""
+
+    def GetIsTrackEnabled(self, track_type: str, index: int) -> Any:  # noqa: N802
+        return None
 
 
 def test_a_track_count_that_will_not_read_exports_rather_than_refuses(attach: Attach) -> None:

--- a/tests/test_audio_acquisition.py
+++ b/tests/test_audio_acquisition.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import shutil
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -40,6 +41,7 @@ from .fakes import (
     FakeResolve,
     FakeTimeline,
     FakeTimelineItem,
+    FakeTrack,
     ffmpeg_absent,
     ffmpeg_refusing,
     media_pool,
@@ -256,6 +258,66 @@ def test_a_timeline_with_audio_on_a_later_track_is_still_exportable(attach: Atta
     record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
 
     assert record.state == "completed", record.error
+
+
+def test_audio_that_sits_only_on_switched_off_tracks_is_refused_too(attach: Attach) -> None:
+    """Live on 21.0.3.7: one clip on A1 with A1 disabled wedges the queue exactly as an
+    empty timeline does. The hang is "nothing to render", not "no items"."""
+    timeline = FakeTimeline(
+        "sunset-set v3",
+        "59.94",
+        video=[[_shot()]],
+        audio=[FakeTrack("Audio 1", [FakeTimelineItem("Board mix.wav", 0, 500)], enabled=False)],
+    )
+    resolve = studio(timeline=timeline)
+    attach(resolve)
+
+    record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "audio_export_failed"
+    assert "switched off" in record.error["cause"]
+    assert _project(resolve).render_jobs == []
+
+
+def test_one_live_audio_track_is_enough_even_beside_switched_off_ones(attach: Attach) -> None:
+    """The refusal is about the whole timeline, not about any one track being off."""
+    timeline = FakeTimeline(
+        "sunset-set v3",
+        "59.94",
+        video=[[_shot()]],
+        audio=[
+            FakeTrack("Audio 1", [FakeTimelineItem("Scratch.wav", 0, 500)], enabled=False),
+            FakeTrack("Audio 2", [FakeTimelineItem("Board mix.wav", 0, 500)]),
+        ],
+    )
+    attach(studio(timeline=timeline))
+
+    record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert record.state == "completed", record.error
+
+
+def test_a_track_count_that_will_not_read_exports_rather_than_refuses(attach: Attach) -> None:
+    """An unreadable count is not zero audio, and must not be spent refusing a real mix.
+
+    The guard trades one failure for another, and this is the direction that trade has to
+    run: a hang announces itself by never finishing, while a false refusal of a timeline
+    that does have a mix on it looks exactly like the truth.
+    """
+    attach(studio(timeline=_TimelineThatWillNotCountItsTracks("sunset-set v3", "59.94")))
+
+    record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert record.state == "completed", record.error
+
+
+class _TimelineThatWillNotCountItsTracks(FakeTimeline):
+    """A handle that answers ``None`` for its audio track count — a dying one, or an old build."""
+
+    def GetTrackCount(self, track_type: str) -> Any:  # noqa: N802 - mirrors the Resolve API
+        return None if track_type == "audio" else super().GetTrackCount(track_type)
 
 
 def _shot() -> FakeTimelineItem:

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -44,6 +44,7 @@ from .fakes import (
     FakeTimeline,
     media_pool,
     studio,
+    with_a_mix,
     write_wav,
 )
 
@@ -70,7 +71,7 @@ def test_four_stems_land_on_disk_keyed_by_content_hash_and_params(
     attach: Attach,
     separating: FakeSeparator,
 ) -> None:
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
 
     record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
 
@@ -94,7 +95,7 @@ def test_the_drum_stem_is_what_the_second_pass_decomposes(
     attach: Attach,
     separating: FakeSeparator,
 ) -> None:
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
 
     record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
 
@@ -105,7 +106,7 @@ def test_the_drum_stem_is_what_the_second_pass_decomposes(
 
 
 def test_each_pass_runs_its_own_model(attach: Attach, separating: FakeSeparator) -> None:
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
     config = get_config()
 
     record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
@@ -122,7 +123,7 @@ def test_the_stems_of_both_passes_are_kept_apart_on_disk(
     separating: FakeSeparator,
 ) -> None:
     """One directory per pass, or the drum decomposition overwrites the drum stem it read."""
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
 
     record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
 
@@ -179,7 +180,7 @@ def test_the_model_downloads_own_bar_is_not_this_passs_progress(tmp_path: Path) 
 
 def test_the_acquisition_is_reported_as_the_first_quarter_of_the_job(attach: Attach) -> None:
     """The export runs inside this job, so its own progress has to be visible from here."""
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
     steps: list[tuple[float, str]] = []
     source = audio_source(get_connection())
 
@@ -197,7 +198,7 @@ def test_a_rerun_on_an_unchanged_timeline_never_separates_again(
     attach: Attach,
     separating: FakeSeparator,
 ) -> None:
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
     first = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
 
     again = separate_stems(get_connection(), runner=separating)
@@ -209,7 +210,7 @@ def test_a_rerun_on_an_unchanged_timeline_never_separates_again(
 
 
 def test_refresh_separates_again(attach: Attach, separating: FakeSeparator) -> None:
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
     wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
 
     again = wait_for(separate_stems(get_connection(), runner=separating, refresh=True)["job_id"])
@@ -276,7 +277,7 @@ def test_the_stems_a_job_owns_are_what_its_cache_entry_verifies(
     separating: FakeSeparator,
 ) -> None:
     """Delete a stem and the next run redoes the work rather than pointing at a gone file."""
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
     first = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
     assert first.result is not None
     Path(first.result["drums"]["kick"]).unlink()
@@ -293,7 +294,7 @@ def test_the_stems_a_job_owns_are_what_its_cache_entry_verifies(
 
 
 def test_no_separator_on_the_machine_is_a_named_failure(attach: Attach) -> None:
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
 
     record = wait_for(separate_stems(get_connection(), runner=_absent)["job_id"])
 
@@ -304,7 +305,7 @@ def test_no_separator_on_the_machine_is_a_named_failure(attach: Attach) -> None:
 
 
 def test_the_separators_own_complaint_travels_back_with_the_failure(attach: Attach) -> None:
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
     refusing = FakeSeparator(FOUR_STEMS, returncode=1, output=("No such model: htdemucs_ft.yaml",))
 
     record = wait_for(separate_stems(get_connection(), runner=refusing)["job_id"])
@@ -316,7 +317,7 @@ def test_the_separators_own_complaint_travels_back_with_the_failure(attach: Atta
 
 
 def test_a_model_that_leaves_a_stem_out_fails_naming_it(attach: Attach) -> None:
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
     partial = FakeSeparator(FOUR_STEMS, ("kick", "snare"))
 
     record = wait_for(separate_stems(get_connection(), runner=partial)["job_id"])
@@ -333,7 +334,7 @@ def test_a_failed_export_fails_the_stem_job_with_the_exports_own_advice(
     separating: FakeSeparator,
 ) -> None:
     """The acquisition runs inside this job, so its failure has to arrive as this job's."""
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     project = resolve.current_project
     assert project is not None
     project.accepts_job = False
@@ -376,7 +377,7 @@ def test_a_source_clip_is_extracted_then_separated(
 
 
 def test_a_clip_scope_with_no_clip_named_is_refused_before_a_job_starts(attach: Attach) -> None:
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
 
     with pytest.raises(InvalidRequestError) as raised:
         separate_stems(get_connection(), scope="clip")
@@ -385,7 +386,7 @@ def test_a_clip_scope_with_no_clip_named_is_refused_before_a_job_starts(attach: 
 
 
 def test_an_unknown_scope_says_which_two_there_are(attach: Attach) -> None:
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
 
     with pytest.raises(InvalidRequestError) as raised:
         separate_stems(get_connection(), scope="project")

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -45,6 +45,7 @@ from .fakes import (
     FakeTimeline,
     media_pool,
     studio,
+    with_a_mix,
     write_wav,
 )
 
@@ -240,7 +241,7 @@ def test_the_transcript_is_keyed_on_the_audio_rather_than_on_the_clips_name(
 
 
 def test_the_timeline_mix_is_transcribed_through_the_render_queue(attach: Attach) -> None:
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     attach(resolve)
 
     record = wait_for(_transcribe()["job_id"])
@@ -258,7 +259,7 @@ def test_a_second_transcript_of_one_timeline_does_not_export_the_mix_twice(
     attach: Attach,
 ) -> None:
     """The acquisition it chains onto has its own cache; a reworded run reuses the WAV."""
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     attach(resolve)
     wait_for(_transcribe()["job_id"])
 
@@ -284,7 +285,7 @@ def test_an_acquisition_that_fails_in_its_thread_fails_the_transcript_with_its_a
     attach: Attach,
 ) -> None:
     """The agent needs the render queue's fix, not "the audio was not acquired"."""
-    resolve = studio(timeline=FakeTimeline("sunset-set v3", "59.94"))
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     _project(resolve).accepts_job = False
     attach(resolve)
 
@@ -360,7 +361,7 @@ def test_the_tool_starts_a_job_and_returns_its_record(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The timeline route, so the only substituted thing is the model itself."""
-    attach(studio(timeline=FakeTimeline("sunset-set v3", "59.94")))
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
     monkeypatch.setattr(whisper, "transcribe", _saying(SPOKEN, []))
 
     reply = analysis_tools.transcribe_audio()


### PR DESCRIPTION
Closes #88.

Resolve queues an audio-only render of a timeline it has nothing to render for, and then never runs it — the job sits at `Ready for background render` at 0%, `IsRenderingInProgress()` reports `True`, no dialog opens, and there is no error and no timeout. Only `DeleteAllRenderJobs()` clears it. The caller blocks until its own timeout with nothing to explain why. This refuses before anything is queued.

## What the ticket asked to decide first

> **Whether the track-item count is trustworthy** — note that `GetIsTrackEnabled` and `GetTakesCount` both return plausible falsy values for a **non-current** timeline (#84). If `GetItemListInTrack` has the same defect, a guard reading zero items could refuse a perfectly good timeline that merely is not current. **This must be verified live before the guard ships.**

Verified live, Studio 21.0.3.7, before writing the guard: **`GetItemListInTrack` does not have #84's defect.** Read on three real timelines while not current and again while current, the answers were identical, zero-item tracks included (`audio: [525, 7, 12, 0, 0, 0, 0]` both ways), and a purpose-built scratch timeline with nothing on any track read `audio: [0]` both ways. So the item count is safe to read from a starter, and this ticket does not block on #84's sweep.

The other decision — `acquire.py` or `render.submit` — went the way the ticket leaned, and for the reason the clip route already sets: `acquire_clip_audio` refuses offline media and linked audio in its *starter*, so the refusal reaches the agent as a reply rather than a job it has to poll. `export_timeline_mix` checks again, so the invariant "nothing reaches the queue unchecked" holds for any future caller.

## The hang is wider than the ticket knew

While verifying the fix, one clip on A1 with **A1 switched off** wedged the queue identically — 45 s at `Ready for background render`, 0%, `IsRenderingInProgress() True`. The hang is not "no audio items", it is "nothing to render", so there is a second check for it. That one reads `GetIsTrackEnabled`, which *does* have #84's defect, so it runs in the worker inside the `current_timeline` block — still before anything queues. This is scope beyond #88's letter, and Daniel left the call to me: **it stays**. Splitting it out would ship the fix for #88 while knowingly leaving an identical wedge reachable, and it is not separable cheaply — it shares `_audio_items` with the check the ticket asked for, so a separate ticket either duplicates that counter or exports it for one caller.

Neither check ever refuses on a reading that failed: a getter that answers `None` leaves the guard silent, because refusing a timeline that has a mix on it is worse than the hang — the hang at least announces itself by never finishing.

## Live results (Studio 21.0.3.7, python.org 3.12, this machine)

| case | before | after |
|---|---|---|
| video item on V1, nothing on A1 | queued, 0%, forever | refused in **0.0 s**, **0 jobs queued** |
| clip on A1, A1 switched off | queued, 0%, 45 s and counting | refused in **1.62 s**, **0 jobs queued** |
| `Mailand clip` (audio on an enabled track) | exports | exports — 59.977 s / 48 kHz / 24-bit WAV, job status `Rendering`, queue drains to 0 |

## Test seam

Fake tier, as the ticket said. The refusals are decisions and verify there. Two things worth calling out:

- `FakeTimeline` is built with **no tracks at all**, so the whole fake tier was exercising the very timeline Resolve will not export — every timeline-mix test was green against the input that hangs. `fakes.with_a_mix` puts a board recording on A1 for the tests that mean to reach the queue.
- The switched-on check is only correct *after* the timeline is current, and nothing structural enforced that. `FakeTimeline.track_flags_need_current` now models #84's lie opt-in (following the `switches_current_timeline` precedent), and a test exports a non-current timeline whose flags read as off beforehand. Confirmed the seam bites: moving the call into the starter turns that test red with exactly the false refusal it guards against.

## Review

`/code-review` (Standards and Spec, parallel sub-agents), then a focused pass over the fix diff.

**Both axes, same defect — fixed in c488589.** The docstring promised a failed getter would raise rather than degrade, and `or 0` / `or []` did exactly the degrading it disclaimed; a handle answering `None` would have counted as "no audio" and refused a timeline with a mix on it. Only a reading that succeeded may refuse now.

**Standards, judgement calls — fixed:** `refuse_a_silent_mix` renamed (a muted or silent clip passes it; only the name said otherwise); `with_a_mix` dropped two parameters no caller passed and now adopts the item it adds, so a `die_after` fake stays truthful.

**Standards, judgement calls — not taken:** the four-line preamble shared by the two starters was left duplicated (the two "no project is open" messages differ, so folding them costs a parameter to save three lines); `with_a_mix` at ~27 call sites was kept over a default audio track on `FakeTimeline`, because a Resolve timeline's tracks are what the fake should report and several tests assert on them.

**Spec:** flagged that the live results existed only in a docstring — they are now on #88 and in this body; and that `export_timeline_mix` stayed publicly callable without the check, which is why it checks too.

**Focused re-review of the fix diff — fixed in 5aada35:** no seam stopped the switched-on check being moved out of the `current_timeline` block (the fake did not model #84, so the tier would have stayed green through the move); the refusal said "every audio track is switched off", a lie for the disabled-A1-plus-empty-A2 timeline it also refuses; the counter's docstring claimed tolerance for a build missing a getter outright, which per #41 dies with `NoneType is not callable` instead; and the unreadable-track-flag path had no test.

Fake tier green, mypy strict clean, ruff clean.

Review: clean — two rounds of findings fixed, third pass over the fix diff clean.
