### PR TITLE
fix: fail a render that never starts in 60s, not 3600 (#92)

### DIFF
--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -282,8 +282,9 @@ def _as_export_failure(exc: RenderQueueError) -> AudioExportError:
     """Re-label a queue failure as an audio one, keeping any fix the queue was specific about.
 
     The generic queue advice is worth replacing with "check the timeline has audio on it".
-    Advice the queue raised for one case — a modal dialog stalling the render — is not:
-    that is the more actionable of the two, so it survives the relabelling.
+    Advice the queue raised for a specific case — a wedged render engine, a modal dialog
+    stalling the render — is not: those are the more actionable of the two, so they survive
+    the relabelling.
     """
     specific = exc.fix if exc.fix != RenderQueueError.default_fix else None
     return AudioExportError(cause=exc.cause, fix=specific, detail=exc.detail)

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -40,10 +40,15 @@ Project = Any
 
 COMPLETE = "Complete"
 FAILED = ("Failed", "Cancelled")
-QUEUED = ("", "Ready", "Ready for background render")
-"""Statuses that mean the job is accepted but not running — the empty one is an unreported
-reading. Anything *not* here counts as started, so a status this build spells differently
-costs the render timeout rather than a false refusal."""
+QUEUED = ("Ready", "Ready for background render")
+"""Statuses that say the job is accepted but not running — the only ones the start deadline
+may refuse on.
+
+Deliberately a whitelist of readings that *succeeded*. A status this build spells
+differently, and an unreported one (the way a dying handle and an unsupported build both
+read), are not "queued": they cost the render timeout rather than a false refusal, because
+a re-render is the worse trade against a wedge that at least announces itself by never
+finishing."""
 POLL_SECONDS = 1.0
 RENDER_TIMEOUT = 3600.0
 START_TIMEOUT = 60.0
@@ -51,6 +56,17 @@ START_TIMEOUT = 60.0
 
 Deliberately generous: the observed healthy transition out of the queue is under 10s, so a
 minute leaves room for a loaded machine, and the cost of being wrong is a re-render."""
+
+WEDGED_FIX = (
+    "Restart Resolve — its render engine can get stuck so that every job it is given sits "
+    "queued forever, and clearing the render queue does not clear it. If that is not it, "
+    "check the Deliver page for a modal dialog holding the queue, then retry."
+)
+"""Both known causes of a job that never starts, likeliest first (#92).
+
+The order is what was observed twice live: in #88's wedge and #92's, no dialog was open, and
+only a restart cleared it. Naming the dialog alone sends the reader to a GUI with nothing to
+show them."""
 
 STATUS = "JobStatus"
 PERCENT = "CompletionPercentage"
@@ -215,7 +231,18 @@ def render(
             detail={"render_job_id": job_id},
         )
     try:
-        _watch(project, job_id, progress, poll, timeout, start_timeout, now, sleep)
+        # Keyword, not positional: timeout and start_timeout are adjacent floats, and
+        # swapping them would typecheck and quietly hand the caller the wrong diagnosis.
+        _watch(
+            project,
+            job_id,
+            progress,
+            poll=poll,
+            timeout=timeout,
+            start_timeout=start_timeout,
+            now=now,
+            sleep=sleep,
+        )
     finally:
         _remove(project, job_id)
 
@@ -244,8 +271,8 @@ def _watch(
     for as long as anyone cares to wait — the distinguishing signal is the transition, not
     the duration, so it is worth a deadline of its own (#92, live on 21.0.3.7).
     """
-    started = now()
-    running = False
+    began_at = now()
+    has_started = False
     while True:
         reading = project.GetRenderJobStatus(job_id) or {}
         status = str(reading.get(STATUS, ""))
@@ -259,25 +286,22 @@ def _watch(
                 cause=f"The render job ended {status}.",
                 detail={"render_job_id": job_id, "status": reading},
             )
-        waited = now() - started
-        if not running and status not in QUEUED:
-            running = True
+        waited = now() - began_at
+        # Three states, not two: a reading that is neither QUEUED nor empty is the job
+        # running, and an empty one is a reading that failed — which neither starts the
+        # clock's other half nor is allowed to refuse.
+        if not has_started and status and status not in QUEUED:
+            has_started = True
             log.info("Render job %s started rendering after %.0fs (%s)", job_id, waited, status)
-        if not running and waited > start_timeout:
+        if not has_started and status in QUEUED and waited > start_timeout:
             raise RenderQueueError(
                 cause=(
                     f"Resolve accepted the render job and never started it: it was still "
-                    f"{status or 'unreported'} after {start_timeout:.0f}s, at "
-                    f"{int(percent * 100)}%. On this build a job stuck at "
-                    f"'Ready for background render' means the render engine is wedged, not "
-                    f"that the render is slow."
+                    f"{status!r} after {start_timeout:.0f}s, at {int(percent * 100)}%. A job "
+                    f"that has not left the queue by now is not a slow render — nothing is "
+                    f"running it."
                 ),
-                fix=(
-                    "Restart Resolve — its render engine can get stuck so that every job it "
-                    "is given sits queued forever, and clearing the render queue does not "
-                    "clear it. If that is not it, check the Deliver page for a modal dialog "
-                    "holding the queue, then retry."
-                ),
+                fix=WEDGED_FIX,
                 detail={
                     "render_job_id": job_id,
                     "start_timeout_seconds": start_timeout,
@@ -288,11 +312,23 @@ def _watch(
             raise RenderQueueError(
                 cause=f"The render job was still {status or 'unreported'} after {timeout:.0f}s.",
                 fix=(
-                    "The job did start, so this is a render that ran long or stalled "
-                    "mid-way. Check the Deliver page — a modal dialog in the Resolve GUI "
-                    "also stalls a running queue. Cancel the job there, then retry."
+                    # Which advice is true here depends on whether the job was ever seen
+                    # running: a caller may set the two deadlines such that this one lands
+                    # first, and a job that never started wants the wedge advice, not a
+                    # confident "it did start".
+                    (
+                        "The job did start, so this is a render that ran long or stalled "
+                        "mid-way. Check the Deliver page — a modal dialog in the Resolve "
+                        "GUI also stalls a running queue. Cancel the job there, then retry."
+                    )
+                    if has_started
+                    else WEDGED_FIX
                 ),
-                detail={"render_job_id": job_id, "timeout_seconds": timeout},
+                detail={
+                    "render_job_id": job_id,
+                    "timeout_seconds": timeout,
+                    "started": has_started,
+                },
             )
         sleep(poll)
 

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -11,6 +11,14 @@ not passed to a call — so three things here are decisions rather than API call
   accepted. The only truthful completion signal is the job's own status going to Complete,
   and a Failed or Cancelled status is a failure even though every call returned True.
 
+* **A job that never starts is a different failure from a slow one.** Resolve's render
+  engine can wedge such that every job it is handed sits at "Ready for background render"
+  at 0% forever — deleting the queue does not clear it, only restarting Resolve does — and
+  from the outside that is identical to a long render (#92, live on Studio 21.0.3.7). The
+  signal that separates them is a status transition, not a duration: a healthy job leaves
+  the queue in seconds. So starting has a deadline of its own, far shorter than the
+  render's, and blowing it says the engine is wedged rather than guessing at the GUI.
+
 * **A completed render still has to have written the file.** Resolve reports success for
   renders that land nothing on disk (an unwritable target directory does this). The caller
   passes the path it expects, and its absence is a failure, not a cache entry.
@@ -32,8 +40,17 @@ Project = Any
 
 COMPLETE = "Complete"
 FAILED = ("Failed", "Cancelled")
+QUEUED = ("", "Ready", "Ready for background render")
+"""Statuses that mean the job is accepted but not running — the empty one is an unreported
+reading. Anything *not* here counts as started, so a status this build spells differently
+costs the render timeout rather than a false refusal."""
 POLL_SECONDS = 1.0
 RENDER_TIMEOUT = 3600.0
+START_TIMEOUT = 60.0
+"""How long a job may sit queued before the engine is called wedged (#92).
+
+Deliberately generous: the observed healthy transition out of the queue is under 10s, so a
+minute leaves room for a loaded machine, and the cost of being wrong is a re-render."""
 
 STATUS = "JobStatus"
 PERCENT = "CompletionPercentage"
@@ -177,10 +194,16 @@ def render(
     progress: Callable[[float, str], None] | None = None,
     poll: float = POLL_SECONDS,
     timeout: float = RENDER_TIMEOUT,
+    start_timeout: float = START_TIMEOUT,
     now: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
 ) -> Path:
     """Start the job, watch it to completion, and hand back the file it wrote.
+
+    Two deadlines, because two different failures wear the same face. ``start_timeout``
+    covers a job that never leaves the queue — Resolve's render engine can wedge such that
+    every job it is given sits at "Ready for background render" at 0% forever — and
+    ``timeout`` covers one that is genuinely running and taking too long.
 
     ``now`` and ``sleep`` are parameters so the polling loop is testable without a test
     that actually waits.
@@ -192,7 +215,7 @@ def render(
             detail={"render_job_id": job_id},
         )
     try:
-        _watch(project, job_id, progress, poll, timeout, now, sleep)
+        _watch(project, job_id, progress, poll, timeout, start_timeout, now, sleep)
     finally:
         _remove(project, job_id)
 
@@ -211,10 +234,18 @@ def _watch(
     progress: Callable[[float, str], None] | None,
     poll: float,
     timeout: float,
+    start_timeout: float,
     now: Callable[[], float],
     sleep: Callable[[float], None],
 ) -> None:
+    """Poll the job until it completes, fails, or blows one of the two deadlines.
+
+    A job that has not left ``QUEUED`` has not started, and a wedged engine leaves it there
+    for as long as anyone cares to wait — the distinguishing signal is the transition, not
+    the duration, so it is worth a deadline of its own (#92, live on 21.0.3.7).
+    """
     started = now()
+    running = False
     while True:
         reading = project.GetRenderJobStatus(job_id) or {}
         status = str(reading.get(STATUS, ""))
@@ -228,12 +259,38 @@ def _watch(
                 cause=f"The render job ended {status}.",
                 detail={"render_job_id": job_id, "status": reading},
             )
-        if now() - started > timeout:
+        waited = now() - started
+        if not running and status not in QUEUED:
+            running = True
+            log.info("Render job %s started rendering after %.0fs (%s)", job_id, waited, status)
+        if not running and waited > start_timeout:
+            raise RenderQueueError(
+                cause=(
+                    f"Resolve accepted the render job and never started it: it was still "
+                    f"{status or 'unreported'} after {start_timeout:.0f}s, at "
+                    f"{int(percent * 100)}%. On this build a job stuck at "
+                    f"'Ready for background render' means the render engine is wedged, not "
+                    f"that the render is slow."
+                ),
+                fix=(
+                    "Restart Resolve — its render engine can get stuck so that every job it "
+                    "is given sits queued forever, and clearing the render queue does not "
+                    "clear it. If that is not it, check the Deliver page for a modal dialog "
+                    "holding the queue, then retry."
+                ),
+                detail={
+                    "render_job_id": job_id,
+                    "start_timeout_seconds": start_timeout,
+                    "status": reading,
+                },
+            )
+        if waited > timeout:
             raise RenderQueueError(
                 cause=f"The render job was still {status or 'unreported'} after {timeout:.0f}s.",
                 fix=(
-                    "Check the Deliver page — a modal dialog in the Resolve GUI stalls the "
-                    "queue. Cancel the job there, then retry."
+                    "The job did start, so this is a render that ran long or stalled "
+                    "mid-way. Check the Deliver page — a modal dialog in the Resolve GUI "
+                    "also stalls a running queue. Cancel the job there, then retry."
                 ),
                 detail={"render_job_id": job_id, "timeout_seconds": timeout},
             )

--- a/tests/test_render_queue.py
+++ b/tests/test_render_queue.py
@@ -82,6 +82,56 @@ def test_a_queue_that_never_finishes_times_out_pointing_at_the_gui(tmp_path: Pat
     assert project.render_queue == []
 
 
+def test_a_job_that_never_leaves_the_queue_fails_at_the_start_deadline(tmp_path: Path) -> None:
+    """#92, live on 21.0.3.7: a wedged render engine holds every job it is given at
+    "Ready for background render" at 0% forever, and deleting the queue does not clear it —
+    only restarting Resolve does. Waiting the render timeout out on that spends an hour on a
+    state that is knowable in seconds, so a job that never starts is refused on its own,
+    much shorter deadline. The clock here holds three readings: exhausting it would raise
+    StopIteration, so a loop that waited the hour out could not pass this.
+    """
+    project = FakeProject("sunset-set")
+    project.render_statuses = ["Ready for background render"]
+    clock = iter([0.0, 0.0, 61.0])
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.render(
+            project,
+            job_id,
+            tmp_path / "mix.wav",
+            now=lambda: next(clock),
+            sleep=_no_sleep,
+        )
+
+    assert "never started" in raised.value.cause
+    assert "Ready for background render" in raised.value.cause
+    assert "Restart Resolve" in raised.value.fix
+    assert raised.value.detail["start_timeout_seconds"] == render.START_TIMEOUT
+    assert project.render_queue == []
+
+
+def test_a_job_that_does_start_keeps_the_full_render_timeout(tmp_path: Path) -> None:
+    """The start deadline is about starting, not about finishing: once the job leaves the
+    queue it gets the whole hour, because a genuinely long render is not a wedge."""
+    project = FakeProject("sunset-set")
+    project.render_statuses = ["Ready for background render", "Rendering"]
+    clock = iter([0.0, 0.0, 100.0, 5_000.0])
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.render(
+            project,
+            job_id,
+            tmp_path / "mix.wav",
+            now=lambda: next(clock),
+            sleep=_no_sleep,
+        )
+
+    assert "still Rendering" in raised.value.cause
+    assert "never started" not in raised.value.cause
+
+
 def test_progress_comes_from_the_jobs_own_percentage(tmp_path: Path) -> None:
     project = FakeProject("sunset-set")
     project.render_statuses = ["Rendering", "Rendering", "Complete"]

--- a/tests/test_render_queue.py
+++ b/tests/test_render_queue.py
@@ -132,6 +132,54 @@ def test_a_job_that_does_start_keeps_the_full_render_timeout(tmp_path: Path) -> 
     assert "never started" not in raised.value.cause
 
 
+def test_a_status_that_does_not_read_is_never_refused_as_wedged(tmp_path: Path) -> None:
+    """Only a reading that succeeded may refuse. An unreported status is how this API says
+    "not on this build" and how a dying handle reads, and a running render behind one would
+    be thrown away by a start deadline that treated it as queued — the false refusal is the
+    worse trade, because the wedge at least announces itself by never finishing.
+    """
+    project = FakeProject("sunset-set")
+    project.render_statuses = [""]
+    clock = iter([0.0, 0.0, 100.0, 5_000.0])
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.render(
+            project,
+            job_id,
+            tmp_path / "mix.wav",
+            now=lambda: next(clock),
+            sleep=_no_sleep,
+        )
+
+    assert "still unreported" in raised.value.cause
+    assert "never started" not in raised.value.cause
+
+
+def test_a_render_timeout_that_lands_first_still_gives_the_wedge_advice(tmp_path: Path) -> None:
+    """The two deadlines are both the caller's to set, so the render timeout can land on a
+    job that never started. What it says then has to follow the job, not the deadline."""
+    project = FakeProject("sunset-set")
+    project.render_statuses = ["Ready for background render"]
+    clock = iter([0.0, 0.0, 61.0])
+    job_id = render.submit(project, {"TargetDir": str(tmp_path)}, ("wav", "lpcm"))
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.render(
+            project,
+            job_id,
+            tmp_path / "mix.wav",
+            timeout=30.0,
+            start_timeout=600.0,
+            now=lambda: next(clock),
+            sleep=_no_sleep,
+        )
+
+    assert "still Ready for background render" in raised.value.cause
+    assert raised.value.fix == render.WEDGED_FIX
+    assert raised.value.detail["started"] is False
+
+
 def test_progress_comes_from_the_jobs_own_percentage(tmp_path: Path) -> None:
     project = FakeProject("sunset-set")
     project.render_statuses = ["Rendering", "Rendering", "Complete"]


### PR DESCRIPTION
Closes #92.

## What changed

Resolve's render engine can wedge so that every job it is handed sits at `Ready for background render` at 0% forever — deleting the queue does not clear it, only restarting Resolve does. `_watch` had a single deadline, so that state was indistinguishable from a long render: the caller blocked for the full hour and was then told to check the Deliver page for a modal dialog, the one cause that was demonstrably *not* it in either observed wedge (#88's and this one's).

The distinguishing signal is a status transition, not a duration — a healthy job leaves the queue in under 10s. So `_watch` now carries a second deadline, `START_TIMEOUT = 60.0`, that applies only until the job leaves `QUEUED`, and its failure names both known causes likeliest-first (restart Resolve; then the dialog). A job that does start keeps the full hour, because a long render is not a wedge.

Decisions taken (both were open questions on the ticket):

* **Hard failure at the start deadline**, not warn-and-wait.
* **60s**, the generous end of the ticket's 30s–1min range: the observed healthy transition is under 10s, so a minute leaves room for a loaded machine, and the cost of being wrong is one re-render.

Only a status reading that *succeeded* may refuse. An unreported status and one this build spells differently are not "queued" — they cost the render timeout rather than a false refusal, the same trade the audio preconditions make.

## Test seam

Fake tier, as the ticket named it: `FakeProject` holds a job at `Ready for background render` indefinitely and `render.render` takes injectable `now`/`sleep`. Four tests — the wedge fails fast, a started job keeps the hour, an unreported status is never refused as wedged, and a render timeout landing first still gives the wedge advice. The wedge test's clock holds only three readings, so a loop that waited the hour out raises `StopIteration` rather than passing. 957 fake-tier tests pass; mypy strict and ruff clean. No live AC: the wedge itself is not reproducible at any seam, only our response to it.

## Review record

`/code-review` against `main` (two-axis, parallel sub-agents), run on the branch before this PR existed.

**Standards** — no documented-standard violations; six judgement calls. Acted on: the `_watch` call is now keyword (`timeout` and `start_timeout` are adjacent floats that would swap silently and invert the diagnosis); `started`/`running` renamed to `began_at`/`has_started`; the duplicated advice text is one constant, `WEDGED_FIX`. Not acted on: splitting the two raise blocks into named helpers (low value against the loop staying readable in one place), and dropping the `start_timeout` parameter as speculative (it earns its place for symmetry with `timeout`, which `deliver.py` sets to six hours — and a test now exercises it).

**Spec** — nothing missing, no scope creep; three findings in the message/edge layer, all fixed:

1. The `cause` un-hedged what the `fix` correctly hedged — it asserted the wedge as *the* explanation, which is the same over-confident diagnosis the ticket was filed about, one cause further along. It now states only what was observed and quotes the status actually read.
2. `""` (unreported) counted as `QUEUED`, so a running render behind a failed reading would be refused as wedged at 60s — the exact false refusal the docstring claimed to avoid. Three states now: `QUEUED` refuses, anything else latches started, an empty reading does neither.
3. The render timeout's fix said "The job did start" unconditionally, true only while `start_timeout < timeout` — both caller-settable. It now follows `has_started`.

The fix commit was re-checked as a focused pass over its own diff, per the workflow.

## Follow-up, deliberately not in this PR

Ticket decision 2 — **whether we should be calling `StopRendering()` at all**. The wedge followed `StopRendering()` + `DeleteAllRenderJobs()` against an in-flight render, and either, both, or neither could be the trigger. Settling it means deliberately wedging the live Resolve again, so it was deferred by the human rather than run. Nothing in this repo calls `StopRendering()`; `_remove` calls `DeleteRenderJob` on a finished job, which is a different and apparently safe thing. Worth its own ticket if we ever want to add a cancel path.

Review: clean — two-axis review run on the branch; all Spec findings and three of six Standards judgement calls fixed, remainder argued above.
