### PR TITLE
fix: sequence offline judged by frames; was_offline read before ReplaceClip (#85)

### DIFF
--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -22,6 +22,7 @@ rather than API calls, and are the reason this file exists at all:
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -49,6 +50,9 @@ BIN_SEPARATOR = "/"
 DEFAULT_LIST_LIMIT = 200
 IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"})
 SEQUENCE_TOKEN = "%"
+# Resolve paths an imported image sequence by folding the index range into the name —
+# shot_[0001-0024].png — a label, not a file (#85, Resolve Studio 21.0.3.7).
+SEQUENCE_RANGE = re.compile(r"\[(\d+)-\d+\]")
 
 FILE_PATH = "File Path"
 FRAMES = "Frames"
@@ -304,15 +308,23 @@ def is_offline(file_path: str) -> bool:
     """Whether the media behind a clip has moved away.
 
     Resolve exposes no offline flag, so this is a disk check. A clip with no path at all
-    (multicam, compound) is pathless rather than offline. A sequence pattern is judged by
-    its folder, since the pattern itself is never a file on disk.
+    (multicam, compound) is pathless rather than offline. Sequence paths are never files on
+    disk, so they get judged by what stands behind them: a ``%0Nd`` pattern by its folder
+    (the range is unknown), a bracketed range — the form Resolve reports for an imported
+    sequence (#85) — by its first frame, which the range makes constructible.
     """
     if not file_path:
         return False
     path = Path(file_path)
+    if path.exists():
+        return False
     if SEQUENCE_TOKEN in path.name:
         return not path.parent.exists()
-    return not path.exists()
+    folded = SEQUENCE_RANGE.search(path.name)
+    if folded:
+        first = path.with_name(SEQUENCE_RANGE.sub(folded.group(1), path.name, count=1))
+        return not first.exists()
+    return True
 
 
 def summarise(bin_path: str, clip: Clip, reported: dict[str, str] | None = None) -> dict[str, Any]:
@@ -759,7 +771,9 @@ def relink_media(
 
     A folder relinks every named clip through ``RelinkClips`` — Resolve matches by file
     name inside it. A file replaces one clip's media outright, which is the route for media
-    that moved *and* was renamed.
+    that moved *and* was renamed. ``ReplaceClip`` also renames the pool clip after the new
+    file (#85), so ``was_offline`` is captured per position before the call — afterwards
+    the clip no longer answers to the name the caller used.
     """
     pool = media_pool(connection)
     if not clips:
@@ -772,10 +786,9 @@ def relink_media(
         raise RelinkFailedError(cause=f"Nothing exists at {path!r} on this machine.")
 
     found = [find_clip(pool, str(name), bin_path) for name in clips]
-    was_offline = {
-        str(located.clip.GetName() or ""): is_offline(properties(located.clip).get(FILE_PATH, ""))
-        for located in found
-    }
+    was_offline = [
+        is_offline(properties(located.clip).get(FILE_PATH, "")) for located in found
+    ]
     if target.is_dir():
         relinked = bool(pool.RelinkClips([located.clip for located in found], str(target)))
         log.info("Relinked %d clip(s) against %s (Resolve said %s)", len(found), target, relinked)
@@ -786,7 +799,7 @@ def relink_media(
                 fix="Relink one clip per file, or pass the folder the media moved to.",
             )
         name = str(found[0].clip.GetName() or "")
-        if not was_offline.get(name):
+        if not was_offline[0]:
             # Not an error — repointing a healthy clip is a legitimate thing to ask for —
             # but it replaces media that was working, so it says so rather than going quiet.
             log.warning("Replacing the media of %s, which was not offline", name)
@@ -797,7 +810,7 @@ def relink_media(
         log.info("Replaced the media of %s with %s", name, target)
 
     results = []
-    for located in found:
+    for located, before in zip(found, was_offline, strict=True):
         clip_name = str(located.clip.GetName() or "")
         file_path = properties(located.clip).get(FILE_PATH, "")
         offline = is_offline(file_path)
@@ -808,7 +821,7 @@ def relink_media(
                 "ok": not offline,
                 "file_path": file_path,
                 "offline": offline,
-                "was_offline": was_offline.get(clip_name, False),
+                "was_offline": before,
             }
         )
     return {"results": results}

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -6,9 +6,11 @@ rather than API calls, and are the reason this file exists at all:
 * **Bin paths are slash-separated from the media pool root** (``"Concert/Angles"``), the
   root's own name optional as a first segment. Resolve's API has no bin path — only
   ``GetSubFolderList()`` walks — and "current folder" state that every import depends on.
-* **Offline means the file is gone**, not that Resolve says so: there is no offline flag in
-  the scripting API. A clip is offline when it has a ``File Path`` that is not on disk. A
-  clip with no path at all (multicam, compound) is not offline, it is pathless.
+* **Offline means the media is gone**, not that Resolve says so: there is no offline flag in
+  the scripting API. A clip is offline when nothing on disk stands behind its ``File Path``
+  — the path itself for ordinary media, the first frame for a sequence, whose path is only
+  a label (``shot_[0001-0024].png``, #85). A clip with no path at all (multicam, compound)
+  is not offline, it is pathless.
 * **Metadata fields route by what the clip itself reports.** The clip property key names are
   undocumented, so nothing is hard-coded: each clip is enumerated once with
   ``GetClipProperty()`` and a field whose key is in that dict is written as a clip property,

--- a/src/resolve_mcp/tools/media.py
+++ b/src/resolve_mcp/tools/media.py
@@ -114,6 +114,9 @@ def relink_media(
     Give a folder to relink several clips at once — Resolve matches them by file name
     inside it. Give a file to replace one clip's media outright, which is the route for
     media that moved and was renamed. Each result says whether that clip is still offline.
+    The file route also renames the pool clip after the new file — Resolve's behaviour,
+    not ours — so follow-up calls must use the name the result reports, not the one
+    passed in.
     """
     connection = get_connection()
     return media.relink_media(connection, clips, path, bin_path=bin)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import contextlib
 import math
 import random
+import re
 import wave
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -842,9 +843,16 @@ class FakeMediaPoolItem:
         return self._audio_mapping
 
     def ReplaceClip(self, file_path: str) -> bool:  # noqa: N802
+        """Mimic the real call's side effect: the pool clip is renamed after the new file.
+
+        Verified on Resolve Studio 21.0.3.7 (#85): after a replace, the clip no longer
+        answers to the name the caller used.
+        """
         if not Path(file_path).exists():
             return False
         self._properties["File Path"] = file_path
+        self._name = Path(file_path).name
+        self._properties["Clip Name"] = self._name
         return True
 
 
@@ -1296,10 +1304,10 @@ def _track_end(timeline: FakeTimeline, track_type: str, index: int) -> int:
 def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
     """Mimic ImportMedia: a path that is not there imports nothing.
 
-    An imported sequence is named and pathed after its first frame rather than after the
-    ``%0Nd`` pattern. Nothing on record says what Resolve really calls it (#18 verified the
-    frame count only), so the fake deliberately does not echo the pattern back — code that
-    matched on it would be relying on an assumption no source supports.
+    An imported sequence is named and pathed by folding the index range into the ``%0Nd``
+    token — ``shot_%04d.png`` with frames 1–24 becomes ``shot_[0001-0024].png`` — which is
+    what Resolve Studio 21.0.3.7 really reports (#85): a label, not a path that exists on
+    disk. ``File Path`` and the clip name both carry the bracketed form.
     """
     if isinstance(item, dict):
         pattern = str(item.get("FilePath", ""))
@@ -1308,10 +1316,10 @@ def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
         frames = max(end - start + 1, 0)
         if not _sequence_exists(pattern, start):
             return None
-        first = _first_frame(pattern, start)
+        label = _sequence_label(pattern, start, end)
         return FakeMediaPoolItem(
-            Path(first).name,
-            first,
+            Path(label).name,
+            label,
             {"Type": "Image Sequence", "Frames": str(frames), "Start": "0", "End": str(frames - 1)},
         )
 
@@ -1335,6 +1343,14 @@ def _first_frame(pattern: str, start: int) -> str:
 
 def _sequence_exists(pattern: str, start: int) -> bool:
     return Path(_first_frame(pattern, start)).exists()
+
+
+def _sequence_label(pattern: str, start: int, end: int) -> str:
+    """The bracketed name Resolve gives an imported sequence: ``shot_[0001-0024].png``."""
+    token = re.search(r"%0?\d*d", pattern)
+    if token is None:
+        return pattern
+    return pattern.replace(token.group(), f"[{token.group() % start}-{token.group() % end}]")
 
 
 class FakeProject:

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -63,13 +63,49 @@ def test_imports_a_video_and_a_png_sequence_into_a_named_bin(
 
     assert result["ok"] is True
     assert result["bin"] == "Concert/Titles"
-    assert [clip["name"] for clip in result["imported"]] == ["C0012.mp4", "song_0001.png"]
+    assert [clip["name"] for clip in result["imported"]] == ["C0012.mp4", "song_[0001-0003].png"]
     assert result["imported"][1]["frames"] == 3
     assert result["not_imported"] == []
     root = pool.GetRootFolder()
     titles = root.GetSubFolderList()[0].GetSubFolderList()[0]
     assert titles.GetName() == "Titles"
     assert len(titles.GetClipList()) == 2
+
+
+def test_an_imported_sequence_whose_frames_are_on_disk_is_not_offline(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Resolve paths a sequence by its bracketed label (#85), which never exists on disk.
+
+    Offline must be judged by the frames behind the label, or every freshly imported
+    sequence reads offline and list_media(offline_only=True) sends a relink chase at
+    healthy media.
+    """
+    for index in range(1, 4):
+        a_file(tmp_path, f"seq/shot_{index:04d}.png")
+    attach(studio(pool=media_pool()))
+
+    result = import_media(
+        sequences=[
+            {"path": str(tmp_path / "seq" / "shot_%04d.png"), "start_index": 1, "end_index": 3}
+        ]
+    )
+
+    assert result["ok"] is True
+    assert result["imported"][0]["name"] == "shot_[0001-0003].png"
+    assert result["imported"][0]["offline"] is False
+    assert list_media(offline_only=True)["count"] == 0
+
+
+def test_a_sequence_whose_frames_moved_away_is_offline(attach: Attach, tmp_path: Path) -> None:
+    """The folder still exists — offline is judged by the first frame, not the folder."""
+    (tmp_path / "seq").mkdir()
+    clip = a_clip(tmp_path / "seq" / "shot_[0001-0003].png")
+    attach(studio(pool=media_pool(bins={"Stills": [clip]})))
+
+    assert [found["name"] for found in list_media(offline_only=True)["clips"]] == [
+        "shot_[0001-0003].png"
+    ]
 
 
 def test_import_applies_the_still_duration_workaround_to_image_media(
@@ -480,6 +516,34 @@ def test_relink_to_an_explicit_file_replaces_that_one_clip(attach: Attach, tmp_p
     assert result["ok"] is True
     assert result["results"][0]["file_path"] == str(renamed)
     assert result["results"][0]["offline"] is False
+
+
+def test_relink_to_a_file_reports_the_state_before_the_replace(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """ReplaceClip renames the pool clip (#85), so the reply must carry the before state.
+
+    was_offline is read before the replace, and the reply's clip name is the one the pool
+    clip answers to afterwards — the caller's name is gone.
+    """
+    clip = a_clip(tmp_path / "old" / "relink_me.png")
+    renamed = a_file(tmp_path, "relink_moved/relink_me_renamed.png")
+    attach(studio(pool=media_pool(bins={"Angles": [clip]})))
+    assert list_media(offline_only=True)["count"] == 1
+
+    result = relink_media(["relink_me.png"], str(renamed))
+
+    assert result["ok"] is True
+    assert result["results"] == [
+        {
+            "clip": "relink_me_renamed.png",
+            "bin": "Angles",
+            "ok": True,
+            "file_path": str(renamed),
+            "offline": False,
+            "was_offline": True,
+        }
+    ]
 
 
 def test_relink_to_a_file_refuses_more_than_one_clip(attach: Attach, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #85.

## Seam

Both findings are decisions, so they verify at the **fake tier**: `tests/fakes.py` now encodes the two live-observed quirks (#85, Resolve Studio 21.0.3.7) — the bracket-folded sequence label as `File Path`, and `ReplaceClip` renaming the pool clip after the new file — and `tests/test_media_tools.py` asserts the exact reply symptoms from the issue. Both new tests were red before the fix. The live seam was exercised too: read-only live smoke, plus a one-off probe against the open project running the issue's two repros (see below).

## What changed

- `is_offline` no longer reads a bracketed sequence label (`shot_[0001-0024].png`) as a missing file: a `[N-M]` range is judged by its first frame, which the range makes constructible; the `%0Nd` form keeps its folder check. Fixes the immediate `offline: true` after import and the `list_media(offline_only=True)` false positive.
- `relink_media` captures `was_offline` per position before the replace, so the file route reports the true before state despite the rename. The rename is stated in the tool docstring: follow-up calls must use the name the result reports.

## Review record

/code-review (Standards + Spec sub-agents), diff `origin/main...HEAD`.

- **Standards:** header docstring of `resolve/media.py` still described offline as a plain file-on-disk check — **fixed** in 03b8d19. Judgement-call smells (parallel `found`/`was_offline` lists, mitigated by `zip(strict=True)`; bracket grammar living in both src and fake, deliberate fake-mimicry) — noted, not changed.
- **Spec:** item 2 complete (before-state capture, docstring truth, `ok`/`offline` untouched); no scope creep. Asked that item 1's diagnosis be closed at the live seam, not just the fake — **done**, see below. New false-negative surface for a missing non-sequence file literally named with a `[N-M]` bracket whose folded sibling exists — contrived, accepted by both reviewers as non-blocking.

## Live verification

Windows 11, Resolve Studio 21.0.3.7, python.org interpreter, project `mcp-tests-zinc`:

- `uv run pytest -m live`: 15 passed, 10 skipped, 5 failed — all 5 pre-existing in cut/interchange/render (live project state: leftover `resolve-mcp-lock-probe` timeline, cut-source ambiguity), none in this diff's path; media-pool live tests passed.
- One-off probe of the issue's repros against the open project (scratch bin, created and deleted): sequence import reads `offline: false` and `offline_only` lists nothing; file-route relink reports `was_offline: true` under the new clip name. Real reply matched the fake's bracketed label byte for byte.
- Observed divergence, not this ticket: real Resolve reports `type: 'Video'` for a sequence where the fake says `Image Sequence`.

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)