### PR TITLE
fix(fakes): an imported sequence is Type 'Video', as Resolve reports

### DIFF
--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1308,6 +1308,10 @@ def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
     token — ``shot_%04d.png`` with frames 1–24 becomes ``shot_[0001-0024].png`` — which is
     what Resolve Studio 21.0.3.7 really reports (#85): a label, not a path that exists on
     disk. ``File Path`` and the clip name both carry the bracketed form.
+
+    ``Type`` is ``Video``, live-verified twice (#85 body, #95 probe): Resolve does not
+    separate a sequence from moving footage here, which is why
+    :func:`resolve_mcp.resolve.media.is_still` keys off the file suffix instead.
     """
     if isinstance(item, dict):
         pattern = str(item.get("FilePath", ""))
@@ -1320,7 +1324,7 @@ def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
         return FakeMediaPoolItem(
             Path(label).name,
             label,
-            {"Type": "Image Sequence", "Frames": str(frames), "Start": "0", "End": str(frames - 1)},
+            {"Type": "Video", "Frames": str(frames), "Start": "0", "End": str(frames - 1)},
         )
 
     path = Path(item)

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -75,10 +75,12 @@ def test_imports_a_video_and_a_png_sequence_into_a_named_bin(
 def test_an_imported_sequence_reports_the_same_type_as_moving_footage(
     attach: Attach, tmp_path: Path
 ) -> None:
-    """Resolve types a sequence ``Video``, exactly as it types a movie (#85, #95 probe).
+    """Pins the fake's fidelity, not a decision in ``src``: ``type`` is a pass-through.
 
-    Nothing in the reply separates the two, which is why ``media.is_still`` judges by file
-    suffix — code that keyed off ``Type`` would be reading a distinction Resolve never draws.
+    Resolve Studio 21.0.3.7 types a sequence ``Video``, exactly as it types a movie (#85
+    body, #95 probe), so the reply draws no distinction between them. The fake claimed
+    ``Image Sequence`` until #97; asserting both clips together is what makes the *absence*
+    of the distinction the thing under test.
     """
     video = a_file(tmp_path, "C0012.mp4")
     for index in range(1, 4):

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -72,6 +72,29 @@ def test_imports_a_video_and_a_png_sequence_into_a_named_bin(
     assert len(titles.GetClipList()) == 2
 
 
+def test_an_imported_sequence_reports_the_same_type_as_moving_footage(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Resolve types a sequence ``Video``, exactly as it types a movie (#85, #95 probe).
+
+    Nothing in the reply separates the two, which is why ``media.is_still`` judges by file
+    suffix — code that keyed off ``Type`` would be reading a distinction Resolve never draws.
+    """
+    video = a_file(tmp_path, "C0012.mp4")
+    for index in range(1, 4):
+        a_file(tmp_path, f"seq/shot_{index:04d}.png")
+    attach(studio(pool=media_pool()))
+
+    result = import_media(
+        paths=[str(video)],
+        sequences=[
+            {"path": str(tmp_path / "seq" / "shot_%04d.png"), "start_index": 1, "end_index": 3}
+        ],
+    )
+
+    assert [clip["type"] for clip in result["imported"]] == ["Video", "Video"]
+
+
 def test_an_imported_sequence_whose_frames_are_on_disk_is_not_offline(
     attach: Attach, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Closes #97.

The fake typed an imported image sequence `Image Sequence` — a distinction the real API never draws. Resolve Studio 21.0.3.7 reports `Video` for a sequence exactly as it does for a movie, live-verified twice (#85 body, #95 probe). `media.is_still` already documents that `Type` does not separate a still from a sequence and keys off the file suffix instead, so the fake's value was the kind of fiction a test could lean on and pass against behaviour that does not exist.

**Seam**: fake tier, as the ticket names — the change is to the fake itself. No live AC: the value is already live-verified twice, and nothing in `src/` changed.

**Sweep**: a repo-wide search (`src/`, `tests/`, `docs/`, `README.md`, case-insensitive, including `ImageSequence`/`image_sequence`) finds no remaining use of the property value. No test was leaning on the fiction, so the sweep claimed no casualties; every other `"Type"` literal in `tests/` is `Audio`, `Still`, `Generator`, or `Video` on hand-built fixtures.

**Verification**: fake tier 961 passed / 30 deselected; mypy strict clean over 132 files; ruff clean. The Spec reviewer independently confirmed the new test is a real regression pin rather than a tautology — reverting `tests/fakes.py` to `origin/main` while keeping the test produces exactly one failure, `assert ['Video', 'Image Sequence'] == ['Video', 'Video']`.

## Review

Two-axis review (`/code-review`, Standards and Spec as parallel sub-agents) against `origin/main`, run on the branch before this PR existed.

**Spec — no findings.** Both requirements landed (value changed, sweep verified independently), no scope creep, and the vacuity risk was tested empirically rather than argued.

**Standards — three findings, all judgement calls:**

1. *The new test asserts the fake's own literal, verifying no decision in `src/`.* Accepted as fake-fidelity pinning, which CLAUDE.md's seam rule allows, but the docstring was rewritten (c824e15) to say that plainly instead of implying the server was under test.
2. *The docstring named `media.is_still`, which the test never exercises.* Fixed in the same commit — the rationale stays in `fakes.py`, where it documents the fake.
3. *No live seam covers the fidelity claim, so the record must live on the ticket.* Not a code change: the ticket states the value is live-verified twice and needs no new live AC. The provenance (#85 body, #95 probe) is recorded in the fake's docstring, the test's docstring, and here.

One baseline smell was raised and declined: *Duplicated Code* between the new test's arrangement and the sequence tests above it. The two-line `for index in range(1, 4): a_file(...)` fixture loop is already the house pattern in this file (`test_an_imported_sequence_whose_frames_are_on_disk_is_not_offline` repeats it verbatim), and folding the assertion into the existing bin test would cost the docstring that carries the live provenance — the point of the ticket.

Review: clean — Spec no findings; Standards' two docstring findings fixed in c824e15, the live-record finding answered by the ticket's own "no new live AC", one smell declined with reason.
