### PR TITLE
fix(#84): report null, not a confident zero, off the current timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ detection, the render/deliver tools, and the `run_python` escape hatch.
 | `organize_media` | Batch bin operations: create nested bins, move clips |
 | `relink_media` | Points offline clips at media that moved (folder relink or file replace) |
 | `list_timelines` | Timelines with version, duration, fps and track stack; names the newest cut |
-| `inspect_timeline` | One timeline at a chosen detail and range, in dual time |
+| `inspect_timeline` | One timeline at a chosen detail and range, in dual time; `make_current` to read the flags Resolve only answers for the open timeline |
 | `list_markers` | Markers in record time, narrowed by colour and range |
 | `set_markers` | Batch marker writes; an existing marker is never overwritten unless asked |
 | `export_timeline` | Writes a timeline out as OTIO, FCPXML or DRT |
@@ -57,6 +57,15 @@ in the project answers to — colliding names walk the `<base> v<N>` convention.
 Resolve's own document and accepts no import options at all, so it names its own timeline;
 what holds there is the check on the way out. Either way the cut already in the project is
 never the thing that gets written over.
+
+Three fields read `null` on any timeline that is not the one open in Resolve: a track's
+`enabled` and `locked`, and a shot's `takes`. Resolve answers those from editor state and
+reports `False`/`0` for every other timeline — no error to catch, just a plausible wrong
+number — so the server reports "unknown" rather than passing it on. The `currency` block in
+the reply names them, and `make_current` switches to the timeline for the read and switches
+back when you want the real values. It is opt-in because the switch is visible in the
+Resolve window. [ADR 0004](docs/adr/0004-editor-state-getters-only-answer-for-the-current-timeline.md)
+has the sweep that established which getters this covers, and which are proven safe.
 
 Editing is declarative and split across two files that never mention each other. The
 **cut file** owns the cut and materialises as a new `<name> v<N>` timeline every build.

--- a/docs/adr/0004-editor-state-getters-only-answer-for-the-current-timeline.md
+++ b/docs/adr/0004-editor-state-getters-only-answer-for-the-current-timeline.md
@@ -1,0 +1,86 @@
+# ADR 0004 — Editor-state getters answer only for the current timeline, and are reported as unknown
+
+- **Status**: accepted
+- **Date**: 2026-08-06
+- **Context**: [#84](https://github.com/danielbaldwin47/resolve-mcp/issues/84), found during
+  the #79 live pass against Resolve Studio 21.0.3.7; the getter sweep is the outstanding
+  half of [#68](https://github.com/danielbaldwin47/resolve-mcp/issues/68)
+
+## Context
+
+On Resolve Studio 21.0.3.7, a small set of `Timeline` and `TimelineItem` getters answer
+from the editor's state rather than from timeline data. Asked about a timeline that is
+**not** the project's current one, each returns the falsy value of its own type — no
+exception, no `None`:
+
+| getter | non-current timeline | current timeline |
+|---|---|---|
+| `GetTakesCount` | `0` | true count |
+| `GetIsTrackEnabled` | `False` | true state |
+| `GetIsTrackLocked` | `False` | true state |
+
+`GetIsTrackLocked` was found by the sweep below; the ticket opened on the other two.
+
+This is the silent-wrong-value shape the wrappers in this repo exist to prevent, and it is
+worse than a refusal because the answer is *plausible*. It has cost real time twice: a live
+sweep read `takes: 0` across every smoke timeline and nearly recorded that a take selector
+had not survived a swap, and a `False` from `GetIsTrackEnabled` was written into #32 as the
+explanation for a WAV that turned out to be fine (the mix measures −17.0 dB mean).
+
+### The sweep
+
+Every `Get*`/`Is*` getter on `Timeline` and `TimelineItem` was read three times against the
+same objects — target current, another timeline current, target current again — and the
+readings diffed. Two things made the result trustworthy:
+
+- **The fixture was built so each true value was non-falsy.** A getter whose real answer is
+  already `0` or `False` cannot be *seen* to lie; `0 → 0` proves nothing. The probe reports
+  those keys as **vacuous** rather than safe, and the fixture was extended — a take
+  selector, a locked track, a clip with a source offset, a marker — until every getter this
+  repo reads had a non-falsy true value.
+- **The third read** catches a probe that disturbs what it measures.
+
+Result: 3 getters drift, 90 are proven stable — frames, names, source bounds,
+`GetClipEnabled`, `GetMarkers`, `GetTrackName`, `GetTrackCount`, `GetMediaPoolItem` among
+them. (`GetCurrentTimecode` also moves, but it is the viewer playhead and nothing reads it.)
+
+**A stale handle was ruled out.** A freshly fetched timeline object, and even one fetched
+from a freshly fetched project object, still read `False`/`0`. There is no cheap re-fetch:
+switching the current timeline is the only route to the real values.
+
+## Decision
+
+`inspect_timeline` reports the three affected fields as **`null`** on any timeline that is
+not current, and says so in a `currency` block naming them and how to get them. `null` is
+the honest reading — not "zero takes", but "not asked in a state where Resolve will say".
+
+`make_current=true` is the opt-in: it wraps the read in `current_timeline(project, timeline)`,
+switching for the read and switching back.
+
+Switching is **not** the default, for a reason the probe turned up: `SetCurrentTimeline`
+moves the viewer playhead and does not reliably put it back (`01:00:00:00 → 00:59:59:23`
+across a switch-and-restore). A read that silently moves the GUI of whoever is sitting at
+the machine is a side effect a *read* has no business having.
+
+Whether a field was withheld is asked of the `Reader`, never inferred from the value.
+Resolve returns `None` from `GetTakesCount` for its own unrelated reasons — a clip kind with
+no selector — and that has always meant zero. Reading "unknown" out of the value puts the
+two back together one line after the reader separated them; doing exactly that broke the
+live tier once while this fix was being written.
+
+## Consequences
+
+- An agent surveying several timelines loses three numbers it was previously given wrongly.
+  That is the trade: the reply now says which three and how to get them.
+- The fakes model the defect behind one opt-in knob (`getters_need_current`), because the
+  three getters share one cause. A test that turns it on is saying "this is read the way an
+  agent surveying a project reads it".
+- **No fake can establish the premise** — the fakes hand back the same object whether or not
+  a timeline is current, so left to themselves they would agree with any wrapper. Two live
+  tests hold it: one asserts Resolve really does answer falsely and the wrapper turns that
+  into `null`, one asserts the switch reads the real flags and restores the timeline.
+- Any getter added to `UNKNOWN_OFF_CURRENT` needs the same evidence — read on a non-current
+  timeline with a non-falsy true value, then read again while current. The list is a
+  measurement, not a rule to reason from.
+- Callers that already switch are unaffected: `Reader` defaults to trusting, and the export
+  and render paths do their reads inside `current_timeline`.

--- a/src/resolve_mcp/resolve/apply.py
+++ b/src/resolve_mcp/resolve/apply.py
@@ -105,8 +105,13 @@ def apply_titles(connection: ResolveConnection, titles_file: str) -> dict[str, A
     pool = media.media_pool(connection)
 
     track = _own_track(timeline, timeline_read.name_of(timeline))
-    _refuse_locked(timeline, track)
+    # The switch comes first: ``GetIsTrackLocked`` answers ``False`` for every track of a
+    # timeline that is not current (#84), so the lock guard below would wave through a
+    # locked track and Resolve would then report titles as placed and place none — the
+    # exact failure the guard exists to catch. Nothing has been written at this point, so
+    # a refusal after the switch still applies nothing.
     _target(project, timeline, track.timeline)
+    _refuse_locked(timeline, track)
     cleared = _clear(timeline, track)
     _place(pool, checked.events, checked.templates, track)
     items = _verify(timeline, checked.events, track)
@@ -228,10 +233,7 @@ def _target(project: Project, timeline: Timeline, name: str) -> None:
 
 def _same(one: Timeline, other: Timeline) -> bool:
     """Identity by Resolve's own id: two proxies for one timeline are not the same object."""
-    first, second = getattr(one, "GetUniqueId", None), getattr(other, "GetUniqueId", None)
-    if callable(first) and callable(second):
-        return bool(first() == second())
-    return bool(timeline_read.name_of(one) == timeline_read.name_of(other))
+    return timeline_read.same_timeline(one, other)
 
 
 def _clear(timeline: Timeline, track: OwnedTrack) -> int:

--- a/src/resolve_mcp/resolve/takes.py
+++ b/src/resolve_mcp/resolve/takes.py
@@ -171,14 +171,24 @@ def swap_take(
     target = timeline_read.find_timeline(project, timeline)
     name = timeline_read.name_of(target)
     record, duration = placements(doc, timeline_read.start_frame(target))[segment]
-    item = _shot_at(target, record, duration, segment, name)
-    _refuse_drift(item, segment, listed, name)
 
-    previous = _selected_take(item)
-    changed = previous != take
-    if changed:
-        _select(item, take, _swap_failure(segment, take, name))
-        log.info("Swapped segment %s of %s from take %d to take %d", segment, name, previous, take)
+    # Both take getters answer for the current timeline only (#84): off it,
+    # ``GetTakesCount`` reads 0 — so the drift check below would refuse every swap with
+    # "holds 0 take(s)" and send the operator off to rebuild a cut file that is perfectly
+    # fine — and ``GetSelectedTakeIndex`` reads 0, which is no take at all. A swap is a
+    # write, so making its timeline current is what the operation means rather than a side
+    # effect of it; the switch is put back either way.
+    with timeline_read.current_timeline(project, target):
+        item = _shot_at(target, record, duration, segment, name)
+        _refuse_drift(item, segment, listed, name)
+
+        previous = _selected_take(item)
+        changed = previous != take
+        if changed:
+            _select(item, take, _swap_failure(segment, take, name))
+            log.info(
+                "Swapped segment %s of %s from take %d to take %d", segment, name, previous, take
+            )
 
     fps = float(doc["timeline"]["fps"])
     return {

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -189,6 +189,23 @@ def next_free_name(requested: str, existing: set[str]) -> str:
     return f"{base} v{number}"
 
 
+def same_timeline(one: Timeline | None, other: Timeline | None) -> bool:
+    """Whether two handles are one timeline, by Resolve's own id.
+
+    Two proxies for the same timeline are not the same Python object — ``GetCurrentTimeline``
+    and ``GetTimelineByIndex`` hand back different ones — so identity has to be asked of
+    Resolve. ``GetUniqueId`` predates neither build this runs on, but a build without it
+    falls back to the name, which is unique within a project because this server refuses to
+    create a colliding one.
+    """
+    if one is None or other is None:
+        return False
+    first, second = getattr(one, "GetUniqueId", None), getattr(other, "GetUniqueId", None)
+    if callable(first) and callable(second):
+        return bool(first() == second())
+    return bool(name_of(one) == name_of(other))
+
+
 @contextlib.contextmanager
 def current_timeline(project: Project, timeline: Timeline) -> Iterator[None]:
     """Work on the timeline that was asked for, and put the director's back afterwards.
@@ -433,13 +450,25 @@ def inspect_timeline(
     timeline = find_timeline(project, name)
     current = current_name(project)
     is_current = name_of(timeline) == current
-    switching = make_current and not is_current
-    reader = Reader(connection, current=is_current or switching)
 
     with contextlib.ExitStack() as stack:
-        if switching:
+        made_current = False
+        if make_current and not is_current:
             log.info("Switching to %r for the read, and back after (#84)", name_of(timeline))
             stack.enter_context(current_timeline(project, timeline))
+            # Whether the switch *landed*, not whether it was asked for. Resolve refuses
+            # ``SetCurrentTimeline`` while a modal dialog is up (#41, and ``_target`` in
+            # apply.py raises on exactly this) — and a refusal here would otherwise have
+            # the reader trust the very falsy answers this whole path exists to distrust,
+            # with ``read_as_current`` certifying them.
+            made_current = same_timeline(project.GetCurrentTimeline(), timeline)
+            if not made_current:
+                log.warning(
+                    "Resolve would not make %r current, so its editor-state fields stay "
+                    "unknown (#84); close any modal dialog in the Resolve GUI",
+                    name_of(timeline),
+                )
+        reader = Reader(connection, current=is_current or made_current)
         heading = summarise(reader, timeline, project, current)
         fps = heading["fps"]
 
@@ -452,6 +481,7 @@ def inspect_timeline(
         ]
         item_count = sum(track["item_count"] for track in tracks)
         markers = _marker_count(reader, timeline)
+        currency = _currency(reader.reads_current, made_current)
 
     result: dict[str, Any] = {
         "timeline": {**heading, "markers": markers},
@@ -459,7 +489,7 @@ def inspect_timeline(
         "range": {"in": dual_time(window[0], fps), "out": dual_time(window[1], fps)},
         "tracks": None if detail == "summary" else [_without_items(track) for track in tracks],
         "item_count": item_count,
-        "currency": _currency(is_current, switching),
+        "currency": currency,
         "truncated": False,
         "spilled_to": None,
     }
@@ -489,12 +519,16 @@ proven safe rather than merely untested. Anything added here needs the same evid
 """
 
 
-def _currency(is_current: bool, switching: bool) -> dict[str, Any]:
-    """Whether the reading's editor-state fields can be believed, and what to do if not."""
-    trustworthy = is_current or switching
+def _currency(trustworthy: bool, made_current: bool) -> dict[str, Any]:
+    """Whether the reading's editor-state fields can be believed, and what to do if not.
+
+    ``made_current`` is what the switch achieved, never what it was asked to do: a switch
+    Resolve refused leaves ``trustworthy`` false, and the reply says the fields are unknown
+    rather than certifying the falsy answers as real.
+    """
     return {
         "read_as_current": trustworthy,
-        "made_current": switching,
+        "made_current": made_current,
         "unknown_fields": [] if trustworthy else list(UNKNOWN_OFF_CURRENT),
         "fix": (
             None
@@ -581,21 +615,18 @@ def _read_track(
         if _touches(placement, window)
     ]
     where = (track_type, index)
+    readable = reader.reads_current
     return {
         "type": track_type,
         "index": index,
-        "name": str(reader.optional(timeline, "GetTrackName", "", track_type, index) or ""),
+        "name": str(reader.optional(timeline, "GetTrackName", "", *where) or ""),
         # ``None``, not ``False``, off the current timeline — see ``Reader.reads_current``.
-        "enabled": (
-            bool(reader.optional(timeline, "GetIsTrackEnabled", True, *where))
-            if reader.reads_current
-            else None
-        ),
-        "locked": (
-            bool(reader.optional(timeline, "GetIsTrackLocked", False, *where))
-            if reader.reads_current
-            else None
-        ),
+        "enabled": bool(reader.optional(timeline, "GetIsTrackEnabled", True, *where))
+        if readable
+        else None,
+        "locked": bool(reader.optional(timeline, "GetIsTrackLocked", False, *where))
+        if readable
+        else None,
         "item_count": len(in_range),
         "items": (
             [

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -293,8 +293,31 @@ class Reader:
     call, and only on the path where a read has already failed.
     """
 
-    def __init__(self, connection: ResolveConnection) -> None:
+    def __init__(self, connection: ResolveConnection, current: bool = True) -> None:
         self._connection = connection
+        self._current = current
+
+    @property
+    def reads_current(self) -> bool:
+        """Whether editor-state getters can be believed on this reader's timeline (#84).
+
+        A handful of getters are backed by editor state rather than timeline data, and for
+        a timeline that is not the project's current one they answer the falsy value of
+        their own type — ``GetTakesCount`` zero, ``GetIsTrackEnabled`` and
+        ``GetIsTrackLocked`` false — with no error and no ``None``. A caller cannot tell
+        that apart from a genuinely empty selector or a genuinely muted track, so reporting
+        the number is reporting a wrong answer confidently.
+
+        The caller asks *this* rather than looking for ``None`` in the answer, because
+        Resolve returns ``None`` from these getters for its own unrelated reasons — a clip
+        kind with no selector — and that has always meant zero. Reading "unknown" out of
+        the value would put the two back together one line after the reader separated them.
+
+        Defaults to trusting: every other reader in this package works on a timeline it has
+        already made current, and only the read that deliberately does not switch sets
+        ``current=False``.
+        """
+        return self._current
 
     def optional(self, target: Any, method: str, default: Any, *args: Any) -> Any:
         getter = getattr(target, method, None)
@@ -392,6 +415,7 @@ def inspect_timeline(
     start: Any = None,
     end: Any = None,
     limit: int = DEFAULT_ITEM_LIMIT,
+    make_current: bool = False,
     config: Config | None = None,
 ) -> dict[str, Any]:
     """Read one timeline at a chosen detail level, over a chosen range."""
@@ -406,27 +430,36 @@ def inspect_timeline(
         )
 
     project = open_project(connection)
-    reader = Reader(connection)
     timeline = find_timeline(project, name)
     current = current_name(project)
-    heading = summarise(reader, timeline, project, current)
-    fps = heading["fps"]
+    is_current = name_of(timeline) == current
+    switching = make_current and not is_current
+    reader = Reader(connection, current=is_current or switching)
 
-    window = _window(heading, start, end, fps)
-    with_items = detail == "clips"
-    tracks = [
-        _read_track(reader, timeline, track_type, index, window, fps, with_items)
-        for track_type, count in heading["tracks"].items()
-        for index in range(1, count + 1)
-    ]
-    item_count = sum(track["item_count"] for track in tracks)
+    with contextlib.ExitStack() as stack:
+        if switching:
+            log.info("Switching to %r for the read, and back after (#84)", name_of(timeline))
+            stack.enter_context(current_timeline(project, timeline))
+        heading = summarise(reader, timeline, project, current)
+        fps = heading["fps"]
+
+        window = _window(heading, start, end, fps)
+        with_items = detail == "clips"
+        tracks = [
+            _read_track(reader, timeline, track_type, index, window, fps, with_items)
+            for track_type, count in heading["tracks"].items()
+            for index in range(1, count + 1)
+        ]
+        item_count = sum(track["item_count"] for track in tracks)
+        markers = _marker_count(reader, timeline)
 
     result: dict[str, Any] = {
-        "timeline": {**heading, "markers": _marker_count(reader, timeline)},
+        "timeline": {**heading, "markers": markers},
         "detail": detail,
         "range": {"in": dual_time(window[0], fps), "out": dual_time(window[1], fps)},
         "tracks": None if detail == "summary" else [_without_items(track) for track in tracks],
         "item_count": item_count,
+        "currency": _currency(is_current, switching),
         "truncated": False,
         "spilled_to": None,
     }
@@ -442,6 +475,38 @@ def inspect_timeline(
             heading["name"], full, config or get_config(), fallback="timeline"
         )
     return result
+
+
+UNKNOWN_OFF_CURRENT: Final = ("enabled", "locked", "takes")
+"""Reply fields whose getters only answer for the current timeline (#84).
+
+Named here rather than inferred, because the list is a live finding and not a rule: the
+#84 sweep read every Timeline and TimelineItem getter twice — once with the timeline
+current, once not — against a fixture built so each true value was non-falsy, since a
+getter whose real answer is already ``0`` cannot be *seen* to lie. Three drifted; the
+other ninety, frames and names and source bounds and ``GetClipEnabled`` among them, are
+proven safe rather than merely untested. Anything added here needs the same evidence.
+"""
+
+
+def _currency(is_current: bool, switching: bool) -> dict[str, Any]:
+    """Whether the reading's editor-state fields can be believed, and what to do if not."""
+    trustworthy = is_current or switching
+    return {
+        "read_as_current": trustworthy,
+        "made_current": switching,
+        "unknown_fields": [] if trustworthy else list(UNKNOWN_OFF_CURRENT),
+        "fix": (
+            None
+            if trustworthy
+            else (
+                "Resolve answers these only for the project's current timeline, and "
+                "answers falsely rather than failing for any other — so they are reported "
+                "as null instead of a plausible zero. Pass make_current=true to switch to "
+                "this timeline for the read and switch back, or open it in Resolve."
+            )
+        ),
+    }
 
 
 def _window(heading: dict[str, Any], start: Any, end: Any, fps: float | None) -> tuple[int, int]:
@@ -515,12 +580,22 @@ def _read_track(
         )
         if _touches(placement, window)
     ]
+    where = (track_type, index)
     return {
         "type": track_type,
         "index": index,
         "name": str(reader.optional(timeline, "GetTrackName", "", track_type, index) or ""),
-        "enabled": bool(reader.optional(timeline, "GetIsTrackEnabled", True, track_type, index)),
-        "locked": bool(reader.optional(timeline, "GetIsTrackLocked", False, track_type, index)),
+        # ``None``, not ``False``, off the current timeline — see ``Reader.reads_current``.
+        "enabled": (
+            bool(reader.optional(timeline, "GetIsTrackEnabled", True, *where))
+            if reader.reads_current
+            else None
+        ),
+        "locked": (
+            bool(reader.optional(timeline, "GetIsTrackLocked", False, *where))
+            if reader.reads_current
+            else None
+        ),
         "item_count": len(in_range),
         "items": (
             [
@@ -613,7 +688,12 @@ def read_item(
         # ``GetTakesCount``, not ``GetTakeCount``: the plural is the method the scripting
         # README actually declares (line 523), and fusionscript answers an unknown name
         # with ``None`` rather than raising — so the singular read as zero takes forever.
-        "takes": int(reader.optional(item, "GetTakesCount", 0) or 0),
+        # ``None`` rather than 0 off the current timeline is #84: same wrong number, and
+        # this time Resolve is the one saying it. A ``None`` *from* the getter still means
+        # zero — see ``Reader.reads_current`` for why the two are not read off one value.
+        "takes": (
+            int(reader.optional(item, "GetTakesCount", 0) or 0) if reader.reads_current else None
+        ),
     }
 
 

--- a/src/resolve_mcp/tools/timeline.py
+++ b/src/resolve_mcp/tools/timeline.py
@@ -38,6 +38,7 @@ def inspect_timeline(
     start: Any = None,
     end: Any = None,
     limit: int = timelines.DEFAULT_ITEM_LIMIT,
+    make_current: bool = False,
 ) -> dict[str, Any]:
     """Read one timeline (the open one by default) at a chosen detail level and range.
 
@@ -50,6 +51,14 @@ def inspect_timeline(
     difference between the two, so that timeline_frame = source_frame + sync_offset. On the
     director's stacked reference that offset is the per-angle sync, one angle per track.
 
+    A track's enabled and locked, and a shot's takes, come back as null on any timeline
+    that is not the project's current one: Resolve answers those three from editor state
+    and reports false/zero for every other timeline, so null is the honest reading and a
+    number would be a confident wrong answer. The currency block in the reply says whether
+    they were readable and names them when they were not. Pass make_current=true to switch
+    to the timeline for the read and switch back — it costs a visible change of the open
+    timeline in the Resolve window, which is why it is not the default.
+
     Past limit shots the reply is capped and the full reading spills to disk (spilled_to);
     narrow the range or read that file rather than raising the cap.
     """
@@ -61,6 +70,7 @@ def inspect_timeline(
         start=start,
         end=end,
         limit=limit,
+        make_current=make_current,
     )
 
 

--- a/tests/currency_probe.py
+++ b/tests/currency_probe.py
@@ -1,0 +1,220 @@
+"""The current-timeline getter sweep (#84, the outstanding half of #68).
+
+One question, asked of every getter rather than of the two that were caught: **does this
+getter answer differently when its timeline is not the project's current one?** Resolve
+answers some of them from editor state, and for any other timeline returns the falsy value
+of their own type — no exception, no ``None`` — which is indistinguishable from a genuinely
+empty selector or a muted track. ADR 0004 records what this found.
+
+So this is a probe, not a wrapper: it lives in ``tests/`` because its output is a finding
+for a ticket, not a tool for an agent. It needs real Resolve — the fakes hand back the same
+object whether or not a timeline is current, so there is nothing for it to measure there.
+
+Three things here are decisions rather than API calls:
+
+* **Every getter is swept, not a chosen few.** The two the ticket opened on were found by
+  accident, a week apart, each after it had cost someone a wrong conclusion. A list of
+  suspects assembled by reasoning would have missed ``GetIsTrackLocked``, which this found.
+* **A falsy true value proves nothing, and is reported as such.** ``GetTakesCount`` reading
+  ``0 -> 0`` says only that the clip has no takes. Those keys come back under ``vacuous``
+  rather than being counted as safe, and the fixture is the thing to fix: give the getter a
+  non-falsy true value — a real selector, a locked track, a source offset, a marker — and
+  ask again. Every getter this repo reads was driven out of ``vacuous`` this way before
+  ADR 0004 called the other ninety proven.
+* **The target is read three times, not two.** The third read, back on the current
+  timeline, catches a probe that disturbs what it measures — and did: switching timelines
+  moves the viewer playhead, which is why ``inspect_timeline`` does not switch by default.
+
+Run it against a project holding at least two timelines:
+
+    uv run python -m tests.currency_probe [target-timeline-name]
+
+It exits non-zero when anything drifted, and is read-only apart from the switch, which it
+puts back.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, NamedTuple
+
+from resolve_mcp.resolve.connection import get_connection
+
+SKIP = frozenset(
+    {
+        # Megabytes of base64, and nothing reads it.
+        "GetCurrentClipThumbnailImage",
+        # The whole settings dict; its own question, and it drowns the diff.
+        "GetSetting",
+        # Deliberately unstable per proxy — comparing it would flag every key.
+        "GetUniqueId",
+    }
+)
+KINDS = ("video", "audio", "subtitle")
+MAX_ITEMS = 4
+FALSY = frozenset({"False", "0", "0.0", "None", "", "<list len=0>", "<tuple len=0>"})
+
+Timeline = Any
+Project = Any
+
+
+class Sweep(NamedTuple):
+    """What three reads of one timeline established about its getters."""
+
+    target: str
+    other: str
+    drift: dict[str, tuple[Any, Any]]
+    """Currency-sensitive: read one way while current, another way while not."""
+    unstable: dict[str, tuple[Any, Any]]
+    """Changed between the first and third read — the probe disturbed it, or Resolve did."""
+    proven: list[str]
+    """Non-falsy while current and unchanged while not: safe, not merely untested."""
+    vacuous: list[str]
+    """Already falsy while current, so a lie would be invisible. Unproven, not safe."""
+
+
+def render(value: Any) -> Any:
+    """A small, stable, comparable rendering of whatever a getter handed back."""
+    if isinstance(value, bool | int | float | str) or value is None:
+        text = str(value)
+        return text if len(text) <= 120 else text[:120] + "..."
+    if isinstance(value, list | tuple):
+        return f"<{type(value).__name__} len={len(value)}>"
+    if isinstance(value, dict):
+        return f"<dict keys={sorted(value)[:8]}>"
+    return f"<{type(value).__name__}>"
+
+
+def zero_arg_getters(obj: Any) -> dict[str, Any]:
+    """Every ``Get``/``Is`` name that answers without arguments.
+
+    A getter that needs arguments raises ``TypeError`` and is covered explicitly by
+    :func:`sweep`; one that raises anything else has said something worth recording, so the
+    exception is kept as the reading rather than dropped.
+    """
+    out: dict[str, Any] = {}
+    for name in sorted(dir(obj)):
+        if name in SKIP or not (name.startswith("Get") or name.startswith("Is")):
+            continue
+        try:
+            out[name] = render(getattr(obj, name)())
+        except TypeError:
+            continue
+        except Exception as exc:  # noqa: BLE001 - a raising getter is itself a datum
+            out[name] = f"<raised {type(exc).__name__}: {exc}>"
+    return out
+
+
+def read_everything(timeline: Timeline) -> dict[str, Any]:
+    """One full reading of a timeline: its own getters, its tracks', and its shots'."""
+    reading: dict[str, Any] = {}
+    for key, value in zero_arg_getters(timeline).items():
+        reading[f"timeline.{key}"] = value
+
+    for kind in KINDS:
+        try:
+            count = int(timeline.GetTrackCount(kind) or 0)
+        except Exception as exc:  # noqa: BLE001
+            reading[f"timeline.GetTrackCount({kind})"] = f"<raised {type(exc).__name__}: {exc}>"
+            continue
+        reading[f"timeline.GetTrackCount({kind})"] = count
+        for index in range(1, count + 1):
+            for getter in ("GetTrackName", "GetIsTrackEnabled", "GetIsTrackLocked"):
+                key = f"timeline.{getter}({kind},{index})"
+                try:
+                    reading[key] = render(getattr(timeline, getter)(kind, index))
+                except Exception as exc:  # noqa: BLE001
+                    reading[key] = f"<raised {type(exc).__name__}: {exc}>"
+            try:
+                items = timeline.GetItemListInTrack(kind, index) or []
+            except Exception as exc:  # noqa: BLE001
+                reading[f"timeline.GetItemListInTrack({kind},{index})"] = (
+                    f"<raised {type(exc).__name__}: {exc}>"
+                )
+                continue
+            reading[f"timeline.GetItemListInTrack({kind},{index})"] = len(items)
+            for position, item in enumerate(items[:MAX_ITEMS]):
+                for key, value in zero_arg_getters(item).items():
+                    reading[f"item[{kind},{index},{position}].{key}"] = value
+    return reading
+
+
+def sweep(project: Project, target: Timeline, other: Timeline) -> Sweep:
+    """Read ``target`` current, not current, then current again, and classify every key.
+
+    The project's own current timeline is restored whatever happens: the probe is run on a
+    machine someone is working at.
+    """
+    was = project.GetCurrentTimeline()
+    try:
+        project.SetCurrentTimeline(target)
+        first = read_everything(target)
+        project.SetCurrentTimeline(other)
+        away = read_everything(target)
+        project.SetCurrentTimeline(target)
+        again = read_everything(target)
+    finally:
+        if was is not None:
+            project.SetCurrentTimeline(was)
+
+    drift = {key: (first[key], away[key]) for key in first if first[key] != away.get(key)}
+    unstable = {key: (first[key], again[key]) for key in first if first[key] != again.get(key)}
+    return Sweep(
+        target=str(target.GetName()),
+        other=str(other.GetName()),
+        drift=drift,
+        unstable=unstable,
+        proven=sorted(k for k in first if k not in drift and str(first[k]) not in FALSY),
+        vacuous=sorted(k for k in first if k not in drift and str(first[k]) in FALSY),
+    )
+
+
+def timelines_of(project: Project) -> list[Timeline]:
+    held = [
+        project.GetTimelineByIndex(index)
+        for index in range(1, int(project.GetTimelineCount() or 0) + 1)
+    ]
+    return [timeline for timeline in held if timeline is not None]
+
+
+def main(argv: list[str]) -> int:
+    project = get_connection().handle().GetProjectManager().GetCurrentProject()
+    if project is None:
+        print("No project open in Resolve.")
+        return 2
+    held = timelines_of(project)
+    names = [str(timeline.GetName()) for timeline in held]
+    if len(held) < 2:
+        print(f"The sweep needs two timelines; this project has {names}.")
+        return 2
+
+    wanted = argv[1] if len(argv) > 1 else None
+    if wanted is None:
+        target = project.GetCurrentTimeline() or held[0]
+    else:
+        found = [t for t in held if str(t.GetName()) == wanted]
+        if not found:
+            print(f"No timeline named {wanted!r}; this project has {names}.")
+            return 2
+        target = found[0]
+    name = str(target.GetName())
+    other = next(t for t in held if str(t.GetName()) != name)
+
+    result = sweep(project, target, other)
+
+    print(f"target={result.target!r} other={result.other!r}")
+    print(f"CURRENCY-SENSITIVE (current -> non-current): {len(result.drift)}")
+    for key, (current, away) in sorted(result.drift.items()):
+        print(f"  {key}: {current!r} -> {away!r}")
+    print(f"UNSTABLE (first read vs third, should be 0): {len(result.unstable)}")
+    for key, (first, third) in sorted(result.unstable.items()):
+        print(f"  {key}: {first!r} -> {third!r}")
+    print(f"PROVEN CURRENCY-SAFE: {len(result.proven)}")
+    print(f"VACUOUS (true value already falsy; unproven): {len(result.vacuous)}")
+    for key in result.vacuous:
+        print(f"  {key}")
+    return 1 if result.drift else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -458,8 +458,14 @@ class FakeTimelineItem(AnswersNone):
         return None
 
     def GetSelectedTakeIndex(self) -> int:  # noqa: N802
-        """Zero when the clip is not a take selector, else the 1-based selection."""
+        """Zero when the clip is not a take selector, else the 1-based selection.
+
+        Also zero off the current timeline, the same #84 lie ``GetTakesCount`` tells — the
+        sweep measured this one drifting ``1 -> 0``, and zero is not a take at all.
+        """
         self._check("GetSelectedTakeIndex")
+        if not self._reads_current():
+            return 0
         return self._selected
 
     def SelectTakeByIndex(self, index: int) -> bool:  # noqa: N802
@@ -570,6 +576,10 @@ class FakeTimeline(AnswersNone):
             for track in tracks:
                 for item in track.items:
                     item.adopt(owner)
+                    # Belt and braces with ``GetItemListInTrack``: a path that reaches an
+                    # item some other way still finds it knowing its timeline, so #84 is
+                    # modelled there too rather than silently reading truthful.
+                    item.held_by(self)
 
     def _check(self) -> None:
         if self._owner is not None:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -317,6 +317,7 @@ class FakeTimelineItem(AnswersNone):
         self.comps: list[FakeFusionComp] = list(comps or ())
         self._missing = set(missing or ()) | FakeTimelineItem.NOT_API_METHODS
         self._owner = owner
+        self._timeline: FakeTimeline | None = None
 
     SOURCE_GETTERS = ("GetSourceStartFrame", "GetSourceEndFrame")
 
@@ -337,6 +338,22 @@ class FakeTimelineItem(AnswersNone):
         self._owner = owner
         for comp in self.comps:
             comp.adopt(owner)
+
+    def held_by(self, timeline: FakeTimeline) -> None:
+        """Remember which timeline this shot sits on — #84 is a fact about that timeline."""
+        self._timeline = timeline
+
+    def _reads_current(self) -> bool:
+        """Whether a getter on this item would be answered truthfully (see #84).
+
+        An item nothing has claimed reads truthfully: a test that never went through a
+        timeline is not testing currency, and defaulting the other way would make every
+        unrelated take assertion depend on project state it never set up.
+        """
+        timeline = self._timeline
+        if timeline is None or not timeline.getters_need_current:
+            return True
+        return timeline._is_current()
 
     def _check(self, method: str = "") -> None:
         if method and method in self._refuses:
@@ -423,8 +440,15 @@ class FakeTimelineItem(AnswersNone):
         return True
 
     def GetTakesCount(self) -> int:  # noqa: N802
-        """Zero for a clip that is not a take selector — not one for its own media."""
+        """Zero for a clip that is not a take selector — not one for its own media.
+
+        Also zero, whatever the selector holds, when the holding timeline is not current
+        and models #84 — the reading that cost the live pass a wrong conclusion about
+        whether a take selector had survived a swap.
+        """
         self._check("GetTakesCount")
+        if not self._reads_current():
+            return 0
         return len(self._selector)
 
     def GetTakeByIndex(self, index: int) -> dict[str, Any] | None:  # noqa: N802
@@ -516,8 +540,8 @@ class FakeTimeline(AnswersNone):
         }
         self._markers = dict(markers or {})
         self._owner = owner
-        #: #84's defect, opt-in: track flags read as off unless this timeline is current.
-        self.track_flags_need_current = False
+        #: #84's defect, opt-in — see :meth:`GetIsTrackEnabled` for what it models.
+        self.getters_need_current = False
         self.marker_writes: list[dict[str, Any]] = []
         self.refuse_markers = False
         # Refusing one marker by name is how a failed *replacement* is staged: Resolve
@@ -613,21 +637,46 @@ class FakeTimeline(AnswersNone):
     ) -> list[FakeTimelineItem] | None:
         self._check()
         track = self._track(track_type, index)
-        return list(track.items) if track else None
+        if track is None:
+            return None
+        # The only route the read path takes to an item, so the cheapest place to tell each
+        # one which timeline holds it — and the only one that also catches items a build
+        # appended after ``adopt``. An item needs that link to model #84 (see
+        # ``GetIsTrackEnabled``): whether ``GetTakesCount`` lies is a fact about its
+        # timeline, not about the item.
+        for item in track.items:
+            item.held_by(self)
+        return list(track.items)
 
     def GetIsTrackEnabled(self, track_type: str, index: int) -> bool:  # noqa: N802
         """Whether the track is on — and, opted into, the lie Resolve tells about that.
 
-        ``track_flags_need_current`` models #84: on Studio 21.0.3.7 this getter answers
-        ``False`` for *every* track of a timeline that is not the project's current one,
-        with no error and no ``None`` to distinguish "off" from "you did not ask the
-        current timeline". It is off by default because the read path documents the
-        defect rather than working around it; a caller whose correctness depends on
-        having switched first turns it on, and then a check that runs before the switch
-        reads every track as off.
+        ``getters_need_current`` models #84: on Studio 21.0.3.7 a handful of getters answer
+        the *falsy value of their own type* for a timeline that is not the project's
+        current one — no error, no ``None`` to distinguish "genuinely off" from "you did
+        not ask the current timeline". The #84 sweep read every Timeline and TimelineItem
+        getter on a non-current timeline and again while current; exactly three of the ones
+        this repo reads drift, and they share this knob because they share one cause:
+
+        ========================  =============  ============
+        getter                    non-current    current
+        ========================  =============  ============
+        ``GetIsTrackEnabled``     ``False``      true state
+        ``GetIsTrackLocked``      ``False``      true state
+        ``GetTakesCount``         ``0``          true count
+        ========================  =============  ============
+
+        The other 90 getters — frames, names, source bounds, ``GetClipEnabled``,
+        ``GetMarkers`` — were read with non-falsy true values and did not drift, so they
+        are proven safe rather than merely untested.
+
+        Off by default because most tests are not about this. A test that turns it on is
+        saying "this timeline is being read the way an agent surveying several timelines
+        reads it", and then a wrapper that trusts the number goes red here rather than on
+        the live machine.
         """
         self._check()
-        if self.track_flags_need_current and not self._is_current():
+        if self.getters_need_current and not self._is_current():
             return False
         track = self._track(track_type, index)
         return bool(track and track.enabled)
@@ -638,6 +687,8 @@ class FakeTimeline(AnswersNone):
 
     def GetIsTrackLocked(self, track_type: str, index: int) -> bool:  # noqa: N802
         self._check()
+        if self.getters_need_current and not self._is_current():
+            return False
         track = self._track(track_type, index)
         return bool(track and track.locked)
 

--- a/tests/test_audio_acquisition.py
+++ b/tests/test_audio_acquisition.py
@@ -309,7 +309,7 @@ def test_the_track_check_runs_after_the_switch_not_before_it(attach: Attach) -> 
     """
     open_now = with_a_mix(FakeTimeline("sunset-set v3", "59.94"))
     other = with_a_mix(FakeTimeline("sunset-set v2", "59.94"))
-    other.track_flags_need_current = True
+    other.getters_need_current = True
     attach(studio(timeline=open_now, timelines=[open_now, other]))
 
     record = wait_for(acquire_timeline_audio(get_connection(), timeline="sunset-set v2")["job_id"])

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -506,11 +506,89 @@ def test_a_real_take_selector_swaps_the_angle_without_moving_the_shot(tmp_path: 
 
 
 def _video_items(name: str) -> list[dict[str, Any]]:
-    read = inspect_timeline(name, detail="clips")
+    """The shots on V1, read so that ``takes`` is a number rather than ``None``.
+
+    ``make_current`` is explicit rather than relied upon: #84 makes the take count readable
+    only on the project's current timeline, and this passed before only because the build
+    happened to leave its timeline current. That is the coincidence the ticket was opened
+    on — asking for the switch says what the reading needs instead of inheriting it.
+    """
+    read = inspect_timeline(name, detail="clips", make_current=True)
     assert read["ok"] is True, read.get("error")
+    assert read["currency"]["read_as_current"] is True
     video = [track for track in read["tracks"] if track["type"] == "video"][0]
     items: list[dict[str, Any]] = video["items"]
     return items
+
+
+def test_a_non_current_timeline_reports_unknown_rather_than_a_confident_zero() -> None:
+    """#84, the half no fake can settle: that Resolve really does answer falsely.
+
+    The fakes model this defect, but only because this test measured it — they hand back
+    the same object whether or not a timeline is current, so left to themselves they would
+    agree with any wrapper. What is checked here is the premise: that reading a timeline
+    the project does not have open yields false/zero from Resolve itself, and that the
+    wrapper turns that into ``null`` rather than passing it on.
+
+    Read-only: it names a timeline that is *not* current and never switches.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    listing = list_timelines()
+    assert listing["ok"] is True
+    others = [entry["name"] for entry in listing["timelines"] if not entry["current"]]
+    if not others:
+        pytest.skip("Project has no timeline other than the open one")
+
+    read = inspect_timeline(others[0], detail="clips")
+
+    assert read["ok"] is True, read.get("error")
+    assert read["timeline"]["current"] is False
+    currency = read["currency"]
+    assert currency["read_as_current"] is False
+    assert currency["made_current"] is False
+    assert currency["unknown_fields"] == ["enabled", "locked", "takes"]
+    for track in read["tracks"]:
+        assert track["enabled"] is None
+        assert track["locked"] is None
+        # The fields the #84 sweep proved currency-safe still answer, so the nulls above
+        # are a named exception and not a whole reading gone dark.
+        assert track["name"]
+        for item in track["items"]:
+            assert item["takes"] is None
+            assert item["record"]["duration"]["frames"] is not None
+
+
+def test_make_current_reads_the_real_flags_and_puts_the_timeline_back() -> None:
+    """The opt-in, live: the switch is what makes those three fields readable at all.
+
+    The #84 probe ruled out every cheaper route — a fresh timeline handle, and even a
+    fresh project object, still read false/zero — so this is the only way to the numbers,
+    and putting the director's timeline back is the price of taking it.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    listing = list_timelines()
+    was_open = listing["current"]
+    others = [entry["name"] for entry in listing["timelines"] if not entry["current"]]
+    if not others or was_open is None:
+        pytest.skip("Project needs an open timeline and one other")
+
+    read = inspect_timeline(others[0], detail="clips", make_current=True)
+
+    assert read["ok"] is True, read.get("error")
+    assert read["currency"] == {
+        "read_as_current": True,
+        "made_current": True,
+        "unknown_fields": [],
+        "fix": None,
+    }
+    for track in read["tracks"]:
+        assert track["enabled"] is not None
+        assert track["locked"] is not None
+        for item in track["items"]:
+            assert item["takes"] is not None
+    assert list_timelines()["current"] == was_open
 
 
 def test_a_rebuild_makes_the_next_version_and_leaves_the_last_one_alone(tmp_path: Path) -> None:

--- a/tests/test_swap_take.py
+++ b/tests/test_swap_take.py
@@ -352,3 +352,31 @@ def test_a_timeline_with_no_video_track_is_refused(attach: Attach, tmp_path: Pat
 
     assert result["ok"] is False
     assert result["error"]["code"] == "invalid_request"
+
+
+def test_a_swap_works_on_a_timeline_the_project_does_not_have_open(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """#84: both take getters answer only for the current timeline.
+
+    Off it, ``GetTakesCount`` reads 0 and the drift check refuses the swap with "holds 0
+    take(s)" — sending the operator away to rebuild a cut file that was never wrong — and
+    ``GetSelectedTakeIndex`` reads 0, which is no take at all. A swap is a write, so making
+    its timeline current is what the operation means, and the operator's timeline goes
+    back afterwards. Every other test here swaps on the timeline the build left open, so
+    this is the only one that would notice the switch going missing.
+    """
+    resolve, cut_file = a_built_cut(attach, tmp_path)
+    timeline = built(resolve, "sunset-set v1")
+    timeline.getters_need_current = True
+    project = resolve.GetProjectManager().GetCurrentProject()
+    elsewhere = FakeTimeline("the one the operator is looking at")
+    project.SetCurrentTimeline(elsewhere)
+
+    result = swap_take(cut_file, "s001", 2, timeline="sunset-set v1")
+
+    assert result["ok"] is True, result.get("error")
+    assert result["changed"] is True
+    assert project.GetCurrentTimeline() is elsewhere
+    project.SetCurrentTimeline(timeline)
+    assert selected(resolve, 0) == 2

--- a/tests/test_timeline_tools.py
+++ b/tests/test_timeline_tools.py
@@ -14,6 +14,7 @@ from resolve_mcp.tools.timeline import inspect_timeline, list_timelines
 from .conftest import Attach
 from .fakes import (
     FakeMediaPoolItem,
+    FakeProject,
     FakeTimeline,
     FakeTimelineItem,
     FakeTrack,
@@ -360,6 +361,143 @@ def test_a_selector_is_counted_by_the_plural_name_the_api_really_declares(
     result = inspect_timeline(detail="clips")
 
     assert result["tracks"][0]["items"][0]["takes"] == 3
+
+
+# --- #84: the getters that only answer for the current timeline -----------------------------
+
+
+def _surveying(other_is_current: bool = True) -> tuple[Any, FakeProject]:
+    """A timeline read the way an agent surveying a project reads it: from the outside.
+
+    ``getters_need_current`` is what the live sweep proved of Studio 21.0.3.7 — enabled,
+    locked and takes all answer falsy for a timeline that is not the project's current one.
+    The flags are set the *opposite* way round from their falsy value (enabled and locked
+    both true, a real selector of three) so that a wrapper reporting the lie cannot pass by
+    coincidence.
+    """
+    item = FakeTimelineItem("C0012.mp4", 0, 10, takes=3)
+    survey = FakeTimeline(
+        "survey v1",
+        video=[FakeTrack("Video 1", [item], enabled=True, locked=True)],
+    )
+    survey.getters_need_current = True
+    open_now = a_cut()
+    current = open_now if other_is_current else survey
+    resolve = studio(timelines=[open_now, survey], timeline=current)
+    project: Any = resolve.GetProjectManager().GetCurrentProject()
+    assert isinstance(project, FakeProject)
+    return resolve, project
+
+
+def test_a_timeline_that_is_not_current_reports_unknown_not_a_confident_zero(
+    attach: Attach,
+) -> None:
+    """#84: ``0`` and "unknown" are different answers, and Resolve returns the first.
+
+    An agent asking "does this shot have alternates?" about a timeline it is not currently
+    looking at got a confident ``takes: 0`` — the exact silent-wrong-value shape the
+    wrappers in this repo exist to prevent. ``None`` is the honest reading, and the reply
+    says which fields it applies to and how to get the real ones.
+    """
+    resolve, project = _surveying()
+    attach(resolve)
+
+    result = inspect_timeline("survey v1", detail="clips")
+
+    assert result["ok"] is True
+    assert result["timeline"]["current"] is False
+    track = result["tracks"][0]
+    assert track["enabled"] is None
+    assert track["locked"] is None
+    assert result["tracks"][0]["items"][0]["takes"] is None
+    currency = result["currency"]
+    assert currency["read_as_current"] is False
+    assert currency["made_current"] is False
+    assert currency["unknown_fields"] == ["enabled", "locked", "takes"]
+    assert "make_current" in (currency["fix"] or "")
+
+
+def test_make_current_switches_for_the_read_and_puts_the_timeline_back(attach: Attach) -> None:
+    """The opt-in: the caller accepts a GUI switch and gets the real numbers for it.
+
+    The switch is the *only* way to get them — the #84 probe proved a fresh handle, and
+    even a fresh project object, still reads falsy — so the restore is what keeps a read
+    from moving the director's timeline out from under them.
+    """
+    resolve, project = _surveying()
+    attach(resolve)
+
+    result = inspect_timeline("survey v1", detail="clips", make_current=True)
+
+    assert result["ok"] is True
+    track = result["tracks"][0]
+    assert track["enabled"] is True
+    assert track["locked"] is True
+    assert result["tracks"][0]["items"][0]["takes"] == 3
+    assert result["currency"]["read_as_current"] is True
+    assert result["currency"]["made_current"] is True
+    assert result["currency"]["unknown_fields"] == []
+    assert project.timeline_switches == ["survey v1", "sunset-set v3"]
+    back = project.GetCurrentTimeline()
+    assert back is not None
+    assert back.GetName() == "sunset-set v3"
+
+
+def test_the_current_timeline_answers_in_full_without_being_switched(attach: Attach) -> None:
+    """The common read is unchanged: no nulls, and no switch to restore."""
+    resolve, project = _surveying(other_is_current=False)
+    attach(resolve)
+
+    result = inspect_timeline("survey v1", detail="clips")
+
+    track = result["tracks"][0]
+    assert track["enabled"] is True
+    assert track["locked"] is True
+    assert result["tracks"][0]["items"][0]["takes"] == 3
+    assert result["currency"] == {
+        "read_as_current": True,
+        "made_current": False,
+        "unknown_fields": [],
+        "fix": None,
+    }
+    assert project.timeline_switches == []
+
+
+def test_make_current_on_the_open_timeline_switches_nothing(attach: Attach) -> None:
+    """Asking for a switch that is not needed must not move anything."""
+    resolve, project = _surveying(other_is_current=False)
+    attach(resolve)
+
+    result = inspect_timeline("survey v1", detail="clips", make_current=True)
+
+    assert result["tracks"][0]["items"][0]["takes"] == 3
+    assert result["currency"]["made_current"] is False
+    assert project.timeline_switches == []
+
+
+def test_the_fields_that_survived_the_sweep_are_still_read_off_a_non_current_timeline(
+    attach: Attach,
+) -> None:
+    """The nulls are confined to the three proven getters, not spread over the reading.
+
+    The #84 sweep read every Timeline and TimelineItem getter with a non-falsy true value
+    on a non-current timeline: frames, names, source bounds, ``GetClipEnabled`` and
+    ``GetMarkers`` did not drift. Blanking those too would answer "unknown" to questions
+    Resolve answers perfectly well.
+    """
+    resolve, project = _surveying()
+    attach(resolve)
+
+    result = inspect_timeline("survey v1", detail="clips")
+
+    assert result["timeline"]["name"] == "survey v1"
+    assert result["tracks"][0]["name"] == "Video 1"
+    assert result["tracks"][0]["item_count"] == 1
+    shot = result["tracks"][0]["items"][0]
+    assert shot["name"] == "C0012.mp4"
+    assert shot["record"]["in"]["frames"] == 0
+    assert shot["record"]["duration"]["frames"] == 10
+    assert shot["enabled"] is True
 
 
 def test_the_out_point_is_one_past_the_last_frame_whatever_get_end_says(attach: Attach) -> None:

--- a/tests/test_timeline_tools.py
+++ b/tests/test_timeline_tools.py
@@ -437,6 +437,10 @@ def test_make_current_switches_for_the_read_and_puts_the_timeline_back(attach: A
     assert result["currency"]["read_as_current"] is True
     assert result["currency"]["made_current"] is True
     assert result["currency"]["unknown_fields"] == []
+    # ``current`` is the project's standing state, which the restore puts back — so it
+    # stays false even though the read itself was taken with the timeline current. The two
+    # answer different questions and are deliberately allowed to disagree here.
+    assert result["timeline"]["current"] is False
     assert project.timeline_switches == ["survey v1", "sunset-set v3"]
     back = project.GetCurrentTimeline()
     assert back is not None
@@ -473,6 +477,32 @@ def test_make_current_on_the_open_timeline_switches_nothing(attach: Attach) -> N
     assert result["tracks"][0]["items"][0]["takes"] == 3
     assert result["currency"]["made_current"] is False
     assert project.timeline_switches == []
+
+
+def test_a_switch_resolve_refuses_leaves_the_fields_unknown_rather_than_certified(
+    attach: Attach,
+) -> None:
+    """``made_current`` is what the switch achieved, never what it was asked to do.
+
+    Resolve refuses ``SetCurrentTimeline`` while a modal dialog is up (#41). Taking the
+    request as the answer would hand the reader the falsy values this whole path exists to
+    distrust — and stamp ``read_as_current: true`` on them, which is worse than the bug it
+    was fixing, because the reply would now vouch for the wrong number.
+    """
+    resolve, project = _surveying()
+    project.refuse_set_current = True
+    attach(resolve)
+
+    result = inspect_timeline("survey v1", detail="clips", make_current=True)
+
+    assert result["ok"] is True
+    assert result["currency"]["read_as_current"] is False
+    assert result["currency"]["made_current"] is False
+    assert result["currency"]["unknown_fields"] == ["enabled", "locked", "takes"]
+    track = result["tracks"][0]
+    assert track["enabled"] is None
+    assert track["locked"] is None
+    assert result["tracks"][0]["items"][0]["takes"] is None
 
 
 def test_the_fields_that_survived_the_sweep_are_still_read_off_a_non_current_timeline(

--- a/tests/test_titles_tools.py
+++ b/tests/test_titles_tools.py
@@ -605,6 +605,37 @@ def test_a_locked_titles_track_is_refused_before_the_clear(
     assert len(titles_on(timeline)) == 1
 
 
+def test_the_lock_check_runs_after_the_switch_not_before_it(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """#84: ``GetIsTrackLocked`` reads False on every track of a non-current timeline.
+
+    So the lock guard is only truthful once the apply has made its timeline current. Run it
+    a moment earlier and it waves a locked track through — and Resolve then reports every
+    title as placed and places none, which is the exact failure the guard exists to catch.
+    The fake tells that lie here on purpose, so moving the check back turns this red rather
+    than the live machine.
+    """
+    open_now = a_timeline("sunset-set v3")
+    target = a_timeline(
+        "sunset-set v4",
+        video=[
+            FakeTrack("Video 1"),
+            FakeTrack("Titles", [FakeTimelineItem("old title", SONG_ONE, 100)], locked=True),
+        ],
+    )
+    target.getters_need_current = True
+    a_session(attach, timeline=open_now, timelines=[open_now, target])
+
+    result = apply_titles(a_titles_file(tmp_path, valid_doc(timeline="sunset-set v4")))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "titles_apply_failed"
+    assert "locked" in result["error"]["cause"]
+    assert len(titles_on(target)) == 1
+
+
 def test_a_build_without_delete_clips_says_so_rather_than_doubling_the_titles(
     attach: Attach,
     tmp_path: Path,


### PR DESCRIPTION
Closes #84.

Resolve answers a few getters from **editor state** rather than timeline data. Asked about a timeline that is not the project's current one, each returns the falsy value of its own type — no exception, no `None`:

| getter | non-current | current |
|---|---|---|
| `GetTakesCount` | `0` | true count |
| `GetIsTrackEnabled` | `False` | true state |
| `GetIsTrackLocked` | `False` | true state |

`GetIsTrackLocked` is a **third instance the ticket had not found**.

## What was measured

A sweep of every `Timeline` and `TimelineItem` getter, read three times against the same objects (target current → another current → target current again). Two things made it trustworthy:

- **A falsy true value proves nothing.** `0 → 0` says only that the clip has no takes. Those keys are reported as **vacuous**, not safe, and the fixture was extended — a real take selector, a locked track, a clip with a source offset, a marker — until every getter this repo reads had a non-falsy true value. `GetSourceStartFrame`, `GetLeftOffset` and `GetMarkers` were all vacuous on the first pass and only classified after that.
- **The third read** catches a probe that disturbs what it measures — and did.

**Result: 3 drift, 90 proven safe** (frames, names, source bounds, `GetClipEnabled`, `GetMarkers`, `GetTrackName`, `GetTrackCount`, `GetMediaPoolItem`, …).

**Hypothesis confirmed:** these are backed by editor state, not timeline data — exactly the viewer-ish getters drift, every data getter is stable.

**Hypothesis refuted:** a stale handle. A fresh timeline object, and even one from a freshly fetched *project* object, still read `False`/`0`. There is no cheap re-fetch; switching is the only route to the values.

## The fix

The three fields come back **`null`** off the current timeline, with a `currency` block naming them and how to get them. `make_current=true` switches for the read and switches back.

Switching is **not** the default: the probe caught `SetCurrentTimeline` moving the viewer playhead and not restoring it (`01:00:00:00 → 00:59:59:23`). A read has no business moving the GUI of whoever is sitting at the machine. Daniel chose this shape over always-switching after seeing that evidence.

Recorded in [ADR 0004](docs/adr/0004-editor-state-getters-only-answer-for-the-current-timeline.md). The probe is checked in as `tests/currency_probe.py` (following the `text_plus_probe` precedent) so the ADR's "anything added needs the same evidence" is runnable.

## Test seams

- **Fake tier** verifies the decisions: null-vs-number, the opt-in switch and its restore, a refused switch, and that the currency-safe fields still answer. `FakeTimeline.getters_need_current` models the defect behind one knob because the getters share one cause.
- **Live smoke** verifies the premise no fake can — that Resolve really does answer falsely. The fakes hand back the same object either way, so left alone they would agree with any wrapper.

## Review

**Standards + Spec (two-axis, parallel sub-agents), then a focused re-check of the fix diff.**

Findings and resolutions:

1. **`make_current` trusted the request, not the result** (both axes, hard). `SetCurrentTimeline` can be refused while a modal dialog is up (#41; `apply.py:_target` already guards it), and the reply would then have stamped `read_as_current: true` on the very falsy values — worse than the bug being fixed. **Fixed**: reads back what the switch achieved via a new `same_timeline()`, lifted out of `apply.py:_same` so identity-by-`GetUniqueId` is written once. Regression test added.
2. **`apply.py` ran `_refuse_locked` before `_target`** (both axes). `GetIsTrackLocked` read `False`, so a locked track waved through and Resolve reported every title as placed while placing none. **Fixed** by reordering; the new test was verified to bite — reverting it prints *"3 of 3 title(s) did not land where the file puts them"*.
3. **`swap_take` never made its timeline current** (both axes). `GetTakesCount` read `0`, so the drift check refused with *"holds 0 take(s), not the 2 this cut file describes"* and sent the operator to rebuild a cut file that was fine; `GetSelectedTakeIndex` reads `0` there too. **Fixed** by wrapping in `current_timeline`; test verified to bite with that exact message.
4. **Sweep evidence was prose only** (Spec). **Fixed**: probe checked in.
5. **`current` vs `read_as_current` disagree under `make_current`** (Spec). **Intentional, now pinned by assertion**: `current` is the project's standing state, which the restore puts back.
6. **Fake item link defaulted truthful** (Spec). **Fixed**: `adopt` stamps it too, alongside `GetItemListInTrack`.
7. **`summarise()` after restore uses a default `Reader`** (re-check). **Declined, non-functional**: `summarise` reads only currency-safe getters, and passing `current=False` would imply currency matters there when it does not.
8. Judgement-call cleanups applied: trust computed once, `where` used consistently, duplicated ternaries collapsed.

Checks: **968 fake tests pass**, mypy strict clean (133 files), ruff clean.

Live tier, run on this machine — Windows 11, Resolve Studio 21.0.3.7, python.org 3.12.10:
- `test_a_non_current_timeline_reports_unknown_rather_than_a_confident_zero` — **passed (ran)**
- `test_make_current_reads_the_real_flags_and_puts_the_timeline_back` — **passed (ran)**
- `test_lists_the_real_timelines`, `test_the_frame_math_holds_on_a_real_timeline` — **passed**
- Original ticket repro re-run through the tool: `[0, 0, 0]` → `[None, None, None]`, and `[2, 2, 0]` with `make_current`, timeline restored.

Five other live tests fail, all **pre-existing**: verified by running the same tests at the base commit `c731d86` in the same environment, where they fail identically. They are environment-dependent (a leftover `resolve-mcp-lock-probe` timeline, a source clip's frame count, which timeline is current). Not touched by this PR — see `## Needs from you` on the ticket.

Review: clean
