### PR TITLE
P2: Text+ in-place edit (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ detection, the render/deliver tools, and the `run_python` escape hatch.
 | `get_titles_schema` | The titles-file contract, its annotated example and the validation rules |
 | `validate_titles` | Dry-runs a titles file before the Titles track is touched |
 | `apply_titles` | Places Text+ titles from `titles.json` onto an owned Titles track, fades and all |
+| `list_titles` | Reads the Titles track back: what each placed title says and which inputs it exposes |
+| `edit_title` | Fixes one placed title in place — its words or its exposed params, neighbours untouched |
 | `grab_frames` | Grabs chosen moments on a clip as JPEGs (≤1568px) the agent reads off disk |
 | `detect_scene_cuts` | Job: catalogs where a clip changes shot, gist inline and the full list on disk |
 | `separate_stems` | Two-pass GPU stem separation: mix → 4 stems, drums → kick/snare/toms |
@@ -66,6 +68,14 @@ file always produces the same track. Title positions are offsets from the *blue 
 naming their song rather than timeline frames, which is what lets one titles file be
 re-applied unchanged to every rebuild. Fades are Fusion opacity keyframes inside each
 placed instance, because Resolve exposes no clip-level fade to the scripting API at all.
+
+A typo is the exception to all of that. `edit_title` writes new words or new exposed
+params straight into one already-placed Text+ instance — no clear, no append, no rebuild —
+and proves it reached only that one by reading every other title on the track before and
+after the write. `list_titles` is how you find the title and see which Fusion input ids it
+exposes, since a media-pool template has no comp to ask. The edit changes the *timeline*
+and not `titles.json`, so the next `apply_titles` puts the old wording back: fix the file
+too whenever the change is one worth keeping.
 
 Heavy work runs as a background job: the starter returns a `job_id` immediately, `get_job`
 polls it, and results are cached under the cache root against the media and the parameters,

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -257,6 +257,35 @@ class TitlesApplyFailedError(ResolveMcpError):
     )
 
 
+class TitleNotFoundError(ResolveMcpError):
+    """No single placed title answers to what the edit asked for — none, or more than one.
+
+    ``detail`` lists what is actually on the Titles track, because the caller's next move
+    is always to pick from that list rather than to guess again.
+    """
+
+    code = "title_not_found"
+    default_fix = (
+        "Run list_titles and copy the text of the one you mean exactly; pass at= its record "
+        "frame as well when two titles read the same."
+    )
+
+
+class TitleEditFailedError(ResolveMcpError):
+    """A placed title was found but would not take the edit, or took it for its neighbours.
+
+    Distinct from ``titles_apply_failed`` because the recovery is different: nothing was
+    cleared and nothing was placed, so the track is exactly as it was apart from whatever
+    this write did land — which ``detail`` says per input.
+    """
+
+    code = "title_edit_failed"
+    default_fix = (
+        "Check the input id against list_titles and that the Titles track is unlocked, then "
+        "edit again — or re-run apply_titles, which rebuilds the track from the file."
+    )
+
+
 class TitleTemplateError(ResolveMcpError):
     """A placed template instance is not one this route can title.
 

--- a/src/resolve_mcp/resolve/apply.py
+++ b/src/resolve_mcp/resolve/apply.py
@@ -157,13 +157,9 @@ def _own_track(timeline: Timeline, name: str) -> OwnedTrack:
     is added but cannot be *named* is refused, because the next apply would not recognise
     it and would stack a second one on top.
     """
-    matching = [
-        index
-        for index in range(1, _track_count(timeline) + 1)
-        if str(timeline.GetTrackName(VIDEO, index) or "") == TRACK_NAME
-    ]
-    if matching:
-        return OwnedTrack(max(matching), name, created=False)
+    standing = find_track(timeline, name)
+    if standing is not None:
+        return standing
 
     if not timeline.AddTrack(VIDEO):
         raise TitlesApplyFailedError(
@@ -171,7 +167,7 @@ def _own_track(timeline: Timeline, name: str) -> OwnedTrack:
             f"was applied.",
             detail={"timeline": name, "track": TRACK_NAME},
         )
-    added = OwnedTrack(_track_count(timeline), name, created=True)
+    added = OwnedTrack(track_count(timeline), name, created=True)
     rename = getattr(timeline, "SetTrackName", None)
     if not (callable(rename) and rename(VIDEO, added.index, TRACK_NAME)):
         raise TitlesApplyFailedError(
@@ -185,7 +181,22 @@ def _own_track(timeline: Timeline, name: str) -> OwnedTrack:
     return added
 
 
-def _track_count(timeline: Timeline) -> int:
+def find_track(timeline: Timeline, name: str) -> OwnedTrack | None:
+    """The topmost video track called ``Titles``, or ``None`` when the timeline has none.
+
+    Split out from :func:`_own_track` because only an *apply* may create the track: a tool
+    that edits what is already there has nothing to put on a track it just made, and a
+    freshly created empty one would be a worse answer than saying there are no titles.
+    """
+    matching = [
+        index
+        for index in range(1, track_count(timeline) + 1)
+        if str(timeline.GetTrackName(VIDEO, index) or "") == TRACK_NAME
+    ]
+    return OwnedTrack(max(matching), name, created=False) if matching else None
+
+
+def track_count(timeline: Timeline) -> int:
     try:
         return int(timeline.GetTrackCount(VIDEO) or 0)
     except (TypeError, ValueError):
@@ -370,4 +381,4 @@ def _write_titles(
     return written
 
 
-__all__ = ["OwnedTrack", "apply_titles"]
+__all__ = ["VIDEO", "OwnedTrack", "apply_titles", "find_track", "track_count"]

--- a/src/resolve_mcp/resolve/fusion.py
+++ b/src/resolve_mcp/resolve/fusion.py
@@ -212,7 +212,7 @@ def read_input(node: TitleNode, key: str) -> Any:
     return node.tool.GetInput(key)
 
 
-def read_params(node: TitleNode, limit: int = PARAM_LIMIT) -> Params:
+def read_params(node: TitleNode) -> Params:
     """The inputs this template *sets*, by id, so the agent can see what makes it itself.
 
     Enumerating everything is not the answer, and the live listing is why: a plain Text+
@@ -225,7 +225,9 @@ def read_params(node: TitleNode, limit: int = PARAM_LIMIT) -> Params:
 
     That is a listing rule, never a permission: ``edit_title`` will write *any* id, listed
     or not, and proves the write by reading it back. ``detail`` says how many were passed
-    over so the reader knows the listing is a summary.
+    over so the reader knows the listing is a summary, and :func:`editable_ids` gives the
+    full set — which is what a refused write reports, so an id that this rule passed over
+    is always reachable at the moment someone needs it.
 
     Never raises: a build that does not enumerate its inputs still takes every write by id,
     so an unusable listing is reported and the edit route stays open. Only scalars are kept
@@ -257,7 +259,7 @@ def read_params(node: TitleNode, limit: int = PARAM_LIMIT) -> Params:
         if _is_set(value, attrs):
             values[str(found)] = value
 
-    shown = dict(sorted(values.items())[:limit])
+    shown = dict(sorted(values.items())[:PARAM_LIMIT])
     detail = (
         f"{len(values)} input(s) this template sets, of {editable} editable "
         f"of {len(listed)} listed"
@@ -265,6 +267,34 @@ def read_params(node: TitleNode, limit: int = PARAM_LIMIT) -> Params:
     if len(shown) < len(values):
         detail += f"; showing the first {len(shown)} by id"
     return Params(shown, True, detail)
+
+
+def editable_ids(node: TitleNode) -> list[str]:
+    """Every input id this node will take a write on, in full and unfiltered.
+
+    :func:`read_params` reports what the template *sets*, which is the useful summary and
+    is deliberately a fraction of what exists. This is the other half of that bargain: an
+    id the summary passed over is still writable, so a write refused for an unknown id
+    reports this list and the caller can see what they should have asked for. Kept off the
+    happy path on purpose — nearly two hundred ids on a stock Text+ is a diagnosis, not a
+    listing.
+    """
+    lister = _callable(node.tool, "GetInputList")
+    if lister is None:
+        return []
+    try:
+        listed = dict(lister() or {})
+    except (TypeError, ValueError):
+        return []
+    found = set()
+    for entry in listed.values():
+        attrs = _attrs_of(entry)
+        if attrs is None or not attrs.get(EXTERNAL):
+            continue
+        key = attrs.get(INPUT_ID)
+        if key is not None:
+            found.add(str(key))
+    return sorted(found)
 
 
 def _attrs_of(entry: Any) -> dict[str, Any] | None:
@@ -432,6 +462,7 @@ __all__ = [
     "Fade",
     "Params",
     "TitleNode",
+    "editable_ids",
     "read_input",
     "read_params",
     "read_text",

--- a/src/resolve_mcp/resolve/fusion.py
+++ b/src/resolve_mcp/resolve/fusion.py
@@ -47,6 +47,26 @@ STYLED_TEXT: Final = "StyledText"
 OPACITY: Final = "Opacity1"
 """Shading element 1's opacity: the Text+ input a fade is written on (#5)."""
 
+INPUT_ID: Final = "INPS_ID"
+"""``GetInputList`` hands back Input *objects*; this attribute is the id ``GetInput`` takes.
+
+The display name (``INPS_Name``) is not it — "Size" on screen can be ``Size`` or
+``StyleSize`` underneath, and only the id round-trips through ``SetInput``.
+"""
+
+EXTERNAL: Final = "INPB_External"
+"""Whether an input is a control at all, as against Fusion's own internal plumbing.
+
+A live Text+ on Studio 21.0.3.7 lists **309** inputs, of which 194 are external and the
+rest are nests, separators and layout furniture that no titler would ever set.
+"""
+
+NUMBER_DEFAULT: Final = "INPN_Default"
+"""A numeric input's stock value. There is no ``INPS_Default``: text declares none."""
+
+PARAM_LIMIT: Final = 40
+"""A hard cap on a params listing, so no template can flood a tool result."""
+
 CLEAR: Final = 0.0
 FULL: Final = 1.0
 
@@ -93,6 +113,23 @@ class Fade:
 
 NO_FADE = Fade(0, 0, (), True, "no fade asked for")
 """A hard cut on and off — the file said nothing about a fade, so nothing was written."""
+
+
+@dataclass(frozen=True)
+class Params:
+    """The exposed inputs of one placed title's Text+ node, and whether they could be read.
+
+    Reported the same way a :class:`Fade` is: a build that will not enumerate its inputs
+    yields empty ``values`` with the reason in ``detail`` rather than an error, because the
+    listing is a convenience — every input can still be *written* by id without it.
+    """
+
+    values: dict[str, Any]
+    read: bool
+    detail: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"values": dict(self.values), "read": self.read, "detail": self.detail}
 
 
 def _callable(obj: Any, name: str) -> Any | None:
@@ -163,6 +200,110 @@ def read_text(node: TitleNode) -> str | None:
     """What the node says its text is now — the only evidence a write landed."""
     value = node.tool.GetInput(STYLED_TEXT)
     return None if value is None else str(value)
+
+
+def set_input(node: TitleNode, key: str, value: Any) -> None:
+    """Write any one exposed input by its id. Reports nothing, like ``set_text``."""
+    node.tool.SetInput(key, value)
+
+
+def read_input(node: TitleNode, key: str) -> Any:
+    """The current value of one exposed input, or ``None`` for one this node has not got."""
+    return node.tool.GetInput(key)
+
+
+def read_params(node: TitleNode, limit: int = PARAM_LIMIT) -> Params:
+    """The inputs this template *sets*, by id, so the agent can see what makes it itself.
+
+    Enumerating everything is not the answer, and the live listing is why: a plain Text+
+    reports 309 inputs, 194 of them external and nearly all sitting at their stock value.
+    A tool result carrying all 194 tells the reader nothing and costs them the context to
+    read it. What identifies a title template is the handful its author moved — on the
+    stock Text+ that is exactly ``Font``, ``Style``, ``Size``, the two justifications and
+    ``Wrap`` — so an input is listed when its value differs from the default this build
+    declares for it, or when it is a string with anything in it.
+
+    That is a listing rule, never a permission: ``edit_title`` will write *any* id, listed
+    or not, and proves the write by reading it back. ``detail`` says how many were passed
+    over so the reader knows the listing is a summary.
+
+    Never raises: a build that does not enumerate its inputs still takes every write by id,
+    so an unusable listing is reported and the edit route stays open. Only scalars are kept
+    — image, mask and gradient inputs answer with objects that mean nothing here — and
+    ``StyledText`` is left out because the words have their own field everywhere else, and
+    two places to write one value is how they drift apart.
+    """
+    lister = _callable(node.tool, "GetInputList")
+    if lister is None:
+        return Params({}, False, f"this build's {TEXT_PLUS} node has no GetInputList")
+    try:
+        listed = dict(lister() or {})
+    except (TypeError, ValueError) as exc:
+        return Params({}, False, f"GetInputList would not answer: {exc}")
+
+    editable = 0
+    values: dict[str, Any] = {}
+    for entry in listed.values():
+        attrs = _attrs_of(entry)
+        if attrs is None or not attrs.get(EXTERNAL):
+            continue
+        found = attrs.get(INPUT_ID)
+        if found is None or str(found) == STYLED_TEXT:
+            continue
+        value = read_input(node, str(found))
+        if not isinstance(value, str | int | float):
+            continue
+        editable += 1
+        if _is_set(value, attrs):
+            values[str(found)] = value
+
+    shown = dict(sorted(values.items())[:limit])
+    detail = (
+        f"{len(values)} input(s) this template sets, of {editable} editable "
+        f"of {len(listed)} listed"
+    )
+    if len(shown) < len(values):
+        detail += f"; showing the first {len(shown)} by id"
+    return Params(shown, True, detail)
+
+
+def _attrs_of(entry: Any) -> dict[str, Any] | None:
+    attrs = _callable(entry, "GetAttrs")
+    if attrs is None:
+        return None
+    reported = attrs()
+    return reported if isinstance(reported, dict) else None
+
+
+def _is_set(value: Any, attrs: dict[str, Any]) -> bool:
+    """Whether this input carries a choice rather than the value it shipped with.
+
+    A number whose build declares no default is passed over rather than guessed at: it
+    would otherwise list every slider on the node, which is the outcome this rule exists
+    to avoid.
+    """
+    if isinstance(value, str):
+        return bool(value)
+    default = attrs.get(NUMBER_DEFAULT)
+    if isinstance(value, int | float) and isinstance(default, int | float):
+        return abs(float(value) - float(default)) > _TOLERANCE
+    return False
+
+
+def same_value(written: Any, read: Any) -> bool:
+    """Whether an input reads back as what was written, allowing for the C bridge.
+
+    A number written from Python comes back as a float, so an exact comparison would call
+    a landed write a failure; anything else has to match outright, because a *different*
+    value read back is the shared-comp symptom this check exists to catch.
+    """
+    if written == read:
+        return True
+    if isinstance(written, bool) or isinstance(read, bool):
+        return False
+    if isinstance(written, int | float) and isinstance(read, int | float):
+        return abs(float(read) - float(written)) <= _TOLERANCE
+    return False
 
 
 def write_fade(node: TitleNode, *, duration: int, fade_in: int, fade_out: int) -> Fade:
@@ -280,13 +421,22 @@ def _as_opacity(value: Any) -> float | None:
 
 __all__ = [
     "CLEAR",
+    "EXTERNAL",
     "FULL",
+    "INPUT_ID",
+    "NUMBER_DEFAULT",
     "OPACITY",
+    "PARAM_LIMIT",
     "STYLED_TEXT",
     "TEXT_PLUS",
     "Fade",
+    "Params",
     "TitleNode",
+    "read_input",
+    "read_params",
     "read_text",
+    "same_value",
+    "set_input",
     "set_text",
     "title_node",
     "write_fade",

--- a/src/resolve_mcp/resolve/title_edit.py
+++ b/src/resolve_mcp/resolve/title_edit.py
@@ -1,0 +1,413 @@
+"""Editing one title that is already on the timeline, without re-placing anything.
+
+``apply.py`` is declarative: the file is the truth and every apply clears the Titles track
+and re-places it. That is the right shape for authoring a set, and the wrong shape for a
+typo — a one-word fix should not cost every title its identity, its Fusion comp and its
+fade, and it should not require the songs to still be marked on the timeline.
+
+So this module is the other half of the pair, and the differences from an apply are all
+deliberate:
+
+* **Nothing is created, cleared, placed or made current.** The track is found or the edit
+  is refused; the clip already there is written *through*. That is what "no rebuild, no
+  re-apply" means, and it is why the target timeline is never opened in the GUI: an
+  ``AppendToTimeline`` lands on whatever is current, but a Fusion input is written through
+  the item's own handle and needs no such switch.
+* **The timeline is the truth, not a file.** A title is named by the words it says, which
+  is what the caller has in front of them when they see the typo. ``titles.json`` is not
+  read at all, so an edit works on a timeline whose markers are gone and whose file has
+  moved on. The cost is real and is the caller's to weigh: re-applying the file afterwards
+  puts the old wording back, and the tool's docstring says so.
+* **Exactly one title, or none.** Two titles reading the same words is a refusal with both
+  their frames rather than a guess, because the wrong guess edits a title nobody was
+  looking at and reports success.
+* **The neighbours are the evidence.** Every other title on the track is read before the
+  write and again after it. If a template's instances share one Fusion comp — the failure
+  #41 exists to catch — then editing one edits them all, and here that is *visible*, where
+  an apply could only see it by writing every title first. A neighbour that moved is
+  reported as the shared comp it is, not as a successful edit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from ..errors import (
+    InvalidRequestError,
+    TitleEditFailedError,
+    TitleNotFoundError,
+    TitleTemplateError,
+)
+from ..logging_config import get_logger
+from ..timing import dual_time, to_frames
+from ..titles.schema import TRACK_NAME
+from . import apply, fusion, session
+from . import timeline as timeline_read
+from .connection import ResolveConnection
+
+log = get_logger("titles")
+
+Item = Any
+Timeline = Any
+
+Scalar = str | int | float
+"""What a Fusion input takes from here. ``bool`` rides in as an ``int`` subclass."""
+
+
+@dataclass(frozen=True)
+class Placed:
+    """One clip standing on the Titles track, read as far as it could be.
+
+    ``node`` is ``None`` for a clip on the track that is not a Text+ title at all — a
+    listing must still be able to report it, because "there is something on the Titles
+    track I did not put there" is exactly the thing worth telling the caller.
+    """
+
+    position: int
+    item: Item
+    record_in: int | None
+    duration: int | None
+    node: fusion.TitleNode | None
+    text: str | None
+    unreadable: str | None
+
+    @property
+    def where(self) -> str:
+        return f"the title at position {self.position} on the {TRACK_NAME} track"
+
+    def as_dict(self, fps: float | None, params: fusion.Params | None) -> dict[str, Any]:
+        return {
+            "position": self.position,
+            "record": dual_time(self.record_in, fps),
+            "duration": dual_time(self.duration, fps),
+            "text": self.text,
+            "node": None
+            if self.node is None
+            else {"name": self.node.name, "text_plus_in_comp": self.node.of_how_many},
+            "params": None if params is None else params.as_dict(),
+            "unreadable": self.unreadable,
+        }
+
+
+def list_titles(connection: ResolveConnection, timeline: str | None = None) -> dict[str, Any]:
+    """Read the Titles track back: what each placed title says, and what it exposes."""
+    project = timeline_read.open_project(connection)
+    target = timeline_read.find_timeline(project, timeline)
+    name = timeline_read.name_of(target)
+    fps = session.frame_rate(project, target)
+
+    track = apply.find_track(target, name)
+    standing = [] if track is None else _standing(target, track)
+    log.info("Read %d title(s) off %s of %r", len(standing), TRACK_NAME, name)
+    return {
+        "timeline": name,
+        "track": None if track is None else track.as_dict(),
+        "titles": [
+            placed.as_dict(fps, None if placed.node is None else fusion.read_params(placed.node))
+            for placed in standing
+        ],
+    }
+
+
+def edit_title(
+    connection: ResolveConnection,
+    title: str | None = None,
+    *,
+    text: str | None = None,
+    params: dict[str, Any] | None = None,
+    at: Any = None,
+    timeline: str | None = None,
+) -> dict[str, Any]:
+    """Write new words and/or new input values into one already-placed Text+ instance."""
+    wanted = _wanted(params)
+    if text is None and not wanted:
+        raise InvalidRequestError(
+            cause="edit_title was asked to change nothing: neither text nor params was given.",
+            fix="Pass text= for the words, params= for exposed inputs, or both.",
+            detail={"title": title},
+        )
+    if title is None and at is None:
+        raise InvalidRequestError(
+            cause="edit_title was not told which title to edit.",
+            fix="Pass title= the exact words the title says now, or at= its record frame — "
+            "list_titles reports both for every title on the track.",
+            detail={},
+        )
+
+    project = timeline_read.open_project(connection)
+    target = timeline_read.find_timeline(project, timeline)
+    name = timeline_read.name_of(target)
+    fps = session.frame_rate(project, target)
+
+    track = apply.find_track(target, name)
+    if track is None:
+        raise TitleNotFoundError(
+            cause=f"{name!r} has no {TRACK_NAME} track, so there is no title to edit.",
+            fix="Run apply_titles to place the titles first — this tool only edits titles "
+            "that are already on the timeline.",
+            detail={"timeline": name, "track": TRACK_NAME},
+        )
+    standing = _standing(target, track)
+    chosen, node = _pick(standing, title, at, fps, track)
+
+    before = _snapshot(standing, wanted)
+    written = _write(node, text, wanted)
+    _refuse_strays(chosen, text, wanted, track)
+    untouched = _refuse_shared_comp(standing, chosen, before, track)
+
+    log.info("Edited %s of %r: %s", chosen.where, name, ", ".join(written))
+    # Read the clip once more rather than reporting what was asked for: the report says
+    # what the timeline holds now, and it is walked to from the item like every other read.
+    edited = _read_one(chosen.item, chosen.position)
+    return {
+        "timeline": name,
+        "track": track.as_dict(),
+        "title": edited.as_dict(
+            fps, None if edited.node is None else fusion.read_params(edited.node)
+        ),
+        "edited": written,
+        "was": chosen.as_dict(fps, None),
+        "other_titles_unchanged": untouched,
+    }
+
+
+# --- reading the track ------------------------------------------------------------------
+
+
+def _standing(timeline: Timeline, track: apply.OwnedTrack) -> list[Placed]:
+    """Every clip on the owned track, in timeline order, each read as far as it goes.
+
+    Ordered by record frame rather than by the order Resolve hands them out: ``position``
+    is quoted back to the caller in every refusal, so it has to mean "third from the left"
+    and not "third in whatever list came back".
+    """
+    items = timeline_read.items_in_track(timeline, apply.VIDEO, track.index)
+    ordered = sorted(items, key=lambda item: timeline_read.read_frames(item.GetStart()) or 0)
+    return [_read_one(item, position) for position, item in enumerate(ordered, start=1)]
+
+
+def _read_one(item: Item, position: int) -> Placed:
+    record_in = timeline_read.read_frames(item.GetStart())
+    duration = timeline_read.read_frames(item.GetDuration())
+    where = f"the title at position {position} on the {TRACK_NAME} track"
+    try:
+        node = fusion.title_node(item, where)
+    except TitleTemplateError as exc:
+        # A listing must survive a clip that is not a title at all; an *edit* of that clip
+        # still refuses, because _pick will not choose one whose node is None.
+        return Placed(position, item, record_in, duration, None, None, exc.cause)
+    return Placed(position, item, record_in, duration, node, fusion.read_text(node), None)
+
+
+def _pick(
+    standing: list[Placed],
+    title: str | None,
+    at: Any,
+    fps: float | None,
+    track: apply.OwnedTrack,
+) -> tuple[Placed, fusion.TitleNode]:
+    """The one title the caller means, or a refusal naming everything on the track."""
+    at_frame = to_frames(at, fps, "at")
+    matching = [
+        placed
+        for placed in standing
+        if (title is None or placed.text == title)
+        and (at_frame is None or placed.record_in == at_frame)
+    ]
+    asked = {"title": title, "at": None if at_frame is None else dual_time(at_frame, fps)}
+
+    if not matching:
+        raise TitleNotFoundError(
+            cause=f"No title on {track.name!r} of {track.timeline!r} matches "
+            f"{_asked_for(title, at_frame)}.",
+            fix="Match the text exactly, character for character — trailing spaces and line "
+            "breaks count. detail.on_track lists what is there.",
+            detail=track.detail(asked=asked, on_track=_listing(standing, fps)),
+        )
+    if len(matching) > 1:
+        raise TitleNotFoundError(
+            cause=f"{len(matching)} titles on {track.name!r} of {track.timeline!r} match "
+            f"{_asked_for(title, at_frame)}, so none was edited.",
+            fix="Pass at= the record frame of the one you mean; detail.matching lists them.",
+            detail=track.detail(asked=asked, matching=_listing(matching, fps)),
+        )
+
+    chosen = matching[0]
+    if chosen.node is None:
+        raise TitleEditFailedError(
+            cause=f"The clip at position {chosen.position} on {track.name!r} of "
+            f"{track.timeline!r} is not a Text+ title: {chosen.unreadable}",
+            detail=track.detail(position=chosen.position),
+        )
+    return chosen, chosen.node
+
+
+def _asked_for(title: str | None, at_frame: int | None) -> str:
+    parts = []
+    if title is not None:
+        parts.append(f"the text {title!r}")
+    if at_frame is not None:
+        parts.append(f"record frame {at_frame}")
+    return " at ".join(parts)
+
+
+def _listing(standing: list[Placed], fps: float | None) -> list[dict[str, Any]]:
+    return [
+        {
+            "position": placed.position,
+            "record": dual_time(placed.record_in, fps),
+            "text": placed.text,
+            "unreadable": placed.unreadable,
+        }
+        for placed in standing
+    ]
+
+
+# --- writing one, and proving it was only one -------------------------------------------
+
+
+def _wanted(params: dict[str, Any] | None) -> dict[str, Scalar]:
+    """The params as something writable, or a refusal — checked before Resolve is touched."""
+    if params is None:
+        return {}
+    if not isinstance(params, dict):
+        raise InvalidRequestError(
+            cause=f"params={params!r} is not a mapping of input id to value.",
+            fix='Pass params as an object, e.g. {"Size": 0.08}. list_titles reports the ids '
+            "this template exposes.",
+            detail={"params": repr(params)},
+        )
+    wanted: dict[str, Scalar] = {}
+    for key, value in params.items():
+        if not isinstance(key, str) or not key.strip():
+            raise InvalidRequestError(
+                cause=f"params has a key that is not an input id: {key!r}.",
+                fix="Keys are Fusion input ids as list_titles reports them.",
+                detail={"key": repr(key)},
+            )
+        if key == fusion.STYLED_TEXT:
+            raise InvalidRequestError(
+                cause=f"{fusion.STYLED_TEXT} is the title's words, so it is not a param here.",
+                fix=f"Pass the words as text= instead — two ways to set {fusion.STYLED_TEXT} "
+                "is how the report and the timeline drift apart.",
+                detail={"key": key},
+            )
+        if not isinstance(value, str | int | float):
+            raise InvalidRequestError(
+                cause=f"params[{key!r}]={value!r} is not a value a Fusion input takes.",
+                fix="Fusion inputs take a number, a string or a boolean — nothing nested.",
+                detail={"key": key, "value": repr(value)},
+            )
+        wanted[key] = value
+    return wanted
+
+
+def _snapshot(standing: list[Placed], wanted: dict[str, Scalar]) -> dict[int, dict[str, Any]]:
+    """What every readable title on the track says now, in the inputs this edit will write.
+
+    Taken before anything is written and over *all* the titles, including the target: the
+    comparison afterwards is what turns "the write landed" into "the write landed on one
+    title", and a snapshot taken any later would already have the damage in it.
+    """
+    return {
+        placed.position: _values_of(placed.node, wanted)
+        for placed in standing
+        if placed.node is not None
+    }
+
+
+def _values_of(node: fusion.TitleNode, keys: Iterable[str]) -> dict[str, Any]:
+    """The text plus each named input, so a before and an after compare key for key."""
+    return {
+        fusion.STYLED_TEXT: fusion.read_text(node),
+        **{key: fusion.read_input(node, key) for key in keys if key != fusion.STYLED_TEXT},
+    }
+
+
+def _write(node: fusion.TitleNode, text: str | None, wanted: dict[str, Scalar]) -> list[str]:
+    written = []
+    if text is not None:
+        fusion.set_text(node, text)
+        written.append(fusion.STYLED_TEXT)
+    for key, value in wanted.items():
+        fusion.set_input(node, key, value)
+        written.append(key)
+    return written
+
+
+def _refuse_strays(
+    chosen: Placed,
+    text: str | None,
+    wanted: dict[str, Scalar],
+    track: apply.OwnedTrack,
+) -> None:
+    """Read every written input back off the clip, walking to the node again to do it.
+
+    The node is re-fetched from the timeline item rather than reused, for the reason
+    ``apply._write_titles`` gives: a Fusion handle can go on answering for a comp the
+    timeline has since replaced, so a read through it proves only that the handle remembers.
+    """
+    fresh = fusion.title_node(chosen.item, chosen.where)
+    strayed: list[dict[str, Any]] = []
+    if text is not None:
+        read = fusion.read_text(fresh)
+        if read != text:
+            strayed.append({"input": fusion.STYLED_TEXT, "wrote": text, "reads": read})
+    for key, value in wanted.items():
+        read = fusion.read_input(fresh, key)
+        if not fusion.same_value(value, read):
+            strayed.append({"input": key, "wrote": value, "reads": read})
+    if not strayed:
+        return
+    raise TitleEditFailedError(
+        cause=f"{len(strayed)} input(s) of the title at position {chosen.position} did not "
+        f"read back as written: {strayed[0]['input']} was given {strayed[0]['wrote']!r} and "
+        f"reads {strayed[0]['reads']!r}.",
+        fix="An input that reads back as nothing is one this template has not got — check "
+        "the id against list_titles. An input that keeps its old value is a refused write: "
+        "unlock the Titles track in the timeline header and edit again.",
+        detail=track.detail(position=chosen.position, strayed=strayed),
+    )
+
+
+def _refuse_shared_comp(
+    standing: list[Placed],
+    chosen: Placed,
+    before: dict[int, dict[str, Any]],
+    track: apply.OwnedTrack,
+) -> int:
+    """Re-read the neighbours and refuse if the edit reached any of them.
+
+    This is the one check an apply cannot make cheaply and an edit gets for free, and it
+    is the whole of "neighbouring titles unaffected": instances of a template that share
+    one Fusion comp all answer for the same inputs, so a title fixed here would silently
+    re-word the one before it. Returns how many neighbours were re-read and confirmed.
+    """
+    moved = []
+    for placed in standing:
+        if placed.position == chosen.position or placed.position not in before:
+            continue
+        was = before[placed.position]
+        now = _values_of(fusion.title_node(placed.item, placed.where), was)
+        for key, old in was.items():
+            if not fusion.same_value(old, now.get(key)):
+                moved.append(
+                    {"position": placed.position, "input": key, "was": old, "reads": now.get(key)}
+                )
+    if moved:
+        raise TitleEditFailedError(
+            cause=f"Editing the title at position {chosen.position} changed "
+            f"{len({entry['position'] for entry in moved})} other title(s) on "
+            f"{track.name!r} of {track.timeline!r}.",
+            fix="The placed instances share one Fusion comp, so this template cannot carry "
+            "per-instance titles and no in-place edit of it is safe. Author a fresh Text+ "
+            "template in the GUI, export its bin again, and re-run apply_titles to restore "
+            "the wording this edit disturbed.",
+            detail=track.detail(position=chosen.position, changed=moved),
+        )
+    return len(before) - (1 if chosen.position in before else 0)
+
+
+__all__ = ["Placed", "edit_title", "list_titles"]

--- a/src/resolve_mcp/resolve/title_edit.py
+++ b/src/resolve_mcp/resolve/title_edit.py
@@ -75,7 +75,7 @@ class Placed:
 
     @property
     def where(self) -> str:
-        return where_of(self.position)
+        return _where_of(self.position)
 
     def as_dict(self, fps: float | None, params: fusion.Params | None) -> dict[str, Any]:
         return {
@@ -188,7 +188,7 @@ def _standing(timeline: Timeline, track: apply.OwnedTrack) -> list[Placed]:
     return [_read_one(item, position) for position, item in enumerate(ordered, start=1)]
 
 
-def where_of(position: int) -> str:
+def _where_of(position: int) -> str:
     """How a title is named in every message about it: by where it is, not by what it says.
 
     Its words are the thing being changed, so they cannot also be the thing that identifies
@@ -200,7 +200,7 @@ def where_of(position: int) -> str:
 def _read_one(item: Item, position: int) -> Placed:
     record_in = timeline_read.read_frames(item.GetStart())
     duration = timeline_read.read_frames(item.GetDuration())
-    where = where_of(position)
+    where = _where_of(position)
     try:
         node = fusion.title_node(item, where)
     except TitleTemplateError as exc:
@@ -477,27 +477,31 @@ def _put_back(
     not turn the diagnosis into a different exception — the caller is owed the finding
     about the shared comp far more than it is owed this.
     """
-    by_position = {placed.position: placed for placed in standing}
-    disturbed = []
-    for position in sorted({int(entry["position"]) for entry in moved}):
-        placed = by_position.get(position)
-        if placed is None or placed.node is None:
-            return False
-        disturbed.append((placed.node, before[position]))
-
+    touched = {int(entry["position"]) for entry in moved}
+    disturbed = [placed for placed in standing if placed.position in touched]
     try:
-        for node, was in disturbed:
+        # Walked afresh from the timeline item, never through the handle the damage was
+        # done with: this module's whole rule is that a Fusion handle can go on answering
+        # for a comp the timeline has replaced, and a restore verified through the
+        # remembered comp would report success at exactly the moment it was not true.
+        nodes = [
+            (fusion.title_node(placed.item, placed.where), before[placed.position])
+            for placed in disturbed
+        ]
+        for node, was in nodes:
             for key, old in was.items():
                 if key == fusion.STYLED_TEXT:
                     fusion.set_text(node, "" if old is None else str(old))
                 else:
                     fusion.set_input(node, key, old)
-        # Read back, for the same reason every other write here is read back.
-        for node, was in disturbed:
-            now = _values_of(node, was)
+        for placed in disturbed:
+            was = before[placed.position]
+            now = _values_of(fusion.title_node(placed.item, placed.where), was)
             if any(not fusion.same_value(old, now.get(key)) for key, old in was.items()):
                 return False
     except Exception:
+        # Including a comp that has stopped answering: the caller is owed the finding
+        # about the shared comp far more than it is owed this, so it is logged and told.
         log.warning("Could not put back the title(s) the edit disturbed", exc_info=True)
         return False
     return True

--- a/src/resolve_mcp/resolve/title_edit.py
+++ b/src/resolve_mcp/resolve/title_edit.py
@@ -75,7 +75,7 @@ class Placed:
 
     @property
     def where(self) -> str:
-        return f"the title at position {self.position} on the {TRACK_NAME} track"
+        return where_of(self.position)
 
     def as_dict(self, fps: float | None, params: fusion.Params | None) -> dict[str, Any]:
         return {
@@ -188,10 +188,19 @@ def _standing(timeline: Timeline, track: apply.OwnedTrack) -> list[Placed]:
     return [_read_one(item, position) for position, item in enumerate(ordered, start=1)]
 
 
+def where_of(position: int) -> str:
+    """How a title is named in every message about it: by where it is, not by what it says.
+
+    Its words are the thing being changed, so they cannot also be the thing that identifies
+    it in the report of the change.
+    """
+    return f"the title at position {position} on the {TRACK_NAME} track"
+
+
 def _read_one(item: Item, position: int) -> Placed:
     record_in = timeline_read.read_frames(item.GetStart())
     duration = timeline_read.read_frames(item.GetDuration())
-    where = f"the title at position {position} on the {TRACK_NAME} track"
+    where = where_of(position)
     try:
         node = fusion.title_node(item, where)
     except TitleTemplateError as exc:
@@ -349,7 +358,7 @@ def _refuse_strays(
     ``apply._write_titles`` gives: a Fusion handle can go on answering for a comp the
     timeline has since replaced, so a read through it proves only that the handle remembers.
     """
-    fresh = fusion.title_node(chosen.item, chosen.where)
+    fresh = _walk_back(chosen, track)
     strayed: list[dict[str, Any]] = []
     if text is not None:
         read = fusion.read_text(fresh)
@@ -365,11 +374,37 @@ def _refuse_strays(
         cause=f"{len(strayed)} input(s) of the title at position {chosen.position} did not "
         f"read back as written: {strayed[0]['input']} was given {strayed[0]['wrote']!r} and "
         f"reads {strayed[0]['reads']!r}.",
-        fix="An input that reads back as nothing is one this template has not got — check "
-        "the id against list_titles. An input that keeps its old value is a refused write: "
-        "unlock the Titles track in the timeline header and edit again.",
-        detail=track.detail(position=chosen.position, strayed=strayed),
+        fix="An input that reads back as nothing is one this template has not got — pick an "
+        "id from detail.editable, which is every input this node will take. An input that "
+        "keeps its old value is a refused write: unlock the Titles track and edit again.",
+        # The full id list, not the summary list_titles reports: an id that summary passed
+        # over is exactly the id someone is most likely to have got wrong.
+        detail=track.detail(
+            position=chosen.position,
+            strayed=strayed,
+            editable=fusion.editable_ids(fresh),
+        ),
     )
+
+
+def _walk_back(placed: Placed, track: apply.OwnedTrack) -> fusion.TitleNode:
+    """Reach a placed title's node again, turning a comp that has gone unreadable into a
+    failure about *this edit* rather than a bare template error.
+
+    It matters most for the neighbours: a comp that will not answer after the write is the
+    shared-comp damage the caller has to hear about, and ``TitleTemplateError`` on its own
+    would name a template without naming the edit that disturbed it.
+    """
+    try:
+        return fusion.title_node(placed.item, placed.where)
+    except TitleTemplateError as exc:
+        raise TitleEditFailedError(
+            cause=f"After the write, {placed.where} of {track.timeline!r} would not answer "
+            f"for its Text+ node: {exc.cause}",
+            fix="Re-run apply_titles to rebuild the track from the file, then check the "
+            "template carries one Text+ node per placed instance.",
+            detail=track.detail(position=placed.position),
+        ) from exc
 
 
 def _refuse_shared_comp(
@@ -378,19 +413,34 @@ def _refuse_shared_comp(
     before: dict[int, dict[str, Any]],
     track: apply.OwnedTrack,
 ) -> int:
-    """Re-read the neighbours and refuse if the edit reached any of them.
+    """Re-read the neighbours, and put back anything the edit reached before refusing.
 
     This is the one check an apply cannot make cheaply and an edit gets for free, and it
     is the whole of "neighbouring titles unaffected": instances of a template that share
     one Fusion comp all answer for the same inputs, so a title fixed here would silently
-    re-word the one before it. Returns how many neighbours were re-read and confirmed.
+    re-word the one before it.
+
+    Two limits on it, stated because the report must not read wider than the check is.
+    Only the inputs this call *wrote* are compared, plus the text — reading all 194 of a
+    Text+'s external inputs on every neighbour would cost more bridge calls than the edit
+    itself, and a shared comp shows up in the written ones first. And only neighbours whose
+    node could be read take part; a clip on the track that is not a title has nothing to
+    compare, which is why the returned count is of neighbours *verified* rather than of
+    clips present.
+
+    The restore is what makes this an unwound edit rather than a reported one. On a shared
+    comp, writing a neighbour's old values back also puts the target's own text back —
+    same comp, same inputs — so the track ends where it started, which is a better place
+    to hand back than half-edited. It is best-effort and its outcome is reported either
+    way: this always raises, because an edit that could not be confined is not an edit
+    anyone should be told succeeded.
     """
     moved = []
     for placed in standing:
         if placed.position == chosen.position or placed.position not in before:
             continue
         was = before[placed.position]
-        now = _values_of(fusion.title_node(placed.item, placed.where), was)
+        now = _values_of(_walk_back(placed, track), was)
         for key, old in was.items():
             if not fusion.same_value(old, now.get(key)):
                 moved.append(
@@ -400,14 +450,57 @@ def _refuse_shared_comp(
         raise TitleEditFailedError(
             cause=f"Editing the title at position {chosen.position} changed "
             f"{len({entry['position'] for entry in moved})} other title(s) on "
-            f"{track.name!r} of {track.timeline!r}.",
+            f"{track.name!r} of {track.timeline!r}, so the edit was put back.",
             fix="The placed instances share one Fusion comp, so this template cannot carry "
             "per-instance titles and no in-place edit of it is safe. Author a fresh Text+ "
-            "template in the GUI, export its bin again, and re-run apply_titles to restore "
-            "the wording this edit disturbed.",
-            detail=track.detail(position=chosen.position, changed=moved),
+            "template in the GUI and export its bin again. detail.restored says whether the "
+            "old wording went back; run apply_titles if it did not.",
+            detail=track.detail(
+                position=chosen.position,
+                changed=moved,
+                restored=_put_back(standing, before, moved),
+            ),
         )
-    return len(before) - (1 if chosen.position in before else 0)
+    # Every entry in `before` is a readable node, and _pick guarantees the target is one
+    # of them, so the neighbours verified are simply the rest.
+    return len(before) - 1
+
+
+def _put_back(
+    standing: list[Placed],
+    before: dict[int, dict[str, Any]],
+    moved: list[dict[str, Any]],
+) -> bool:
+    """Write the disturbed neighbours' old values back. Never raises; says if it worked.
+
+    Called only on the way into a failure, so a Resolve that has stopped answering must
+    not turn the diagnosis into a different exception — the caller is owed the finding
+    about the shared comp far more than it is owed this.
+    """
+    by_position = {placed.position: placed for placed in standing}
+    disturbed = []
+    for position in sorted({int(entry["position"]) for entry in moved}):
+        placed = by_position.get(position)
+        if placed is None or placed.node is None:
+            return False
+        disturbed.append((placed.node, before[position]))
+
+    try:
+        for node, was in disturbed:
+            for key, old in was.items():
+                if key == fusion.STYLED_TEXT:
+                    fusion.set_text(node, "" if old is None else str(old))
+                else:
+                    fusion.set_input(node, key, old)
+        # Read back, for the same reason every other write here is read back.
+        for node, was in disturbed:
+            now = _values_of(node, was)
+            if any(not fusion.same_value(old, now.get(key)) for key, old in was.items()):
+                return False
+    except Exception:
+        log.warning("Could not put back the title(s) the edit disturbed", exc_info=True)
+        return False
+    return True
 
 
 __all__ = ["Placed", "edit_title", "list_titles"]

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -46,7 +46,9 @@ change is a rebuild into a new version, with one exception: swap_take flips a sh
 of its alternates in place. It is yours to keep the cut file in step afterwards — the
 server never writes it, and the swap report says exactly what to change. Titles are
 declarative too and live outside the cut file: get_titles_schema, then apply_titles, which
-owns a Titles track and can be re-applied to every rebuild.
+owns a Titles track and can be re-applied to every rebuild. A typo in one placed title
+needs neither: list_titles reads the track back and edit_title fixes that one instance,
+leaving every other title alone — fix titles.json too, or the next apply undoes it.
 
 When the audio evidence is ambiguous, look: grab_frames writes JPEGs you can read at any
 moment on any angle, and detect_scene_cuts catalogs where a piece of b-roll changes shot.

--- a/src/resolve_mcp/titles/schema.py
+++ b/src/resolve_mcp/titles/schema.py
@@ -120,8 +120,13 @@ _RERUN: Final = """\
 `apply_titles` is declarative and idempotent: same file, same timeline, same
 result. Nothing is validated against the previous run, and no state is kept
 between runs — the timeline *is* the state. Edit the file and re-apply to move,
-retime or re-word titles, including a one-word typo fix: re-applying costs one
-clear and one append, and it is the only route this server offers today."""
+retime or re-word titles: re-applying costs one clear and one append.
+
+A typo in a title already placed does not need that. `edit_title` writes new
+words, or new exposed template params, into that one instance in place and
+leaves the rest of the track alone. It edits the timeline and not this file, so
+the next apply puts the old wording back — change both when the fix is one to
+keep."""
 
 _RULES: Final = """\
 ## 5. Validation

--- a/src/resolve_mcp/tools/titles.py
+++ b/src/resolve_mcp/tools/titles.py
@@ -69,11 +69,16 @@ def list_titles(timeline: str | None = None) -> dict[str, Any]:
 
     The counterpart to apply_titles: that one writes the track from a file, this one reads
     the track as it now is. Each title reports its position along the track, where it sits,
-    the words it says and the Fusion inputs its template exposes — `params.values` is the
-    list of input ids edit_title will accept, read off the placed instance itself, since a
-    media-pool template has no comp to ask.
+    the words it says, and the Fusion inputs its template *sets* — read off the placed
+    instance itself, since a media-pool template has no comp to ask.
 
-    Run it before edit_title to copy the exact wording and to see what is editable. A
+    `params.values` is a summary, not the limit of what is editable: a stock Text+ carries
+    194 settable inputs and nearly all sit at their stock value, so what is reported is the
+    handful the template moved — its font, size and justification — which is what tells one
+    template from another. `params.detail` gives both counts. edit_title takes any id the
+    node has, and names them all if you get one wrong.
+
+    Run it before edit_title to copy the exact wording and to see what the template sets. A
     build that will not enumerate its inputs says so in `params.detail` and reports none;
     the inputs can still be written by id. Anything on the track that is not a Text+ title
     is listed too, with `unreadable` saying why — a stray clip on the Titles track is
@@ -94,15 +99,17 @@ def edit_title(
 
     For the typo you spot in the review, this is one call and it costs nothing else: no
     rebuild, no re-apply, no clear. The title keeps its Fusion comp, its fade and its
-    position, and every other title on the track is read before and after the write and
-    reported unchanged — `other_titles_unchanged` is that count.
+    position. Every other readable title on the track has its text and the inputs this
+    call writes read before and after, and `other_titles_unchanged` is how many were
+    confirmed — if one moved, the instances share a Fusion comp, the edit is put back and
+    the call fails rather than reporting a success that re-worded someone else's title.
 
     Name the title by `title`, the exact words it says now (list_titles reports them), or
     by `at`, its record frame — or both when two titles read the same. Nothing matching,
     or more than one, is refused with everything on the track listed rather than guessed
     at. `text` sets the words; `params` sets exposed inputs by Fusion id,
-    e.g. {"Size": 0.08}. Every write is read back off the clip, and an input that does not
-    read back as written is an error, not a silent no-op.
+    e.g. {"Size": 0.08}. Any id the node has works, not just the ones list_titles shows —
+    a write that does not read back fails and names every id it would have taken.
 
     This edits the timeline, not titles.json — so the next apply_titles puts the old
     wording back. Fix the file too when the change is one you want to keep.

--- a/src/resolve_mcp/tools/titles.py
+++ b/src/resolve_mcp/tools/titles.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..resolve import apply, titles
+from ..resolve import apply, title_edit, titles
 from ..resolve.connection import get_connection
 from .envelope import tool
 
@@ -63,10 +63,73 @@ def apply_titles(titles_file: str) -> dict[str, Any]:
     return apply.apply_titles(get_connection(), titles_file)
 
 
+@tool
+def list_titles(timeline: str | None = None) -> dict[str, Any]:
+    """Read back every title standing on a timeline's Titles track, and what it exposes.
+
+    The counterpart to apply_titles: that one writes the track from a file, this one reads
+    the track as it now is. Each title reports its position along the track, where it sits,
+    the words it says and the Fusion inputs its template exposes — `params.values` is the
+    list of input ids edit_title will accept, read off the placed instance itself, since a
+    media-pool template has no comp to ask.
+
+    Run it before edit_title to copy the exact wording and to see what is editable. A
+    build that will not enumerate its inputs says so in `params.detail` and reports none;
+    the inputs can still be written by id. Anything on the track that is not a Text+ title
+    is listed too, with `unreadable` saying why — a stray clip on the Titles track is
+    worth knowing about, since the next apply_titles will delete it.
+    """
+    return title_edit.list_titles(get_connection(), timeline)
+
+
+@tool
+def edit_title(
+    title: str | None = None,
+    text: str | None = None,
+    params: dict[str, Any] | None = None,
+    at: Any = None,
+    timeline: str | None = None,
+) -> dict[str, Any]:
+    """Fix one already-placed title in place — its words, its exposed params, or both.
+
+    For the typo you spot in the review, this is one call and it costs nothing else: no
+    rebuild, no re-apply, no clear. The title keeps its Fusion comp, its fade and its
+    position, and every other title on the track is read before and after the write and
+    reported unchanged — `other_titles_unchanged` is that count.
+
+    Name the title by `title`, the exact words it says now (list_titles reports them), or
+    by `at`, its record frame — or both when two titles read the same. Nothing matching,
+    or more than one, is refused with everything on the track listed rather than guessed
+    at. `text` sets the words; `params` sets exposed inputs by Fusion id,
+    e.g. {"Size": 0.08}. Every write is read back off the clip, and an input that does not
+    read back as written is an error, not a silent no-op.
+
+    This edits the timeline, not titles.json — so the next apply_titles puts the old
+    wording back. Fix the file too when the change is one you want to keep.
+    """
+    return title_edit.edit_title(
+        get_connection(),
+        title,
+        text=text,
+        params=params,
+        at=at,
+        timeline=timeline,
+    )
+
+
 TOOLS: tuple[Any, ...] = (
     get_titles_schema,
     validate_titles,
     apply_titles,
+    list_titles,
+    edit_title,
 )
 
-__all__ = ["TOOLS", "apply_titles", "get_titles_schema", "validate_titles"]
+__all__ = [
+    "TOOLS",
+    "apply_titles",
+    "edit_title",
+    "get_titles_schema",
+    "list_titles",
+    "validate_titles",
+]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -74,7 +74,54 @@ class FakeSpline:
         return self.keyframes.get(float(frame))
 
 
-class FakeFusionTool:
+class FakeFusionInput:
+    """One entry of ``tool.GetInputList()``: an Input *object*, not an id and not a value.
+
+    Modelled off the real thing, read live on Studio 21.0.3.7: a stock Text+ lists **309**
+    inputs, and the three attributes that make that number usable are all here.
+
+    The display name is deliberately not the id — Fusion's "Size" on screen is ``Size`` or
+    ``StyleSize`` underneath, and only the id round-trips through ``GetInput``/``SetInput``.
+    A fake whose two names agreed would let a wrapper reading ``INPS_Name`` pass here and
+    then write to an input that does not exist on a real Text+.
+
+    ``INPB_External`` is false for Fusion's own nests, separators and layout furniture —
+    115 of that 309 — and ``INPN_Default`` is the stock value a *number* shipped with.
+    There is deliberately no ``INPS_Default``: text inputs declare none live, so a fake
+    that invented one would hide the branch that has to cope without it.
+    """
+
+    def __init__(
+        self,
+        input_id: str,
+        name: str | None = None,
+        owner: FakeResolve | None = None,
+        external: bool = True,
+        default: Any = None,
+    ):
+        self.input_id = input_id
+        self.display_name = name if name is not None else input_id.upper()
+        self.external = external
+        self.default = default
+        self._owner = owner
+
+    def _check(self) -> None:
+        if self._owner is not None:
+            self._owner._check()
+
+    def GetAttrs(self, key: str | None = None) -> Any:  # noqa: N802
+        self._check()
+        attrs: dict[str, Any] = {
+            "INPS_ID": self.input_id,
+            "INPS_Name": self.display_name,
+            "INPB_External": self.external,
+        }
+        if isinstance(self.default, int | float) and not isinstance(self.default, bool):
+            attrs["INPN_Default"] = self.default
+        return attrs if key is None else attrs.get(key)
+
+
+class FakeFusionTool(AnswersNone):
     """One node inside a Fusion comp; for titling only the Text+ node matters.
 
     ``SetInput`` returns ``None`` in the real API — it reports nothing, so the only way to
@@ -90,6 +137,16 @@ class FakeFusionTool:
     accepted, nothing is connected, and the attribute still reads back as ``None``.
     ``reads_at_a_time=False`` models a build whose ``GetInput`` takes no time argument, so
     an animated value cannot be read back at a keyframe.
+
+    ``refuses`` is the write that lies: ``SetInput`` returns ``None`` whether it wrote or
+    not, so a named input here takes the call, keeps its old value and says nothing —
+    which is what a locked track and a read-only input both look like from Python.
+    ``missing`` hides a *method* the way fusionscript does, answering ``None`` rather than
+    raising, so a build with no ``GetInputList`` is modelled as ``missing={"GetInputList"}``.
+
+    ``defaults`` is the stock value each *number* shipped with and ``internal`` is the set
+    that is not a control at all — both are what a real listing is filtered by, and a fake
+    without them would make a 194-input dump look like a reasonable answer.
     """
 
     def __init__(
@@ -100,17 +157,25 @@ class FakeFusionTool:
         owner: FakeResolve | None = None,
         animatable: bool = True,
         reads_at_a_time: bool = True,
+        refuses: frozenset[str] | set[str] | None = None,
+        missing: frozenset[str] | set[str] | None = None,
+        defaults: dict[str, Any] | None = None,
+        internal: frozenset[str] | set[str] | None = None,
     ) -> None:
         # Every field is set while the node is still being built, so nothing here can be
         # mistaken for an input connection — and no list of field names has to be kept in
         # step with this signature for that to hold.
         object.__setattr__(self, "_built", False)
+        object.__setattr__(self, "_missing", set(missing or ()))
         self.tool_id = tool_id
         self.name = name
         self.inputs: dict[str, Any] = dict(inputs or {"StyledText": "TEMPLATE"})
         self.animated: dict[str, FakeSpline] = {}
         self.animatable = animatable
         self.reads_at_a_time = reads_at_a_time
+        self.refuses = set(refuses or ())
+        self.defaults: dict[str, Any] = dict(defaults or {})
+        self.internal = set(internal or ())
         self._owner = owner
         object.__setattr__(self, "_built", True)
 
@@ -139,6 +204,10 @@ class FakeFusionTool:
             self._owner,
             self.animatable,
             self.reads_at_a_time,
+            set(self.refuses),
+            set(self._missing),
+            dict(self.defaults),
+            set(self.internal),
         )
 
     def adopt(self, owner: FakeResolve) -> None:
@@ -156,7 +225,22 @@ class FakeFusionTool:
 
     def SetInput(self, key: str, value: Any) -> None:  # noqa: N802
         self._check()
+        if key in self.refuses:
+            return  # taken and dropped: the API reports nothing either way
         self.inputs[key] = value
+
+    def GetInputList(self) -> dict[int, FakeFusionInput]:  # noqa: N802
+        """A *one-based dict of Input objects*, the way GetToolList answers with tools."""
+        self._check()
+        return {
+            index: FakeFusionInput(
+                key,
+                owner=self._owner,
+                external=key not in self.internal,
+                default=self.defaults.get(key),
+            )
+            for index, key in enumerate(self.inputs, start=1)
+        }
 
     def GetInput(self, key: str, time: Any = None) -> Any:  # noqa: N802
         """The input's value, at a time when one is asked for and the build answers for it."""

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -224,8 +224,15 @@ class FakeFusionTool(AnswersNone):
         return attrs if key is None else attrs.get(key)
 
     def SetInput(self, key: str, value: Any) -> None:  # noqa: N802
+        """A write lands only on an input this node actually has.
+
+        A Fusion node's inputs are fixed by its type: ``SetInput`` with an id the node
+        does not carry is ignored, and ``GetInput`` then answers ``None``. Nothing in the
+        return value says so — it is ``None`` either way — so a fake that grew a new input
+        on demand would let a typo'd id read back as a clean write and pass.
+        """
         self._check()
-        if key in self.refuses:
+        if key in self.refuses or key not in self.inputs:
             return  # taken and dropped: the API reports nothing either way
         self.inputs[key] = value
 

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -52,7 +52,7 @@ from resolve_mcp.tools.timeline import (
     list_markers,
     list_timelines,
 )
-from resolve_mcp.tools.titles import apply_titles
+from resolve_mcp.tools.titles import apply_titles, edit_title, list_titles
 from resolve_mcp.tools.video import detect_scene_cuts, grab_frames
 
 from . import otio
@@ -966,6 +966,147 @@ def test_apply_titles_places_text_plus_instances_with_their_own_text_and_fades(
         if was_on is not None:
             project.SetCurrentTimeline(was_on)
         pool.DeleteTimelines([scratch])
+
+
+SMOKE_TITLE = "Text+"
+"""Resolve's own stock Fusion title, which every Studio install has in its Effects library."""
+
+
+def test_edit_title_fixes_one_placed_title_and_leaves_the_other_alone() -> None:
+    """#43's three ACs against real Text+ instances: text in place, params in place, alone.
+
+    Everything here is a claim only a real comp can settle, and each one had a surprise in
+    it. `GetInputList` on a live Text+ answers with **309** inputs, 194 of them external —
+    which is why `list_titles` reports the handful the template *sets* rather than the lot.
+    Whether `SetInput` on an input other than `StyledText` takes on a *placed* instance is
+    the same open question the fade had. And whether editing one instance leaves its
+    neighbour alone is the shared-comp finding #41 went looking for, asked the only way
+    that answers it — by reading the neighbour back off the timeline afterwards.
+
+    Unlike #41 and #42 this needs **no fixture and no environment variable**:
+    `InsertFusionTitleIntoTimeline` places Resolve's own stock Text+ straight onto a
+    timeline, so the whole run is built and torn down by the API. It works on a scratch
+    timeline it creates and deletes again, so it never touches a cut anyone is reviewing.
+
+        uv run pytest -m live -s -k edit_title
+
+    Paste the printed report onto the ticket.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+
+    connection = get_connection()
+    pool = media_pool(connection)
+    project = connection.handle().GetProjectManager().GetCurrentProject()
+    was_on = project.GetCurrentTimeline()
+
+    name = timestamped_name("edit-title-smoke", "", "edit-title-smoke")
+    scratch = pool.CreateEmptyTimeline(name)
+    assert scratch is not None, f"Resolve created no timeline called {name!r}"
+    try:
+        assert project.SetCurrentTimeline(scratch), f"Resolve would not open {name!r}"
+        # The tool owns the track called Titles; a fresh timeline's only video track is V1.
+        assert scratch.SetTrackName("video", 1, "Titles"), "Resolve would not name video 1"
+        inserter = getattr(scratch, "InsertFusionTitleIntoTimeline", None)
+        assert callable(inserter), "this build cannot insert a Fusion title"
+        for timecode in ("01:00:00:00", "01:00:10:00"):
+            assert scratch.SetCurrentTimecode(timecode), f"playhead would not go to {timecode}"
+            assert inserter(SMOKE_TITLE) is not None, f"Resolve inserted no {SMOKE_TITLE!r}"
+
+        listed = list_titles(timeline=name)
+        assert listed["ok"] is True, listed.get("error")
+        assert len(listed["titles"]) == 2, "two Text+ did not land on the Titles track"
+        first, second = (one["record"]["frames"] for one in listed["titles"])
+
+        # Both instances start life saying the same thing, so they are named by frame.
+        fixed = edit_title(at=first, text="Live smoke fixed", timeline=name)
+        param = _a_writable_param(listed["titles"][0]["params"])
+        with_param = (
+            None
+            if param is None
+            else edit_title(at=first, params={param[0]: param[1]}, timeline=name)
+        )
+        after = list_titles(timeline=name)
+
+        print("\n" + _render_edit(listed, fixed, with_param, after))
+        assert fixed["ok"] is True, fixed.get("error")
+        assert fixed["other_titles_unchanged"] == 1, (
+            "the neighbour was not re-read, or the two instances share one Fusion comp"
+        )
+        assert [one["text"] for one in after["titles"]] == ["Live smoke fixed", "Custom Title"]
+        assert [one["record"]["frames"] for one in after["titles"]] == [first, second]
+        if param is not None and with_param is not None:
+            assert with_param["ok"] is True, with_param.get("error")
+            assert with_param["title"]["params"]["values"][param[0]] == param[1]
+    finally:
+        if was_on is not None:
+            project.SetCurrentTimeline(was_on)
+        pool.DeleteTimelines([scratch])
+
+
+def _a_writable_param(exposed: dict[str, Any] | None) -> tuple[str, float] | None:
+    """A numeric input that is safe to nudge and read back, or nothing.
+
+    Only ``Size``: it is a plain continuous slider, so a value near its own is taken
+    verbatim. The other numbers a stock Text+ sets are enumerations wearing numbers — the
+    two justifications, ``Wrap`` — and Fusion clamping one of those to a legal value would
+    read back as a failed write when nothing had gone wrong.
+    """
+    if exposed is None or not exposed["read"]:
+        return None
+    value = exposed["values"].get("Size")
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        return None
+    return ("Size", round(float(value) + 0.01, 4))
+
+
+def _render_edit(
+    listed: dict[str, Any],
+    fixed: dict[str, Any],
+    with_param: dict[str, Any] | None,
+    after: dict[str, Any],
+) -> str:
+    """The report the ticket asks for: what was exposed, what was written, what moved."""
+    if not listed["ok"]:
+        return f"list_titles failed: {listed['error']['cause']}"
+    lines = [f"timeline:      {listed['timeline']}", f"track:         {listed['track']}"]
+    for one in listed["titles"]:
+        params = one["params"]
+        node = one["node"]
+        lines.append(
+            f"  before: {one['text']!r} @ {one['record']['frames']} for "
+            f"{one['duration']['frames']}f — node {node and node['name']!r}, "
+            f"{node and node['text_plus_in_comp']} Text+ in comp"
+        )
+        lines.append(
+            f"          params read={params and params['read']}: {params and params['detail']}"
+        )
+        if params and params["values"]:
+            lines.append(f"          sets: {params['values']}")
+    if fixed["ok"]:
+        lines.append(
+            f"text edit:     {fixed['was']['text']!r} -> {fixed['title']['text']!r}, "
+            f"edited={fixed['edited']}, others unchanged={fixed['other_titles_unchanged']}"
+        )
+    else:
+        lines.append(
+            f"text edit:     FAILED {fixed['error']['cause']}\n  fix: {fixed['error']['fix']}"
+        )
+    if with_param is None:
+        lines.append("param edit:    skipped — this template set no plain numeric input")
+    elif with_param["ok"]:
+        lines.append(
+            f"param edit:    edited={with_param['edited']}, "
+            f"now={with_param['title']['params']['values']}"
+        )
+    else:
+        lines.append(
+            f"param edit:    FAILED {with_param['error']['cause']}\n"
+            f"  fix: {with_param['error']['fix']}"
+        )
+    for one in after["titles"]:
+        lines.append(f"  after:  {one['text']!r} @ {one['record']['frames']}")
+    return "\n".join(lines)
 
 
 def test_correlate_measures_a_real_hand_edited_timeline() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,6 +41,8 @@ def test_registers_the_p1_session_media_timeline_cut_titling_render_and_job_tool
         "get_titles_schema",
         "validate_titles",
         "apply_titles",
+        "list_titles",
+        "edit_title",
         "swap_take",
         "grab_frames",
         "detect_scene_cuts",

--- a/tests/test_title_edit.py
+++ b/tests/test_title_edit.py
@@ -498,10 +498,8 @@ def test_a_write_that_is_taken_and_dropped_is_reported_rather_than_believed(
 
 
 def test_an_input_id_this_template_has_not_got_is_reported(attach: Attach) -> None:
-    a_session(
-        attach,
-        a_timeline([a_title("Sunset Boulevard", FIRST, refuses={"StyleSize"})]),
-    )
+    """A Text+ carries a fixed set of inputs, so a wrong id is dropped and reads as None."""
+    a_session(attach, a_timeline([a_title("Sunset Boulevard", FIRST)]))
 
     failure = error(edit_title(title="Sunset Boulevard", params={"StyleSize": 0.08}))
 
@@ -537,6 +535,74 @@ def test_instances_sharing_one_fusion_comp_are_refused_by_reading_the_neighbour(
             "reads": "Sunset Boulevard",
         }
     ]
+
+
+def test_an_edit_a_shared_comp_spread_is_put_back_before_the_refusal(attach: Attach) -> None:
+    """The neighbour is the one that was damaged, so the neighbour is what gets restored —
+    and on a shared comp that puts the target back too, leaving the track as it was."""
+    shared = FakeFusionComp([FakeFusionTool(inputs={"StyledText": "Sunset Boulevar"})])
+    timeline = a_session(
+        attach,
+        a_timeline(
+            [
+                a_title("Sunset Boulevar", FIRST, comp=shared),
+                a_title("Sunset Boulevar", SECOND, comp=shared),
+            ]
+        ),
+    )
+
+    failure = error(edit_title(at=FIRST, text="Sunset Boulevard"))
+
+    assert failure["detail"]["restored"] is True
+    assert [text_of(item) for item in items_on(timeline)] == [
+        "Sunset Boulevar",
+        "Sunset Boulevar",
+    ]
+
+
+def test_a_restore_that_will_not_take_is_reported_rather_than_claimed(attach: Attach) -> None:
+    shared = FakeFusionComp(
+        [FakeFusionTool(inputs={"StyledText": "Sunset Boulevar"}, refuses={"StyledText"})]
+    )
+    a_session(
+        attach,
+        a_timeline(
+            [
+                a_title("Sunset Boulevar", FIRST, comp=shared),
+                a_title("Sunset Boulevar", SECOND, comp=shared),
+            ]
+        ),
+    )
+
+    # The write is dropped, so _refuse_strays catches it first — the target never strays
+    # into the neighbour at all, and the caller is told about the input, not the comp.
+    failure = error(edit_title(at=FIRST, text="Sunset Boulevard"))
+
+    assert failure["code"] == "title_edit_failed"
+    assert failure["detail"]["strayed"][0]["input"] == "StyledText"
+
+
+def test_a_refused_write_names_every_input_the_node_would_have_taken(attach: Attach) -> None:
+    a_session(
+        attach,
+        a_timeline(
+            [
+                a_title(
+                    "Sunset Boulevard",
+                    FIRST,
+                    inputs={"Size": 0.09, "Red1": 1.0, "Nest": 0.0},
+                    defaults={"Size": 0.08, "Red1": 1.0},
+                    internal={"Nest"},
+                )
+            ]
+        ),
+    )
+
+    failure = error(edit_title(title="Sunset Boulevard", params={"Siez": 0.1}))
+
+    # Red1 is not in the params listing (it sits at its default) but is still writable, so
+    # the id the caller should have used is here even though the summary passed it over.
+    assert failure["detail"]["editable"] == ["Red1", "Size", "StyledText"]
 
 
 def test_a_clip_on_the_track_that_is_not_a_title_cannot_be_edited(attach: Attach) -> None:

--- a/tests/test_title_edit.py
+++ b/tests/test_title_edit.py
@@ -1,0 +1,593 @@
+"""list_titles and edit_title at the Resolve seam: fixing one title without re-applying.
+
+The claim under test is narrow and the whole of #43: a typo fix is one call that reaches
+exactly one placed Text+ instance, changes its words or its exposed inputs, and leaves
+everything else — the other titles, their fades, the clips themselves — exactly as it
+found them.
+
+So three things carry the weight here:
+
+* **In place means in place.** The tests hold on to the very ``FakeTimelineItem`` objects
+  that were on the track before the edit and assert the same objects are there after, with
+  their opacity keyframes intact. A tool that quietly re-placed the title would produce a
+  correct-looking report and fail these.
+* **The neighbours are read, not assumed.** A template whose instances share one Fusion
+  comp is modelled by handing two items the *same* ``FakeFusionComp``, which is what #41
+  went looking for live. Editing one title then re-words the other, and the test asserts
+  that is refused rather than reported as a success.
+* **A write that reports nothing is not evidence.** ``SetInput`` answers ``None`` whether
+  it wrote or not, so ``refuses`` models the write that is taken and dropped, and an input
+  id this template has not got reads back as ``None``. Both must fail loudly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.tools.titles import apply_titles, edit_title, list_titles
+
+from .conftest import Attach
+from .fakes import (
+    FakeFusionComp,
+    FakeFusionTool,
+    FakeTimeline,
+    FakeTimelineItem,
+    FakeTrack,
+    media_pool,
+    studio,
+    text_plus_template,
+)
+
+TITLES_TRACK = 2
+"""Where the Titles track sits on a timeline that also carries one video track."""
+
+FIRST = 3840
+SECOND = 4560
+
+
+def a_title(
+    text: str,
+    record: int,
+    duration: int = 360,
+    *,
+    inputs: dict[str, Any] | None = None,
+    defaults: dict[str, Any] | None = None,
+    internal: set[str] | None = None,
+    comp: FakeFusionComp | None = None,
+    refuses: set[str] | None = None,
+    missing: set[str] | None = None,
+) -> FakeTimelineItem:
+    """One Text+ instance standing on the Titles track, as an apply would have left it.
+
+    ``comp`` is passed in when two instances have to *share* one, which is the failure
+    mode the neighbour check exists for; otherwise each gets its own.
+    """
+    own = comp or FakeFusionComp(
+        [
+            FakeFusionTool(
+                inputs={"StyledText": text, **(inputs or {})},
+                refuses=refuses,
+                missing=missing,
+                defaults=defaults,
+                internal=internal,
+            )
+        ]
+    )
+    return FakeTimelineItem("Song Title", record, duration, comps=[own])
+
+
+def a_timeline(
+    titles: list[FakeTimelineItem] | None = None,
+    name: str = "sunset-set v3",
+) -> FakeTimeline:
+    """A cut with a Titles track above it, holding whatever the test put there."""
+    tracks = [FakeTrack("Video 1", [FakeTimelineItem("C0012.mp4", 3600, 12000)])]
+    if titles is not None:
+        tracks.append(FakeTrack("Titles", titles))
+    return FakeTimeline(name, start_frame=3600, end_frame=20000, video=tracks)
+
+
+def a_session(
+    attach: Attach,
+    timeline: FakeTimeline | None = None,
+    timelines: list[FakeTimeline] | None = None,
+) -> FakeTimeline:
+    cut = timeline if timeline is not None else a_timeline([a_title("Sunset Boulevard", FIRST)])
+    held: list[FakeTimeline | None] = list(timelines or [cut])
+    attach(studio(timeline=cut, timelines=held))
+    return cut
+
+
+def items_on(timeline: FakeTimeline, track: int = TITLES_TRACK) -> list[FakeTimelineItem]:
+    return list(timeline.GetItemListInTrack("video", track) or [])
+
+
+def text_of(item: FakeTimelineItem) -> Any:
+    return item.comps[0].tools[0].GetInput("StyledText")
+
+
+def input_of(item: FakeTimelineItem, key: str) -> Any:
+    return item.comps[0].tools[0].GetInput(key)
+
+
+def error(result: dict[str, Any]) -> dict[str, Any]:
+    assert result["ok"] is False, result
+    return dict(result["error"])
+
+
+# --- list_titles: what is on the track --------------------------------------------------
+
+
+def test_every_title_on_the_track_is_listed_in_timeline_order(attach: Attach) -> None:
+    a_session(
+        attach,
+        a_timeline([a_title("Night Ferry", SECOND), a_title("Sunset Boulevard", FIRST)]),
+    )
+    result = list_titles()
+
+    assert result["ok"] is True
+    assert [(one["position"], one["text"]) for one in result["titles"]] == [
+        (1, "Sunset Boulevard"),
+        (2, "Night Ferry"),
+    ]
+    assert [one["record"]["frames"] for one in result["titles"]] == [FIRST, SECOND]
+    assert result["track"] == {"index": TITLES_TRACK, "name": "Titles", "created": False}
+
+
+def test_the_inputs_the_template_sets_are_listed_by_their_fusion_ids(attach: Attach) -> None:
+    a_session(
+        attach,
+        a_timeline(
+            [
+                a_title(
+                    "Sunset Boulevard",
+                    FIRST,
+                    inputs={"Size": 0.09, "Font": "Open Sans", "Wrap": 1.0},
+                    defaults={"Size": 0.08, "Wrap": 1.0},
+                )
+            ]
+        ),
+    )
+    result = list_titles()
+
+    params = result["titles"][0]["params"]
+    assert params["read"] is True
+    # Size was moved off its default and Font carries a choice, so both are the template's
+    # own. Wrap is sitting where it shipped, and StyledText is left out on purpose: the
+    # words have their own field, and two places to write one value is how they drift.
+    assert params["values"] == {"Size": 0.09, "Font": "Open Sans"}
+
+
+def test_a_listing_says_how_many_inputs_it_passed_over(attach: Attach) -> None:
+    """A live Text+ lists 309 inputs; the reader has to know the listing is a summary."""
+    a_session(
+        attach,
+        a_timeline(
+            [
+                a_title(
+                    "Sunset Boulevard",
+                    FIRST,
+                    inputs={"Size": 0.09, "Wrap": 1.0, "Angle": 0.0, "Nest": 0.0},
+                    defaults={"Size": 0.08, "Wrap": 1.0, "Angle": 0.0, "Nest": 0.0},
+                    internal={"Nest"},
+                )
+            ]
+        ),
+    )
+    result = list_titles()
+
+    params = result["titles"][0]["params"]
+    assert params["values"] == {"Size": 0.09}
+    # StyledText, Size, Wrap and Angle are editable; Nest is Fusion's own furniture.
+    assert params["detail"] == "1 input(s) this template sets, of 3 editable of 5 listed"
+
+
+def test_an_input_that_is_not_a_control_is_never_listed(attach: Attach) -> None:
+    a_session(
+        attach,
+        a_timeline(
+            [
+                a_title(
+                    "Sunset Boulevard",
+                    FIRST,
+                    inputs={"SettingsNest": "grouping", "Font": "Open Sans"},
+                    internal={"SettingsNest"},
+                )
+            ]
+        ),
+    )
+    result = list_titles()
+
+    assert result["titles"][0]["params"]["values"] == {"Font": "Open Sans"}
+
+
+def test_an_input_whose_value_is_not_a_scalar_is_left_out_of_the_listing(
+    attach: Attach,
+) -> None:
+    a_session(
+        attach,
+        a_timeline(
+            [
+                a_title(
+                    "Sunset Boulevard",
+                    FIRST,
+                    inputs={"Size": 0.09, "Image1": object()},
+                    defaults={"Size": 0.08},
+                )
+            ]
+        ),
+    )
+    result = list_titles()
+
+    assert result["titles"][0]["params"]["values"] == {"Size": 0.09}
+
+
+def test_a_flood_of_set_inputs_is_capped_and_says_so(attach: Attach) -> None:
+    many = {f"Input{index:03d}": float(index + 1) for index in range(60)}
+    stock = dict.fromkeys(many, 0.0)
+    a_session(
+        attach,
+        a_timeline([a_title("Sunset Boulevard", FIRST, inputs=many, defaults=stock)]),
+    )
+    result = list_titles()
+
+    params = result["titles"][0]["params"]
+    assert len(params["values"]) == 40
+    assert sorted(params["values"])[0] == "Input000"
+    assert params["detail"].endswith("showing the first 40 by id")
+
+
+def test_a_build_that_will_not_enumerate_inputs_says_so_and_still_reads_the_text(
+    attach: Attach,
+) -> None:
+    a_session(
+        attach,
+        a_timeline([a_title("Sunset Boulevard", FIRST, missing={"GetInputList"})]),
+    )
+    result = list_titles()
+
+    assert result["titles"][0]["text"] == "Sunset Boulevard"
+    assert result["titles"][0]["params"] == {
+        "values": {},
+        "read": False,
+        "detail": "this build's TextPlus node has no GetInputList",
+    }
+
+
+def test_a_timeline_with_no_titles_track_lists_nothing_rather_than_failing(
+    attach: Attach,
+) -> None:
+    a_session(attach, a_timeline())
+    result = list_titles()
+
+    assert result["ok"] is True
+    assert result["track"] is None
+    assert result["titles"] == []
+
+
+def test_a_clip_on_the_titles_track_that_is_not_a_title_is_listed_with_the_reason(
+    attach: Attach,
+) -> None:
+    stray = FakeTimelineItem("B-roll.mp4", SECOND, 200)
+    a_session(attach, a_timeline([a_title("Sunset Boulevard", FIRST), stray]))
+    result = list_titles()
+
+    assert [one["text"] for one in result["titles"]] == ["Sunset Boulevard", None]
+    assert "carries no Fusion comp" in result["titles"][1]["unreadable"]
+    assert result["titles"][1]["params"] is None
+
+
+def test_a_named_timeline_is_read_rather_than_the_current_one(attach: Attach) -> None:
+    other = a_timeline([a_title("Night Ferry", FIRST)], name="holiday-gig v1")
+    a_session(attach, timelines=[a_timeline([a_title("Sunset Boulevard", FIRST)]), other])
+
+    result = list_titles(timeline="holiday-gig v1")
+
+    assert [one["text"] for one in result["titles"]] == ["Night Ferry"]
+
+
+# --- edit_title: the typo fix -----------------------------------------------------------
+
+
+def test_the_words_of_one_title_are_changed_in_place(attach: Attach) -> None:
+    timeline = a_session(attach, a_timeline([a_title("Sunset Boulevar", FIRST)]))
+    standing = items_on(timeline)
+
+    result = edit_title(title="Sunset Boulevar", text="Sunset Boulevard")
+
+    assert result["ok"] is True
+    assert text_of(standing[0]) == "Sunset Boulevard"
+    # The same clip object, still on the track: nothing was cleared, placed or re-appended.
+    assert items_on(timeline) == standing
+    assert result["edited"] == ["StyledText"]
+
+
+def test_an_exposed_param_is_changed_in_place(attach: Attach) -> None:
+    timeline = a_session(
+        attach,
+        a_timeline([a_title("Sunset Boulevard", FIRST, inputs={"Size": 0.05})]),
+    )
+
+    result = edit_title(title="Sunset Boulevard", params={"Size": 0.08})
+
+    assert result["ok"] is True
+    assert input_of(items_on(timeline)[0], "Size") == 0.08
+    assert text_of(items_on(timeline)[0]) == "Sunset Boulevard"
+    assert result["edited"] == ["Size"]
+
+
+def test_words_and_params_change_together_and_both_are_reported(attach: Attach) -> None:
+    started = a_title("Sunset Boulevar", FIRST, inputs={"Size": 0.05}, defaults={"Size": 0.1})
+    timeline = a_session(attach, a_timeline([started]))
+
+    result = edit_title(
+        title="Sunset Boulevar",
+        text="Sunset Boulevard",
+        params={"Size": 0.08},
+    )
+
+    assert result["edited"] == ["StyledText", "Size"]
+    assert result["was"]["text"] == "Sunset Boulevar"
+    assert result["title"]["text"] == "Sunset Boulevard"
+    assert result["title"]["params"]["values"]["Size"] == 0.08
+    assert input_of(items_on(timeline)[0], "Size") == 0.08
+
+
+def test_the_neighbouring_titles_keep_their_words_and_are_counted(attach: Attach) -> None:
+    timeline = a_session(
+        attach,
+        a_timeline(
+            [
+                a_title("Sunset Boulevar", FIRST),
+                a_title("Bass — Ana Ruiz", SECOND),
+                a_title("Night Ferry", 5400),
+            ]
+        ),
+    )
+
+    result = edit_title(title="Sunset Boulevar", text="Sunset Boulevard")
+
+    assert [text_of(item) for item in items_on(timeline)] == [
+        "Sunset Boulevard",
+        "Bass — Ana Ruiz",
+        "Night Ferry",
+    ]
+    assert result["other_titles_unchanged"] == 2
+
+
+def test_the_edited_title_keeps_the_fade_the_apply_gave_it(attach: Attach) -> None:
+    timeline = a_session(attach, a_timeline([a_title("Sunset Boulevar", FIRST)]))
+    spline = items_on(timeline)[0].comps[0].BezierSpline()
+    spline[0] = 0.0
+    spline[24] = 1.0
+    items_on(timeline)[0].comps[0].tools[0].Opacity1 = spline
+
+    edit_title(title="Sunset Boulevar", text="Sunset Boulevard")
+
+    kept = items_on(timeline)[0].comps[0].tools[0].animated["Opacity1"]
+    assert kept.keyframes == {0.0: 0.0, 24.0: 1.0}
+
+
+def test_a_record_frame_picks_between_two_titles_that_read_the_same(attach: Attach) -> None:
+    timeline = a_session(
+        attach,
+        a_timeline([a_title("Intro", FIRST), a_title("Intro", SECOND)]),
+    )
+
+    result = edit_title(title="Intro", at=SECOND, text="Reprise")
+
+    assert [text_of(item) for item in items_on(timeline)] == ["Intro", "Reprise"]
+    assert result["title"]["record"]["frames"] == SECOND
+
+
+def test_a_record_frame_alone_names_a_title_whose_words_are_hard_to_type(
+    attach: Attach,
+) -> None:
+    timeline = a_session(attach, a_timeline([a_title("Bass — Ana Ruiz", FIRST)]))
+
+    result = edit_title(at=FIRST, text="Bass — Ana Ruíz")
+
+    assert result["ok"] is True
+    assert text_of(items_on(timeline)[0]) == "Bass — Ana Ruíz"
+
+
+def test_a_named_timeline_is_edited_rather_than_the_current_one(attach: Attach) -> None:
+    other = a_timeline([a_title("Night Fery", FIRST)], name="holiday-gig v1")
+    current = a_timeline([a_title("Sunset Boulevard", FIRST)])
+    a_session(attach, timelines=[current, other])
+
+    edit_title(title="Night Fery", text="Night Ferry", timeline="holiday-gig v1")
+
+    assert text_of(items_on(other)[0]) == "Night Ferry"
+    assert text_of(items_on(current)[0]) == "Sunset Boulevard"
+
+
+# --- edit_title: what it refuses --------------------------------------------------------
+
+
+def test_words_that_match_nothing_are_refused_with_the_track_listed(attach: Attach) -> None:
+    a_session(attach, a_timeline([a_title("Sunset Boulevard", FIRST)]))
+
+    failure = error(edit_title(title="Sunset Blvd", text="Sunset Boulevard"))
+
+    assert failure["code"] == "title_not_found"
+    assert [one["text"] for one in failure["detail"]["on_track"]] == ["Sunset Boulevard"]
+
+
+def test_two_titles_reading_the_same_are_refused_rather_than_guessed_between(
+    attach: Attach,
+) -> None:
+    timeline = a_session(
+        attach,
+        a_timeline([a_title("Intro", FIRST), a_title("Intro", SECOND)]),
+    )
+
+    failure = error(edit_title(title="Intro", text="Reprise"))
+
+    assert failure["code"] == "title_not_found"
+    assert [one["record"]["frames"] for one in failure["detail"]["matching"]] == [FIRST, SECOND]
+    assert [text_of(item) for item in items_on(timeline)] == ["Intro", "Intro"]
+
+
+def test_a_timeline_with_no_titles_track_refuses_the_edit(attach: Attach) -> None:
+    a_session(attach, a_timeline())
+
+    failure = error(edit_title(title="Sunset Boulevard", text="Sunset Blvd"))
+
+    assert failure["code"] == "title_not_found"
+    assert "no Titles track" in failure["cause"]
+
+
+def test_an_edit_that_changes_nothing_is_refused(attach: Attach) -> None:
+    a_session(attach)
+
+    failure = error(edit_title(title="Sunset Boulevard"))
+
+    assert failure["code"] == "invalid_request"
+    assert "change nothing" in failure["cause"]
+
+
+def test_an_edit_that_names_no_title_is_refused(attach: Attach) -> None:
+    a_session(attach)
+
+    failure = error(edit_title(text="Sunset Blvd"))
+
+    assert failure["code"] == "invalid_request"
+    assert "not told which title" in failure["cause"]
+
+
+def test_the_words_cannot_be_smuggled_in_as_a_param(attach: Attach) -> None:
+    timeline = a_session(attach)
+
+    failure = error(edit_title(title="Sunset Boulevard", params={"StyledText": "Sunset Blvd"}))
+
+    assert failure["code"] == "invalid_request"
+    assert text_of(items_on(timeline)[0]) == "Sunset Boulevard"
+
+
+def test_a_param_value_a_fusion_input_cannot_take_is_refused_before_anything_is_written(
+    attach: Attach,
+) -> None:
+    timeline = a_session(attach)
+
+    failure = error(
+        edit_title(title="Sunset Boulevard", text="Sunset Blvd", params={"Size": {"x": 1}})
+    )
+
+    assert failure["code"] == "invalid_request"
+    # Refused before Resolve was touched: the text it would also have written is unchanged.
+    assert text_of(items_on(timeline)[0]) == "Sunset Boulevard"
+
+
+def test_a_write_that_is_taken_and_dropped_is_reported_rather_than_believed(
+    attach: Attach,
+) -> None:
+    a_session(
+        attach,
+        a_timeline(
+            [a_title("Sunset Boulevar", FIRST, inputs={"Size": 0.05}, refuses={"Size"})],
+        ),
+    )
+
+    failure = error(edit_title(title="Sunset Boulevar", params={"Size": 0.08}))
+
+    assert failure["code"] == "title_edit_failed"
+    assert failure["detail"]["strayed"] == [{"input": "Size", "wrote": 0.08, "reads": 0.05}]
+
+
+def test_an_input_id_this_template_has_not_got_is_reported(attach: Attach) -> None:
+    a_session(
+        attach,
+        a_timeline([a_title("Sunset Boulevard", FIRST, refuses={"StyleSize"})]),
+    )
+
+    failure = error(edit_title(title="Sunset Boulevard", params={"StyleSize": 0.08}))
+
+    assert failure["code"] == "title_edit_failed"
+    assert failure["detail"]["strayed"] == [
+        {"input": "StyleSize", "wrote": 0.08, "reads": None},
+    ]
+
+
+def test_instances_sharing_one_fusion_comp_are_refused_by_reading_the_neighbour(
+    attach: Attach,
+) -> None:
+    shared = FakeFusionComp([FakeFusionTool(inputs={"StyledText": "Sunset Boulevar"})])
+    a_session(
+        attach,
+        a_timeline(
+            [
+                a_title("Sunset Boulevar", FIRST, comp=shared),
+                a_title("Sunset Boulevar", SECOND, comp=shared),
+            ]
+        ),
+    )
+
+    failure = error(edit_title(at=FIRST, text="Sunset Boulevard"))
+
+    assert failure["code"] == "title_edit_failed"
+    assert "share one Fusion comp" in failure["fix"]
+    assert failure["detail"]["changed"] == [
+        {
+            "position": 2,
+            "input": "StyledText",
+            "was": "Sunset Boulevar",
+            "reads": "Sunset Boulevard",
+        }
+    ]
+
+
+def test_a_clip_on_the_track_that_is_not_a_title_cannot_be_edited(attach: Attach) -> None:
+    a_session(attach, a_timeline([FakeTimelineItem("B-roll.mp4", FIRST, 200)]))
+
+    failure = error(edit_title(at=FIRST, text="Sunset Boulevard"))
+
+    assert failure["code"] == "title_edit_failed"
+    assert "is not a Text+ title" in failure["cause"]
+
+
+# --- apply, then fix the typo -----------------------------------------------------------
+
+
+def test_a_typo_is_fixed_on_an_applied_track_without_re_applying_the_file(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """The ticket's whole story end to end: apply the file, then fix one word by hand."""
+    cut = FakeTimeline(
+        "sunset-set v3",
+        start_frame=3600,
+        end_frame=20000,
+        video=[FakeTrack("Video 1", [FakeTimelineItem("C0012.mp4", 3600, 12000)])],
+        markers={0: {"color": "Blue", "name": "sunset-boulevard", "note": "", "duration": 1}},
+    )
+    attach(
+        studio(
+            timeline=cut,
+            timelines=[cut],
+            pool=media_pool({"Titles": [text_plus_template("Song Title")]}),
+        )
+    )
+    events = [
+        {"id": "t01", "kind": "title", "text": "Sunset Boulevar", "in": 240, "out": 720},
+        {"id": "t02", "kind": "title", "text": "Night Ferry", "in": 960, "out": 1320},
+    ]
+    doc = {
+        "schema": 1,
+        "templates": {"title": {"clip": "Song Title"}},
+        "songs": [{"key": "sunset-boulevard", "events": events}],
+    }
+    path = tmp_path / "titles.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    assert apply_titles(str(path))["ok"] is True
+    placed = items_on(cut)
+
+    result = edit_title(title="Sunset Boulevar", text="Sunset Boulevard")
+
+    assert result["ok"] is True
+    assert [text_of(item) for item in items_on(cut)] == ["Sunset Boulevard", "Night Ferry"]
+    # Same two clips, never cleared and re-placed — and the apply's fade is still on them.
+    assert items_on(cut) == placed
+    assert cut.deleted_clips == []

--- a/tests/test_title_edit.py
+++ b/tests/test_title_edit.py
@@ -560,7 +560,9 @@ def test_an_edit_a_shared_comp_spread_is_put_back_before_the_refusal(attach: Att
     ]
 
 
-def test_a_restore_that_will_not_take_is_reported_rather_than_claimed(attach: Attach) -> None:
+def test_a_write_the_shared_comp_refuses_is_caught_before_the_neighbour_check(
+    attach: Attach,
+) -> None:
     shared = FakeFusionComp(
         [FakeFusionTool(inputs={"StyledText": "Sunset Boulevar"}, refuses={"StyledText"})]
     )


### PR DESCRIPTION
Closes #43.

`apply_titles` is declarative: every apply clears the Titles track and re-places it from
the file. Right for authoring a set, wrong for a typo — a one-word fix should not cost
every title its Fusion comp, its fade and its position, nor require the songs to still be
marked on the timeline. This is the other half of that pair.

- **`list_titles`** reads the Titles track back: what each placed title says, where it
  sits, and which Fusion inputs its template sets.
- **`edit_title`** writes new words and/or new exposed params into one already-placed
  instance. Nothing is created, cleared, placed or made current; the clip already there is
  written through. The timeline is never switched, because a Fusion input goes through the
  item's own handle — only an append needs the current timeline.

Every write is read back off the clip, walking to the node again rather than reusing the
handle it wrote through. Every other readable title has its text and the written inputs
read before and after; if one moved, the instances share a Fusion comp, **the edit is put
back** and the call fails rather than reporting a success that re-worded someone else's
title.

**Seam** (per CLAUDE.md): the fake tier verifies the decisions — selection and its
refusals, param validation, read-back of every write, the shared-comp detection and
restore, and that the edit is genuinely in place (the tests hold the very
`FakeTimelineItem` objects and assert the same objects are on the track afterwards, with
their opacity keyframes intact and `deleted_clips == []`). 32 new tests; fake tier is 993
passing. The live tier is what settles whether real fusionscript behaves as modelled, and
it ran — see below.

## Live pass (#43)

**Hardware / interpreter:** Windows 11, DaVinci Resolve Studio 21.0.3.7, python.org CPython
3.12.10, direct attach. Project `mcp-tests-zinc`.

```
uv run pytest -m live -s -k edit_title   ->  1 passed
```

```
track:         {'index': 1, 'name': 'Titles', 'created': False}
  before: 'Custom Title' @ 86400 for 120f - node 'Template', 1 Text+ in comp
          params read=True: 14 input(s) this template sets, of 193 editable of 309 listed
          sets: {'Font': 'Open Sans', 'Size': 0.09, 'Style': 'Semibold',
                 'HorizontalJustificationNew': 3.0, 'VerticalJustificationNew': 3.0,
                 'Wrap': 0.0, 'FitMask': 'Crop', 'EffectMask_LayerSelect': ':Auto',
                 'Gamut.ColorSpace': 'NoChange', ...}
  before: 'Custom Title' @ 86640 for 120f - node 'Template', 1 Text+ in comp
text edit:     'Custom Title' -> 'Live smoke fixed', edited=['StyledText'], others unchanged=1
param edit:    edited=['Size'], now={... 'Size': 0.1 ...}
  after:  'Live smoke fixed' @ 86400
  after:  'Custom Title' @ 86640
```

**This live test needs no fixture and no environment variable**, unlike #41's and #42's.
`InsertFusionTitleIntoTimeline("Text+")` places Resolve's own stock Text+ straight onto a
timeline, so the whole run is built and torn down by the API on a scratch timeline. That
also bears on a route #42 recorded as needing a hand-exported `.drb` — see "Gaps" below.

### ACs

- [x] **Edit text of a placed Text+ instance in place** — fake tier and **live**:
  `'Custom Title'` -> `'Live smoke fixed'`, same clip, comp and fade.
- [x] **Edit exposed template params in place** — fake tier and **live**: `Size` 0.09 ->
  0.1, read back off the clip.
- [x] **No rebuild or re-apply; neighbouring titles unaffected** — fake tier proves the
  clip objects and their keyframes survive and nothing is deleted; **live** reports
  `others unchanged=1` and the second title still reads `'Custom Title'`.

## Decisions worth your attention

1. **Two tools where the ticket describes one call.** AC2 is unreachable without
   discovery — the agent cannot write an input id it has no way to learn, and a media-pool
   template has no comp to ask, so the ids can only be read off a *placed* instance. That
   is `list_titles`. It is **not** `list_title_templates` (#12's third titling tool, which
   lists pool templates); that one is still ticketless. This spends against the same
   undecided catalogue budget #42 opened — see Needs from you.
2. **The params listing reports what the template *sets*, not everything settable.** The
   live probe is the reason: a stock Text+ reports **309** inputs, 194 external, nearly all
   at their stock value. Listing them all costs the reader more context than it gives. So
   an input is listed when its value differs from the default the build declares, or it is
   a non-empty string — 14 rather than 194 live. It is a listing rule, never a permission:
   `edit_title` writes any id, and a refused write reports `detail.editable`, every id the
   node will take. Residual noise: 6 of those 14 are `Gamut.*` plumbing, because text
   inputs declare no default so "non-empty" is the only available proxy.
3. **`edit_title` edits the timeline, not `titles.json`** — so a later `apply_titles` puts
   the old wording back. Consistent with the ticket ("no full re-apply"), and disclosed in
   four places: the tool docstring, `server.py` INSTRUCTIONS, `README.md`, and the schema's
   section 4.
4. **A locked track is not pre-refused.** Whether a lock blocks a Fusion input write is not
   something any seam can answer, so rather than assume, the read-back catches it and the
   fix hint names the lock.

## Gaps this surfaced but does not own

- **#41 and #42's live ACs are still unrun, and may no longer need the `.drb`.**
  `InsertFusionTitleIntoTimeline` gets a real Text+ onto a timeline with no GUI fixture at
  all. It does not make the *pool clip* those two tickets place from, so it does not
  replace their fixture outright — but it is worth a look before more hand-authoring.
- `list_title_templates` (#12) still has no ticket.
- The neighbour check compares the text plus the inputs this call wrote, not all 194 — a
  shared comp that moved only an unwritten input would pass. Widening it would cost more
  bridge calls than the edit. Stated in the docstring rather than implied.
- `detail.restored: False` has no fake-tier coverage: reaching it needs a comp that takes
  the first write and refuses the restore, and inventing that knob to reach one branch
  seemed worse than the gap.

## Review

Reviewed with `/code-review` (two-axis, Standards and Spec as parallel sub-agents) against
`origin/main`, on the branch before this PR existed, then the fix diff re-checked.

**Standards findings, all fixed** (commits 2 and 3):
- `_refuse_shared_comp` had a dead branch in its return (`_pick` guarantees the target is
  readable, so it is always in `before`) -> `len(before) - 1`.
- Both post-write re-walks called `fusion.title_node` unguarded, so a neighbour whose comp
  had gone unreadable escaped as `TitleTemplateError` naming a template but not the edit
  that disturbed it -> both go through `_walk_back`.
- `read_params` took a `limit` nobody passed (Speculative Generality) -> inlined.
- `Placed.where` and `_read_one` built the same string (Duplicated Code) -> `_where_of`.

**Spec findings, all fixed** (commit 2):
- "Neighbouring titles unaffected" was *detected*, not delivered — the neighbour kept the
  overwritten text. `_put_back` now restores before raising and reports `detail.restored`;
  on a shared comp that restores the target too, so the track ends where it started.
- "Exposed params" is wider than what `read_params` lists, and with no other discovery
  route an id the summary passed over was unreachable -> a refused write reports
  `fusion.editable_ids`.

**Re-check of the fix diff found one more, fixed** (commit 3): `_put_back` wrote and
verified through `placed.node`, the handle captured *before* the write — breaking this
module's own rule that a handle can go on answering for a comp the timeline has replaced.
Both the write and its read-back now walk to the node from the timeline item.

Also tightened `tests/fakes.py`: `FakeFusionTool.SetInput` grew a new input on demand, so a
typo'd id read back as a clean write and passed. A real node's inputs are fixed by its
type, so an unknown id is now dropped and reads as `None` — which is what makes the
read-back check mean anything. No existing test relied on the old behaviour.

CI: fake tier 993 passing, mypy strict clean, ruff clean.

Review: clean — two-axis review plus a focused re-check of the fix diff; all findings fixed.
