### PR TITLE
P2: PNG title route

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Build contract: [issue #22](https://github.com/danielbaldwin47/resolve-mcp/issue
 P1 in progress, P2 titling started. Shipped so far: the server skeleton, the
 session/project tools, the media pool tools, the timeline read, marker and interchange
 tools, the declarative cut file and `build_timeline`, the titling tools on both the Text+
-and PNG routes, the
-background-job infrastructure with audio acquisition, frame grabs and scene-cut
-detection, the render/deliver tools, and the `run_python` escape hatch.
+and PNG routes, the background-job infrastructure with audio acquisition, frame grabs and
+scene-cut detection, the render/deliver tools, and the `run_python` escape hatch.
 
 | Tool | What it does |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Build contract: [issue #22](https://github.com/danielbaldwin47/resolve-mcp/issue
 
 P1 in progress, P2 titling started. Shipped so far: the server skeleton, the
 session/project tools, the media pool tools, the timeline read, marker and interchange
-tools, the declarative cut file and `build_timeline`, the Text+ titling tools, the
+tools, the declarative cut file and `build_timeline`, the titling tools on both the Text+
+and PNG routes, the
 background-job infrastructure with audio acquisition, frame grabs and scene-cut
 detection, the render/deliver tools, and the `run_python` escape hatch.
 
@@ -36,7 +37,7 @@ detection, the render/deliver tools, and the `run_python` escape hatch.
 | `build_timeline` | Builds a cut file into a fresh `<name> v<N>` timeline and verifies what landed |
 | `get_titles_schema` | The titles-file contract, its annotated example and the validation rules |
 | `validate_titles` | Dry-runs a titles file before the Titles track is touched |
-| `apply_titles` | Places Text+ titles from `titles.json` onto an owned Titles track, fades and all |
+| `apply_titles` | Places Text+ and PNG titles from `titles.json` onto an owned Titles track, fades and all |
 | `list_titles` | Reads the Titles track back: what each placed title says and which inputs it exposes |
 | `edit_title` | Fixes one placed title in place — its words or its exposed params, neighbours untouched |
 | `grab_frames` | Grabs chosen moments on a clip as JPEGs (≤1568px) the agent reads off disk |
@@ -75,8 +76,16 @@ Editing is declarative and split across two files that never mention each other.
 `Titles` — every apply clears that track whole and re-places from the file, so the same
 file always produces the same track. Title positions are offsets from the *blue marker*
 naming their song rather than timeline frames, which is what lets one titles file be
-re-applied unchanged to every rebuild. Fades are Fusion opacity keyframes inside each
-placed instance, because Resolve exposes no clip-level fade to the scripting API at all.
+re-applied unchanged to every rebuild.
+
+Each event picks one of two routes, and both land in the same pass. **Text+** places an
+instance of a GUI-authored template and writes its words and its fade into that instance's
+Fusion comp — clip-level fades are not exposed to the scripting API at all, so the fade is
+an opacity spline. **PNG** places a designed card exported to frames with alpha, its words
+and its ramps already in the pixels; the server consumes cards, never generates them. A
+card is imported once into `04_Assets/Text/<song>` and found rather than re-imported on
+every later apply, and gets the one-time out-point write that makes Resolve honour the
+requested length instead of dropping every image at the default still duration.
 
 A typo is the exception to all of that. `edit_title` writes new words or new exposed
 params straight into one already-placed Text+ instance — no clear, no append, no rebuild —

--- a/src/resolve_mcp/resolve/apply.py
+++ b/src/resolve_mcp/resolve/apply.py
@@ -18,6 +18,12 @@ That gives the order everything here follows:
   "rebuild the cut, re-apply the titles" safe.
 * **Songs are found by marker, not by frame.** Every event's position is an offset from
   the blue marker naming its song, so the same file lands correctly on every rebuild.
+* **Two routes, one append.** A Text+ instance and a designed PNG card are different media
+  and different fades, but they are the same placement: one clip, one record frame, one
+  duration. So the routes part only where they must — where the source clip comes from,
+  and whether a fade has to be written or arrived baked — and every event of the file goes
+  onto the track in a single call, in document order. Cards are imported *before* the
+  track is cleared, so a card Resolve refuses costs nothing that was already there.
 * **Resolve's answer is never the evidence.** ``AppendToTimeline`` writes to the *current*
   timeline (so the switch is made and verified first), reports success on a locked track,
   and slides an append that overlaps. Every placement is read back off the track, and
@@ -28,11 +34,12 @@ That gives the order everything here follows:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Final, NamedTuple
 
 from ..errors import TitlesApplyFailedError, TitlesInvalidError
 from ..logging_config import get_logger
 from ..timing import dual_time
+from ..titles.assets import Asset
 from ..titles.schema import TRACK_NAME
 from ..titles.validate import Event
 from . import fusion, media
@@ -51,8 +58,17 @@ VIDEO: Final = "video"
 MEDIA_TYPE_VIDEO: Final = 1
 """Resolve's ``mediaType`` for a video-only append. Never omitted: it drops the clip."""
 
-TEMPLATE_SOURCE_IN: Final = 0
-"""A title template is placed from its own first frame; it has no other content."""
+SOURCE_IN: Final = 0
+"""Both routes are placed from their source's first frame — a template has no other
+content, and a card is the whole event with its ramps already in it."""
+
+
+class Titled(NamedTuple):
+    """One placed event and how it fades: through a Text+ node, or baked into a card."""
+
+    event: Event
+    node: fusion.TitleNode | None
+    fade: fusion.Fade
 
 
 @dataclass(frozen=True)
@@ -112,8 +128,11 @@ def apply_titles(connection: ResolveConnection, titles_file: str) -> dict[str, A
     # a refusal after the switch still applies nothing.
     _target(project, timeline, track.timeline)
     _refuse_locked(timeline, track)
+    # Cards come into the pool before the clear, never after: an import Resolve refuses
+    # must not cost the titles that were standing on the track.
+    cards = _import_cards(pool, checked.assets, track)
     cleared = _clear(timeline, track)
-    _place(pool, checked.events, checked.templates, track)
+    _place(pool, checked.events, checked.templates, cards, track)
     items = _verify(timeline, checked.events, track)
     titled = _write_titles(checked.events, items)
 
@@ -129,28 +148,45 @@ def apply_titles(connection: ResolveConnection, titles_file: str) -> dict[str, A
         ),
         "track": track.as_dict(),
         "cleared": cleared,
-        "placed": [_placed(event, node, fade, checked.fps) for event, node, fade in titled],
+        "placed": [_placed(one, checked.fps, checked.assets.get(one.event.id)) for one in titled],
         "warnings": [finding.as_dict() for finding in checked.warnings],
     }
 
 
-def _placed(
-    event: Event,
-    node: fusion.TitleNode,
-    fade: fusion.Fade,
-    fps: float | None,
-) -> dict[str, Any]:
-    return {
+def _placed(titled: Titled, fps: float | None, card: Asset | None) -> dict[str, Any]:
+    """One placed title, reported in the terms of the route that placed it.
+
+    ``route`` comes first and the route-specific keys are simply absent on the other one:
+    a ``template`` on a PNG entry or an ``asset`` on a Text+ entry would be a field the
+    reader has to know is meaningless, and this report is read by an agent deciding what
+    to fix.
+    """
+    event = titled.event
+    common = {
         "id": event.id,
         "song": event.song,
         "kind": event.kind,
-        "template": event.template,
-        "text": event.text,
+        "route": event.route,
         "record": dual_time(event.record_in, fps),
         "duration": dual_time(event.duration, fps),
-        "node": {"name": node.name, "text_plus_in_comp": node.of_how_many},
-        "fade": fade.as_dict(),
+        "fade": titled.fade.as_dict(),
         "note": event.note,
+    }
+    if event.is_png:
+        return {
+            **common,
+            "asset": event.asset,
+            "bin": None if card is None else card.bin_path,
+            "frames": None if card is None else card.frames,
+        }
+    node = titled.node
+    return {
+        **common,
+        "template": event.template,
+        "text": event.text,
+        "node": (
+            None if node is None else {"name": node.name, "text_plus_in_comp": node.of_how_many}
+        ),
     }
 
 
@@ -274,19 +310,72 @@ def _clear(timeline: Timeline, track: OwnedTrack) -> int:
     return len(standing)
 
 
+def _import_cards(
+    pool: Pool,
+    cards: dict[str, Asset],
+    track: OwnedTrack,
+) -> dict[str, media.LocatedClip]:
+    """Every PNG card in the pool exactly once, with its duration unlocked.
+
+    Deduplicated by the bin and the card's first frame: two events sharing one card share
+    one clip, and a card already sitting in that bin from an earlier apply is *found*
+    rather than imported again. That second half is what keeps the file re-runnable — an
+    apply that imported afresh every time would grow the media pool by a copy of every
+    card on every run, and the pool is the operator's, not this tool's.
+    """
+    located: dict[str, media.LocatedClip] = {}
+    already: dict[tuple[str, str], media.LocatedClip] = {}
+    for event_id, card in cards.items():
+        key = (card.bin_path, card.first_frame())
+        if key not in already:
+            already[key] = _card_clip(pool, card, track)
+        located[event_id] = already[key]
+    if located:
+        log.info("%d png card(s) ready in the pool for %r", len(already), track.timeline)
+    return located
+
+
+def _card_clip(pool: Pool, card: Asset, track: OwnedTrack) -> media.LocatedClip:
+    """The pool clip for one card: the one already there, or a fresh import of it."""
+    target = media.ensure_bin(pool, card.bin_path)
+    standing = media.clip_at_path(pool, target.path, card.first_frame())
+    if standing is None:
+        imported = media.import_into(pool, [card.request()], target)
+        if not imported:
+            raise TitlesApplyFailedError(
+                cause=f"Resolve imported nothing for the card {card.declared!r} of "
+                f"{card.event!r}, so nothing was applied and the {track.name!r} track was "
+                f"not touched.",
+                fix="The frames are on disk — check Resolve can read this image format and "
+                "that the sequence is numbered without gaps, then apply again.",
+                detail=track.detail(id=card.event, asset=card.declared, bin=target.path),
+            )
+        standing = media.LocatedClip(target.path, imported[0])
+        log.info("Imported the card %s into %r", card.declared, target.path or "the root")
+    # The out point is written on every apply, not only on the import: a card put into the
+    # pool by hand has never had one, and without it Resolve ignores ``endFrame`` outright
+    # and lands the card at the project's default still duration instead of the event's.
+    media.apply_still_workaround(standing.clip, media.properties(standing.clip))
+    return standing
+
+
 def _place(
     pool: Pool,
     events: list[Event],
     templates: dict[str, media.LocatedClip],
+    cards: dict[str, media.LocatedClip],
     track: OwnedTrack,
 ) -> None:
-    """One call for the whole file. Its return value is counted, never believed."""
+    """One call for the whole file, both routes in it. Its return value is counted,
+    never believed."""
     if not events:
         return
     placements = [
         {
-            "mediaPoolItem": templates[event.template].clip,
-            "startFrame": TEMPLATE_SOURCE_IN,
+            "mediaPoolItem": (
+                cards[event.id].clip if event.is_png else templates[event.template].clip
+            ),
+            "startFrame": SOURCE_IN,
             "endFrame": event.duration,
             "mediaType": MEDIA_TYPE_VIDEO,
             "trackIndex": track.index,
@@ -299,9 +388,9 @@ def _place(
         raise TitlesApplyFailedError(
             cause=f"Asked Resolve for {len(events)} title(s) on {track.timeline!r} and got "
             f"back {len(returned)}.",
-            fix="A template shorter than the span asked for is refused rather than trimmed "
-            "— shorten the longest event, or lengthen the template in the Resolve GUI and "
-            "export its bin again.",
+            fix="A source shorter than the span asked for is refused rather than trimmed "
+            "— shorten the longest event, lengthen the template in the Resolve GUI and "
+            "export its bin again, or re-bake the card to the frames the event asks for.",
             detail=track.detail(asked=len(events), returned=len(returned)),
         )
     log.info("Appended %d title(s) to %r", len(events), track.timeline)
@@ -341,20 +430,24 @@ def _verify(timeline: Timeline, events: list[Event], track: OwnedTrack) -> list[
     return [landed[event.record_in] for event in events]
 
 
-def _write_titles(
-    events: list[Event],
-    items: list[Item],
-) -> list[tuple[Event, fusion.TitleNode, fusion.Fade]]:
-    """Set every title's text and fade, then read every text back off the placed clips.
+def _write_titles(events: list[Event], items: list[Item]) -> list[Titled]:
+    """Set every Text+ title's text and fade, then read every text back off the placed clips.
 
     Every write happens before any read on purpose (#41): reading a title straight after
     writing it would pass whether or not the instances share one Fusion comp, because the
     write that overwrites an earlier title has not happened yet. For the same reason the
     read-back walks to the node again from the timeline item rather than reusing the node
     it wrote through — a handle can go on answering for a comp the timeline has replaced.
+
+    A PNG card is skipped by both halves. It carries no Fusion comp to write into and its
+    words and its ramps were exported into the pixels, so the placement *is* the title —
+    there is nothing left to say to it, and asking it for a Text+ node would fail.
     """
-    written: list[tuple[Event, fusion.TitleNode, fusion.Fade]] = []
+    written: list[Titled] = []
     for event, item in zip(events, items, strict=True):
+        if event.is_png:
+            written.append(Titled(event, None, fusion.baked_fade(event.fade_in, event.fade_out)))
+            continue
         node = fusion.title_node(item, f"title {event.id!r}")
         fusion.set_text(node, event.text)
         fade = fusion.write_fade(
@@ -363,10 +456,13 @@ def _write_titles(
             fade_in=event.fade_in,
             fade_out=event.fade_out,
         )
-        written.append((event, node, fade))
+        written.append(Titled(event, node, fade))
 
     strayed: list[tuple[Event, str | None]] = []
-    for (event, _, _), item in zip(written, items, strict=True):
+    for titled, item in zip(written, items, strict=True):
+        event = titled.event
+        if event.is_png:
+            continue
         read = fusion.read_text(fusion.title_node(item, f"title {event.id!r}"))
         if read != event.text:
             strayed.append((event, read))
@@ -383,4 +479,4 @@ def _write_titles(
     return written
 
 
-__all__ = ["VIDEO", "OwnedTrack", "apply_titles", "find_track", "track_count"]
+__all__ = ["VIDEO", "OwnedTrack", "Titled", "apply_titles", "find_track", "track_count"]

--- a/src/resolve_mcp/resolve/apply.py
+++ b/src/resolve_mcp/resolve/apply.py
@@ -355,6 +355,12 @@ def _card_clip(pool: Pool, card: Asset, track: OwnedTrack) -> media.LocatedClip:
     # The out point is written on every apply, not only on the import: a card put into the
     # pool by hand has never had one, and without it Resolve ignores ``endFrame`` outright
     # and lands the card at the project's default still duration instead of the event's.
+    #
+    # Nothing is written about the card's alpha, and that is deliberate. Resolve reports
+    # ``Alpha mode: Straight`` on a freshly imported PNG (probed on Studio 21.0.3), which
+    # is what an HTML export writes — the ramps composite correctly untouched. The property
+    # is settable if that ever stops being true; writing it now would only be a chance to
+    # premultiply a card that was not.
     media.apply_still_workaround(standing.clip, media.properties(standing.clip))
     return standing
 

--- a/src/resolve_mcp/resolve/fusion.py
+++ b/src/resolve_mcp/resolve/fusion.py
@@ -115,6 +115,19 @@ NO_FADE = Fade(0, 0, (), True, "no fade asked for")
 """A hard cut on and off — the file said nothing about a fade, so nothing was written."""
 
 
+def baked_fade(frames_in: int, frames_out: int) -> Fade:
+    """The PNG route's fade: already in the pixels, so there is nothing to write or read.
+
+    Reported in the same shape as a written one so a caller reading the apply report does
+    not have to branch on the route to find out how a title fades. ``verified`` is true
+    because the ramp arrived with the card — the frames were counted against the event's
+    duration before anything was placed (T11), which is the whole of the check available.
+    """
+    if not (frames_in or frames_out):
+        return NO_FADE
+    return Fade(frames_in, frames_out, (), True, "baked into the exported frames")
+
+
 @dataclass(frozen=True)
 class Params:
     """The exposed inputs of one placed title's Text+ node, and whether they could be read.
@@ -462,6 +475,7 @@ __all__ = [
     "Fade",
     "Params",
     "TitleNode",
+    "baked_fade",
     "editable_ids",
     "read_input",
     "read_params",

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -229,6 +229,22 @@ def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> LocatedClip
     return matches[0]
 
 
+def clip_at_path(pool: Pool, bin_path: str, file_path: str) -> LocatedClip | None:
+    """The clip in ``bin_path`` that already stands for ``file_path``, if one does.
+
+    Identity is the first frame on disk rather than the reported path or the clip name,
+    because Resolve renames and re-paths an imported sequence into a folded label
+    (:func:`first_frame_of`). ``None`` — rather than a raise — because "not imported yet"
+    is the ordinary answer on a first run, not a failure.
+    """
+    wanted = Path(first_frame_of(file_path))
+    for found in _clips_under(find_bin(pool, bin_path), recursive=True):
+        standing = properties(found.clip).get(FILE_PATH, "")
+        if standing and Path(first_frame_of(standing)) == wanted:
+            return found
+    return None
+
+
 def clips_named(pool: Pool, names: Iterable[str]) -> list[LocatedClip]:
     """Every clip anywhere in the pool whose name is one of ``names``.
 
@@ -306,6 +322,22 @@ def is_still(reported: dict[str, str]) -> bool:
     return _looks_like_image(reported.get(FILE_PATH, ""))
 
 
+def first_frame_of(file_path: str) -> str:
+    """The one file a clip's path really stands for, sequence labels unfolded.
+
+    Resolve reports an imported sequence as ``shot_[0001-0024].png`` (#85) — a label, not
+    a path — so the first frame is the only form of a sequence's address that is a real
+    file both before the import (where the caller has a ``%0Nd`` pattern) and after it.
+    That makes it the identity a re-run can recognise an already-imported card by.
+    Anything that is not a folded range comes back unchanged.
+    """
+    folded = SEQUENCE_RANGE.search(Path(file_path).name)
+    if folded is None:
+        return file_path
+    path = Path(file_path)
+    return str(path.with_name(SEQUENCE_RANGE.sub(folded.group(1), path.name, count=1)))
+
+
 def is_offline(file_path: str) -> bool:
     """Whether the media behind a clip has moved away.
 
@@ -322,10 +354,9 @@ def is_offline(file_path: str) -> bool:
         return False
     if SEQUENCE_TOKEN in path.name:
         return not path.parent.exists()
-    folded = SEQUENCE_RANGE.search(path.name)
-    if folded:
-        first = path.with_name(SEQUENCE_RANGE.sub(folded.group(1), path.name, count=1))
-        return not first.exists()
+    first = first_frame_of(file_path)
+    if first != file_path:
+        return not Path(first).exists()
     return True
 
 
@@ -405,28 +436,33 @@ def apply_still_workaround(clip: Clip, reported: dict[str, str]) -> bool:
     return True
 
 
+def import_into(pool: Pool, items: list[str | dict[str, Any]], target: LocatedBin) -> list[Clip]:
+    """``ImportMedia`` into one bin, and leave the pool where it was found.
+
+    Imports land in the media pool's *current* folder, so the current folder is moved for
+    the call and put back afterwards — a tool must not leave the GUI somewhere else. Every
+    route that imports goes through here so no route can forget the second half.
+    """
+    previous = pool.GetCurrentFolder()
+    pool.SetCurrentFolder(target.folder)
+    try:
+        return list(pool.ImportMedia(items) or [])
+    finally:
+        if previous is not None:
+            pool.SetCurrentFolder(previous)
+
+
 def import_media(
     connection: ResolveConnection,
     paths: list[str] | None = None,
     bin_path: str | None = None,
     sequences: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    """Import media into ``bin_path``, creating the bin if needed.
-
-    Imports land in the media pool's *current* folder, so the current folder is moved for
-    the call and put back afterwards — a tool must not leave the GUI somewhere else.
-    """
+    """Import media into ``bin_path``, creating the bin if needed."""
     pool = media_pool(connection)
     items = _requests(paths, sequences)
     target = ensure_bin(pool, bin_path)
-
-    previous = pool.GetCurrentFolder()
-    pool.SetCurrentFolder(target.folder)
-    try:
-        imported = list(pool.ImportMedia(items) or [])
-    finally:
-        if previous is not None:
-            pool.SetCurrentFolder(previous)
+    imported = import_into(pool, items, target)
 
     summaries: list[dict[str, Any]] = []
     landed: set[str] = set()

--- a/src/resolve_mcp/resolve/titles.py
+++ b/src/resolve_mcp/resolve/titles.py
@@ -20,15 +20,19 @@ from typing import Any
 from ..document import LoadedDocument
 from ..findings import Finding, severity_of
 from ..logging_config import get_logger
+from ..titles.assets import Asset
 from ..titles.document import read_titles_file
 from ..titles.schema import ANNOTATED_EXAMPLE, SCHEMA_DOC, SCHEMA_VERSION
 from ..titles.validate import (
     ANCHOR_COLOR,
+    PNG,
     RULE_DESCRIPTIONS,
     Event,
     TemplateFacts,
     plan,
+    route_of,
     template_of,
+    validate_assets,
     validate_project,
     validate_structure,
 )
@@ -72,6 +76,7 @@ class Preflight:
     timeline: Timeline | None = None
     fps: float | None = None
     templates: dict[str, media.LocatedClip] = field(default_factory=dict)
+    assets: dict[str, Asset] = field(default_factory=dict)
     events: list[Event] = field(default_factory=list)
 
     @property
@@ -95,6 +100,11 @@ def preflight(connection: ResolveConnection, titles_file: str) -> Preflight:
         return Preflight(loaded, findings)
 
     doc: dict[str, Any] = loaded.doc
+    # The cards are judged before the connection is opened: a card that was never exported
+    # is worth saying so on a machine that cannot reach Resolve at all.
+    asset_findings, assets = validate_assets(doc, base=loaded.path.parent)
+    findings = [*findings, *asset_findings]
+
     project = timeline_read.open_project(connection)
     timeline = timeline_read.find_timeline(project, doc.get("timeline"))
     fps = frame_rate(project, timeline)
@@ -103,17 +113,20 @@ def preflight(connection: ResolveConnection, titles_file: str) -> Preflight:
     facts, located = _templates(pool, doc)
     anchors = markers.markers_by_name(connection, timeline, fps, ANCHOR_COLOR)
     log.info(
-        "Titling %r: %d %s marker(s), %d template(s) declared",
+        "Titling %r: %d %s marker(s), %d template(s) declared, %d png card(s)",
         timeline_read.name_of(timeline),
         len(anchors),
         ANCHOR_COLOR.lower(),
         len(facts),
+        len(assets),
     )
     findings = [
         *findings,
         *validate_project(doc, anchors=anchors, templates=facts, span=_span(timeline)),
     ]
-    return Preflight(loaded, findings, project, timeline, fps, located, plan(doc, anchors))
+    return Preflight(
+        loaded, findings, project, timeline, fps, located, assets, plan(doc, anchors)
+    )
 
 
 def _span(timeline: Timeline) -> tuple[int, int]:
@@ -136,8 +149,13 @@ def _templates(
     template at once — and the resolved handles come back beside them so the apply places
     the very clips the rules were judged against.
     """
-    used = {template_of(event) for song in doc["songs"] for event in song["events"]}
-    declared = {name: one for name, one in doc["templates"].items() if name in used}
+    used = {
+        template_of(event)
+        for song in doc["songs"]
+        for event in song["events"]
+        if route_of(event) != PNG
+    }
+    declared = {name: one for name, one in doc.get("templates", {}).items() if name in used}
     found = media.clips_named(pool, {str(one["clip"]) for one in declared.values()})
 
     facts: list[TemplateFacts] = []

--- a/src/resolve_mcp/resolve/titles.py
+++ b/src/resolve_mcp/resolve/titles.py
@@ -100,8 +100,9 @@ def preflight(connection: ResolveConnection, titles_file: str) -> Preflight:
         return Preflight(loaded, findings)
 
     doc: dict[str, Any] = loaded.doc
-    # The cards are judged before the connection is opened: a card that was never exported
-    # is worth saying so on a machine that cannot reach Resolve at all.
+    # The cards are judged off disk alone — no project, no pool — so a card that was never
+    # exported is named in the same pass as a malformed one, and named before anything is
+    # looked up in Resolve rather than after a lookup that would have to succeed first.
     asset_findings, assets = validate_assets(doc, base=loaded.path.parent)
     findings = [*findings, *asset_findings]
 
@@ -125,7 +126,14 @@ def preflight(connection: ResolveConnection, titles_file: str) -> Preflight:
         *validate_project(doc, anchors=anchors, templates=facts, span=_span(timeline)),
     ]
     return Preflight(
-        loaded, findings, project, timeline, fps, located, assets, plan(doc, anchors)
+        loaded,
+        findings,
+        project=project,
+        timeline=timeline,
+        fps=fps,
+        templates=located,
+        assets=assets,
+        events=plan(doc, anchors),
     )
 
 

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -48,9 +48,9 @@ server never writes it, and the swap report says exactly what to change. Titles 
 declarative too and live outside the cut file: get_titles_schema, then apply_titles, which
 owns a Titles track and can be re-applied to every rebuild. Each event picks its route —
 a Text+ template instance, or a designed PNG card already exported to frames — and both
-land in the same pass. A typo in one placed title
-needs neither: list_titles reads the track back and edit_title fixes that one instance,
-leaving every other title alone — fix titles.json too, or the next apply undoes it.
+land in the same pass. A typo in one placed title needs neither: list_titles reads the
+track back and edit_title fixes that one instance, leaving every other title alone — fix
+titles.json too, or the next apply undoes it.
 
 When the audio evidence is ambiguous, look: grab_frames writes JPEGs you can read at any
 moment on any angle, and detect_scene_cuts catalogs where a piece of b-roll changes shot.

--- a/src/resolve_mcp/server.py
+++ b/src/resolve_mcp/server.py
@@ -46,7 +46,9 @@ change is a rebuild into a new version, with one exception: swap_take flips a sh
 of its alternates in place. It is yours to keep the cut file in step afterwards — the
 server never writes it, and the swap report says exactly what to change. Titles are
 declarative too and live outside the cut file: get_titles_schema, then apply_titles, which
-owns a Titles track and can be re-applied to every rebuild. A typo in one placed title
+owns a Titles track and can be re-applied to every rebuild. Each event picks its route —
+a Text+ template instance, or a designed PNG card already exported to frames — and both
+land in the same pass. A typo in one placed title
 needs neither: list_titles reads the track back and edit_title fixes that one instance,
 leaving every other title alone — fix titles.json too, or the next apply undoes it.
 

--- a/src/resolve_mcp/titles/assets.py
+++ b/src/resolve_mcp/titles/assets.py
@@ -1,0 +1,172 @@
+"""PNG title assets: what an event points at on disk, and how many frames stand behind it.
+
+The PNG route consumes designed cards; it never makes them (#14 §4). A card is exported
+as frames — the alpha ramp baked in at the head, the hold frozen in the middle, the ramp
+out at the tail — and this module is the one place that answers what is actually there.
+
+Two decisions live here rather than in the rules that use them:
+
+* **A relative asset path is relative to the titles file, never to the server's cwd.** The
+  file and its cards travel together in a project folder; resolving against the process
+  would make the same file valid from one directory and broken from another.
+* **Frames are counted off disk, not declared in the file.** ``ImportMedia`` needs a start
+  and end index, and a count the file merely *claims* would be a second source of truth
+  that drifts the moment a card is re-baked. Counting is also what lets T10 and T11 say
+  "the sequence is not there" and "it is 480 frames, not the 500 asked for" before Resolve
+  is touched at all.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from .schema import ASSET_BIN
+
+SEQUENCE_TOKEN: Final = "%"
+BIN_SEPARATOR: Final = "/"
+# Both mirror ``resolve.media`` deliberately rather than importing it: this layer is the
+# pure one, and a titles file has to be judged on a machine with no Resolve on it.
+
+SEQUENCE_INDEX: Final = re.compile(r"%0?\d*d")
+"""The printf token an exported sequence is named with: ``title_%04d.png``."""
+
+
+@dataclass(frozen=True)
+class Asset:
+    """One event's card, resolved against disk.
+
+    ``frames`` is what is really there — zero when nothing is — so a missing sequence and
+    a mis-baked one are the same reading answered by two different rules, and the apply
+    gets the start index it needs for ``ImportMedia`` without looking at the disk again.
+    """
+
+    event: str
+    song: str
+    declared: str
+    path: Path
+    start_index: int | None
+    frames: int
+    bin_path: str
+
+    @property
+    def is_sequence(self) -> bool:
+        """Whether the asset is a ``%0Nd`` frame run rather than one still image."""
+        return self.start_index is not None
+
+    @property
+    def missing(self) -> bool:
+        return self.frames == 0
+
+    def request(self) -> str | dict[str, Any]:
+        """The ``ImportMedia`` argument for this asset: a path, or a sequence descriptor."""
+        if self.start_index is None:
+            return str(self.path)
+        return {
+            "FilePath": str(self.path),
+            "StartIndex": self.start_index,
+            "EndIndex": self.start_index + self.frames - 1,
+        }
+
+    def first_frame(self) -> str:
+        """The one file that really exists — the identity a re-run recognises the clip by.
+
+        A sequence's ``File Path`` is a label rather than a file (``card_[0001-0480].png``,
+        #85), and the ``%0Nd`` pattern is not a file either. The first frame is the only
+        form of the address that is the same string before the import and after it.
+        """
+        if self.start_index is None:
+            return str(self.path)
+        return _frame_path(self.path, self.start_index)
+
+
+def resolve_asset(event: Mapping[str, Any], song: str, *, base: Path) -> Asset:
+    """What one PNG event points at, counted off disk. Never raises on a missing card."""
+    declared = str(event.get("asset", ""))
+    path = Path(declared)
+    resolved = path if path.is_absolute() else (base / path)
+    start, frames = frames_on_disk(resolved)
+    return Asset(
+        event=str(event["id"]),
+        song=song,
+        declared=declared,
+        path=resolved,
+        start_index=start,
+        frames=frames,
+        bin_path=bin_for(event, song),
+    )
+
+
+def bin_for(event: Mapping[str, Any], song: str) -> str:
+    """Where the card lands in the media pool: the event's own bin, or the convention.
+
+    The convention is ``04_Assets/Text/<song key>`` (#57), which is where a human titling
+    the same set by hand would have put it. An explicit ``bin`` always wins, and nothing is
+    ever refused for being off-convention.
+    """
+    declared = event.get("bin")
+    if isinstance(declared, str) and declared.strip():
+        return declared
+    return f"{ASSET_BIN}{BIN_SEPARATOR}{song}"
+
+
+def frames_on_disk(path: Path) -> tuple[int | None, int]:
+    """``(start index, frame count)`` for an asset path — ``(None, n)`` for a still image.
+
+    A sequence is counted as the *contiguous* run from its lowest frame: Resolve imports a
+    start and an end index and reads every frame between them, so a run with a hole in it
+    is not a shorter sequence, it is a broken one — and reporting the run that Resolve
+    would actually get is what makes T11's frame count mean something.
+    """
+    if SEQUENCE_TOKEN not in path.name:
+        return None, 1 if path.is_file() else 0
+
+    token = SEQUENCE_INDEX.search(path.name)
+    if token is None:
+        return None, 0
+    found = _indices_on_disk(path, token.group())
+    if not found:
+        return None, 0
+
+    start = min(found)
+    frames = 0
+    while start + frames in found:
+        frames += 1
+    return start, frames
+
+
+def _indices_on_disk(path: Path, token: str) -> set[int]:
+    """Every frame number present in the asset's folder, read from the file names."""
+    if not path.parent.is_dir():
+        return set()
+    pattern = re.compile(
+        "".join(
+            r"(\d+)" if part == token else re.escape(part)
+            for part in _split_once(path.name, token)
+        )
+        + "$"
+    )
+    found: set[int] = set()
+    for entry in path.parent.iterdir():
+        match = pattern.match(entry.name)
+        if match is not None and entry.is_file():
+            found.add(int(match.group(1)))
+    return found
+
+
+def _split_once(name: str, token: str) -> list[str]:
+    head, _, tail = name.partition(token)
+    return [head, token, tail]
+
+
+def _frame_path(path: Path, index: int) -> str:
+    token = SEQUENCE_INDEX.search(path.name)
+    if token is None:
+        return str(path)
+    return str(path.with_name(path.name.replace(token.group(), token.group() % index, 1)))
+
+
+__all__ = ["Asset", "bin_for", "frames_on_disk", "resolve_asset"]

--- a/src/resolve_mcp/titles/schema.py
+++ b/src/resolve_mcp/titles/schema.py
@@ -167,9 +167,12 @@ project folder moves in one piece. Two forms:
 * **A `%0Nd` frame run** — `cards/<song>/personnel_%04d.png`. This is the full
   event: the fade-in ramp at the head, the hold in the middle, the fade-out ramp
   at the tail, all baked. Its frame count must equal `out - in` exactly (T11).
-  Trimming it would cut the fade-out off, and Resolve cannot stretch a clip past
-  its own media, so the length is the exporter's job and re-timing an event means
-  re-baking the card.
+  Both directions are refused for the same reason: the fade-out lives in the last
+  frames, so trimming a long card cuts it off, and a short one cannot be held out
+  to length either — the hold belongs *before* the ramp, and there is no way to
+  freeze a frame in the middle of a sequence from the API. So the length is the
+  exporter's job, and re-timing an event means re-baking the card. Baking the hold
+  on disk is what the titling spec (#14 §6) asks the exporter for.
 * **One still image** — `cards/<song>/title.png`. Freeze-extended to whatever
   duration the event asks for, so it retimes freely, but it carries no ramp: its
   fades must be zero (T11).

--- a/src/resolve_mcp/titles/schema.py
+++ b/src/resolve_mcp/titles/schema.py
@@ -31,10 +31,13 @@ KINDS: Final = ("title", "personnel", "custom")
 """What an event is for. ``kind`` picks the template unless ``template`` overrides it."""
 
 ROUTES: Final = ("textplus", "png")
-"""How an event is rendered. Only ``textplus`` is placed today; ``png`` is the PNG route."""
+"""How an event is rendered: a Text+ template instance, or a designed PNG card."""
 
-SUPPORTED_ROUTES: Final = ("textplus",)
-"""The routes this build can place. A declared-but-unsupported route is a T6 error."""
+DEFAULT_ROUTE: Final = ROUTES[0]
+"""The route an event that names none is placed by — Text+, the cheapest to iterate on."""
+
+ASSET_BIN: Final = "04_Assets/Text"
+"""Where a PNG card lands unless the event names a bin: ``04_Assets/Text/<song key>`` (#57)."""
 
 ANNOTATED_EXAMPLE: Final = """\
 {
@@ -42,7 +45,8 @@ ANNOTATED_EXAMPLE: Final = """\
   "timeline": "sunset-set v4",       // optional; default = the current timeline
 
   // GUI-authored Text+ templates, already in the media pool. Identity = clip name
-  // + optional bin, resolved to exactly one media-pool clip at apply.
+  // + optional bin, resolved to exactly one media-pool clip at apply. Omit the whole
+  // block in a file whose events are all PNG.
   "templates": {
     "title":     { "clip": "Song Title", "bin": "Titles/Templates" },
     "personnel": { "clip": "Personnel" }
@@ -55,12 +59,22 @@ ANNOTATED_EXAMPLE: Final = """\
         {
           "id": "t01",               // required, unique across the whole file
           "kind": "title",           // title | personnel | custom
-          "route": "textplus",       // textplus (png = the PNG route, not this one)
-          "template": "title",       // optional; default = kind
-          "text": "Sunset Boulevard",     // the final string, verbatim; \\n for a line break
+          "route": "textplus",       // optional; textplus | png, default textplus
+          "template": "title",       // textplus only; optional, default = kind
+          "text": "Sunset Boulevard",     // textplus only; the final string, verbatim
           "in": 240, "out": 720,     // frames from the song's marker, half-open [in, out)
           "fade": { "in": 24, "out": 36 },  // optional; frames of opacity ramp (§3)
           "note": "let four bars play"      // free text; server ignores; feeds the report
+        },
+        {
+          "id": "t02",
+          "kind": "personnel",
+          "route": "png",            // a designed card, exported to frames (§6)
+          "asset": "cards/sunset-boulevard/personnel_%04d.png",  // png only; relative to
+                                     // this file. A %0Nd run, or one still image.
+          "bin": "04_Assets/Text/sunset-boulevard",  // optional; this is also the default
+          "in": 960, "out": 1440,
+          "fade": { "in": 24, "out": 24 }   // describes the ramp already in the frames
         }
       ]
     }
@@ -93,18 +107,24 @@ song is reported as a warning, never an error — a set list is often titled a s
 at a time."""
 
 _FADES: Final = """\
-## 3. Fades are Fusion opacity keyframes
+## 3. Fades never use the clip's fade handles
 
 Resolve's clip-level fade handles are not reachable from the scripting API at
-all, so a fade is written *inside* the placed instance's Fusion comp: a
-BezierSpline on the Text+ node's `Opacity1`, keyframed 0 -> 1 over `fade.in` at
-the head and 1 -> 0 over `fade.out` at the tail. Omit `fade` for a hard cut on
-and off. `fade.in + fade.out` must fit inside the event's duration (T4).
+all, so each route fades some other way, and `fade` means the same thing to
+both: frames of opacity ramp at the head and at the tail. Omit it for a hard cut
+on and off. `fade.in + fade.out` must fit inside the event's duration (T4).
+
+* **Text+** — a BezierSpline on the placed instance's `Opacity1`, keyframed
+  0 -> 1 over `fade.in` and 1 -> 0 over `fade.out`. Written per instance, so a
+  re-fade is one re-apply. The report says per event whether the written spline
+  read back, because a Resolve build that will not answer for an animated input
+  is the one thing here no test can check.
+* **PNG** — already in the pixels (§6). Nothing is written at apply, and `fade`
+  is a record of what the exporter baked. A one-image card is held by freezing
+  that image, which no ramp can survive, so a fade on one is a T11 error.
 
 Fade timing is a judgement call, not a default: fast tune roughly 0.5-1 s,
-ballad roughly 2-4 s. The report says per event whether the written spline read
-back, because a Resolve build that will not answer for an animated input is the
-one thing here no test can check."""
+ballad roughly 2-4 s."""
 
 _TIME: Final = """\
 ## Time
@@ -131,10 +151,38 @@ keep."""
 _RULES: Final = """\
 ## 5. Validation
 
-9 hard errors (T1-T9) block an apply; 2 warnings (W1-W2) never do. A single
+11 hard errors (T1-T11) block an apply; 2 warnings (W1-W2) never do. A single
 error aborts before the Titles track is touched, so a refused apply always
 leaves the timeline exactly as it was. Every finding is
 `{rule, id, message, fix_hint}` — see the `rules` field of this result."""
+
+_PNG: Final = """\
+## 6. The PNG route
+
+A `route: "png"` event carries `asset` instead of `text` and `template`: a path
+to a designed card, exported to frames with an alpha channel at the timeline's
+resolution and frame rate. Relative paths are relative to the titles file, so a
+project folder moves in one piece. Two forms:
+
+* **A `%0Nd` frame run** — `cards/<song>/personnel_%04d.png`. This is the full
+  event: the fade-in ramp at the head, the hold in the middle, the fade-out ramp
+  at the tail, all baked. Its frame count must equal `out - in` exactly (T11).
+  Trimming it would cut the fade-out off, and Resolve cannot stretch a clip past
+  its own media, so the length is the exporter's job and re-timing an event means
+  re-baking the card.
+* **One still image** — `cards/<song>/title.png`. Freeze-extended to whatever
+  duration the event asks for, so it retimes freely, but it carries no ramp: its
+  fades must be zero (T11).
+
+Cards are consumed, never generated: designing one and baking its ramps happen
+outside this server. A designated card that is not on disk is a T10 error, named
+before Resolve is touched at all.
+
+The card is imported once per apply into `04_Assets/Text/<song key>`, or into the
+event's own `bin`, and a card already in that bin is reused rather than imported
+twice. Every imported image gets a one-time out-point write, which is what makes
+`endFrame` respected: without it Resolve ignores the requested length and lands
+every image at the project's default still duration."""
 
 SCHEMA_DOC: Final = "\n\n".join(
     [
@@ -146,6 +194,7 @@ SCHEMA_DOC: Final = "\n\n".join(
         _FADES,
         _RERUN,
         _RULES,
+        _PNG,
     ]
 )
 """The full schema document: prose contract with the annotated example embedded."""

--- a/src/resolve_mcp/titles/validate.py
+++ b/src/resolve_mcp/titles/validate.py
@@ -1,4 +1,4 @@
-"""The titles-file validation rules: 9 hard errors, 2 warnings, one implementation.
+"""The titles-file validation rules: 11 hard errors, 2 warnings, one implementation.
 
 The list is identical in the ``validate_titles`` dry run and in ``apply_titles``'
 pre-flight, so it lives here once and both call it. A failing file must abort before the
@@ -120,7 +120,7 @@ class Event:
 
     @property
     def is_png(self) -> bool:
-        """Which of the two routes places this event — the one branch the apply takes."""
+        """Which of the two routes places this event: a designed card, or a Text+ instance."""
         return self.route == PNG
 
     @property
@@ -446,18 +446,18 @@ def validate_assets(
 
     The resolved cards come back beside the findings for the same reason the templates do:
     the apply imports the very files the rules counted, so a card cannot be judged at one
-    length and placed at another. Events on the Text+ route are not represented at all.
+    length and placed at another. Events on the Text+ route are not represented at all, and
+    neither is a PNG event with no ``asset``: T6 has already said that is what is wrong with
+    it, and resolving an empty path would answer "nothing on disk" about the wrong thing.
     """
-    resolved = {
-        str(event["id"]): resolve_asset(event, str(song["key"]), base=base)
-        for song, event in _events(doc)
-        if route_of(event) == PNG
-    }
     findings: list[Finding] = []
-    for _song, event in _events(doc):
-        asset = resolved.get(str(event["id"]))
-        if asset is not None:
-            findings += _asset_errors(asset, int(event["out"]) - int(event["in"]), fades(event))
+    resolved: dict[str, Asset] = {}
+    for song, event in _events(doc):
+        if route_of(event) != PNG or not event.get("asset"):
+            continue
+        asset = resolve_asset(event, str(song["key"]), base=base)
+        resolved[asset.event] = asset
+        findings += _asset_errors(asset, int(event["out"]) - int(event["in"]), fades(event))
     return ordered(findings), resolved
 
 

--- a/src/resolve_mcp/titles/validate.py
+++ b/src/resolve_mcp/titles/validate.py
@@ -6,10 +6,13 @@ Titles track is cleared — a track emptied for titles that were never placed is
 outcome this file exists to prevent, and it is worse than the cut's equivalent because
 the thing destroyed is the *previous* good state.
 
-Two passes, because they need different things:
+Three passes, because they need different things:
 
-* :func:`validate_structure` reads the document alone — no project, no connection. Shape,
-  ids, ranges, fades and routes (T1-T4, T6, W1).
+* :func:`validate_structure` reads the document alone — no project, no connection, no
+  disk. Shape, ids, ranges, fades and route coherence (T1-T4, T6, W1).
+* :func:`validate_assets` reads the disk, and nothing else: the PNG cards an event points
+  at, and whether they carry the frames it asks for (T10, T11). It runs before Resolve is
+  opened, because a card that was never exported is worth saying so without a connection.
 * :func:`validate_project` takes the song anchors and template facts already read off the
   timeline and the media pool, and answers everything that depends on them (T5, T7-T9,
   W2). It is a pure function over those facts, so every rule here is unit-testable
@@ -24,14 +27,19 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Final, TypeGuard
 
 from ..findings import Finding, ordered
 from ..logging_config import get_logger
 from ..timing import ranges_overlap
-from .schema import KINDS, ROUTES, SCHEMA_VERSION, SUPPORTED_ROUTES
+from .assets import Asset, resolve_asset
+from .schema import DEFAULT_ROUTE, KINDS, ROUTES, SCHEMA_VERSION
 
 log = get_logger("titles")
+
+PNG: Final = "png"
+TEXTPLUS: Final = "textplus"
 
 RULE_DESCRIPTIONS: Final[dict[str, str]] = {
     "T1": "JSON parses; schema-valid; schema version supported",
@@ -39,10 +47,12 @@ RULE_DESCRIPTIONS: Final[dict[str, str]] = {
     "T3": "in < out on every event",
     "T4": "fade in + fade out fit inside the event's duration",
     "T5": "every template resolves to exactly one media-pool clip",
-    "T6": "event route supported by this build (textplus)",
+    "T6": "every event carries the fields its route needs (text, or asset)",
     "T7": "every song key names exactly one blue marker on the timeline",
     "T8": "events do not overlap — one Titles track shows one title at a time",
     "T9": "every event lands inside the timeline",
+    "T10": "every png asset is on disk",
+    "T11": "every png asset carries the frames its event asks for",
     "W1": "a song with no events",
     "W2": "a blue marker with no song in the file",
 }
@@ -53,10 +63,14 @@ _FIX_HINTS: Final[dict[str, str]] = {
     "T3": "Ranges are half-open [in, out); make out strictly greater than in.",
     "T4": "Shorten the fades or lengthen the event — a fade cannot run past the title.",
     "T5": "Import the template bin into the media pool, or fix templates.<name>.clip/.bin.",
-    "T6": "Only textplus titles are placed today; png titles land with the PNG route.",
+    "T6": "A textplus event needs 'text' and a template; a png event needs 'asset'.",
     "T7": "Name a blue marker exactly this key with set_markers, or fix the key.",
     "T8": "Stagger the events — one Titles track can only show one title at a time.",
     "T9": "Pull the event inside the timeline, or re-mark the song on the version you title.",
+    "T10": "Export the card to that path, or fix the event's 'asset' — paths are relative "
+    "to the titles file.",
+    "T11": "Re-bake the sequence to out - in frames, or retime the event to the frames it "
+    "has; a one-image card is frozen to length and can carry no fade.",
     "W1": "Add events to the song, or drop it from the file.",
     "W2": "Expected while titling a set a song at a time; otherwise add the song.",
 }
@@ -97,11 +111,17 @@ class Event:
     route: str
     template: str
     text: str
+    asset: str
     record_in: int
     duration: int
     fade_in: int
     fade_out: int
     note: str
+
+    @property
+    def is_png(self) -> bool:
+        """Which of the two routes places this event — the one branch the apply takes."""
+        return self.route == PNG
 
     @property
     def record_out(self) -> int:
@@ -162,13 +182,18 @@ def _target_errors(doc: dict[str, Any]) -> Iterator[Finding]:
 
 
 def _templates_errors(doc: dict[str, Any]) -> Iterator[Finding]:
-    templates = doc.get("templates")
-    if not isinstance(templates, dict) or not templates:
+    """The block is optional — a file whose events are all PNG declares no templates.
+
+    A missing one is not reported here even when a Text+ event needs it: T5 already names
+    the template that could not be found, against the event that wanted it, which is the
+    finding that says what to do about it.
+    """
+    templates = doc.get("templates", {})
+    if not isinstance(templates, dict):
         yield _finding(
             "T1",
             None,
-            "'templates' must be a non-empty object of name -> {clip, bin}; a Text+ title "
-            "is placed from a template clip and there is no default one.",
+            "'templates' must be an object of name -> {clip, bin} when present.",
         )
         return
     for name, template in templates.items():
@@ -216,13 +241,21 @@ def _event_errors(event: Any, where: str, song: str | None) -> Iterator[Finding]
         yield _finding("T1", id, f"'{where}.route' must be one of: {', '.join(ROUTES)}.")
     if "template" in event and not isinstance(event["template"], str):
         yield _finding("T1", id, f"'{where}.template' must be a template name.")
-    if not isinstance(event.get("text"), str) or not event["text"].strip():
+    if "text" in event and not (isinstance(event["text"], str) and event["text"].strip()):
         yield _finding(
             "T1",
             id,
             f"'{where}.text' must be the non-empty string to show; the server never "
             f"formats prose, so pass the final text.",
         )
+    if "asset" in event and not (isinstance(event["asset"], str) and event["asset"].strip()):
+        yield _finding(
+            "T1",
+            id,
+            f"'{where}.asset' must be a non-empty path to the exported card.",
+        )
+    if "bin" in event and not isinstance(event["bin"], str):
+        yield _finding("T1", id, f"'{where}.bin' must be a media-pool bin path when present.")
     for edge in ("in", "out"):
         if not _is_int(event.get(edge)):
             yield _finding(
@@ -342,20 +375,36 @@ def fades(event: Mapping[str, Any]) -> tuple[int, int]:
 
 
 def _route_errors(doc: dict[str, Any]) -> Iterator[Finding]:
-    """T6: a route this build cannot place, named now rather than half-applied later."""
+    """T6: the two routes take different fields, and neither ignores the other's.
+
+    A ``text`` on a PNG event is the mistake worth catching loudest: the words are baked
+    into the card, so the file would read as if it said them while the placed title showed
+    whatever was exported — a disagreement nothing downstream can see.
+    """
     for _, event in _events(doc):
+        id = str(event["id"])
         route = route_of(event)
-        if route not in SUPPORTED_ROUTES:
+        wanted, unwanted = (
+            ("asset", ("text", "template")) if route == PNG else ("text", ("asset", "bin"))
+        )
+        if not event.get(wanted):
             yield _finding(
                 "T6",
-                str(event["id"]),
-                f"Route {route!r} is not placed by this tool; it places "
-                f"{', '.join(SUPPORTED_ROUTES)}.",
+                id,
+                f"A {route} event needs {wanted!r}, and this one has none.",
             )
+        for field in unwanted:
+            if field in event:
+                yield _finding(
+                    "T6",
+                    id,
+                    f"{field!r} means nothing on a {route} event; it is a "
+                    f"{TEXTPLUS if route == PNG else PNG} field.",
+                )
 
 
 def route_of(event: Mapping[str, Any]) -> str:
-    return str(event.get("route", SUPPORTED_ROUTES[0]))
+    return str(event.get("route", DEFAULT_ROUTE))
 
 
 def template_of(event: Mapping[str, Any]) -> str:
@@ -365,15 +414,17 @@ def template_of(event: Mapping[str, Any]) -> str:
 
 def _declared_template_errors(doc: dict[str, Any]) -> Iterator[Finding]:
     """T5's first leg: a template the file never declared cannot be looked up at all."""
-    declared = set(doc["templates"])
+    declared = set(doc.get("templates", {}))
+    names = ", ".join(sorted(declared)) if declared else "none"
     for _, event in _events(doc):
+        if route_of(event) == PNG:
+            continue  # a PNG card is its own artwork; there is no template to resolve
         wanted = template_of(event)
         if wanted not in declared:
             yield _finding(
                 "T5",
                 str(event["id"]),
-                f"No template called {wanted!r} is declared; the file declares "
-                f"{', '.join(sorted(declared))}.",
+                f"No template called {wanted!r} is declared; the file declares {names}.",
             )
 
 
@@ -381,6 +432,62 @@ def _empty_song_warnings(doc: dict[str, Any]) -> Iterator[Finding]:
     for song in _songs(doc):
         if not song["events"]:
             yield _finding("W1", str(song["key"]), "This song has no title events.")
+
+
+# --- the asset pass -----------------------------------------------------------------------
+
+
+def validate_assets(
+    doc: dict[str, Any],
+    *,
+    base: Path,
+) -> tuple[list[Finding], dict[str, Asset]]:
+    """T10-T11: every PNG card, counted off disk, judged against the event that wants it.
+
+    The resolved cards come back beside the findings for the same reason the templates do:
+    the apply imports the very files the rules counted, so a card cannot be judged at one
+    length and placed at another. Events on the Text+ route are not represented at all.
+    """
+    resolved = {
+        str(event["id"]): resolve_asset(event, str(song["key"]), base=base)
+        for song, event in _events(doc)
+        if route_of(event) == PNG
+    }
+    findings: list[Finding] = []
+    for _song, event in _events(doc):
+        asset = resolved.get(str(event["id"]))
+        if asset is not None:
+            findings += _asset_errors(asset, int(event["out"]) - int(event["in"]), fades(event))
+    return ordered(findings), resolved
+
+
+def _asset_errors(asset: Asset, duration: int, fade: tuple[int, int]) -> Iterator[Finding]:
+    """One card's own rules: it is there (T10), and it is the right length (T11)."""
+    if asset.missing:
+        what = "sequence" if asset.is_sequence else "image"
+        yield _finding(
+            "T10",
+            asset.event,
+            f"No {what} stands behind {asset.declared!r} (looked at {asset.path}).",
+        )
+        return
+    if duration <= 0:
+        return  # T3 already said the event has no frames; a length check would repeat it
+    if asset.is_sequence and asset.frames != duration:
+        yield _finding(
+            "T11",
+            asset.event,
+            f"{asset.declared!r} is {asset.frames} frame(s) and the event asks for "
+            f"{duration}. A sequence is placed whole — the fade-out is in its last frames, "
+            f"so it is neither trimmed nor stretched.",
+        )
+    if not asset.is_sequence and any(fade):
+        yield _finding(
+            "T11",
+            asset.event,
+            f"{asset.declared!r} is one image, held by freezing it, so the "
+            f"{fade[0]}-in/{fade[1]}-out fade this event asks for cannot be shown.",
+        )
 
 
 # --- the project pass ---------------------------------------------------------------------
@@ -477,14 +584,16 @@ def plan(doc: dict[str, Any], anchors: Mapping[str, Sequence[int]]) -> list[Even
         anchor = found[0]
         for event in song["events"]:
             fade_in, fade_out = fades(event)
+            png = route_of(event) == PNG
             planned.append(
                 Event(
                     id=str(event["id"]),
                     song=str(song["key"]),
                     kind=str(event["kind"]),
                     route=route_of(event),
-                    template=template_of(event),
-                    text=str(event["text"]),
+                    template="" if png else template_of(event),
+                    text="" if png else str(event.get("text", "")),
+                    asset=str(event.get("asset", "")) if png else "",
                     record_in=anchor + int(event["in"]),
                     duration=int(event["out"]) - int(event["in"]),
                     fade_in=fade_in,
@@ -540,7 +649,9 @@ def _unused_anchor_warnings(
 
 __all__ = [
     "ANCHOR_COLOR",
+    "PNG",
     "RULE_DESCRIPTIONS",
+    "TEXTPLUS",
     "Event",
     "TemplateFacts",
     "fades",
@@ -548,6 +659,7 @@ __all__ = [
     "plan",
     "route_of",
     "template_of",
+    "validate_assets",
     "validate_project",
     "validate_structure",
 ]

--- a/src/resolve_mcp/tools/titles.py
+++ b/src/resolve_mcp/tools/titles.py
@@ -50,9 +50,12 @@ def apply_titles(titles_file: str) -> dict[str, Any]:
     cut, mark the songs on the new version, re-apply this file unchanged.
 
     Each song's events are positioned from the blue marker whose name is the song key, so
-    the file needs no timeline frames in it. Text comes from the file verbatim, and fades
-    are written as Fusion opacity keyframes inside each placed instance, because Resolve
-    exposes no clip-level fade to the API at all.
+    the file needs no timeline frames in it. An event takes one of two routes and both are
+    placed in the same pass: `textplus` puts an instance of a media-pool template down and
+    writes the file's text and an opacity-keyframe fade into its Fusion comp, because
+    Resolve exposes no clip-level fade to the API at all; `png` places a designed card
+    already exported to frames with alpha, whose words and ramps are in the pixels. Cards
+    are imported for you into `04_Assets/Text/<song>`, once, and reused on later applies.
 
     The validate_titles rules run first: a single error aborts before the track is
     cleared, so a refused apply leaves the previous titles in place. The target timeline

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -24,6 +24,7 @@ import importlib.util
 import json
 import os
 import shutil
+import zlib
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -37,7 +38,14 @@ from resolve_mcp.jobs import cache
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.naming import timestamped_name
 from resolve_mcp.resolve.connection import get_connection
-from resolve_mcp.resolve.media import find_clip, media_pool
+from resolve_mcp.resolve.media import (
+    apply_still_workaround,
+    ensure_bin,
+    find_clip,
+    import_into,
+    media_pool,
+    properties,
+)
 from resolve_mcp.tools.analysis import correlate_timeline
 from resolve_mcp.tools.cut import build_timeline, swap_take, validate_cut
 from resolve_mcp.tools.escape_hatch import run_python
@@ -1268,6 +1276,197 @@ def _smoke_titles(timeline: str, template: str) -> dict[str, Any]:
             for position, key in enumerate(SMOKE_SONGS, start=1)
         ],
     }
+
+
+PNG_SONG = "smoke-png-song"
+PNG_SEQUENCE_FRAMES = 60
+"""What the card is baked to, and therefore exactly what its event may ask for (T11)."""
+
+PNG_STILL_FRAMES = 45
+"""What the one-image card is freeze-extended to — a length it does not have on disk."""
+
+
+def _write_png(path: Path, size: int = 64) -> None:
+    """A real RGBA PNG, built here so the live tier needs no image library and no fixture.
+
+    Hand-rolled rather than a checked-in blob because the sequence needs *many* files and
+    Resolve has to read them as an image sequence: a wrong byte would look like a Resolve
+    refusal, which is the one failure this test must not be able to fake.
+    """
+    raw = b"".join(b"\x00" + b"\x00\x00\x00\xff" * size for _ in range(size))
+
+    def chunk(kind: bytes, body: bytes) -> bytes:
+        return (
+            len(body).to_bytes(4, "big")
+            + kind
+            + body
+            + zlib.crc32(kind + body).to_bytes(4, "big")
+        )
+
+    side = size.to_bytes(4, "big")
+    header = side + side + b"\x08\x06\x00\x00\x00"  # 8-bit RGBA, no interlace
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", header)
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b"")
+    )
+
+
+def test_apply_titles_places_png_cards_at_the_exact_duration_asked_for(tmp_path: Path) -> None:
+    """#44 ACs 1-4: the one thing no fake can answer — does Resolve honour ``endFrame`` on
+    a freshly imported image once the out point has been written?
+
+    Everything else about the PNG route is a decision and verifies against the fake. This
+    is the API behaviour the whole route rests on: without the one-time ``Out`` write both
+    cards land at the project's default still duration instead of the length the file asks
+    for, and nothing in the return value says so — the durations read back off the track
+    are the only evidence. The sequence and the one-image card are both here because they
+    reach that behaviour differently: the sequence is placed whole, the still is frozen to
+    a length it does not have on disk.
+
+    It needs no Text+ template and no media of yours: the cards are written into a temp
+    folder and the scratch timeline is created, marked, titled and deleted again.
+
+    Paste the printed report onto the ticket — that is the record the ticket asks for.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+
+    cards = tmp_path / "cards" / PNG_SONG
+    for index in range(1, PNG_SEQUENCE_FRAMES + 1):
+        _write_png(cards / f"card_{index:04d}.png")
+    _write_png(cards / "still.png")
+
+    connection = get_connection()
+    pool = media_pool(connection)
+    project = connection.handle().GetProjectManager().GetCurrentProject()
+    was_on = project.GetCurrentTimeline()
+
+    name = timestamped_name("apply-png-smoke", "", "apply-png-smoke")
+    scratch = pool.CreateEmptyTimeline(name)
+    assert scratch is not None, f"Resolve created no timeline called {name!r}"
+    try:
+        assert project.SetCurrentTimeline(scratch), f"Resolve would not open {name!r}"
+        start = int(scratch.GetStartFrame())
+        # Something on V1 so the timeline has a span for the titles to land inside. The
+        # filler is the sequence itself, which is also the first proof that Resolve reads
+        # these frames as an image sequence at all.
+        cards_bin = ensure_bin(pool, "04_Assets/Text/" + PNG_SONG)
+        imported = import_into(
+            pool,
+            [
+                {
+                    "FilePath": str(cards / "card_%04d.png"),
+                    "StartIndex": 1,
+                    "EndIndex": PNG_SEQUENCE_FRAMES,
+                }
+            ],
+            cards_bin,
+        )
+        assert imported, "Resolve imported nothing for the baked card sequence"
+        landed = imported[0]
+        apply_still_workaround(landed, properties(landed))
+        # Twice over, so V1 spans past the last title: T9 refuses an event that would land
+        # outside the timeline, and the timeline is only as long as what is on it.
+        assert pool.AppendToTimeline(
+            [
+                {
+                    "mediaPoolItem": landed,
+                    "startFrame": 0,
+                    "endFrame": PNG_SEQUENCE_FRAMES,
+                    "mediaType": 1,
+                    "trackIndex": 1,
+                    "recordFrame": start + offset,
+                }
+                for offset in (0, PNG_SEQUENCE_FRAMES)
+            ]
+        ), "the imported sequence would not append — Resolve did not read it as a sequence"
+        assert scratch.AddMarker(0, "Blue", PNG_SONG, "png smoke", 1), (
+            "Resolve refused the blue marker the song is anchored to"
+        )
+
+        file = tmp_path / "titles.json"
+        file.write_text(json.dumps(_smoke_png_titles(name, cards)), encoding="utf-8")
+
+        result = apply_titles(str(file))
+        again = apply_titles(str(file))
+
+        print("\n" + _render_png_titles(result, again))
+        assert result["ok"] is True, result.get("error")
+        assert [one["route"] for one in result["placed"]] == ["png", "png"]
+        assert result["placed"][0]["fade"]["detail"] == "baked into the exported frames"
+        # The claim itself: what the file asked for is what stands on the track.
+        placed = inspect_timeline(name, detail="clips")
+        titles = [track for track in placed["tracks"] if track["name"] == "Titles"][0]
+        assert [item["record"]["duration"]["frames"] for item in titles["items"]] == [
+            PNG_SEQUENCE_FRAMES,
+            PNG_STILL_FRAMES,
+        ]
+        assert again["ok"] is True, again.get("error")
+        assert again["cleared"] == 2, "a second apply must replace the cards, not stack them"
+    finally:
+        if was_on is not None:
+            project.SetCurrentTimeline(was_on)
+        pool.DeleteTimelines([scratch])
+        # The cards go too. They are a temp folder's worth of 64-pixel squares, and a bin
+        # left behind would make the *next* run of this test ambiguous rather than failing.
+        pool.DeleteFolders([ensure_bin(pool, "04_Assets/Text/" + PNG_SONG).folder])
+
+
+def _smoke_png_titles(timeline: str, cards: Path) -> dict[str, Any]:
+    """A PNG-only titles file: the sequence card, then the one-image card held after it."""
+    return {
+        "schema": 1,
+        "timeline": timeline,
+        "songs": [
+            {
+                "key": PNG_SONG,
+                "events": [
+                    {
+                        "id": "png-01",
+                        "kind": "title",
+                        "route": "png",
+                        "asset": str(cards / "card_%04d.png"),
+                        "in": 0,
+                        "out": PNG_SEQUENCE_FRAMES,
+                        # Baked, not written: the ramps are in the frames the exporter made,
+                        # so this only has to fit inside the card and be reported as such.
+                        "fade": {"in": FADE_FRAMES, "out": FADE_FRAMES},
+                    },
+                    {
+                        "id": "png-02",
+                        "kind": "personnel",
+                        "route": "png",
+                        "asset": str(cards / "still.png"),
+                        "in": PNG_SEQUENCE_FRAMES,
+                        "out": PNG_SEQUENCE_FRAMES + PNG_STILL_FRAMES,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def _render_png_titles(first: dict[str, Any], second: dict[str, Any]) -> str:
+    """The report the ticket asks for: what landed, at what length, out of which bin."""
+    if not first["ok"]:
+        return f"apply failed: {first['error']['cause']}\nfix: {first['error']['fix']}"
+    lines = [
+        f"timeline:      {first['timeline']['name']}",
+        f"track:         {first['track']['name']} "
+        f"(video {first['track']['index']}, created={first['track']['created']})",
+        f"second apply:  cleared {second.get('cleared')}, ok={second['ok']}",
+    ]
+    for one in first["placed"]:
+        lines.append(
+            f"  {one['id']}: {Path(one['asset']).name} @ {one['record']['frames']} for "
+            f"{one['duration']['frames']}f — {one['frames']} frame(s) on disk, bin "
+            f"{one['bin']!r}, fade {one['fade']['in']}/{one['fade']['out']} "
+            f"({one['fade']['detail']})"
+        )
+    return "\n".join(lines)
 
 
 def _render_titles(first: dict[str, Any], second: dict[str, Any]) -> str:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -1286,14 +1286,30 @@ PNG_STILL_FRAMES = 45
 """What the one-image card is freeze-extended to — a length it does not have on disk."""
 
 
-def _write_png(path: Path, size: int = 64) -> None:
-    """A real RGBA PNG, built here so the live tier needs no image library and no fixture.
+def _ramp(index: int) -> int:
+    """The alpha of frame ``index``: up over the fade in, full, down over the fade out.
+
+    The same shape a real exporter bakes (#14 §6), so the sequence Resolve imports is a
+    card with ramps in it rather than sixty identical squares.
+    """
+    if index <= FADE_FRAMES:
+        return round(255 * index / FADE_FRAMES)
+    if index > PNG_SEQUENCE_FRAMES - FADE_FRAMES:
+        return round(255 * (PNG_SEQUENCE_FRAMES - index + 1) / FADE_FRAMES)
+    return 255
+
+
+def _write_png(path: Path, alpha: int = 255, size: int = 64) -> None:
+    """A real RGBA PNG at the given opacity, so the frames carry an actual alpha channel.
 
     Hand-rolled rather than a checked-in blob because the sequence needs *many* files and
     Resolve has to read them as an image sequence: a wrong byte would look like a Resolve
-    refusal, which is the one failure this test must not be able to fake.
+    refusal, which is the one failure this test must not be able to fake. ``alpha`` is what
+    makes the baked ramp real rather than nominal — whether Resolve *keys* it is a visual
+    check no API call can make, and belongs to a human looking at the timeline.
     """
-    raw = b"".join(b"\x00" + b"\x00\x00\x00\xff" * size for _ in range(size))
+    pixel = bytes((255, 255, 255, alpha))
+    raw = b"".join(b"\x00" + pixel * size for _ in range(size))
 
     def chunk(kind: bytes, body: bytes) -> bytes:
         return (
@@ -1336,7 +1352,7 @@ def test_apply_titles_places_png_cards_at_the_exact_duration_asked_for(tmp_path:
 
     cards = tmp_path / "cards" / PNG_SONG
     for index in range(1, PNG_SEQUENCE_FRAMES + 1):
-        _write_png(cards / f"card_{index:04d}.png")
+        _write_png(cards / f"card_{index:04d}.png", alpha=_ramp(index))
     _write_png(cards / "still.png")
 
     connection = get_connection()

--- a/tests/test_titles_assets.py
+++ b/tests/test_titles_assets.py
@@ -1,0 +1,199 @@
+"""PNG title cards: what stands behind an event on disk, and the two rules about it.
+
+The disk is the seam here — there is no fake for it and none is wanted, because the thing
+under test *is* the reading of real files. Every card in this file is written into
+``tmp_path``, so a sequence with a hole in it or a card that was never exported is an
+arrangement of actual files rather than a mocked answer about them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.findings import Finding
+from resolve_mcp.titles.assets import bin_for, frames_on_disk, resolve_asset
+from resolve_mcp.titles.validate import validate_assets
+
+PATTERN = "cards/sunset-boulevard/personnel_%04d.png"
+
+
+def a_card(**overrides: Any) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "id": "p01",
+        "kind": "personnel",
+        "route": "png",
+        "asset": PATTERN,
+        "in": 0,
+        "out": 240,
+    }
+    event.update(overrides)
+    return event
+
+
+def a_doc(*events: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema": 1,
+        "songs": [{"key": "sunset-boulevard", "events": list(events)}],
+    }
+
+
+def bake(base: Path, pattern: str, indices: Sequence[int]) -> None:
+    """Write the frames of a sequence. Content is irrelevant; only the names are read."""
+    for index in indices:
+        frame = base / (pattern % index)
+        frame.parent.mkdir(parents=True, exist_ok=True)
+        frame.write_bytes(b"\x89PNG")
+
+
+def rules_of(findings: Sequence[Finding]) -> list[str]:
+    return [finding.rule for finding in findings]
+
+
+# --- counting frames off disk -------------------------------------------------------------
+
+
+def test_a_sequence_is_counted_from_its_lowest_frame(tmp_path: Path) -> None:
+    bake(tmp_path, PATTERN, range(1, 49))
+    assert frames_on_disk(tmp_path / PATTERN) == (1, 48)
+
+
+def test_a_sequence_numbered_from_zero_starts_at_zero(tmp_path: Path) -> None:
+    bake(tmp_path, PATTERN, range(0, 10))
+    assert frames_on_disk(tmp_path / PATTERN) == (0, 10)
+
+
+def test_a_sequence_is_counted_only_as_far_as_it_is_contiguous(tmp_path: Path) -> None:
+    """Resolve imports a start and an end index and reads everything between them, so a
+    run with a hole in it is a broken sequence, not a shorter one."""
+    bake(tmp_path, PATTERN, [1, 2, 3, 7, 8])
+    assert frames_on_disk(tmp_path / PATTERN) == (1, 3)
+
+
+def test_a_sequence_with_no_frames_on_disk_counts_none(tmp_path: Path) -> None:
+    assert frames_on_disk(tmp_path / PATTERN) == (None, 0)
+
+
+def test_frames_of_another_sequence_in_the_same_folder_are_not_counted(tmp_path: Path) -> None:
+    bake(tmp_path, PATTERN, range(1, 25))
+    bake(tmp_path, "cards/sunset-boulevard/title_%04d.png", range(1, 200))
+    assert frames_on_disk(tmp_path / PATTERN) == (1, 24)
+
+
+def test_a_still_counts_one_frame_when_it_is_there(tmp_path: Path) -> None:
+    card = tmp_path / "cards" / "title.png"
+    card.parent.mkdir(parents=True)
+    card.write_bytes(b"\x89PNG")
+    assert frames_on_disk(card) == (None, 1)
+
+
+def test_a_still_that_is_not_there_counts_none(tmp_path: Path) -> None:
+    assert frames_on_disk(tmp_path / "cards" / "title.png") == (None, 0)
+
+
+# --- resolving an event's card ------------------------------------------------------------
+
+
+def test_a_relative_asset_resolves_against_the_titles_file_not_the_cwd(tmp_path: Path) -> None:
+    bake(tmp_path, PATTERN, range(1, 25))
+    card = resolve_asset(a_card(), "sunset-boulevard", base=tmp_path)
+    assert card.path == tmp_path / PATTERN
+    assert card.frames == 24
+
+
+def test_an_absolute_asset_is_left_alone(tmp_path: Path) -> None:
+    bake(tmp_path, PATTERN, range(1, 25))
+    absolute = str(tmp_path / PATTERN)
+    card = resolve_asset(a_card(asset=absolute), "sunset-boulevard", base=Path("/elsewhere"))
+    assert card.path == Path(absolute)
+    assert card.frames == 24
+
+
+def test_a_sequences_import_request_names_the_range_it_really_has(tmp_path: Path) -> None:
+    bake(tmp_path, PATTERN, range(1, 25))
+    card = resolve_asset(a_card(), "sunset-boulevard", base=tmp_path)
+    assert card.request() == {
+        "FilePath": str(tmp_path / PATTERN),
+        "StartIndex": 1,
+        "EndIndex": 24,
+    }
+
+
+def test_a_stills_import_request_is_just_its_path(tmp_path: Path) -> None:
+    card = tmp_path / "title.png"
+    card.write_bytes(b"\x89PNG")
+    resolved = resolve_asset(a_card(asset="title.png"), "sunset-boulevard", base=tmp_path)
+    assert resolved.request() == str(card)
+    assert not resolved.is_sequence
+
+
+def test_a_sequences_identity_is_its_first_frame(tmp_path: Path) -> None:
+    """The pattern is not a file and Resolve re-paths the clip to a folded label, so the
+    first frame is the only address that is the same string on both sides of the import."""
+    bake(tmp_path, PATTERN, range(7, 31))
+    card = resolve_asset(a_card(), "sunset-boulevard", base=tmp_path)
+    assert card.first_frame() == str(tmp_path / "cards/sunset-boulevard/personnel_0007.png")
+
+
+def test_a_card_lands_in_the_song_bin_by_convention() -> None:
+    assert bin_for(a_card(), "sunset-boulevard") == "04_Assets/Text/sunset-boulevard"
+
+
+def test_an_explicit_bin_always_wins() -> None:
+    assert bin_for(a_card(bin="Concert/Cards"), "sunset-boulevard") == "Concert/Cards"
+
+
+# --- T10 and T11 --------------------------------------------------------------------------
+
+
+def test_a_card_that_was_never_exported_is_t10(tmp_path: Path) -> None:
+    findings, _ = validate_assets(a_doc(a_card()), base=tmp_path)
+    assert rules_of(findings) == ["T10"]
+    assert "personnel_%04d.png" in findings[0].message
+
+
+def test_a_sequence_shorter_than_its_event_is_t11(tmp_path: Path) -> None:
+    bake(tmp_path, PATTERN, range(1, 100))
+    findings, _ = validate_assets(a_doc(a_card()), base=tmp_path)
+    assert rules_of(findings) == ["T11"]
+    assert "99 frame(s)" in findings[0].message and "asks for 240" in findings[0].message
+
+
+def test_a_sequence_longer_than_its_event_is_t11_because_trimming_cuts_the_fade(
+    tmp_path: Path,
+) -> None:
+    bake(tmp_path, PATTERN, range(1, 400))
+    assert rules_of(validate_assets(a_doc(a_card()), base=tmp_path)[0]) == ["T11"]
+
+
+def test_a_sequence_of_exactly_the_events_length_has_nothing_said_about_it(
+    tmp_path: Path,
+) -> None:
+    bake(tmp_path, PATTERN, range(1, 241))
+    findings, cards = validate_assets(a_doc(a_card()), base=tmp_path)
+    assert findings == []
+    assert cards["p01"].frames == 240
+
+
+def test_a_still_is_freeze_extended_so_any_duration_fits(tmp_path: Path) -> None:
+    (tmp_path / "title.png").write_bytes(b"\x89PNG")
+    doc = a_doc(a_card(asset="title.png", out=9000))
+    findings, cards = validate_assets(doc, base=tmp_path)
+    assert findings == []
+    assert cards["p01"].frames == 1
+
+
+def test_a_still_asked_to_fade_is_t11_because_freezing_it_shows_no_ramp(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "title.png").write_bytes(b"\x89PNG")
+    doc = a_doc(a_card(asset="title.png", fade={"in": 24, "out": 24}))
+    findings, _ = validate_assets(doc, base=tmp_path)
+    assert rules_of(findings) == ["T11"]
+    assert "one image" in findings[0].message
+
+
+def test_a_textplus_event_is_not_an_asset_at_all(tmp_path: Path) -> None:
+    doc = a_doc({"id": "t01", "kind": "title", "text": "Sunset", "in": 0, "out": 240})
+    assert validate_assets(doc, base=tmp_path) == ([], {})

--- a/tests/test_titles_tools.py
+++ b/tests/test_titles_tools.py
@@ -27,6 +27,7 @@ from resolve_mcp.tools.titles import apply_titles, get_titles_schema, validate_t
 
 from .conftest import Attach
 from .fakes import (
+    STILL_DEFAULT_FRAMES,
     FakeFusionComp,
     FakeFusionTool,
     FakeMediaPool,
@@ -170,6 +171,85 @@ def text_of(item: FakeTimelineItem) -> Any:
 def keyframes_of(item: FakeTimelineItem) -> dict[float, float]:
     spline = item.comps[0].tools[0].animated.get("Opacity1")
     return {} if spline is None else spline.keyframes
+
+
+CARD = "cards/sunset-boulevard/personnel_%04d.png"
+"""A designed card, relative to the titles file — which is what makes a project portable."""
+
+
+def bake(base: Path, pattern: str, indices: range) -> None:
+    """Export a card's frames. Only the names are ever read; the bytes are a formality."""
+    for index in indices:
+        frame = base / (pattern % index)
+        frame.parent.mkdir(parents=True, exist_ok=True)
+        frame.write_bytes(b"\x89PNG")
+
+
+def a_card(**overrides: Any) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "id": "p01",
+        "kind": "personnel",
+        "route": "png",
+        "asset": CARD,
+        "in": 240,
+        "out": 720,
+    }
+    event.update(overrides)
+    return event
+
+
+def one_card(**overrides: Any) -> dict[str, Any]:
+    """One song, one PNG card — the smallest file the PNG route places."""
+    return valid_doc(songs=[{"key": "sunset-boulevard", "events": [a_card(**overrides)]}])
+
+
+def mixed_doc() -> dict[str, Any]:
+    """A Text+ title and a PNG personnel card on one song, in one pass."""
+    return valid_doc(
+        songs=[
+            {
+                "key": "sunset-boulevard",
+                "events": [
+                    {
+                        "id": "t01",
+                        "kind": "title",
+                        "text": "Sunset Boulevard",
+                        "in": 240,
+                        "out": 720,
+                    },
+                    a_card(id="p01", **{"in": 960, "out": 1320}),
+                ],
+            }
+        ]
+    )
+
+
+def cards_in(pool: FakeMediaPool) -> list[tuple[str, FakeMediaPoolItem]]:
+    """Every clip in the pool that came off disk, with its bin path.
+
+    The Text+ templates are pathless generators, so a file path is what separates an
+    imported card from the fixtures the session was seeded with.
+    """
+    found: list[tuple[str, FakeMediaPoolItem]] = []
+
+    def walk(folder: Any, prefix: str) -> None:
+        for clip in folder.GetClipList() or []:
+            if clip.GetClipProperty("File Path"):
+                found.append((prefix, clip))
+        for sub in folder.GetSubFolderList() or []:
+            name = str(sub.GetName() or "")
+            walk(sub, f"{prefix}/{name}" if prefix else name)
+
+    walk(pool.GetRootFolder(), "")
+    return found
+
+
+def imported_cards(pool: FakeMediaPool) -> list[FakeMediaPoolItem]:
+    return [clip for _, clip in cards_in(pool)]
+
+
+def bins_of(pool: FakeMediaPool) -> list[str]:
+    return [path for path, _ in cards_in(pool)]
 
 
 # --- the happy path ---------------------------------------------------------------------
@@ -524,6 +604,191 @@ def test_a_comp_that_will_not_say_its_range_fades_over_the_instance_instead(
     apply_titles(a_titles_file(tmp_path, one_event(fade={"in": 24, "out": 24})))
 
     assert keyframes_of(titles_on(timeline)[0]) == {0.0: 0.0, 24.0: 1.0, 455.0: 1.0, 479.0: 0.0}
+
+
+# --- the png route ------------------------------------------------------------------------
+
+
+def test_a_png_card_is_imported_and_placed_at_the_frames_the_file_asks_for(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    bake(tmp_path, CARD, range(1, 481))
+    apply_titles(a_titles_file(tmp_path, one_card()))
+
+    assert [(item.GetStart(), item.GetDuration()) for item in titles_on(timeline)] == [
+        (SONG_ONE + 240, 480)
+    ]
+
+
+def test_the_out_point_is_written_so_the_requested_duration_is_honoured(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    """Resolve ignores ``endFrame`` on an image clip that has never had an out point
+    written, landing every card at the default still duration instead (#18 (a)). The
+    one-time write is the whole reason a PNG title can be the length the file asks for."""
+    pool = a_pool()
+    timeline = a_session(attach, pool=pool)
+    bake(tmp_path, CARD, range(1, 481))
+    apply_titles(a_titles_file(tmp_path, one_card()))
+
+    card = imported_cards(pool)[0]
+    assert [key for key, _ in card.property_writes] == ["Out"]
+    assert titles_on(timeline)[0].GetDuration() == 480 != STILL_DEFAULT_FRAMES
+
+
+def test_a_still_card_is_freeze_extended_to_whatever_the_event_asks_for(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    (tmp_path / "cards").mkdir()
+    (tmp_path / "cards" / "title.png").write_bytes(b"\x89PNG")
+    apply_titles(a_titles_file(tmp_path, one_card(asset="cards/title.png", out=3600)))
+
+    assert titles_on(timeline)[0].GetDuration() == 3360
+
+
+def test_a_png_fade_is_reported_as_baked_and_nothing_is_written_into_the_clip(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    bake(tmp_path, CARD, range(1, 481))
+    placed = apply_titles(a_titles_file(tmp_path, one_card(fade={"in": 24, "out": 36})))["placed"]
+
+    assert placed[0]["fade"] == {
+        "in": 24,
+        "out": 36,
+        "keyframes": [],
+        "verified": True,
+        "detail": "baked into the exported frames",
+    }
+    assert titles_on(timeline)[0].comps == []
+
+
+def test_text_plus_and_png_titles_coexist_in_one_pass(attach: Attach, tmp_path: Path) -> None:
+    """One append for the whole file, whatever mix of routes is in it — the routes differ
+    only in where the source clip comes from."""
+    pool = a_pool()
+    timeline = a_session(attach, pool=pool)
+    bake(tmp_path, CARD, range(1, 361))
+    apply_titles(a_titles_file(tmp_path, mixed_doc()))
+
+    assert len(pool.append_calls) == 1
+    landed = titles_on(timeline)
+    assert [(item.GetStart(), item.GetDuration()) for item in landed] == [
+        (SONG_ONE + 240, 480),
+        (SONG_ONE + 960, 360),
+    ]
+    assert text_of(landed[0]) == "Sunset Boulevard"
+    assert landed[1].comps == []
+
+
+def test_the_report_names_a_cards_asset_and_bin_rather_than_a_template(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    a_session(attach)
+    bake(tmp_path, CARD, range(1, 361))
+    placed = apply_titles(a_titles_file(tmp_path, mixed_doc()))["placed"]
+
+    assert placed[0]["route"] == "textplus"
+    assert placed[0]["template"] == "title" and "asset" not in placed[0]
+    assert placed[1]["route"] == "png"
+    assert placed[1]["asset"] == CARD
+    assert placed[1]["bin"] == "04_Assets/Text/sunset-boulevard"
+    assert placed[1]["frames"] == 360
+    assert "template" not in placed[1] and "node" not in placed[1]
+
+
+def test_a_card_lands_in_the_song_bin_by_convention(attach: Attach, tmp_path: Path) -> None:
+    pool = a_pool()
+    a_session(attach, pool=pool)
+    bake(tmp_path, CARD, range(1, 481))
+    apply_titles(a_titles_file(tmp_path, one_card()))
+
+    assert bins_of(pool) == ["04_Assets/Text/sunset-boulevard"]
+
+
+def test_an_explicit_bin_on_the_event_wins(attach: Attach, tmp_path: Path) -> None:
+    pool = a_pool()
+    a_session(attach, pool=pool)
+    bake(tmp_path, CARD, range(1, 481))
+    apply_titles(a_titles_file(tmp_path, one_card(bin="Concert/Cards")))
+
+    assert bins_of(pool) == ["Concert/Cards"]
+
+
+def test_re_applying_reuses_the_card_already_in_the_pool(attach: Attach, tmp_path: Path) -> None:
+    """A declarative apply is run over and over; importing afresh each time would grow the
+    operator's media pool by a copy of every card on every run."""
+    pool = a_pool()
+    timeline = a_session(attach, pool=pool)
+    bake(tmp_path, CARD, range(1, 481))
+    file = a_titles_file(tmp_path, one_card())
+
+    apply_titles(file)
+    apply_titles(file)
+
+    assert pool.calls.count("ImportMedia") == 1
+    assert len(imported_cards(pool)) == 1
+    assert len(titles_on(timeline)) == 1
+
+
+def test_one_card_shared_by_two_events_is_imported_once(attach: Attach, tmp_path: Path) -> None:
+    pool = a_pool()
+    a_session(attach, pool=pool)
+    bake(tmp_path, CARD, range(1, 481))
+    doc = valid_doc(
+        templates={},
+        songs=[
+            {
+                "key": "sunset-boulevard",
+                "events": [
+                    a_card(id="p01", **{"in": 240, "out": 720}),
+                    a_card(id="p02", **{"in": 960, "out": 1440}),
+                ],
+            }
+        ],
+    )
+    apply_titles(a_titles_file(tmp_path, doc))
+
+    assert pool.calls.count("ImportMedia") == 1
+
+
+def test_a_card_that_was_never_exported_refuses_before_the_track_is_touched(
+    attach: Attach,
+    tmp_path: Path,
+) -> None:
+    timeline = a_session(attach)
+    result = apply_titles(a_titles_file(tmp_path, one_card()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "titles_invalid"
+    assert [finding["rule"] for finding in result["error"]["detail"]["errors"]] == ["T10"]
+    assert timeline.GetTrackCount("video") == 1
+
+
+def test_a_card_the_wrong_length_for_its_event_refuses(attach: Attach, tmp_path: Path) -> None:
+    a_session(attach)
+    bake(tmp_path, CARD, range(1, 100))
+    result = apply_titles(a_titles_file(tmp_path, one_card()))
+
+    assert [finding["rule"] for finding in result["error"]["detail"]["errors"]] == ["T11"]
+
+
+def test_a_png_only_file_needs_no_templates_block(attach: Attach, tmp_path: Path) -> None:
+    timeline = a_session(attach)
+    bake(tmp_path, CARD, range(1, 481))
+    doc = one_card()
+    doc.pop("templates")
+    result = apply_titles(a_titles_file(tmp_path, doc))
+
+    assert result["ok"] is True
+    assert len(titles_on(timeline)) == 1
 
 
 # --- what never starts --------------------------------------------------------------------

--- a/tests/test_titles_validate.py
+++ b/tests/test_titles_validate.py
@@ -75,6 +75,20 @@ def an_event(**overrides: Any) -> dict[str, Any]:
     return event
 
 
+def a_card(**overrides: Any) -> dict[str, Any]:
+    """A PNG event. ``asset=None`` drops the field, which is how T6 is provoked."""
+    event: dict[str, Any] = {
+        "id": "p01",
+        "kind": "personnel",
+        "route": "png",
+        "asset": "cards/sunset-boulevard/personnel_%04d.png",
+        "in": 0,
+        "out": 240,
+    }
+    event.update(overrides)
+    return {key: value for key, value in event.items() if value is not None}
+
+
 def one_song(*events: dict[str, Any], key: str = "sunset-boulevard") -> dict[str, Any]:
     return valid_doc(songs=[{"key": key, "events": list(events)}])
 
@@ -96,14 +110,21 @@ def test_an_unsupported_schema_version_is_t1() -> None:
     assert "schema 1" in findings[0].message
 
 
-def test_a_file_with_no_templates_is_t1_because_a_title_needs_one() -> None:
-    findings = validate_structure(valid_doc(templates={}))
-    assert "templates" in findings[0].message
+def test_a_textplus_event_with_no_template_declared_is_t5() -> None:
+    """The templates block is optional now the PNG route needs none, so the event that
+    wanted one is where the missing declaration is reported."""
+    findings = only(validate_structure(valid_doc(templates={})), "T5")
+    assert len(findings) == 3
+    assert "declares none" in findings[0].message
 
 
-def test_an_event_with_no_text_is_t1() -> None:
+def test_a_templates_block_that_is_not_an_object_is_t1() -> None:
+    assert "templates" in only(validate_structure(valid_doc(templates=[])), "T1")[0].message
+
+
+def test_an_event_with_no_text_is_t6() -> None:
     doc = one_song({"id": "t01", "kind": "title", "in": 0, "out": 240})
-    assert "text" in only(validate_structure(doc), "T1")[0].message
+    assert "'text'" in only(validate_structure(doc), "T6")[0].message
 
 
 def test_a_blank_text_is_t1_because_the_server_never_writes_the_words() -> None:
@@ -189,10 +210,38 @@ def test_a_custom_event_must_name_its_own_template() -> None:
     assert rules_of(validate_structure(doc)) == ["T5"]
 
 
-def test_the_png_route_is_refused_until_the_png_tool_lands() -> None:
-    doc = one_song(an_event(route="png"))
-    findings = only(validate_structure(doc), "T6")
-    assert "textplus" in findings[0].message
+def test_a_png_event_carrying_an_asset_passes_the_structural_pass() -> None:
+    """The two routes coexist in one file: the structural rules judge each on its own
+    fields, and only the disk pass (T10/T11) has anything more to ask of a card."""
+    doc = one_song(a_card(), an_event(**{"in": 600, "out": 900}))
+    assert validate_structure(doc) == []
+
+
+def test_a_png_event_with_no_asset_is_t6() -> None:
+    doc = one_song(a_card(asset=None))
+    assert "'asset'" in only(validate_structure(doc), "T6")[0].message
+
+
+def test_a_png_event_carrying_text_is_t6_because_the_words_are_in_the_card() -> None:
+    doc = one_song(a_card(text="Sunset Boulevard"))
+    message = only(validate_structure(doc), "T6")[0].message
+    assert "'text'" in message and "textplus field" in message
+
+
+def test_a_png_event_carrying_a_template_is_t6() -> None:
+    doc = one_song(a_card(template="title"))
+    assert "'template'" in only(validate_structure(doc), "T6")[0].message
+
+
+def test_a_textplus_event_carrying_an_asset_is_t6() -> None:
+    doc = one_song(an_event(asset="cards/title_%04d.png"))
+    assert "'asset'" in only(validate_structure(doc), "T6")[0].message
+
+
+def test_a_png_event_needs_no_template_to_be_declared() -> None:
+    """T5 is a Text+ rule: a card is its own artwork and resolves to no pool template."""
+    doc = valid_doc(templates={}, songs=[{"key": "sunset-boulevard", "events": [a_card()]}])
+    assert validate_structure(doc) == []
 
 
 def test_a_song_with_no_events_is_only_a_warning() -> None:


### PR DESCRIPTION
Closes #44.

## What this builds

A titles.json event now picks its route per event, and both routes land in one
`AppendToTimeline`. A `route: "png"` event carries `asset` — a designed card exported to
frames with alpha, or one still image — instead of `text` and `template`, and its fade
arrived baked into the pixels.

- **New pure layer** `titles/assets.py`: resolves an asset against the titles file's own
  folder (so a project folder moves in one piece) and counts the contiguous frame run on
  disk. That is what lets the two new rules run without a connection.
- **T10** — the card is on disk. **T11** — it carries the frames the event asks for: a
  sequence exactly, a one-image card with no fade (a freeze shows no ramp).
- **T6 changes subject** from "route this build supports" (which had nothing left to do
  once both routes ship) to "the fields the route needs". The `templates` block became
  optional, so a PNG-only file declares none.
- **At apply**: cards are imported *before* the track is cleared — an import Resolve
  refuses must not cost the titles already standing — deduplicated by bin and first frame,
  and found rather than re-imported on later runs, so a declarative re-apply does not grow
  the operator's media pool. Cards land in `04_Assets/Text/<song>` per #57.
- **Exact durations** come from the one-time out-point write on every imported image;
  without it Resolve ignores `endFrame` and drops the clip at the project's default still
  duration. PNG events skip the Fusion write and read-back entirely — there is no comp.

`list_titles` already reports a clip with no Text+ node with `unreadable` saying why, and
`edit_title` already refuses one, so a PNG card on the track needed no change there
(covered by `test_title_edit.py:270` and `:610`).

## Test seams

- **Fake tier** (the decisions): `tests/test_titles_assets.py` — frame counting off real
  files in `tmp_path`, asset resolution, T10/T11. `tests/test_titles_tools.py` — import,
  exact duration, the out-point write, baked fades, the convention bin, per-event bin
  override, re-run reuse, one card shared by two events, and Text+/PNG coexistence in one
  append. `tests/test_titles_validate.py` — T6 field coherence both ways, templates now
  optional.
- **Live smoke** (the thing no fake can answer): `test_apply_titles_places_png_cards_at_
  the_exact_duration_asked_for`. Self-contained — no Text+ template, no media of yours; it
  writes real PNGs byte by byte into a temp folder and deletes both the scratch timeline
  and the cards bin afterwards.

**Live run recorded** — Resolve Studio 21.0.3, Windows 11, python.org 3.12, 2026-08-06:
**passed.**

```
timeline:      apply-png-smoke-20260806-200340
track:         Titles (video 2, created=True)
second apply:  cleared 2, ok=True
  png-01: card_%04d.png @ 86400 for 60f — 60 frame(s) on disk, bin
          '04_Assets/Text/smoke-png-song', fade 12/12 (baked into the exported frames)
  png-02: still.png @ 86460 for 45f — 1 frame(s) on disk, bin
          '04_Assets/Text/smoke-png-song', fade 0/0 (no fade asked for)
```

The 60-frame sequence landed at exactly 60 frames and the one-frame still at exactly 45 —
AC1 and AC3 against real Resolve. The first live run failed on a T9 bounds error (the
test's filler was shorter than its own titles), which is the tier doing its job.

The rest of the live tier has 7 failures on this box. They are **pre-existing**: the same
7 fail on `origin/main` at `eb9a94e`, verified by running the tier from a detached
checkout of main in this worktree. All are open-project state (an ambiguous `FX6` source
alias, a timeline with no audio items, a timeline too short to render two ranges) and
belong to #62/#79.

## Review

Two-axis review (`/code-review` since `origin/main`), Standards and Spec as parallel
sub-agents.

### Standards — 1 hard violation, 6 judgement calls

| Finding | Resolution |
| --- | --- |
| `validate.py` module docstring still said "9 hard errors" after T10/T11 landed, contradicting the schema doc the tool serves | **Fixed** — 11 |
| `Preflight(...)` built from 8 positional args with `assets` inserted mid-order | **Fixed** — the one call site names them |
| `Event.is_png` docstring called itself "the one branch the apply takes"; it is four | **Fixed** — reworded |
| `validate_assets` walked `_events(doc)` twice | **Fixed** — one walk |
| README / server.py ragged mid-paragraph wrapping | **Fixed** |
| Repeated route conditional across 7 sites | **Not changed** — two routes do not earn polymorphism; the overstated docstring that made it look worse is fixed |
| `Titled.node: TitleNode \| None` encodes the route a second time | **Not changed** — `_placed` branching on `route` rather than on `node is None` is deliberate: a Text+ title whose node failed must not report as PNG |
| Test helpers (`a_card`, `bake`) re-declared per file | **Not changed** — the repo's existing per-file-helper convention (`valid_doc` already exists three times); the documented standard overrides the smell |

### Spec — 5 findings

| Finding | Resolution |
| --- | --- |
| A png event with no `asset` reported both T6 and T10 (an empty path resolves to the card folder and reads as missing) | **Fixed** — `validate_assets` skips an event T6 has already spoken for |
| The asset pass claimed cards are judged "before the connection is opened", which `open_project` three lines later makes false | **Fixed** — now says what is true: judged off disk alone, before anything is looked up in Resolve |
| AC1 says "with alpha", but the live card's frames were fully opaque, so the claim was nominal | **Fixed** — the frames now carry a real baked ramp (up over the fade in, full, down over the fade out). Whether Resolve *keys* that alpha is a visual check no API call can make, and the docstring now says so — see Needs from you |
| "The freeze-extend hold is not implemented; the ramp-plus-hold card can only come from an exporter this repo does not ship" | **Disagreed, with reason.** #14 §6 puts the baking on a disk utility — "alpha ramps baked into frames **by a disk utility** — fade-in at head, freeze-extend hold (duplicated last frame), fade-out ramp" — and §4 makes generation "skill-layer flow, **never a server tool**". The server consuming a finished card is the spec, not a gap. The one-image card additionally gets a Resolve-side freeze via the out-point write, which #14 §4 records as already verified in #18 |
| T11 tightens "error if the animation **alone exceeds** the chosen duration" into exact equality, refusing a legitimately short card | **Deliberate, now documented.** A short sequence cannot be held out to length: the hold belongs *before* the fade-out ramp, and there is no API to freeze a frame mid-sequence (#5 (c) — "no scripting access to Change Speed, Retime Controls, or Freeze Frame"). Holding it would silently place the ramp-out early. Schema §6 now explains this and T11's fix hint says to re-bake; #14 §6 already accepts "re-fade = re-bake + re-import" as the route's cost |

**Scope note for you to reject if you'd rather:** the per-event `bin` override is one key
beyond #14 §3's event shape. It follows #57's "an explicit bin always wins. Never
enforced", and defaults to the convention when absent — but it is new schema surface the
ticket did not ask for.

Fixes re-checked over the fix diff only (`2aeacc9..HEAD`), focused pass: clean. Verified
that a png event dropped from `assets` can never reach `_place`, since T6 is a hard error
that aborts before any write.

Fake tier 1042 passed, mypy strict clean on 137 files, ruff clean.

## Alpha, settled by probe rather than by eye

An earlier revision of this body asked you to eyeball a PNG title in the GUI to confirm
Resolve keys the embedded alpha. That was over-cautious — PNG alpha keying is settled
behaviour and not worth your time. The narrower question underneath it (premultiplied vs
straight, which shows up as fringing on the fade edges rather than as no transparency) is
now answered directly. Probed against the live Studio 21.0.3.7:

```
'Alpha mode' = 'Straight'                                  # on a freshly imported PNG sequence
SetClipProperty('Alpha mode', 'Premultiplied') -> True     # settable, but not needed
```

`Straight` is what an HTML export writes, so the default already matches and the baked
ramps composite correctly with nothing written. `apply.py::_card_clip` now records this
next to the out-point write, including that the property is settable if it ever stops
being true — writing it now would only be a chance to premultiply a card that was not. The
GUI check is withdrawn.

## Needs from you

- **Decide on the per-event `bin` override** (see the scope note above): keep it, or drop
  it back to the `04_Assets/Text/<song>` convention alone.
- Nothing else — the live AC ran and is recorded above, and the alpha question is closed.

Review: clean

Commit `326d542`+ add a comment block in `apply.py::_card_clip` and this section — prose
only, no executable change, re-checked by inline pass against the probe output above.

Review: clean — prose only, single-pass

