### PR TITLE
docs: writing-for-agents pass on CONTEXT.md + context discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,18 +126,15 @@ big files; do not re-read a file after editing it. The hooks in
 `.claude/hooks/` enforce the cat/tail rules and whole-file re-reads — a block
 from them is the rule firing, not an obstacle to route around.
 
-The same scratch-file rule covers `gh`: issue bodies, comment threads, and
-PR diffs are the biggest single results observed in past sessions (a
-`gh issue view --comments` dump is ~6k tokens, a `gh pr diff` more). Write
-them to a scratch file (`gh issue view <n> --json body -q .body >
-issue.scratch.log`) and Grep back the section you need; never dump a full
-diff or comment thread into the session to read once.
+The same scratch-file rule covers `gh` — issue bodies, comment threads,
+and PR diffs were the biggest single results in past sessions:
+`gh issue view <n> --json body -q .body > issue.scratch.log`, then Grep
+back the section you need.
 
-**Orient from `CONTEXT.md`, not exploration.** The repo map there answers
-"which module owns X, where is the seam, which test file covers Y" — read
-it before spawning an Explore agent, and scope any explore to what the map
-can't hold (exact signatures, current behaviour). A PR that adds, moves,
-or deletes a module updates the map in the same PR.
+**Orient from `CONTEXT.md` first** — the repo map answers "which module
+owns X, where is the seam, which test file covers Y"; explores are for
+what a map can't hold (exact signatures, current behaviour). A PR that
+adds, moves, or deletes a module updates the map in the same PR.
 
 Long multi-PR sweeps (merge trains, cross-PR audits) shard per-PR into
 subagents; the orchestrating session keeps receipts, not diffs — past

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,10 +1,7 @@
 # CONTEXT.md
 
-Repo map and vocabulary for agents. Read this instead of exploring the tree;
-spawn an Explore agent only for what this file can't hold — exact signatures,
-current line numbers, behaviour. Structural only, no signatures: those go
-stale silently. **Maintenance rule: a PR that adds, moves, or deletes a
-module updates this map in the same PR.**
+Repo map and vocabulary for agents. Structural on purpose — module names
+and responsibilities, no signatures or line numbers: those rot silently.
 
 ## What this project is
 


### PR DESCRIPTION
`/writing-for-agents` quality pass over yesterday's docs (#105): CONTEXT.md and the CLAUDE.md context-discipline additions.

**Findings applied**

- **Duplication (single source of truth):** the map-maintenance rule ("a PR that adds/moves/deletes a module updates the map") and the explore-scoping rule ("explores are for what a map can't hold") were stated verbatim in both files. Both now live only in CLAUDE.md — always loaded, so they fire at PR-authoring and explore-spawning time regardless of whether CONTEXT.md was read. CONTEXT.md's header keeps only its own content contract (structural, no signatures/line numbers).
- **Exposition + trailing negation:** the gh scratch-rule paragraph carried token measurements ("~6k tokens…") and ended on a prohibition ("never dump a full diff…") that restated the positive instruction already given. Trimmed to the why-clause plus the positive command.
- **Left alone deliberately:** pre-existing CLAUDE.md prose (forest-shell anecdotes, seam rationale) — established house style, out of scope for this pass. CONTEXT.md body unchanged: vocabulary entries are leading-word anchors reused as tokens (the seam, envelope, spill), the wayfinder line is a cache of an expensive tracker lookup, and every module-map line is live reference.

**Review record**

Single inline pass (prose only): net −6 lines, no meaning lost — both deleted statements survive at their single remaining site; checked the two files still cross-reference correctly (CLAUDE.md → CONTEXT.md pointer intact, no dangling back-references); no conflict markers.

Review: clean — prose only, single-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
