### PR TITLE
Hook: block whole-file Reads of >400-line repo code/config files

### DIFF
--- a/.claude/hooks/read-guard.py
+++ b/.claude/hooks/read-guard.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
-"""Read-after-edit guard, both halves in one script (dispatched on hook_event_name).
+"""Read guards, all halves in one script (dispatched on hook_event_name).
 
 PostToolUse on Edit/Write/MultiEdit: record the edited path, keyed by session.
-PreToolUse on Read: block (exit 2) a whole-file Read of a path this session
-already edited — the content is in context and Edit/Write fail loudly on a
-miss, so the re-read buys nothing. A ranged Read (offset/limit present) is
-allowed: needing a different section of a big file is legitimate.
+PreToolUse on Read, blocking (exit 2) on either rule:
+  1. Re-read: a whole-file Read of a path this session already edited — the
+     content is in context and Edit/Write fail loudly on a miss, so the re-read
+     buys nothing.
+  2. Big first read: a whole-file Read of a repo file over BIG_FILE_LINES —
+     CLAUDE.md's "ranged (grep first) on big files", which prose alone did not
+     hold under load (one session full-read a 656-line module three times).
+A ranged Read (offset/limit present) is allowed by both: needing a different
+section of a big file is legitimate, and a deliberate `offset: 1, limit: <n>`
+remains the escape hatch, so this is a speed bump rather than a wall.
 
 Measured motivation: read-after-edit ran ~46% of sessions pre-rules and ~39%
 after prose alone (2026-08-05 transcript audit) — the one axis prose never moved.
@@ -15,24 +21,67 @@ import os
 import sys
 import tempfile
 
+BIG_FILE_LINES = 400
+
+# Text formats where a whole-file pull is the thing being rationed. Markdown is
+# deliberately absent: reading a whole ADR or CONTEXT.md is the intended use.
+# Anything unlisted (images, PDFs, notebooks, extensionless files) passes — a
+# line count is meaningless there.
+GUARDED_EXT = {
+    ".py",
+    ".pyi",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".toml",
+    ".sh",
+    ".ini",
+    ".cfg",
+    ".conf",
+    ".txt",
+    ".log",
+}
+
+
+def in_project(path):
+    """True when *path* sits inside the project root (job tmp dirs are outside)."""
+    root = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+    try:
+        root = os.path.normcase(os.path.realpath(root))
+        target = os.path.normcase(os.path.realpath(path))
+    except OSError:
+        return False
+    return target == root or target.startswith(root + os.sep)
+
+
+def line_count(path):
+    """Lines in *path*, or None when it cannot be counted (missing, binary, …)."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return sum(1 for _ in f)
+    except OSError:
+        return None
+
+
 try:
     data = json.load(sys.stdin)
 except Exception:
     sys.exit(0)
 
 session = data.get("session_id") or ""
-if not session:
-    sys.exit(0)
-
 state_dir = os.path.join(tempfile.gettempdir(), "claude-read-guard")
-state_file = os.path.join(state_dir, session)
+state_file = os.path.join(state_dir, session) if session else ""
 event = data.get("hook_event_name", "")
 tool = data.get("tool_name", "")
 tool_input = data.get("tool_input", {}) or {}
 
 if event == "PostToolUse" and tool in ("Edit", "Write", "MultiEdit"):
     path = tool_input.get("file_path", "")
-    if path:
+    if path and state_file:
         os.makedirs(state_dir, exist_ok=True)
         with open(state_file, "a") as f:
             f.write(path + "\n")
@@ -42,11 +91,13 @@ if event == "PreToolUse" and tool == "Read":
     if "offset" in tool_input or "limit" in tool_input:
         sys.exit(0)
     path = tool_input.get("file_path", "")
-    try:
-        with open(state_file) as f:
-            edited = set(f.read().splitlines())
-    except OSError:
-        sys.exit(0)
+    edited = set()
+    if state_file:
+        try:
+            with open(state_file) as f:
+                edited = set(f.read().splitlines())
+        except OSError:
+            edited = set()
     if path in edited:
         sys.stderr.write(
             "Blocked (context discipline): this session already edited that file — its content is in your "
@@ -54,5 +105,19 @@ if event == "PreToolUse" and tool == "Read":
             "If you need a specific section, grep -n for it and Read with offset/limit.\n"
         )
         sys.exit(2)
+
+    if os.path.splitext(path)[1].lower() in GUARDED_EXT and in_project(path):
+        lines = line_count(path)
+        if lines is not None and lines > BIG_FILE_LINES:
+            sys.stderr.write(
+                "Blocked (context discipline): {} is {} lines — over the {}-line whole-file limit.\n".format(
+                    os.path.basename(path), lines, BIG_FILE_LINES
+                )
+                + "Grep for the symbol you need first, then Read with offset/limit around the hit.\n"
+                "If you truly need the whole file, say so with an explicit range: offset 1, limit {}.\n".format(
+                    lines
+                )
+            )
+            sys.exit(2)
 
 sys.exit(0)

--- a/.claude/hooks/read-guard.py
+++ b/.claude/hooks/read-guard.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
-"""Read guards, all halves in one script (dispatched on hook_event_name).
+"""Read guards, all three in one script (dispatched on hook_event_name).
 
 PostToolUse on Edit/Write/MultiEdit: record the edited path, keyed by session.
 PreToolUse on Read, blocking (exit 2) on either rule:
   1. Re-read: a whole-file Read of a path this session already edited — the
      content is in context and Edit/Write fail loudly on a miss, so the re-read
-     buys nothing.
-  2. Big first read: a whole-file Read of a repo file over BIG_FILE_LINES —
-     CLAUDE.md's "ranged (grep first) on big files", which prose alone did not
-     hold under load (one session full-read a 656-line module three times).
-A ranged Read (offset/limit present) is allowed by both: needing a different
-section of a big file is legitimate, and a deliberate `offset: 1, limit: <n>`
-remains the escape hatch, so this is a speed bump rather than a wall.
+     buys nothing. Any offset/limit is the escape: wanting a different section
+     of a big file is legitimate.
+  2. Big first read: a whole-file Read of a guarded-extension repo file
+     (GUARDED_EXT below) over BIG_FILE_LINES — CLAUDE.md's "ranged (grep first)
+     on big files". Here the escape is `limit`, since a bare `offset` still
+     pulls Read's 2000-line default. A deliberate `offset: 1, limit: <n>` passes,
+     so this is a speed bump rather than a wall.
 
-Measured motivation: read-after-edit ran ~46% of sessions pre-rules and ~39%
-after prose alone (2026-08-05 transcript audit) — the one axis prose never moved.
+Measured motivation (2026-08-05 transcript audit): read-after-edit ran ~46% of
+sessions pre-rules and ~39% after prose alone — the one axis prose never moved;
+and one session full-read a 656-line module three times under the grep-first
+prose rule.
 """
 import json
 import os
@@ -88,35 +90,41 @@ if event == "PostToolUse" and tool in ("Edit", "Write", "MultiEdit"):
     sys.exit(0)
 
 if event == "PreToolUse" and tool == "Read":
-    if "offset" in tool_input or "limit" in tool_input:
-        sys.exit(0)
     path = tool_input.get("file_path", "")
-    edited = set()
-    if state_file:
-        try:
-            with open(state_file) as f:
-                edited = set(f.read().splitlines())
-        except OSError:
-            edited = set()
-    if path in edited:
-        sys.stderr.write(
-            "Blocked (context discipline): this session already edited that file — its content is in your "
-            "context, and Edit/Write fail loudly on a miss, so a whole-file re-read buys nothing.\n"
-            "If you need a specific section, grep -n for it and Read with offset/limit.\n"
-        )
-        sys.exit(2)
 
-    if os.path.splitext(path)[1].lower() in GUARDED_EXT and in_project(path):
+    # The re-read rule's escape is unchanged: any offset/limit means the model is
+    # after a section, not the file.
+    if "offset" not in tool_input and "limit" not in tool_input:
+        edited = set()
+        if state_file:
+            try:
+                with open(state_file) as f:
+                    edited = set(f.read().splitlines())
+            except OSError:
+                edited = set()
+        if path in edited:
+            sys.stderr.write(
+                "Blocked (context discipline): this session already edited that file — its content is in your "
+                "context, and Edit/Write fail loudly on a miss, so a whole-file re-read buys nothing.\n"
+                "If you need a specific section, grep -n for it and Read with offset/limit.\n"
+            )
+            sys.exit(2)
+
+    # The size rule wants a *bounded* read, so it takes `limit` alone as the
+    # escape: a bare `offset` still pulls Read's 2000-line default, which is the
+    # whole of any file this rule covers.
+    if (
+        "limit" not in tool_input
+        and os.path.splitext(path)[1].lower() in GUARDED_EXT
+        and in_project(path)
+    ):
         lines = line_count(path)
         if lines is not None and lines > BIG_FILE_LINES:
             sys.stderr.write(
-                "Blocked (context discipline): {} is {} lines — over the {}-line whole-file limit.\n".format(
-                    os.path.basename(path), lines, BIG_FILE_LINES
-                )
-                + "Grep for the symbol you need first, then Read with offset/limit around the hit.\n"
-                "If you truly need the whole file, say so with an explicit range: offset 1, limit {}.\n".format(
-                    lines
-                )
+                f"Blocked (context discipline): {os.path.basename(path)} is {lines} lines — "
+                f"over the {BIG_FILE_LINES}-line whole-file limit.\n"
+                f"Grep for the symbol you need first, then Read with offset/limit around the hit.\n"
+                f"If you truly need the whole file, say so with an explicit range: offset 1, limit {lines}.\n"
             )
             sys.exit(2)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,11 @@ gitignored; never commit a log). Never `| tail` — a tail caps one run and
 runs repeat. Delegate exploration to
 a read-only subagent; Read only what you will edit, ranged (grep first) on
 big files; do not re-read a file after editing it. The hooks in
-`.claude/hooks/` enforce the cat/tail rules and whole-file re-reads — a block
-from them is the rule firing, not an obstacle to route around.
+`.claude/hooks/` enforce the cat/tail rules, whole-file re-reads, and
+whole-file reads of repo source files over 400 lines — a block from them is
+the rule firing, not an obstacle to route around. On a big-file block, grep
+for the symbol and Read a range around the hit; `offset: 1, limit: <n>` stays
+available for the rare file you genuinely need whole.
 
 The same scratch-file rule covers `gh` — issue bodies, comment threads,
 and PR diffs were the biggest single results in past sessions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,10 +124,9 @@ runs repeat. Delegate exploration to
 a read-only subagent; Read only what you will edit, ranged (grep first) on
 big files; do not re-read a file after editing it. The hooks in
 `.claude/hooks/` enforce the cat/tail rules, whole-file re-reads, and
-whole-file reads of repo source files over 400 lines — a block from them is
-the rule firing, not an obstacle to route around. On a big-file block, grep
-for the symbol and Read a range around the hit; `offset: 1, limit: <n>` stays
-available for the rare file you genuinely need whole.
+whole-file reads of code/config files over 400 lines (markdown exempt) — a
+block from them is the rule firing, not an obstacle to route around; the
+block message names the fix.
 
 The same scratch-file rule covers `gh` — issue bodies, comment threads,
 and PR diffs were the biggest single results in past sessions:

--- a/tests/test_read_guard.py
+++ b/tests/test_read_guard.py
@@ -1,0 +1,190 @@
+"""Fake-tier tests for the PreToolUse ``Read`` guard in ``.claude/hooks/``.
+
+The hook is executable config: it runs as a subprocess with the tool payload on
+stdin and signals a block with exit 2 plus a message on stderr. That process
+boundary *is* the seam, so these tests drive the real script the same way the
+harness does — no import, no monkeypatching.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "read-guard.py"
+
+
+def run_hook(payload: dict[str, object], project_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Invoke the hook exactly as the harness does: JSON on stdin, exit code out."""
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={"CLAUDE_PROJECT_DIR": str(project_dir), "SYSTEMROOT": "C:\\Windows", "PATH": ""},
+    )
+
+
+def read_event(path: Path, session: str = "s1", **extra: object) -> dict[str, object]:
+    return {
+        "session_id": session,
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(path), **extra},
+    }
+
+
+def write_lines(path: Path, count: int) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(f"line {i}\n" for i in range(count)), encoding="utf-8")
+    return path
+
+
+def test_blocks_whole_file_read_of_big_source_file(tmp_path: Path) -> None:
+    big = write_lines(tmp_path / "src" / "timeline.py", 656)
+
+    result = run_hook(read_event(big), tmp_path)
+
+    assert result.returncode == 2
+    assert "656" in result.stderr
+    assert "grep" in result.stderr.lower()
+    assert "offset" in result.stderr
+
+
+def test_ranged_read_of_big_file_passes(tmp_path: Path) -> None:
+    big = write_lines(tmp_path / "src" / "timeline.py", 656)
+
+    result = run_hook(read_event(big, offset=120, limit=60), tmp_path)
+
+    assert result.returncode == 0
+
+
+def test_deliberate_whole_file_range_is_the_escape_hatch(tmp_path: Path) -> None:
+    """``offset: 1, limit: <n>`` stays possible — the hook is a speed bump."""
+    big = write_lines(tmp_path / "src" / "timeline.py", 656)
+
+    result = run_hook(read_event(big, offset=1, limit=656), tmp_path)
+
+    assert result.returncode == 0
+
+
+def test_small_source_file_passes(tmp_path: Path) -> None:
+    small = write_lines(tmp_path / "src" / "config.py", 400)
+
+    result = run_hook(read_event(small), tmp_path)
+
+    assert result.returncode == 0
+
+
+def test_markdown_passes_at_any_size(tmp_path: Path) -> None:
+    doc = write_lines(tmp_path / "docs" / "adr" / "0001-attach.md", 900)
+
+    result = run_hook(read_event(doc), tmp_path)
+
+    assert result.returncode == 0
+
+
+def test_out_of_repo_path_passes(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    outside = write_lines(tmp_path / "jobdir" / "tmp" / "dump.py", 900)
+
+    result = run_hook(read_event(outside), project)
+
+    assert result.returncode == 0
+
+
+def test_missing_project_dir_env_does_not_block(tmp_path: Path) -> None:
+    big = write_lines(tmp_path / "src" / "timeline.py", 656)
+    result = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(read_event(big)),
+        capture_output=True,
+        text=True,
+        env={"SYSTEMROOT": "C:\\Windows", "PATH": ""},
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 2  # cwd is the fallback project root
+
+
+def test_unreadable_file_passes(tmp_path: Path) -> None:
+    result = run_hook(read_event(tmp_path / "src" / "gone.py"), tmp_path)
+
+    assert result.returncode == 0
+
+
+def test_binary_extension_passes(tmp_path: Path) -> None:
+    """Images and PDFs have no line concept — the size rule must not touch them."""
+    blob = tmp_path / "assets" / "frame.png"
+    blob.parent.mkdir(parents=True)
+    blob.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 200_000)
+
+    result = run_hook(read_event(blob), tmp_path)
+
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize("name", ["pytest.scratch.log", "pyproject.toml", "ci.yml", "hook.js"])
+def test_other_guarded_extensions_block_when_big(tmp_path: Path, name: str) -> None:
+    big = write_lines(tmp_path / name, 500)
+
+    result = run_hook(read_event(big), tmp_path)
+
+    assert result.returncode == 2
+
+
+def test_edited_file_rule_still_blocks_whole_file_reread(tmp_path: Path) -> None:
+    """The pre-existing read-after-edit behaviour is unchanged."""
+    small = write_lines(tmp_path / "src" / "config.py", 20)
+    session = "session-reread"
+
+    record = run_hook(
+        {
+            "session_id": session,
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": str(small)},
+        },
+        tmp_path,
+    )
+    assert record.returncode == 0
+
+    result = run_hook(read_event(small, session=session), tmp_path)
+
+    assert result.returncode == 2
+    assert "already edited" in result.stderr
+
+
+def test_edited_file_ranged_reread_still_passes(tmp_path: Path) -> None:
+    small = write_lines(tmp_path / "src" / "config.py", 20)
+    session = "session-ranged"
+
+    run_hook(
+        {
+            "session_id": session,
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": str(small)},
+        },
+        tmp_path,
+    )
+    result = run_hook(read_event(small, session=session, offset=5, limit=5), tmp_path)
+
+    assert result.returncode == 0
+
+
+def test_malformed_stdin_passes(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input="not json",
+        capture_output=True,
+        text=True,
+        env={"CLAUDE_PROJECT_DIR": str(tmp_path), "SYSTEMROOT": "C:\\Windows", "PATH": ""},
+    )
+
+    assert result.returncode == 0

--- a/tests/test_read_guard.py
+++ b/tests/test_read_guard.py
@@ -9,6 +9,7 @@ harness does — no import, no monkeypatching.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -18,14 +19,38 @@ import pytest
 HOOK = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "read-guard.py"
 
 
-def run_hook(payload: dict[str, object], project_dir: Path) -> subprocess.CompletedProcess[str]:
+def hook_env(tmp_path: Path, project_dir: Path | None = None) -> dict[str, str]:
+    """A hermetic environment for one test.
+
+    The temp vars matter: the hook keeps its per-session edited-paths state under
+    ``tempfile.gettempdir()``, so pointing them at ``tmp_path`` is what keeps one
+    test's session file from leaking into the next — and off the developer's real
+    temp dir. ``SYSTEMROOT`` is what a bare Python needs to start on Windows.
+    """
+    env = {
+        "SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"),
+        "PATH": "",
+        "TMPDIR": str(tmp_path),
+        "TEMP": str(tmp_path),
+        "TMP": str(tmp_path),
+    }
+    if project_dir is not None:
+        env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    return env
+
+
+def run_hook(
+    payload: dict[str, object],
+    project_dir: Path,
+    tmp_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
     """Invoke the hook exactly as the harness does: JSON on stdin, exit code out."""
     return subprocess.run(
         [sys.executable, str(HOOK)],
         input=json.dumps(payload),
         capture_output=True,
         text=True,
-        env={"CLAUDE_PROJECT_DIR": str(project_dir), "SYSTEMROOT": "C:\\Windows", "PATH": ""},
+        env=hook_env(tmp_path if tmp_path is not None else project_dir, project_dir),
     )
 
 
@@ -35,6 +60,15 @@ def read_event(path: Path, session: str = "s1", **extra: object) -> dict[str, ob
         "hook_event_name": "PreToolUse",
         "tool_name": "Read",
         "tool_input": {"file_path": str(path), **extra},
+    }
+
+
+def edit_event(path: Path, session: str) -> dict[str, object]:
+    return {
+        "session_id": session,
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Edit",
+        "tool_input": {"file_path": str(path)},
     }
 
 
@@ -72,6 +106,15 @@ def test_deliberate_whole_file_range_is_the_escape_hatch(tmp_path: Path) -> None
     assert result.returncode == 0
 
 
+def test_bare_offset_is_not_an_escape(tmp_path: Path) -> None:
+    """``offset`` alone still pulls Read's 2000-line default — the whole file."""
+    big = write_lines(tmp_path / "src" / "timeline.py", 656)
+
+    result = run_hook(read_event(big, offset=1), tmp_path)
+
+    assert result.returncode == 2
+
+
 def test_small_source_file_passes(tmp_path: Path) -> None:
     small = write_lines(tmp_path / "src" / "config.py", 400)
 
@@ -98,18 +141,19 @@ def test_out_of_repo_path_passes(tmp_path: Path) -> None:
     assert result.returncode == 0
 
 
-def test_missing_project_dir_env_does_not_block(tmp_path: Path) -> None:
+def test_missing_project_dir_env_falls_back_to_cwd(tmp_path: Path) -> None:
+    """With ``CLAUDE_PROJECT_DIR`` unset the hook still guards the tree it runs in."""
     big = write_lines(tmp_path / "src" / "timeline.py", 656)
     result = subprocess.run(
         [sys.executable, str(HOOK)],
         input=json.dumps(read_event(big)),
         capture_output=True,
         text=True,
-        env={"SYSTEMROOT": "C:\\Windows", "PATH": ""},
+        env=hook_env(tmp_path),
         cwd=str(tmp_path),
     )
 
-    assert result.returncode == 2  # cwd is the fallback project root
+    assert result.returncode == 2
 
 
 def test_unreadable_file_passes(tmp_path: Path) -> None:
@@ -143,15 +187,7 @@ def test_edited_file_rule_still_blocks_whole_file_reread(tmp_path: Path) -> None
     small = write_lines(tmp_path / "src" / "config.py", 20)
     session = "session-reread"
 
-    record = run_hook(
-        {
-            "session_id": session,
-            "hook_event_name": "PostToolUse",
-            "tool_name": "Edit",
-            "tool_input": {"file_path": str(small)},
-        },
-        tmp_path,
-    )
+    record = run_hook(edit_event(small, session), tmp_path)
     assert record.returncode == 0
 
     result = run_hook(read_event(small, session=session), tmp_path)
@@ -164,15 +200,7 @@ def test_edited_file_ranged_reread_still_passes(tmp_path: Path) -> None:
     small = write_lines(tmp_path / "src" / "config.py", 20)
     session = "session-ranged"
 
-    run_hook(
-        {
-            "session_id": session,
-            "hook_event_name": "PostToolUse",
-            "tool_name": "Edit",
-            "tool_input": {"file_path": str(small)},
-        },
-        tmp_path,
-    )
+    run_hook(edit_event(small, session), tmp_path)
     result = run_hook(read_event(small, session=session, offset=5, limit=5), tmp_path)
 
     assert result.returncode == 0
@@ -184,7 +212,7 @@ def test_malformed_stdin_passes(tmp_path: Path) -> None:
         input="not json",
         capture_output=True,
         text=True,
-        env={"CLAUDE_PROJECT_DIR": str(tmp_path), "SYSTEMROOT": "C:\\Windows", "PATH": ""},
+        env=hook_env(tmp_path, tmp_path),
     )
 
     assert result.returncode == 0


### PR DESCRIPTION
Closes #103.

Extends the PreToolUse `Read` guard so a whole-file Read of a guarded-extension
file inside the project root is blocked once it exceeds 400 lines, with a message
that names the rule and the explicit-range escape.

## What changed

- `.claude/hooks/read-guard.py` — new size rule alongside the existing
  read-after-edit rule. Guards `GUARDED_EXT` (`.py`, `.js/.ts`, `.json/.yml/.toml`,
  `.sh`, `.txt/.log`, …); markdown is deliberately absent, so a whole ADR or
  CONTEXT.md still reads whole. Out-of-repo paths (job tmp dirs), unlisted
  extensions (images, PDFs) and unreadable files pass. The escape is `limit`:
  `offset: 1, limit: <n>` passes, a bare `offset` does not.
- `tests/test_read_guard.py` — first tests for `.claude/hooks/`. The hook runs as
  a subprocess with JSON on stdin, so that process boundary is the seam and the
  tests drive it directly; no import, no monkeypatching. 17 cases covering the new
  rule, its exclusions, and the pre-existing read-after-edit behaviour (AC3).
- `CLAUDE.md` — the hooks paragraph now names the third rule.

## Seam

Fake tier (`uv run pytest -m 'not live'`), per the ticket's "fake-tier-style unit
test" — no live seam applies, this is harness config with no Resolve involvement.
1059 passed, mypy strict clean, ruff clean.

## Review

Two-axis `/code-review` on the branch before this PR existed, plus a
`/writing-for-agents` pass on the prose (both the CLAUDE.md hunk and the hook
docstring), per the mid-session request.

Findings and resolutions:

1. **Spec — bare `offset` bypassed the rule.** `{"offset": 1}` with no `limit`
   passed the presence-only check while still pulling Read's 2000-line default,
   i.e. the whole of any file the rule covers. **Fixed**: the size rule now takes
   `limit` as its escape; the re-read rule keeps its any-offset/limit escape
   unchanged. Test added.
2. **Standards + Spec — test name contradicted its assertion.**
   `test_missing_project_dir_env_does_not_block` asserted exit 2. **Fixed**:
   renamed to `test_missing_project_dir_env_falls_back_to_cwd`.
3. **Spec — test env stripped `TMPDIR`/`TEMP`/`TMP`**, so the hook's session state
   file landed outside `tmp_path` and isolation between the read-after-edit tests
   was accidental. **Fixed**: temp vars now point at `tmp_path`.
4. **Standards — duplicated env dict (3×) and inlined PostToolUse payloads.**
   **Fixed**: extracted `hook_env` and `edit_event` helpers.
5. **Standards — fragile message construction** (mixed `+` concat and adjacent
   literals, so one `.format` silently spanned two literals). **Fixed**: f-strings.
6. **Docs — CLAUDE.md restated the hook's own block message.** **Fixed**: sentence
   dropped; the message delivers that instruction at the moment of the block, and
   a second copy costs every session and drifts. Also corrected "repo source files"
   to "code/config files (markdown exempt)", which is what the hook guards.
7. **Docs — docstring overstated rule 2's scope** and buried the motivating
   anecdote inside the rule. **Fixed**: scope names `GUARDED_EXT`; anecdote moved
   to the measured-motivation paragraph.
8. **Standards — `GUARDED_EXT` duplicates `context-guard.py`'s `SRC_EXT`.**
   **Declined, with reason**: the two hooks are standalone scripts invoked by path
   under a bare `python3`; a shared module would need import-path setup in both and
   buys little for two short literals that intentionally disagree on `.md`.
9. **Standards — the escape hatch is self-advertised.** **Declined**: the ticket
   asks for exactly this ("the hook is a speed bump, not a wall").
10. **Spec — `.txt`/`.log` guarded, and scope of the exclusion list.** **Kept as
    built**: guarding scratch logs matches CLAUDE.md's grep-the-log rule and mirrors
    `context-guard.py`'s `SRC_EXT`. The allowlist is narrower than "any file over
    the threshold" — for a Python repo this trades a few unguarded formats (`.rst`,
    `.sql`) for never mis-blocking a binary Read. Flagged here as a deliberate call.

Review: clean — two-axis review plus a writing-for-agents prose pass; 7 findings fixed, 3 declined with reasons above.
