### PR TITLE
P3: the style layer, and the anchor measured into it (#45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,3 +158,9 @@ The five canonical triage roles, each label string equal to its role name. See `
 
 Single-context — `CONTEXT.md` (repo map + vocabulary) and `docs/adr/` at
 the repo root. See `docs/agents/domain.md`.
+
+### The style layer
+
+`styles/` — profiles and angle sidecars, agent-authored and never touched by
+server code. Provenance tags, sidecar format, and how a corpus pass is run:
+`docs/agents/style-layer.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,16 @@ timelines. The server measures; Claude decides.
   default) vs `-m live` against a running Resolve Studio. See CLAUDE.md.
 - **stem** — separated audio (mix → vocals/drums/bass/other; drums →
   kick/snare/toms), path is a content hash (ADR 0003).
+- **style layer** — `styles/` at the repo root: layered Markdown style
+  profiles (`base.md` + `concert.md`), the corpus record (`corpus.md`) and
+  per-project angle sidecars (`angles/*.json`). Agent-authored,
+  director-editable, and **never touched by server code** — see
+  `docs/agents/style-layer.md`, guarded by `tests/test_style_layer.py`.
+- **provenance tag** — what every style claim ends with, saying how well it is
+  known: `[measured: …, n=…]`, `[believed, unverified]`, `[director]`.
+- **angle sidecar** — one JSON file per Resolve project labelling each camera
+  by subject × character; `role` is the only key `correlate_timeline` reads,
+  and it arrives as a mapping the agent lifted, never as a path.
 
 ## Module map — `src/resolve_mcp/`
 
@@ -93,6 +103,9 @@ project + dry run).
 and calls `mcp.tool(fn)` — nothing binds to FastMCP at import, so every
 tool is callable in tests without the transport.
 
+There is no `styles/` module and there never will be: the style layer is data
+the agent owns, not code the server runs.
+
 `video/` — `ffmpeg` (the two commands video routes run), `frames` (frame
 grabs — the one compute route that is not a job), `jpeg` (read back
 dimensions), `scenes` (scene-cut detection as cached job), `source` (clip
@@ -140,5 +153,6 @@ Test files pair 1:1 with the module they cover (`test_cut_validate.py` ↔
   analysis models are injected; 0003 stems fingerprinted (path is a
   content hash).
 - `docs/agents/` — issue-tracker conventions (wayfinder map ops), triage
-  labels, domain-docs usage.
+  labels, domain-docs usage, the style layer (sidecar + profile formats,
+  provenance tags, how a corpus pass is run).
 - Wayfinder: map = issue #1, scope = #2, spec = #22, build tickets #23–#47.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,7 +34,9 @@ timelines. The server measures; Claude decides.
   director-editable, and **never touched by server code** — see
   `docs/agents/style-layer.md`, guarded by `tests/test_style_layer.py`.
 - **provenance tag** — what every style claim ends with, saying how well it is
-  known: `[measured: …, n=…]`, `[believed, unverified]`, `[director]`.
+  known. The vocabulary is settled in #13: `[stated principle]`,
+  `[measured — N projects, n=…, context]`, `[review feedback, YYYY-MM]`,
+  `[believed, unverified]`.
 - **angle sidecar** — one JSON file per Resolve project labelling each camera
   by subject × character; `role` is the only key `correlate_timeline` reads,
   and it arrives as a mapping the agent lifted, never as a path.

--- a/docs/agents/style-layer.md
+++ b/docs/agents/style-layer.md
@@ -1,0 +1,144 @@
+# The style layer
+
+`styles/` is the agent's half of the project: angle sidecars and style
+profiles, both authored by Claude and editable by the director, both invisible
+to server code. Nothing under `src/resolve_mcp/` reads or writes anything in
+this directory — that is story 59 of spec #22 and the guard test
+`tests/test_style_layer.py` holds it.
+
+The server measures; these documents decide. `correlate_timeline` reports that
+a shot starts 47 ms after the nearest transient; whether 47 ms is musical is a
+sentence in `styles/concert.md`.
+
+## Layout
+
+```
+styles/
+├── base.md              claims that hold for every kind of edit
+├── concert.md           claims that hold for concert style-cuts (overrides base)
+├── corpus.md            what was measured, in what order, with what context tags
+└── angles/<project>.json   one angle sidecar per Resolve project
+```
+
+Profiles are **layered**: `concert.md` is read on top of `base.md`, and where
+the two speak to the same thing, concert wins. A claim only belongs in
+`concert.md` if it would be wrong in a studio-session edit; otherwise it is a
+base claim and every pillar gets it.
+
+## Provenance tags
+
+**Every claim carries a tag.** A profile whose claims cannot be told apart by
+how well they are known is a black box with extra steps — the tags are the
+whole reason this is a document rather than a prompt.
+
+| Tag | Means | Earned by |
+| --- | --- | --- |
+| `[measured: <corpus>, n=<cuts>]` | The corpus says so, and the numbers are in `corpus.md` | a `correlate_timeline` pass over named timelines |
+| `[believed, unverified]` | Held on thin evidence — a handful of cuts, one timeline, or reasoning from the instrument rather than from the corpus | anything the corpus has not yet confirmed |
+| `[director]` | The director said so in a review round | a review note, quoted in the claim |
+
+Two rules keep the tags honest:
+
+- **Thin claims downgrade.** A claim measured over fewer than ~30 cuts, or over
+  a single timeline, is `[believed, unverified]` regardless of how clean the
+  number looked. Corpus breadth is what a measured tag asserts.
+- **A rerun can demote.** When a corpus pass contradicts a `[measured]` claim,
+  the claim moves down to `[believed, unverified]` with the disagreement noted
+  — it does not quietly keep its tag, and it does not quietly vanish.
+
+`[director]` outranks both: a director note lands in the profile the round it
+arrives (story 49), and a later corpus pass that disagrees with it gets written
+up as a disagreement rather than overwriting it.
+
+## Angle sidecars
+
+One JSON file per Resolve project, named for the project, holding what each
+camera actually is. This is what stops the agent re-deriving "which one is the
+drummer cam" from frame grabs every session.
+
+```json
+{
+  "project": "Jaded Symphony - The Sinclair",
+  "context": "concert",
+  "labelled": "2026-08-06",
+  "method": "frame grabs at 3 times per angle, read by the agent",
+  "angles": {
+    "A001_C012.mov": {
+      "role": "drums",
+      "subject": "drum kit, three-quarters from house left",
+      "character": "reaction",
+      "framing": "medium",
+      "motion": "static",
+      "confidence": "high",
+      "evidence": ["frames/A001_C012_00-01-30.jpg"]
+    }
+  }
+}
+```
+
+`role` is the only key `correlate_timeline` consumes; the rest is for the agent
+and the director. The keys mean:
+
+- **`role`** — the short handle the measurement groups by (`drums`, `wide`,
+  `soloist`, `piano`, `bass`, `audience`). Keep the vocabulary small and reuse
+  it across projects, because cross-project claims are grouped on this string.
+- **`subject`** — what the camera is pointed at, in words. The half of
+  "subject × character" that says *who*.
+- **`character`** — what the angle is *for* in a cut: `establishing`,
+  `hero` (carries a solo), `reaction`, `detail` (hands, sticks, keys),
+  `texture` (audience, room, atmosphere). The half that says *why cut to it*.
+- **`framing`**, **`motion`** — `wide`/`medium`/`tight`, `static`/`roaming`.
+- **`confidence`**, **`evidence`** — how sure the label is and the frame grabs
+  it was read from; a `low` here is why a corpus claim about that angle is
+  thin.
+
+An entry with no `role` is dropped by `correlate_timeline` rather than refused,
+so a half-labelled project still measures — its shots land under `unlabelled`.
+
+Pass a sidecar to the tool by lifting the `angles` object straight through:
+
+```python
+angles = json.loads(Path("styles/angles/<project>.json").read_text())["angles"]
+correlate_timeline(beats=..., timeline=..., angles=angles)
+```
+
+## Labelling a project
+
+1. `inspect_timeline` for the distinct clip names on the angle tracks (or the
+   sidecar's own last pass, when you are only filling gaps).
+2. `grab_frames` on each clip at three well-separated times — one is a lens cap
+   or a black frame more often than you would think.
+3. Read the grabs. Write the sidecar. Every angle gets `subject` **and**
+   `character`; a camera you cannot identify gets `confidence: "low"` and says
+   what it looks like, rather than a guess that reads as fact.
+
+## Running a corpus pass
+
+The corpus is **ordered** — timelines newest-last — because taste drifts and a
+claim that holds only in the last three edits is a different claim from one
+that holds across all fifteen. Each timeline is **context-tagged** (`concert`,
+`studio-session`) so base and concert claims can be told apart.
+
+Per timeline:
+
+1. Get a WAV and run `analyze_music` on it for the beat grid. A concert cut to
+   a director-supplied master mix takes that file directly; otherwise the
+   timeline's own mix has to be exported — `separate_stems(scope="timeline")`
+   acquires it on the way, and its job result names the acquired audio.
+2. `correlate_timeline(beats=…, timeline=…, angles=…)` with the project's
+   sidecar.
+3. Record the result path and its gist in `styles/corpus.md`, with the
+   timeline's order index and context tag.
+
+Then read across the results — not one at a time — and write the profile.
+Aggregate before claiming: the number that matters is the distribution over the
+corpus, and the tag you are entitled to is set by how many cuts and how many
+timelines stand behind it.
+
+**`alignment.mode` decides whether a result is usable at all.** `audio_clip`
+means the times were read through the audio the analysis was run on;
+`timeline_start` means the timeline said nothing about where the mix sits and
+the times count from its own first frame instead. A whole file measured against
+the wrong zero looks exactly like a whole file measured against the right one,
+so a corpus pass records the mode per timeline and excludes `timeline_start`
+readings from every timing claim.

--- a/docs/agents/style-layer.md
+++ b/docs/agents/style-layer.md
@@ -72,6 +72,15 @@ One JSON file per corpus project, labelling each camera on **two axes**:
 `tight`, `moving`). The style profile speaks in roles; the camera→role mapping
 for a given project lives here, with the project, not in the profile (#13).
 
+#13 says that mapping "lives with the project, not the style doc". That is read
+here as *one file per project, keyed to the project, kept out of the profile* —
+not as a file sitting beside the Resolve project on the media drive. A sidecar
+next to the footage is outside version control, and on an archived project it
+is on whichever drive that project was archived to; the labels are the agent's
+own document and their history is worth as much as the profiles'. If the
+director wants them beside the footage instead, only this path changes —
+nothing reads them but the agent.
+
 ```json
 {
   "project": "2026-06_Zinc_and_Monkfish",

--- a/docs/agents/style-layer.md
+++ b/docs/agents/style-layer.md
@@ -1,29 +1,39 @@
 # The style layer
 
-`styles/` is the agent's half of the project: angle sidecars and style
-profiles, both authored by Claude and editable by the director, both invisible
-to server code. Nothing under `src/resolve_mcp/` reads or writes anything in
-this directory — that is story 59 of spec #22 and the guard test
+`styles/` is the agent's half of the project: style profiles and angle
+sidecars, both authored by Claude, both reviewed by the director, both
+invisible to server code. Nothing under `src/resolve_mcp/` reads or writes
+anything in this directory — that is story 59 of spec #22, and
 `tests/test_style_layer.py` holds it.
 
 The server measures; these documents decide. `correlate_timeline` reports that
 a shot starts 47 ms after the nearest transient; whether 47 ms is musical is a
 sentence in `styles/concert.md`.
 
+The decisions behind everything here: **#13** (what a style profile is, its
+section schema, the analysis workflow) and **#21** (which projects form the
+corpus, and the corpus policies). Read those before changing a format; this
+file is their working form, not a second opinion.
+
 ## Layout
 
 ```
 styles/
-├── base.md              claims that hold for every kind of edit
-├── concert.md           claims that hold for concert style-cuts (overrides base)
-├── corpus.md            what was measured, in what order, with what context tags
-└── angles/<project>.json   one angle sidecar per Resolve project
+├── base.md                 cross-domain taste
+├── concert.md              the concert domain (v1 authors this one only)
+├── corpus.md               which timelines were measured, in what order
+└── angles/<project>.json   one angle sidecar per corpus project
 ```
 
-Profiles are **layered**: `concert.md` is read on top of `base.md`, and where
-the two speak to the same thing, concert wins. A claim only belongs in
-`concert.md` if it would be wrong in a studio-session edit; otherwise it is a
-base claim and every pillar gets it.
+Profiles are **layered**: Claude loads `base.md` plus the relevant domain doc
+at cut time. Base holds cross-domain taste — the transparency principle,
+transient philosophy, variation instinct, pacing taste. A claim belongs in a
+domain doc only if it would be wrong outside that domain. Per-band or
+per-person variants live as sections inside a domain doc until they outgrow it.
+Git history is the style-evolution record, which is why these are committed
+files and not cache.
+
+Future domains (vlog, talking-head) are the same structure and out of v1 scope.
 
 ## Provenance tags
 
@@ -31,112 +41,113 @@ base claim and every pillar gets it.
 how well they are known is a black box with extra steps — the tags are the
 whole reason this is a document rather than a prompt.
 
-| Tag | Means | Earned by |
-| --- | --- | --- |
-| `[measured: <corpus>, n=<cuts>]` | The corpus says so, and the numbers are in `corpus.md` | a `correlate_timeline` pass over named timelines |
-| `[believed, unverified]` | Held on thin evidence — a handful of cuts, one timeline, or reasoning from the instrument rather than from the corpus | anything the corpus has not yet confirmed |
-| `[director]` | The director said so in a review round | a review note, quoted in the claim |
+| Tag | Means |
+| --- | --- |
+| `[stated principle]` | The director said so. Principles are the defaults. |
+| `[measured — N projects, n=<cuts>, <context>]` | The corpus says so; the evidence row is in `corpus.md`. Sample size and context are part of the tag (#21 policy 4). |
+| `[review feedback, YYYY-MM]` | Landed from a cut-review round, dated. |
+| `[believed, unverified]` | Held on thin evidence — reasoning from the instrument, one project, or a handful of cuts. |
 
-Two rules keep the tags honest:
+Four rules keep the tags honest:
 
-- **Thin claims downgrade.** A claim measured over fewer than ~30 cuts, or over
-  a single timeline, is `[believed, unverified]` regardless of how clean the
-  number looked. Corpus breadth is what a measured tag asserts.
-- **A rerun can demote.** When a corpus pass contradicts a `[measured]` claim,
-  the claim moves down to `[believed, unverified]` with the disagreement noted
-  — it does not quietly keep its tag, and it does not quietly vanish.
-
-`[director]` outranks both: a director note lands in the profile the round it
-arrives (story 49), and a later corpus pass that disagrees with it gets written
-up as a disagreement rather than overwriting it.
+- **Measurement never sands off a principle.** Where the corpus disagrees with
+  a stated principle, both stay and the conflict is written down as a conflict
+  (#13). A measured deviation is a fact about the edits; the principle is a
+  fact about the intent, and losing either one loses the interesting part.
+- **Thin support downgrades.** Few instances, or support from a single
+  project, means `[believed, unverified]` with the partial evidence noted —
+  however clean the number looked. No minimum-n gate blocks a first analysis
+  run; the tag carries the weakness instead (#21 policy 4).
+- **Context is attributed, agreement graduates.** A measured claim names its
+  context (`concert` or `studio-session`). A claim that holds across both
+  graduates to `base.md` (#21 policy 3).
+- **Taste beats recency, and recent work breaks ties.** Membership is "would
+  you cut it the same way today?", not a date cutoff; where old and new work
+  disagree, the profile resolves toward the recent (#21 policy 2).
 
 ## Angle sidecars
 
-One JSON file per Resolve project, named for the project, holding what each
-camera actually is. This is what stops the agent re-deriving "which one is the
-drummer cam" from frame grabs every session.
+One JSON file per corpus project, labelling each camera on **two axes**:
+**subject** (who or what — drummer, keys, ensemble) × **character** (`wide`,
+`tight`, `moving`). The style profile speaks in roles; the camera→role mapping
+for a given project lives here, with the project, not in the profile (#13).
 
 ```json
 {
-  "project": "Jaded Symphony - The Sinclair",
+  "project": "2026-06_Zinc_and_Monkfish",
   "context": "concert",
   "labelled": "2026-08-06",
-  "method": "frame grabs at 3 times per angle, read by the agent",
+  "confirmed_by_director": false,
   "angles": {
     "A001_C012.mov": {
-      "role": "drums",
-      "subject": "drum kit, three-quarters from house left",
-      "character": "reaction",
-      "framing": "medium",
-      "motion": "static",
+      "role": "drums-tight",
+      "subject": "drums",
+      "character": "tight",
+      "note": "drum kit three-quarters from house left; locked off",
       "confidence": "high",
-      "evidence": ["frames/A001_C012_00-01-30.jpg"]
+      "evidence": ["…/frames/A001_C012_00-01-30.jpg"]
     }
   }
 }
 ```
 
-`role` is the only key `correlate_timeline` consumes; the rest is for the agent
-and the director. The keys mean:
-
-- **`role`** — the short handle the measurement groups by (`drums`, `wide`,
-  `soloist`, `piano`, `bass`, `audience`). Keep the vocabulary small and reuse
-  it across projects, because cross-project claims are grouped on this string.
-- **`subject`** — what the camera is pointed at, in words. The half of
-  "subject × character" that says *who*.
-- **`character`** — what the angle is *for* in a cut: `establishing`,
-  `hero` (carries a solo), `reaction`, `detail` (hands, sticks, keys),
-  `texture` (audience, room, atmosphere). The half that says *why cut to it*.
-- **`framing`**, **`motion`** — `wide`/`medium`/`tight`, `static`/`roaming`.
-- **`confidence`**, **`evidence`** — how sure the label is and the frame grabs
-  it was read from; a `low` here is why a corpus claim about that angle is
-  thin.
+- **`role`** is the only key `correlate_timeline` consumes, and it is what
+  cross-project claims group on — so keep the vocabulary small and reuse it
+  across projects. `<subject>-<character>` is the default shape.
+- **`subject`** and **`character`** are the two axes kept apart, because
+  "the drummer" and "a moving shot" are different facts about the same camera
+  and the profile makes claims about each.
+- **`confidence`** and **`evidence`** are why a claim resting on this angle is
+  thin or not: a `low` here is a reason a corpus claim downgrades.
+- **`confirmed_by_director`** — labelling is auto-labelled by Claude and
+  confirmed once by the director; reruns never re-ask (#13). Until that flip,
+  every claim resting on these labels is `[believed, unverified]`.
 
 An entry with no `role` is dropped by `correlate_timeline` rather than refused,
 so a half-labelled project still measures — its shots land under `unlabelled`.
 
-Pass a sidecar to the tool by lifting the `angles` object straight through:
+Pass a sidecar by lifting its `angles` object straight through; the tool takes
+labels, never a path:
 
 ```python
 angles = json.loads(Path("styles/angles/<project>.json").read_text())["angles"]
 correlate_timeline(beats=..., timeline=..., angles=angles)
 ```
 
-## Labelling a project
+## The analysis workflow, per corpus project
 
-1. `inspect_timeline` for the distinct clip names on the angle tracks (or the
-   sidecar's own last pass, when you are only filling gaps).
-2. `grab_frames` on each clip at three well-separated times — one is a lens cap
-   or a black frame more often than you would think.
-3. Read the grabs. Write the sidecar. Every angle gets `subject` **and**
-   `character`; a camera you cannot identify gets `confidence: "low"` and says
-   what it looks like, rather than a guess that reads as fact.
+Per #13, and in this order:
 
-## Running a corpus pass
+1. **Pre-flight** (#21). Open the project. Spot-check `GetClipProperty("File
+   Path")` on timeline clips — archived projects under `Archive/Client` are
+   the likely relink candidates. Confirm **2+ source angles**: single-camera
+   timelines leave the corpus at labelling time without a re-decision, because
+   angle-switch behaviour is the core signal. Confirm the concert audio is
+   reachable and that frame grabs render.
+2. **Angle labelling.** `inspect_timeline` for the distinct source clips,
+   `grab_frames` on each at three well-separated times — one grab in three is
+   a lens cap or a black frame — then read the grabs and write the sidecar.
+   Clip and file names are a hint layer when they cooperate, never the label.
+   The director confirms or corrects once.
+3. **Music analysis.** `analyze_music` on the concert audio for beats,
+   downbeats and energy; `analyze_structure` for tunes and solo changes. A
+   concert cut to a director-supplied master mix uses that file; otherwise the
+   timeline's own mix has to be exported, and `separate_stems(scope="timeline")`
+   acquires it on the way. **Rubato regions are excluded from cut-placement
+   evidence** via beat-confidence gating — a grid fitted to free time measures
+   nothing.
+4. **`correlate_timeline`** with the sidecar's labels. This is the one tested
+   measurement path: Claude interprets its records and never recomputes
+   statistics ad hoc.
+5. **Draft.** Update the profile sections from the records, tag every claim,
+   record the row in `corpus.md`. The director reviews; then commit.
 
-The corpus is **ordered** — timelines newest-last — because taste drifts and a
-claim that holds only in the last three edits is a different claim from one
-that holds across all fifteen. Each timeline is **context-tagged** (`concert`,
-`studio-session`) so base and concert claims can be told apart.
-
-Per timeline:
-
-1. Get a WAV and run `analyze_music` on it for the beat grid. A concert cut to
-   a director-supplied master mix takes that file directly; otherwise the
-   timeline's own mix has to be exported — `separate_stems(scope="timeline")`
-   acquires it on the way, and its job result names the acquired audio.
-2. `correlate_timeline(beats=…, timeline=…, angles=…)` with the project's
-   sidecar.
-3. Record the result path and its gist in `styles/corpus.md`, with the
-   timeline's order index and context tag.
-
-Then read across the results — not one at a time — and write the profile.
-Aggregate before claiming: the number that matters is the distribution over the
-corpus, and the tag you are entitled to is set by how many cuts and how many
-timelines stand behind it.
+Read **across** the corpus before claiming, not one project at a time: the
+number that matters is the distribution, and the tag a claim is entitled to is
+set by how many cuts and how many projects stand behind it.
 
 **`alignment.mode` decides whether a result is usable at all.** `audio_clip`
-means the times were read through the audio the analysis was run on;
+means the times were read through the audio the analysis ran on;
 `timeline_start` means the timeline said nothing about where the mix sits and
 the times count from its own first frame instead. A whole file measured against
 the wrong zero looks exactly like a whole file measured against the right one,

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -48,6 +48,7 @@ from ..resolve.session import frame_rate
 from ..resolve.timeline import (
     FIRST_TRACK,
     Reader,
+    angle_name,
     clip_name,
     find_timeline,
     fingerprint,
@@ -263,9 +264,39 @@ def _shots(reader: Reader, timeline: Any, track: int) -> list[Shot]:
         if record_in is None or duration is None:
             log.warning("Skipped a shot on video track %d: Resolve gave no position", track)
             continue
-        name = clip_name(reader, item) or str(item.GetName() or "")
+        name = angle_name(reader, item) or str(item.GetName() or "")
         found.append(Shot(clip=name, record_in=record_in, duration=duration))
-    return sorted(found, key=lambda shot: shot.record_in)
+    return _without_transitions(sorted(found, key=lambda shot: shot.record_in), track)
+
+
+def _without_transitions(shots: Sequence[Shot], track: int) -> list[Shot]:
+    """Drop the transitions Resolve hands back alongside the shots.
+
+    ``GetItemListInTrack`` returns a dissolve as an item of its own, sitting across the
+    boundary it softens: on a hand-edited concert that is a short item every time the
+    editor did anything other than a straight cut, and one real corpus timeline came back
+    159 of them in 525 items. Left in, each one is a shot that was never cut — its start is
+    half a transition *before* the cut it belongs to, which lands in the offset
+    distribution as a cut the editor did not make, and its length lands in the duration
+    stats as a shot nobody held.
+
+    Two items cannot overlap on one video track, so overlapping the shot before it is what
+    a transition is and a shot is not. That is a fact about tracks rather than about any
+    getter, which is why it is the test rather than the absence of a media pool item — a
+    generator has none of those either, and a generator on the cut track is a shot.
+    """
+    kept: list[Shot] = []
+    dropped = 0
+    for shot in shots:
+        if kept and shot.record_in < kept[-1].record_out:
+            dropped += 1
+            continue
+        kept.append(shot)
+    if dropped:
+        log.info(
+            "Video track %d: %d transitions read past, %d shots kept", track, dropped, len(kept)
+        )
+    return kept
 
 
 def _clock(reader: Reader, timeline: Any, fps: float, mix: Path | None) -> Clock:

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -55,6 +55,12 @@ DEFAULT_ITEM_LIMIT = 100
 DETAIL_LEVELS = ("summary", "tracks", "clips")
 TRACK_TYPES = ("video", "audio", "subtitle")
 
+CLIP_TYPE = "Type"
+"""The media pool property naming what kind of clip it is."""
+
+MULTICAM_TYPE = "Multicam"
+"""The one clip kind whose angles all share a single pool item — see :func:`angle_name`."""
+
 VERSION = re.compile(r"^(?P<base>.*?)[\s_-]*v(?P<number>\d+)$", re.IGNORECASE)
 
 Project = Any
@@ -763,5 +769,30 @@ def clip_name(reader: Reader, item: TimelineItem) -> str | None:
     clip = reader.optional(item, "GetMediaPoolItem", None)
     if clip is None:
         return None
+    name = reader.optional(clip, "GetName", None)
+    return None if name is None else str(name)
+
+
+def angle_name(reader: Reader, item: TimelineItem) -> str | None:
+    """What to call the angle a shot came from, which is not always its pool clip.
+
+    A multicam clip is the exception, and the reason this is not just :func:`clip_name`:
+    every angle of a multicam shares *one* media pool item, so the pool name is the same
+    string for the drummer cam and the wide. A cut measured by it has no angle switches in
+    it at all — which is the one signal a style corpus is read for (#21), so getting this
+    wrong does not look like an error, it looks like an editor who never cut away.
+
+    Resolve puts the angle in the timeline item's own name instead ("<clip> - Video 2"), so
+    that is what a multicam shot answers. Everything else keeps the pool name, which
+    survives a shot being renamed on the timeline.
+    """
+    clip = reader.optional(item, "GetMediaPoolItem", None)
+    if clip is None:
+        return None
+    kind = reader.optional(clip, "GetClipProperty", None, CLIP_TYPE)
+    if str(kind or "") == MULTICAM_TYPE:
+        angle = reader.optional(item, "GetName", None)
+        if angle is not None:
+            return str(angle)
     name = reader.optional(clip, "GetName", None)
     return None if name is None else str(name)

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -794,5 +794,4 @@ def angle_name(reader: Reader, item: TimelineItem) -> str | None:
         angle = reader.optional(item, "GetName", None)
         if angle is not None:
             return str(angle)
-    name = reader.optional(clip, "GetName", None)
-    return None if name is None else str(name)
+    return clip_name(reader, item)

--- a/styles/angles/2026-06_Zinc_and_Monkfish.json
+++ b/styles/angles/2026-06_Zinc_and_Monkfish.json
@@ -1,0 +1,60 @@
+{
+  "project": "2026-06_Zinc_and_Monkfish",
+  "context": "concert",
+  "labelled": "2026-08-06",
+  "method": "frame grabs off the multicam's source clips, read by the agent",
+  "confirmed_by_director": false,
+  "note": "Zinc - Set 2 only. Monkfish Main is corpus entry 5 and is not labelled yet.",
+  "angles": {
+    "Zinc - Set 2 Multicam - Video 1": {
+      "role": "ensemble-wide",
+      "subject": "ensemble",
+      "character": "wide",
+      "note": "Front-of-house wide across the whole stage - piano and bass at house left, sax centre, drums at house right. Operated rather than locked off: the framing is not identical between grabs.",
+      "camera": "FX6",
+      "confidence": "low",
+      "evidence": [
+        "frames/A015C001_2606170J.MXF-346744bd6d0a.jpg",
+        "frames/A015C001_2606170J.MXF-d56bbb4ba2fd.jpg"
+      ]
+    },
+    "Zinc - Set 2 Multicam - Video 2": {
+      "role": "drums-tight",
+      "subject": "drums",
+      "character": "tight",
+      "note": "Locked off at stage right, level with the kit: drummer in the foreground right, sax and bass beyond him, piano deep at frame left. Framing is the same in every grab.",
+      "camera": "A7IV",
+      "confidence": "low",
+      "evidence": [
+        "frames/20260617_D_A7IV_0006.MP4-7b06dd289e54.jpg",
+        "frames/20260617_D_A7IV_0006.MP4-e924bd957d6e.jpg"
+      ]
+    }
+  },
+  "sources": {
+    "FX6": {
+      "clips": [
+        "A014C002_2606170Z.MXF",
+        "A015C001_2606170J.MXF"
+      ],
+      "subject": "ensemble",
+      "character": "wide",
+      "confidence": "high"
+    },
+    "A7IV": {
+      "clips": [
+        "20260617_D_A7IV_0006.MP4"
+      ],
+      "subject": "drums",
+      "character": "tight",
+      "confidence": "high"
+    }
+  },
+  "mapping_basis": {
+    "what_is_known": "What each camera is, read off its own frame grabs. That part is not in doubt.",
+    "what_is_inferred": "Which camera is multicam angle Video 1 and which is Video 2. Resolve's scripting API does not say: the multicam clip's 'Angle' property comes back empty, and a timeline item only carries the angle name, not the source behind it.",
+    "how_it_was_guessed": "Video 1 holds 68.5% of screen time over 188 cuts (13.8s a shot) and Video 2 holds 31.5% over 178 cuts (6.7s a shot). A two-camera concert cut that way has a home angle held long and a second angle cut to briefly, so the wide was assigned to Video 1.",
+    "how_to_settle_it": "Open Zinc - Set 2 Main, park on any shot, and say which camera is on screen. One look fixes it for good; until then every role-conditioned claim in styles/concert.md stays unverified.",
+    "if_it_is_backwards": "Swap the two role/subject/character/camera blocks. Nothing else in the corpus depends on the mapping - the timing measurements are angle-blind."
+  }
+}

--- a/styles/base.md
+++ b/styles/base.md
@@ -1,0 +1,54 @@
+# Base style profile
+
+Claims that hold for every kind of edit in this project. `concert.md` is read
+on top of this and wins where the two speak to the same thing.
+
+Every claim carries a provenance tag; the vocabulary and the rules for earning
+one are in `docs/agents/style-layer.md`. **A claim with no tag is a bug in this
+document** — it means someone wrote down a preference without saying how it is
+known, which is the black box this file exists to replace.
+
+This profile is deliberately thin. What is not here is not "no opinion" — it is
+"not yet measured", and the corpus pass in `corpus.md` is what fills it.
+
+## What a cut is for
+
+- **The cut follows where the attention already is, rather than directing it.**
+  In a performance the audience is already looking somewhere; the edit's job is
+  to be there, not to argue. `[director]` — spec #22, story 45: "follows
+  where-the-attention-is energy, so that the edit feels like a musician cut
+  it."
+- **Nothing about a cut is a rule about a number.** `correlate_timeline`
+  reports a shot two frames late as two frames late; whether that is musical is
+  a claim in this document, and a claim in this document is answerable to the
+  corpus. `[director]` — spec #22, story 32.
+
+## Timing
+
+- **Transients, not the beat grid, are the fourth-wall risk.** A cut that lands
+  exactly on an attack reads as a machine's decision, because the attack is the
+  thing the ear is already committed to. Measure against the transient column
+  first and the beat column second. `[director]` — spec #22 implementation
+  decisions: "Core principle: transients, not the beat grid, are the fourth-wall
+  risk."
+- Cut-offset distribution across the corpus — the shape of where cuts actually
+  land relative to the nearest transient and the nearest beat. *Awaiting the
+  corpus pass; see `corpus.md`.*
+- Shot-duration floor and typical range. *Awaiting the corpus pass.*
+
+## Angles
+
+- **An angle is chosen for what it is for, not for what it shows.** Sidecars
+  carry `subject` and `character` separately because "the drum kit" and "the
+  thing I cut to when the horn player is between phrases" are different facts
+  about the same camera. `[believed, unverified]` — this is how the sidecar
+  format was designed (#45), not yet something the corpus has confirmed about
+  the edits themselves.
+- Angle-share and role-share distributions; which roles open a piece and which
+  close it. *Awaiting the corpus pass.*
+
+## Review
+
+- **A style-level note from the director lands here the round it arrives**, not
+  at the end of the project, so the next cut is already better.
+  `[director]` — spec #22, story 49.

--- a/styles/base.md
+++ b/styles/base.md
@@ -42,7 +42,10 @@ opinion" — it is "not yet measured", and `corpus.md` is where it gets filled.
 - Cutting on a big moment is an emphasis move, made on purpose or not at all.
   `[stated principle]`
 - The offset distribution the corpus actually shows — signed, early against
-  late, and how it conditions on context. *Open; see `corpus.md`.*
+  late, and how it conditions on context. *Open here on purpose. The concert
+  entry has numbers (`concert.md` §1), but a claim only graduates to this layer
+  once contexts agree (#21 policy 3), and no studio-session timeline has been
+  measured.*
 
 ## Energy
 
@@ -76,8 +79,13 @@ opinion" — it is "not yet measured", and `corpus.md` is where it gets filled.
 Free prose, first-class, anywhere in this document. Nothing here is waiting for
 a number to be allowed to be said.
 
-- The corpus is not yet measured, so every distribution above is open and the
-  profile currently runs on stated principle alone. That is the intended state
-  for a first pass (#21 policy 4: no minimum-n gate blocks the first analysis
-  run) — but it does mean nothing here has yet been checked against a real
-  edit.
+- One concert timeline is measured and no studio session is, so nothing has
+  graduated to this layer yet and every distribution here is still open. That
+  is the intended state for a first pass (#21 policy 4: no minimum-n gate
+  blocks the first analysis run), but it does mean this file still runs on
+  stated principle alone.
+- The first measured entry did not contradict any principle above — the anchor
+  puts the median cut 33 ms off the nearest transient with 2 of 360 landing on
+  one, which is the transient philosophy behaving as stated. A principle
+  surviving its first contact with the corpus is worth recording; it is not yet
+  worth re-tagging.

--- a/styles/base.md
+++ b/styles/base.md
@@ -1,54 +1,83 @@
 # Base style profile
 
-Claims that hold for every kind of edit in this project. `concert.md` is read
-on top of this and wins where the two speak to the same thing.
+Cross-domain taste: what holds whatever is being cut. Claude loads this plus
+the relevant domain doc (`concert.md` in v1) at cut time; where the two speak
+to the same thing, the domain doc wins.
 
-Every claim carries a provenance tag; the vocabulary and the rules for earning
-one are in `docs/agents/style-layer.md`. **A claim with no tag is a bug in this
-document** — it means someone wrote down a preference without saying how it is
+Every claim carries a provenance tag — `[stated principle]`,
+`[measured — N projects, n=…, context]`, `[review feedback, YYYY-MM]`,
+`[believed, unverified]`. The vocabulary and the rules for earning one are in
+`docs/agents/style-layer.md`. **A claim with no tag is a bug in this
+document**: it means a preference got written down without saying how it is
 known, which is the black box this file exists to replace.
 
-This profile is deliberately thin. What is not here is not "no opinion" — it is
-"not yet measured", and the corpus pass in `corpus.md` is what fills it.
+This is principles plus evidence, not a rulebook. Feel is subjective; the
+measurements exist to absorb it from the corpus, not to reduce it to rules. Where
+a measurement disagrees with a principle below, both stay and the disagreement
+is written down — a measured deviation is a fact about the edits, the principle
+is a fact about the intent, and dropping either loses the interesting part.
 
-## What a cut is for
+Sections that are still open name what would settle them. That is not "no
+opinion" — it is "not yet measured", and `corpus.md` is where it gets filled.
 
-- **The cut follows where the attention already is, rather than directing it.**
-  In a performance the audience is already looking somewhere; the edit's job is
-  to be there, not to argue. `[director]` — spec #22, story 45: "follows
-  where-the-attention-is energy, so that the edit feels like a musician cut
-  it."
-- **Nothing about a cut is a rule about a number.** `correlate_timeline`
-  reports a shot two frames late as two frames late; whether that is musical is
-  a claim in this document, and a claim in this document is answerable to the
-  corpus. `[director]` — spec #22, story 32.
+## Transparency
 
-## Timing
+- **Nothing sticks out unless it is meant to.** The edit is not the
+  performance; a viewer who notices a cut was either meant to notice it or was
+  pulled out of the room. Everything else in this document is downstream of
+  this. `[stated principle]`
+- Emphasis is the exception that proves it: a cut that *is* meant to be felt is
+  a deliberate move, and the profile says so where it makes one.
+  `[stated principle]`
 
-- **Transients, not the beat grid, are the fourth-wall risk.** A cut that lands
-  exactly on an attack reads as a machine's decision, because the attack is the
-  thing the ear is already committed to. Measure against the transient column
-  first and the beat column second. `[director]` — spec #22 implementation
-  decisions: "Core principle: transients, not the beat grid, are the fourth-wall
-  risk."
-- Cut-offset distribution across the corpus — the shape of where cuts actually
-  land relative to the nearest transient and the nearest beat. *Awaiting the
-  corpus pass; see `corpus.md`.*
-- Shot-duration floor and typical range. *Awaiting the corpus pass.*
+## Transients
 
-## Angles
+- **Transients, not the beat grid, are the fourth-wall risk.** A cut landing
+  directly on a big transient — an obvious snare hit — reads as the *sound
+  having triggered the edit*, and that is the thing that breaks transparency.
+  `[stated principle]`
+- **The downbeat itself is fine**, and rhythmic grid positions (beat 2, a
+  mid-beat) are good when the music grooves. The risk is the attack, not the
+  grid. `[stated principle]`
+- Cutting on a big moment is an emphasis move, made on purpose or not at all.
+  `[stated principle]`
+- The offset distribution the corpus actually shows — signed, early against
+  late, and how it conditions on context. *Open; see `corpus.md`.*
 
-- **An angle is chosen for what it is for, not for what it shows.** Sidecars
-  carry `subject` and `character` separately because "the drum kit" and "the
-  thing I cut to when the horn player is between phrases" are different facts
-  about the same camera. `[believed, unverified]` — this is how the sidecar
-  format was designed (#45), not yet something the corpus has confirmed about
-  the edits themselves.
-- Angle-share and role-share distributions; which roles open a piece and which
-  close it. *Awaiting the corpus pass.*
+## Energy
 
-## Review
+- **Energy is where the attention is** — band-member interactions,
+  expressions, fills, the moment it simply feels right. `[stated principle]`
+- **Loudness and onset density are proxies for energy, never its definition.**
+  A number that correlates with attention is not attention, and a cut that
+  chases the meter instead of the room is the failure mode this distinction
+  exists to name. `[stated principle]`
 
-- **A style-level note from the director lands here the round it arrives**, not
-  at the end of the project, so the next cut is already better.
-  `[director]` — spec #22, story 49.
+## Variation
+
+- **Avoid runs of similar shot lengths.** Sameness is itself a thing that
+  sticks out, which puts this downstream of transparency rather than beside it.
+  `[stated principle]`
+- **Spectacle earns a hold** — and especially so on a moving camera, where the
+  move is the reason to stay. `[stated principle]`
+- Shot-duration distributions, conditioned on section type and energy band.
+  *Open; see `corpus.md`.*
+
+## Angle roles
+
+- **Every angle carries two axes: subject × character.** Subject is who or
+  what (drummer, keys, ensemble); character is `wide`, `tight` or `moving`.
+  This document speaks in roles; which camera *is* which role is a fact about a
+  project and lives in that project's sidecar. `[stated principle]`
+- Wide-as-reset, and hold lengths per role. *Open; see `corpus.md`.*
+
+## Observations
+
+Free prose, first-class, anywhere in this document. Nothing here is waiting for
+a number to be allowed to be said.
+
+- The corpus is not yet measured, so every distribution above is open and the
+  profile currently runs on stated principle alone. That is the intended state
+  for a first pass (#21 policy 4: no minimum-n gate blocks the first analysis
+  run) — but it does mean nothing here has yet been checked against a real
+  edit.

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -1,58 +1,91 @@
 # Concert style profile
 
-Read on top of `base.md`. Everything here is about cutting a jazz concert shot
-on 2–3 cameras — wide static, drummer cam, roaming soloist cam — to a master
-mix the director hands over.
+The concert domain: a jazz set shot on 2–3 cameras and cut to a master mix the
+director hands over. Read on top of `base.md`; where the two speak to the same
+thing, this file wins.
 
-A claim belongs in this file only if it would be **wrong** in a studio-session
-edit. Anything that would also be true there is a base claim.
+A claim belongs here only if it would be **wrong** in another domain. Anything
+that also holds for a studio session or a vlog is a base claim — and a measured
+claim that turns out to hold across contexts graduates to `base.md` (#21
+policy 3).
 
-Every claim carries a provenance tag (`docs/agents/style-layer.md`).
+Sections follow the schema settled in #13. Every claim carries a provenance
+tag; the vocabulary is in `docs/agents/style-layer.md`.
 
-## Timing against the music
+## 1. Cut placement — transients, not the beat grid
 
-- **Near-beat, not on-beat.** Cuts sit close to the grid without landing on the
-  attack that the grid is made of. `[director]` — spec #22, story 45: "cutting
-  that avoids transient-triggered cuts (near-beat, not on-beat)."
-- The offset window that "near" actually means in this director's edits — the
-  distribution of signed transient offsets across the concert corpus, early
-  against late. *Awaiting the corpus pass; see `corpus.md`.*
-- Where in the bar cuts land: whether the corpus favours the bar line, the back
-  half, or is flat. *Awaiting the corpus pass.*
+The base transient philosophy applies as written. What is concert-specific is
+that the grid is a live band's grid, so it moves.
 
-## Reacting to the band
+- **Rubato is not measurable and not evidence.** Where the beat confidence
+  drops — free intros, out-of-time codas — cut placement there says nothing
+  about taste and is gated out of the evidence rather than averaged in.
+  `[stated principle]` (#13, analysis workflow)
+- Offset-to-nearest-strong-transient distribution across the concert corpus,
+  signed, with direction bias. *Open — the measurement is
+  `correlate_timeline`'s `transient_offsets`; see `corpus.md`.*
+- Beat-grid position patterns, in frames and in beat-fraction, conditioned on
+  context. *Open — `beat_offsets` and the bar histogram.*
 
-- **Drum fills are a cue to cut, not noise to avoid.** A fill is the band
-  telling the room something is about to change, and the edit answers it.
-  `[director]` — spec #22, story 45: "reacts to drum fills."
-- **Solo changes are structural.** Who is out front is the first thing that
-  decides which angle a passage lives on; the structure analysis names when the
-  front changed, not who it is, and the sidecar's `role` closes that gap.
-  `[believed, unverified]` — follows from how `analyze_structure` and the
-  sidecar are built (#38, #45); the corpus has not yet been read for how
-  strictly past edits actually follow the front.
-- Whether shots get shorter through a solo's build and longer through a head.
-  *Awaiting the corpus pass.*
+## 2. Energy — the master concept
 
-## Angles
+- The band is the source of energy and the mix is a proxy for it, so a concert
+  cut follows interactions and expressions first and the loudness curve second.
+  `[stated principle]` (base: "energy is where the attention is")
+- v1 evidence for chasing energy is audio analysis + angle labels + targeted
+  frame grabs. Per-angle visual-energy metrics are post-v1, which means claims
+  in this section rest on less than the timing claims do and are tagged
+  accordingly. `[stated principle]` (#13, scope)
 
-- The concert role vocabulary is `wide`, `drums`, `soloist`, plus whatever a
-  given night's third camera was. `[believed, unverified]` — from the rig the
-  director describes (spec #22 problem statement: "wide static, drummer cam,
-  roaming soloist cam"); the sidecars are what will make it fact per project.
-- Angle share per tune, and which angle a tune opens on. *Awaiting the corpus
-  pass.*
+## 3. Shot rhythm
 
-## The set as one thing
+- Duration distributions conditioned on section type and energy band. *Open;
+  see `corpus.md`.*
+- The variation instinct and "spectacle earns a hold" are base claims and apply
+  here unchanged.
+- Whether shots shorten through a solo's build and lengthen through a head.
+  *Open.*
 
-- **A set is one continuous cut over one master-audio clip**, planned
-  song-by-song but never assembled as separate timelines. `[director]` — spec
-  #22, story 44.
+## 4. Angle roles
 
-## Self-review
+- **Prioritise the soloist, but keep moving.** Sitting on the soloist for the
+  whole solo is not the same as serving it — the band's interactions are part
+  of what the solo is. `[stated principle]`
+- **Soloist doing something worth seeing → show him. Drummer lighting up at
+  the same time → cut between them.** The two are not in competition; the
+  exchange is the content. `[stated principle]`
+- Wide-as-reset patterns, transition habits between roles, and hold length per
+  role. *Open — `roles` and `shot_seconds` per role across the corpus.*
+- The role vocabulary a given night supports is whatever its sidecar says;
+  concert rigs here are a static wide, a drummer cam, and a roaming soloist
+  cam. `[believed, unverified]` — from the rig described in spec #22; the
+  sidecars are what make it fact per project.
 
-- **Every build is measured before the director sees it**, and every outlier is
-  either fixed or written down with a reason. An outlier here means a shot
-  whose offset or duration falls outside what this profile claims — which is
-  only possible because the claims above are numbers, not adjectives.
-  `[director]` — spec #22, story 47.
+## 5. Event-reactive moves
+
+Per event type: the response, and its **timing signature** — the lead/lag
+distribution measured by correlating detected events against actual cut points.
+
+- **Drum fill** — arrive on the drummer around the start of the fill, ride
+  through the transition, and leave after the new section has settled.
+  `[believed, unverified]` — seed pattern recorded as such in #13; the lead/lag
+  numbers are exactly what a corpus pass is for.
+- **Solo change** — the front changing is structural, and it is the first thing
+  that decides which angle a passage lives on. `analyze_structure` names when
+  the front changed, never who it is; the sidecar's `role` closes that gap.
+  `[believed, unverified]` — follows from how #38 and the sidecar are built;
+  the corpus has not been read yet for how strictly past edits follow the front.
+- **Section boundary**, **build** — response and timing signature. *Open.*
+
+## 6. Observations
+
+Free prose, first-class.
+
+- The concert corpus (#21) is ~7 concert-context timelines, anchored on
+  **Zinc - Set 2 Main** as the strongest current-taste exemplar. Full-set
+  timelines carry many tunes, so per-cut sample counts run into the hundreds —
+  the thin-corpus risk here is *project* count, not cut count, which is why the
+  tag format names both.
+- Nothing in this file has been measured yet. Every claim above is either a
+  stated principle or a seed belief, and the first corpus pass is what turns
+  the open sections into numbers.

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -21,11 +21,19 @@ that the grid is a live band's grid, so it moves.
   drops — free intros, out-of-time codas — cut placement there says nothing
   about taste and is gated out of the evidence rather than averaged in.
   `[stated principle]` (#13, analysis workflow)
-- Offset-to-nearest-strong-transient distribution across the concert corpus,
-  signed, with direction bias. *Open — the measurement is
-  `correlate_timeline`'s `transient_offsets`; see `corpus.md`.*
+- **Cuts land close to a transient without landing on one.** On the anchor, the
+  median cut sits 33 ms from the nearest transient (mean 46 ms, max 345 ms) and
+  exactly **2 of 360 cuts land on one**. That is the stated principle showing up
+  as a number: near, not on. `[believed, unverified]` — n=360 cuts but a single
+  project, so #21 policy 4 downgrades it; `corpus.md` entry 1 has the evidence.
+- **The direction bias is close to even, tipped early**: 195 cuts early against
+  163 late. Not the lopsided distribution a rule like "always cut just before"
+  would leave. `[believed, unverified]` — same single project.
 - Beat-grid position patterns, in frames and in beat-fraction, conditioned on
-  context. *Open — `beat_offsets` and the bar histogram.*
+  context. *Open, and blocked rather than merely unmeasured: the anchor's grid
+  does not fit its music (`meter: 1` at 214 bpm over a jazz set), so the bar
+  histogram and the beat offsets from it are not yet evidence. Rubato gating
+  comes first — see `corpus.md` entry 1.*
 
 ## 2. Energy — the master concept
 
@@ -39,8 +47,14 @@ that the grid is a live band's grid, so it moves.
 
 ## 3. Shot rhythm
 
+- **Shots are long, and their spread is enormous.** On the anchor: median
+  7.3 s, mean 10.4 s, from 0.46 s to 71 s. A concert cut here is not a montage
+  — half the shots run longer than seven seconds — and the 71-second hold says
+  the variation instinct has a very wide range to play in.
+  `[believed, unverified]` — n=366 shots, one project (#21 policy 4).
 - Duration distributions conditioned on section type and energy band. *Open;
-  see `corpus.md`.*
+  the conditioning needs the structure analysis, which has not been run over
+  the corpus.*
 - The variation instinct and "spectacle earns a hold" are base claims, and a
   concert changes nothing about them — they carry their tags in `base.md` and
   are named here only so this section is not read as silent on them.
@@ -55,12 +69,23 @@ that the grid is a live band's grid, so it moves.
 - **Soloist doing something worth seeing → show him. Drummer lighting up at
   the same time → cut between them.** The two are not in competition; the
   exchange is the content. `[stated principle]`
+- **The wide is the home angle; the drummer cam is cut to, not lived on.** On
+  the anchor the wide holds 68.5% of screen time across 188 cuts (13.8 s a
+  shot) against the drummer cam's 31.5% across 178 cuts (6.7 s a shot):
+  near-equal cut counts, roughly double the hold. Two angles traded evenly
+  would not look like this. `[believed, unverified]` — one project, and the
+  angle-number-to-camera mapping is inferred rather than read (see the
+  sidecar's `mapping_basis`), so this claim is one director glance away from
+  being either confirmed or exactly inverted.
 - Wide-as-reset patterns, transition habits between roles, and hold length per
-  role. *Open — `roles` and `shot_seconds` per role across the corpus.*
-- The role vocabulary a given night supports is whatever its sidecar says;
-  concert rigs here are a static wide, a drummer cam, and a roaming soloist
-  cam. `[believed, unverified]` — from the rig described in spec #22; the
-  sidecars are what make it fact per project.
+  role. *Open — needs the angle sidecar; `roles` came back null on the anchor
+  because nothing is labelled yet.*
+- The role vocabulary a given night supports is whatever its sidecar says. Spec
+  #22 describes the rig as a static wide, a drummer cam and a roaming soloist
+  cam — but the anchor night ran **two** cameras and the other way round: the
+  wide is the operated one and the drummer cam is locked off.
+  `[believed, unverified]` — one night, from its frame grabs. Worth watching
+  across the corpus rather than assuming either way.
 
 ## 5. Event-reactive moves
 
@@ -87,6 +112,13 @@ Free prose, first-class.
   timelines carry many tunes, so per-cut sample counts run into the hundreds —
   the thin-corpus risk here is *project* count, not cut count, which is why the
   tag format names both.
-- Nothing in this file has been measured yet. Every claim above is either a
-  stated principle or a seed belief, and the first corpus pass is what turns
-  the open sections into numbers.
+- One of seven concert entries is measured (the anchor). Every number above
+  therefore carries `[believed, unverified]` rather than `[measured — …]`, not
+  because the sample is small — 360 cuts is not small — but because one project
+  cannot tell this director's taste apart from this night's room. Entry 2
+  onward is what changes the tags.
+- The most useful thing the first pass produced was not a number but a
+  correction: two defects in `correlate_timeline` that only real footage
+  exposes (transitions counted as shots, multicam angles sharing one name).
+  Everything above is measured with those fixed; nothing measured before them
+  should be believed.

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -1,0 +1,58 @@
+# Concert style profile
+
+Read on top of `base.md`. Everything here is about cutting a jazz concert shot
+on 2–3 cameras — wide static, drummer cam, roaming soloist cam — to a master
+mix the director hands over.
+
+A claim belongs in this file only if it would be **wrong** in a studio-session
+edit. Anything that would also be true there is a base claim.
+
+Every claim carries a provenance tag (`docs/agents/style-layer.md`).
+
+## Timing against the music
+
+- **Near-beat, not on-beat.** Cuts sit close to the grid without landing on the
+  attack that the grid is made of. `[director]` — spec #22, story 45: "cutting
+  that avoids transient-triggered cuts (near-beat, not on-beat)."
+- The offset window that "near" actually means in this director's edits — the
+  distribution of signed transient offsets across the concert corpus, early
+  against late. *Awaiting the corpus pass; see `corpus.md`.*
+- Where in the bar cuts land: whether the corpus favours the bar line, the back
+  half, or is flat. *Awaiting the corpus pass.*
+
+## Reacting to the band
+
+- **Drum fills are a cue to cut, not noise to avoid.** A fill is the band
+  telling the room something is about to change, and the edit answers it.
+  `[director]` — spec #22, story 45: "reacts to drum fills."
+- **Solo changes are structural.** Who is out front is the first thing that
+  decides which angle a passage lives on; the structure analysis names when the
+  front changed, not who it is, and the sidecar's `role` closes that gap.
+  `[believed, unverified]` — follows from how `analyze_structure` and the
+  sidecar are built (#38, #45); the corpus has not yet been read for how
+  strictly past edits actually follow the front.
+- Whether shots get shorter through a solo's build and longer through a head.
+  *Awaiting the corpus pass.*
+
+## Angles
+
+- The concert role vocabulary is `wide`, `drums`, `soloist`, plus whatever a
+  given night's third camera was. `[believed, unverified]` — from the rig the
+  director describes (spec #22 problem statement: "wide static, drummer cam,
+  roaming soloist cam"); the sidecars are what will make it fact per project.
+- Angle share per tune, and which angle a tune opens on. *Awaiting the corpus
+  pass.*
+
+## The set as one thing
+
+- **A set is one continuous cut over one master-audio clip**, planned
+  song-by-song but never assembled as separate timelines. `[director]` — spec
+  #22, story 44.
+
+## Self-review
+
+- **Every build is measured before the director sees it**, and every outlier is
+  either fixed or written down with a reason. An outlier here means a shot
+  whose offset or duration falls outside what this profile claims — which is
+  only possible because the claims above are numbers, not adjectives.
+  `[director]` — spec #22, story 47.

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -41,8 +41,9 @@ that the grid is a live band's grid, so it moves.
 
 - Duration distributions conditioned on section type and energy band. *Open;
   see `corpus.md`.*
-- The variation instinct and "spectacle earns a hold" are base claims and apply
-  here unchanged.
+- The variation instinct and "spectacle earns a hold" are base claims, and a
+  concert changes nothing about them — they carry their tags in `base.md` and
+  are named here only so this section is not read as silent on them.
 - Whether shots shorten through a solo's build and lengthen through a head.
   *Open.*
 

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -18,7 +18,7 @@ recency breaks ties).
 
 | # | Project | Timeline(s) | Context | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `2026-06_Zinc_and_Monkfish` | Zinc - Set 2 Main | concert | not started | **Anchor** — strongest current-taste exemplar; two-camera, 2026 |
+| 1 | `2026-06_Zinc_and_Monkfish` | Zinc - Set 2 Main | concert | **measured, unlabelled** | **Anchor** — strongest current-taste exemplar; two-camera, 2026 |
 | 2 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Freefall Timeline, Sunshine Timeline, Mercies Timeline | concert | not started | Canonical snapshot for Ryan and Hang; music-performance cuts only |
 | 3 | `Mike Tucker Scullers` | Concert Full Cut | concert | not started | Good two-camera concert; older, so recency weighting applies |
 | 4 | `Archive/Client/Ryan Devlin Projects Current` | Stablemates | concert | not started | Older but explicitly taste-endorsed |
@@ -78,4 +78,38 @@ the right one.
 
 | # | Timeline | Context | Cuts | Alignment | Sidecar | Result |
 | --- | --- | --- | --- | --- | --- | --- |
-| _(none yet)_ | | | | | | |
+| 1 | Zinc - Set 2 Main | concert | 366 (360 measured, 6 openings) | `audio_clip`, matched | `angles/2026-06_Zinc_and_Monkfish.json` (unconfirmed) | `…/analysis/Zinc---Set-2-Main-dcb16e19eca1.correlate.json` |
+
+**Entry 1, measured 2026-08-06.** Against `Zinc Set 2 Reaper v4.wav` (74:10,
+48 kHz, the Reaper master mix on A3), beats from `analyze_music` (11,130 beats,
+4,831 downbeats). Two angles, both multicam: Video 1 holds 188 cuts and 68.5%
+of screen time (13.8 s a shot), Video 2 holds 178 cuts and 31.5% (6.7 s a
+shot) — a home angle held long against an angle cut to briefly.
+
+Labelled from frame grabs off the multicam's source clips: an operated
+front-of-house **wide** on the FX6, and a locked-off **drummer cam** on the
+A7IV at stage right. **Which angle number is which camera is inferred, not
+read** — Resolve's API does not expose the multicam's angle mapping, so the
+sidecar assigns the wide to Video 1 from the screen-time shape and marks both
+`confidence: "low"`. One look at the timeline settles it; until then every
+role-conditioned claim is unverified.
+
+| Measure | Value |
+| --- | --- |
+| Offset to nearest transient | median 33 ms, mean 46 ms, max 345 ms; 195 early / 163 late / 2 on |
+| Offset to nearest beat | median 88 ms, mean 1.31 s, max 43.5 s; 194 early / 165 late / 1 on |
+| Shot length | median 7.26 s, mean 10.39 s, min 0.46 s, max 71.07 s |
+| Bar position | 1:171, 2:111, 3:44, 4:30, 5:2, 6:2 — **not usable, see below** |
+
+Two cautions on this row:
+
+- **The beat grid does not fit this music.** `analyze_music` reported
+  `tempo_bpm: 214.29` with `meter: 1` over a jazz set, and the beat-offset mean
+  (1.31 s) sits fifteen times its own median (88 ms) — a grid that fits in
+  places and wanders in others. The bar-position histogram is derived from that
+  grid, so it says nothing yet, and the beat-offset numbers are worth much less
+  than the transient ones. This is the rubato gating #13 calls for, not yet
+  applied.
+- **The transient numbers do not depend on the grid.** Onsets are measured off
+  the mix directly, which is why they are the row's trustworthy half — and
+  they are also the half the profile's core principle is about.

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -1,0 +1,81 @@
+# The style corpus
+
+Which timelines the profiles are learned from, in what order, and how far each
+one got. Every `[measured — …]` tag in `base.md` or `concert.md` points back
+here; a claim whose evidence is not in the measured table is not measured,
+whatever its tag says.
+
+The selection is settled in **#21** — it is the director's call, not an
+inference from project names, and it is closed: *"judged sufficient for v1 — no
+further corpus hunting."* The list below is that decision in working form.
+
+The corpus is **ordered**. First entries get labelled and measured first and
+seed the profile's first draft, and where old and new work disagree the profile
+resolves toward the recent (#21 policy 2 — taste beats recency for membership,
+recency breaks ties).
+
+## The list
+
+| # | Project | Timeline(s) | Context | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `2026-06_Zinc_and_Monkfish` | Zinc - Set 2 Main | concert | not started | **Anchor** — strongest current-taste exemplar; two-camera, 2026 |
+| 2 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Freefall Timeline, Sunshine Timeline, Mercies Timeline | concert | not started | Canonical snapshot for Ryan and Hang; music-performance cuts only |
+| 3 | `Mike Tucker Scullers` | Concert Full Cut | concert | not started | Good two-camera concert; older, so recency weighting applies |
+| 4 | `Archive/Client/Ryan Devlin Projects Current` | Stablemates | concert | not started | Older but explicitly taste-endorsed |
+| 5 | `2026-06_Zinc_and_Monkfish` | Monkfish Main | concert | not started | **Partial** — only a couple of tunes cut; measure those tunes only |
+| 6 | `Archive/Client/Side Step Blues Clues Album` | Blues Clues Main, Devlin Time Main, For All The Other Times Main, Intro Main, Outro Main, People We Love Main, Walk Spirit Talk Spirit Main, EJ's Blues Main | studio-session | not started | Multi-camera studio album shoot — a distinct cutting context |
+| 7 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Blues for Alice timeline, Three Card Molly timeline | concert | conditional | Include **only if** pre-flight shows 2+ cameras; suspected single-camera |
+
+~7 concert-context timelines + 8 studio-session timelines. Full-set timelines
+carry many tunes, so per-cut counts run into the hundreds.
+
+## Excluded, and why
+
+- **Jaded Symphony - The Sinclair** — colour grade only; the cutting is not the
+  director's.
+- **6-17-18 Zinc Bar and Monkfish** — mislabelled copy of
+  `2026-06_Zinc_and_Monkfish`; ignore entirely.
+- **Five Spot January 2025**, **Zinc Bar August 2025 import**, **Judson's Album
+  Promo** — single-camera.
+- **Aberdeen and Everything Yes at Rockwood Boston** — audience clips, not a
+  concert cut.
+- All Ryan and Hang podcast / interview / reel / promo timelines — out of
+  corpus.
+- Duplicate Ryan and Hang snapshots (Main in 4-30-24, 5-17-24 Backup, and
+  Ryan Devlin Projects Current for overlapping timelines) — one canonical
+  source per timeline, no double-counting.
+
+**Single-camera timelines leave the corpus at labelling time without a
+re-decision** (#21 policy 1): angle-switch behaviour is the core signal, so a
+timeline that turns out to have one camera simply drops out.
+
+## Pre-flight, per project
+
+Run when the project is opened, because offline `Project.db` inspection can
+enumerate timelines but not media paths — path data lives in blobs, so link
+status is only verifiable live through the scripting API.
+
+- [ ] Media linked — spot-check `GetClipProperty("File Path")` on timeline
+      clips; relink if archived media moved. Everything under `Archive/Client`
+      is a likely relink candidate; entries 1 and 5 are recent and expected
+      clean.
+- [ ] 2+ source angles — gates the conditional entry, and drops any timeline
+      that turns out single-camera.
+- [ ] Concert / master audio reachable for the analysis pipeline (#19).
+- [ ] Frame grabs render and the sidecar can be written (#13).
+
+## Measured
+
+One row per timeline, appended in order, never rewritten: a rerun that
+disagrees with an earlier row gets its own row and a note, because the
+disagreement is itself evidence.
+
+`alignment` is `correlate_timeline`'s reading of where the times were measured
+from. **`timeline_start` rows are excluded from every timing claim** — those
+times count from the timeline's own first frame rather than from the mix, and a
+file measured against the wrong zero looks exactly like a file measured against
+the right one.
+
+| # | Timeline | Context | Cuts | Alignment | Sidecar | Result |
+| --- | --- | --- | --- | --- | --- | --- |
+| _(none yet)_ | | | | | | |

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -75,6 +75,27 @@ def _shot(name: str, start: int, duration: int, source_start: int) -> FakeTimeli
     )
 
 
+def _a_cut_with(extra: FakeTimelineItem) -> FakeTimeline:
+    """The fixture cut with one more item on the cut track — a transition, or a generator."""
+    return FakeTimeline(
+        "sunset-set v3",
+        FPS,
+        start_frame=100,
+        video=[FakeTrack("Video 1", [_shot(*shot) for shot in SHOTS] + [extra])],
+        audio=[FakeTrack("Master", [_shot("master_mix.wav", 100, 200, 0)])],
+    )
+
+
+def _angle(name: str, start: int, duration: int, source_start: int, clip: Any) -> FakeTimelineItem:
+    """One shot of a multicam: its own name is the angle, its pool item is shared."""
+    return FakeTimelineItem(name, start, duration, source_start=source_start, media_item=clip)
+
+
+def _dissolve(start: int, duration: int) -> FakeTimelineItem:
+    """A transition as Resolve hands it back: no pool item, and it overlaps both neighbours."""
+    return FakeTimelineItem("Cross Dissolve", start, duration)
+
+
 def beats_file(tmp_path: Path, seconds: Sequence[float] = BEAT_SECONDS) -> Path:
     """A beats file in the shape analyze_music writes: header, then one record per line.
 
@@ -280,6 +301,93 @@ def test_an_entry_with_no_role_in_it_is_dropped_rather_than_refused(
     result = _measured(tmp_path, angles={"C0012.mp4": {"subject": "the room"}})
 
     assert result["roles"] is None
+
+
+def test_a_dissolve_is_not_a_shot(attach: Attach, tmp_path: Path) -> None:
+    """Resolve hands transitions back in the item list, sitting across the cut they soften.
+
+    Live on the corpus anchor (#45) that was 159 of them in 525 items. Counted as shots
+    they would add a cut the editor never made — half a transition early — and a run of
+    identical short durations to the shot stats.
+    """
+    attach(studio(timeline=_a_cut_with(_dissolve(start=155, duration=14))))
+
+    result = _measured(tmp_path)
+
+    assert [one["clip"] for one in _rows(result)] == ["C0012.mp4", "C0031.mp4", "C0012.mp4"]
+    assert result["cuts"] == 3
+
+
+def test_a_generator_on_the_cut_track_is_still_a_shot(attach: Attach, tmp_path: Path) -> None:
+    """The transition test is overlap, not the absence of a pool item — a generator has none."""
+    slate = FakeTimelineItem("Solid Color", 299, 30, source_start=0)
+    attach(studio(timeline=_a_cut_with(slate)))
+
+    result = _measured(tmp_path)
+
+    assert [one["clip"] for one in _rows(result)][-1] == "Solid Color"
+    assert result["cuts"] == 4
+
+
+def test_each_multicam_angle_is_its_own_clip(attach: Attach, tmp_path: Path) -> None:
+    """Every angle of a multicam shares one pool item, so the pool name is not the angle.
+
+    Live on the corpus anchor (#45): both cameras answered "Zinc - Set 2 Multicam", which
+    reads as an hour of concert with no angle switch in it — the one signal the corpus is
+    measured for (#21).
+    """
+    multicam = FakeMediaPoolItem("Zinc - Set 2 Multicam", properties={"Type": "Multicam"})
+    angles = FakeTimeline(
+        "zinc v1",
+        FPS,
+        start_frame=100,
+        video=[
+            FakeTrack(
+                "Video 1",
+                [
+                    _angle("Zinc - Set 2 Multicam - Video 1", 100, 62, 1000, multicam),
+                    _angle("Zinc - Set 2 Multicam - Video 2", 162, 87, 4200, multicam),
+                ],
+            )
+        ],
+        audio=[FakeTrack("Master", [_shot("master_mix.wav", 100, 200, 0)])],
+    )
+    attach(studio(timeline=angles))
+
+    result = _measured(tmp_path)
+
+    assert set(result["clips"]) == {
+        "Zinc - Set 2 Multicam - Video 1",
+        "Zinc - Set 2 Multicam - Video 2",
+    }
+
+
+def test_a_multicam_angle_can_be_labelled_in_the_sidecar(attach: Attach, tmp_path: Path) -> None:
+    """Which is the point of telling them apart: the sidecar keys on what the shot answers."""
+    multicam = FakeMediaPoolItem("Zinc - Set 2 Multicam", properties={"Type": "Multicam"})
+    angles = FakeTimeline(
+        "zinc v1",
+        FPS,
+        start_frame=100,
+        video=[
+            FakeTrack(
+                "Video 1",
+                [
+                    _angle("Zinc - Set 2 Multicam - Video 1", 100, 62, 1000, multicam),
+                    _angle("Zinc - Set 2 Multicam - Video 2", 162, 87, 4200, multicam),
+                ],
+            )
+        ],
+        audio=[FakeTrack("Master", [_shot("master_mix.wav", 100, 200, 0)])],
+    )
+    attach(studio(timeline=angles))
+
+    result = _measured(
+        tmp_path, angles={"Zinc - Set 2 Multicam - Video 2": {"role": "drums-tight"}}
+    )
+
+    assert result["roles"]["drums-tight"]["cuts"] == 1
+    assert result["roles"]["unlabelled"]["cuts"] == 1
 
 
 def test_shots_are_counted_per_clip_even_without_a_sidecar(

--- a/tests/test_style_layer.py
+++ b/tests/test_style_layer.py
@@ -23,17 +23,26 @@ from resolve_mcp.config import Config
 from resolve_mcp.errors import InvalidRequestError
 from resolve_mcp.resolve.connection import get_connection
 
+from .conftest import Attach
+from .fakes import studio
+
 SOURCE = Path(__file__).resolve().parent.parent / "src" / "resolve_mcp"
 
 STYLE_LAYER = re.compile(
     r"""
-      \bstyles [/\\]            # the directory itself, in a path
-    | \bsidecars? [/\\]         # or a sidecar named as one
-    | (?:base|concert) \.md     # or a profile by name
+      \bstyles [/\\]      # the directory itself, in a path
+    | \bsidecars? [/\\]   # or a sidecar directory named as one
     """,
     re.VERBOSE | re.IGNORECASE,
 )
-"""What reading or writing the style layer would have to look like in source."""
+"""What reading or writing the style layer would have to look like in source.
+
+Deliberately a path shape rather than a profile's name: ``concert.md`` on its own
+appears in prose about the style layer, and prose about it is exactly what the modules
+here *should* carry — the docstrings in ``analysis/correlate.py`` explain why the sidecar
+is the agent's document. Matching a separator is what tells naming a path apart from
+naming an idea.
+"""
 
 STYLE_LAYER_WORDS = re.compile(r"style[_ ]?profile|sidecar|angle[_ ]?label", re.IGNORECASE)
 """The vocabulary — allowed in prose, never in the name of a directory the server owns."""
@@ -84,8 +93,10 @@ def test_config_grew_no_directory_this_test_does_not_know_about(tmp_path: Path) 
     assert found == set(DIRECTORIES)
 
 
-def test_correlate_timeline_refuses_a_sidecar_path_as_angles() -> None:
+def test_correlate_timeline_refuses_a_sidecar_path_as_angles(attach: Attach) -> None:
     """angles is labels already lifted out of the sidecar, never the sidecar to go and read."""
+    attach(studio())
+
     with pytest.raises(InvalidRequestError) as raised:
         correlate.correlate_timeline(
             get_connection(),

--- a/tests/test_style_layer.py
+++ b/tests/test_style_layer.py
@@ -1,0 +1,96 @@
+"""The style layer is the agent's, not the server's.
+
+Story 59 of spec #22: the server never writes the director's cut files, style profiles or
+angle sidecars. The profiles and sidecars are the half of that promise nothing else tests,
+because the way it would break is not a failing assertion somewhere — it is a helpful
+convenience landing in ``src/`` one day that reads ``styles/concert.md`` "just to check",
+and from then on taste is server behaviour.
+
+So this reads the source: no module names the style layer, no directory the server writes
+to is inside it, and the one tool that consumes angle labels takes them as a mapping the
+caller already lifted out of its own document rather than as a file it opens.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.analysis import correlate
+from resolve_mcp.config import Config
+from resolve_mcp.errors import InvalidRequestError
+from resolve_mcp.resolve.connection import get_connection
+
+SOURCE = Path(__file__).resolve().parent.parent / "src" / "resolve_mcp"
+
+STYLE_LAYER = re.compile(
+    r"""
+      \bstyles [/\\]            # the directory itself, in a path
+    | \bsidecars? [/\\]         # or a sidecar named as one
+    | (?:base|concert) \.md     # or a profile by name
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+"""What reading or writing the style layer would have to look like in source."""
+
+STYLE_LAYER_WORDS = re.compile(r"style[_ ]?profile|sidecar|angle[_ ]?label", re.IGNORECASE)
+"""The vocabulary — allowed in prose, never in the name of a directory the server owns."""
+
+SOURCE_FILES = sorted(SOURCE.rglob("*.py"))
+
+DIRECTORIES = (
+    "cache_dir",
+    "snapshot_dir",
+    "listing_dir",
+    "job_dir",
+    "result_dir",
+    "audio_dir",
+    "stems_dir",
+    "frame_dir",
+    "analysis_dir",
+    "render_dir",
+    "interchange_dir",
+)
+"""Every directory the server writes into, by the name Config gives it."""
+
+
+def test_the_source_tree_is_there_to_be_scanned() -> None:
+    """A scan over nothing passes loudly, so the corpus of files is asserted first."""
+    assert len(SOURCE_FILES) > 20
+
+
+@pytest.mark.parametrize("path", SOURCE_FILES, ids=lambda path: path.name)
+def test_no_module_names_the_style_layer(path: Path) -> None:
+    """No server module reaches for a profile or a sidecar by path."""
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        assert not STYLE_LAYER.search(line), f"{path.name}:{number} names the style layer: {line!r}"
+
+
+def test_no_directory_the_server_writes_to_is_the_style_layer(tmp_path: Path) -> None:
+    """Config is the whole list of places the server writes; none of them is ``styles/``."""
+    config = Config.from_env({"RESOLVE_MCP_CACHE": str(tmp_path)})
+    for name in DIRECTORIES:
+        directory = str(getattr(config, name))
+        assert not STYLE_LAYER.search(directory), f"config.{name} is inside the style layer"
+        assert not STYLE_LAYER_WORDS.search(directory), f"config.{name} names the style layer"
+
+
+def test_config_grew_no_directory_this_test_does_not_know_about(tmp_path: Path) -> None:
+    """The list above is only a guard while it is the whole list."""
+    config = Config.from_env({"RESOLVE_MCP_CACHE": str(tmp_path)})
+    found = {name for name in dir(config) if name.endswith("_dir")}
+    assert found == set(DIRECTORIES)
+
+
+def test_correlate_timeline_refuses_a_sidecar_path_as_angles() -> None:
+    """angles is labels already lifted out of the sidecar, never the sidecar to go and read."""
+    with pytest.raises(InvalidRequestError) as raised:
+        correlate.correlate_timeline(
+            get_connection(),
+            beats="beats.json",
+            angles="styles/angles/sunset-set.json",  # type: ignore[arg-type]
+        )
+
+    assert "mapping" in raised.value.cause


### PR DESCRIPTION
Part of #45. **The ticket is not finished — this is the first corpus entry of seven, plus the fixes that had to land before any entry meant anything.** #45 stays open.

## Which seam verifies this

- **Fake tier** — the two `correlate_timeline` fixes, and the style-layer guard (`tests/test_style_layer.py`: no module under `src/` names a profile or sidecar path, no `Config` directory sits inside `styles/`, `angles` still refuses a path). AC4 verifies entirely here.
- **Live tier, run this session** on the Windows box with Resolve Studio 21 open on `2026-06_Zinc_and_Monkfish`: pre-flight, the shot reader against the real anchor timeline, `analyze_music` over the 74-minute Reaper master mix, `grab_frames` on the multicam source clips, and two `correlate_timeline` passes (with and without the sidecar). Results in `styles/corpus.md`.
- **Prose** — the profiles and `docs/agents/style-layer.md`.

## What this delivers

`styles/` — the style layer #13 settled: `base.md` + `concert.md` (layered, every claim provenance-tagged), `corpus.md` (the measurement record), and `angles/<project>.json` (the sidecar format). `docs/agents/style-layer.md` pins the formats and the corpus-pass procedure. The corpus list itself is #21's decision transcribed, not re-derived.

Corpus entry 1 (the anchor, `Zinc - Set 2 Main`) measured and labelled: 366 cuts, alignment `audio_clip`/matched, **median cut 33 ms from the nearest transient, 2 of 360 landing on one**, shots median 7.3 s out to a 71 s hold, wide 68.5% of screen time against the drummer cam's 31.5%.

## Two defects this found in #40's code

Pointing `correlate_timeline` at a real corpus timeline broke it in two ways the fakes never could. Both are fixed here rather than filed, because AC2 is meaningless while either stands — a corpus measured with them is worse than no corpus, since it looks fine.

1. **Transitions counted as shots.** `GetItemListInTrack` returns dissolves as items straddling the cut they soften — 159 of them in 525 items on the anchor. Each became a cut the editor never made, half a transition early, plus a run of identical short durations in the shot stats. Filtered on track overlap (two items cannot overlap on one video track), so a generator — which also has no media pool item — is still a shot.
2. **Multicam angles collapsed into one name.** Every angle shares one media pool item, so `clip_name` answered `Zinc - Set 2 Multicam` for both cameras: an hour of concert with no angle switch in it, which is the one signal #21 calls core. `angle_name()` answers the timeline item's name for a multicam shot and keeps the pool name otherwise.

Live check after the fix: 366 shots, zero overlaps, cameras 188/178.

## Review

`/code-review` on the branch before this PR existed — Standards and Spec as parallel sub-agents.

**Standards — 3 hard, 5 judgement calls.**

- *CONTEXT.md carried a provenance vocabulary contradicting #13* (`[director]`, which exists nowhere else; no `[stated principle]`). **Fixed** — it quotes #13's four tags.
- *`docs/agents/style-layer.md` unregistered in CLAUDE.md*, where every other `docs/agents/*.md` has a subsection. **Fixed.**
- *`concert.md` had one untagged claim*, against the rule the file itself states. **Fixed** — reworded as a plain pointer at `base.md`.
- *Duplicated code: `angle_name` repeated `clip_name`'s body.* **Fixed** — delegates.
- *The guard test is a text lint that would fail on legitimate prose* (`concert.md` anywhere in a source line). **Fixed** — it now requires a path separator, so naming a path is caught and naming an idea is not.
- *A guard test bypassed the seam*, using `get_connection()` rather than the `attach` fixture; green only because `_roles()` runs before the timeline read. **Fixed.**
- *`_without_transitions(shots, track)` takes `track` only for the log line.* **Kept** — CLAUDE.md wants a line for every live lifecycle event, and which track it was is the diagnostic.
- *Bare `"Start"` literal in `_media_start` beside the new named constants.* **Not taken** — untouched pre-existing code, out of this diff's scope.

**Spec — 3 partial, 1 scope question, 3 correctness.**

- *AC1 partial* — one sidecar of six projects. **Accepted and stated**: the anchor is labelled, the rest is the remaining corpus pass.
- *AC2 partial* — one timeline of ~15. **Accepted and stated.**
- *AC3 — untagged claims.* One real (fixed above); the reviewer's second citation (`base.md` "Emphasis is the exception") was already tagged.
- *Scope: `correlate.py`/`timeline.py` are #40's code.* Reviewer judged it justified; called out in its own section above rather than buried.
- *CONTEXT.md's wrong tag vocabulary* — same finding as Standards, fixed once.
- *Character axis (`wide`/`tight`/`moving`) matches #13* — confirmed correct.
- *Sidecar location deviates from #13's "lives with the project, not the style doc".* **Interpretation stated rather than silently taken**: read as one file per project, kept out of the profile — not a file on the media drive, which would be outside version control and, for archived projects, on whichever drive that project was archived to. Written into `docs/agents/style-layer.md`; flagged on the ticket for the director, and only that path changes if the answer is different.

Re-checked the fix diff only. Fake tier green, `mypy --strict` clean over 150 files, `ruff check` clean.

Review: clean

---

## Second pass — director's answers, entries 2 and 3, two more defects

Commits `2568fda`, `e8af22c`, `7cf9813`, `4361bf8`, `01b9580`.

### Which seam verifies this

- **Fake tier** — both `correlate_timeline` fixes, TDD'd: `test_a_dissolve_that_starts_on_the_cut_takes_no_shot_with_it`, `test_a_dissolve_into_a_generator_does_not_eat_the_generator`, `test_saying_where_the_mix_starts_beats_reading_it_off_a_clip_that_is_not_it`.
- **Live, run this session** — pre-flight, labelling and measurement of four more timelines across two more projects; and after the review's rule change, a re-read of all five measured timelines confirming identical shot counts, zero overlaps and zero surviving transitions.
- **Prose** — corpus rows, profile claims, `docs/agents/style-layer.md`.

### The director's answers, recorded

Zinc Set 2's angle mapping is **confirmed** (Video 1 = FX6 wide, Video 2 = A7IV drummer cam); sidecars stay at `styles/angles/<project>.json`; long corpus passes are fine to run. The corpus narrowed: Stablemates reads from the entry-2 project, Blues for Alice and Three Card Molly are confirmed single-camera and dropped under #21 policy 1, Side Step is deferred (footage not on the box, and studio-session is a different cutting context).

### Two more defects the corpus found

1. **A second dissolve shape.** Dissolves are sometimes centred on the cut and sometimes aligned to the incoming shot. The adjacency rule caught the first and kept the second — then dropped the *real* shot behind it, since that is the item which overlaps. Sunshine swapped 2 shots for 2 dissolves, Mercies 6 for 6, **and the cut count stayed exactly right**. A miscount announces itself; a swap does not.
2. **Audio that is not on the timeline.** These cuts get their music through the multicam's own audio angle, so no clip *is* the mastered mix and every existing alignment mode was guessing — invisibly, with every time shifted by the same amount. Measured against entry 2's own A1 the error would have been 15 s on one tune and 40 s on another. `correlate_timeline` now takes `audio_at`; a full-timeline render makes the frame knowable rather than guessed (durations matched to within 0.02 s, under a frame).

### What was measured

Entries 2 and 3: four timelines, 481 more cuts, two more projects. **The transient claim now replicates across three projects** — median cut 17–34 ms from the nearest transient on all five timelines, three rooms, four years apart — and is the first thing in the profile to carry `[measured — …]`.

**Entry 2 corrected a claim rather than confirming it.** The anchor's "the wide is the home angle" (68.5%) does not survive contact with a project that has a roaming operator: there the wide holds 14–17% and the roaming camera 74–76%. Exactly what #21 policy 4 exists to catch.

Ten angles labelled at confidence high by **reading the render** — a frame of the finished cut at a moment an angle is on screen *is* that angle — which removes the inference that made the anchor need a director's eye. Method and its safety check are in `docs/agents/style-layer.md`.

### Review — 7 findings, all taken

`/code-review` on `2568fda..HEAD`, Standards and Spec as parallel sub-agents.

- *`_without_transitions` could still swap a generator for a dissolve into it* — neither has a pool item, so "overlaps something real" cannot separate them. **Fixed**, and the first attempt (overlap with anything) was wrong too: it dropped both. The rule is now **coverage** — a shot holds some track exclusively, a transition never does. Re-verified live on all five timelines: identical counts.
- *`concert.md` §6 contradicted its own tags*, still claiming one entry measured. **Fixed.**
- *New tags dropped the `n=` and context the format requires*, so a 43-cut claim read like a 360-cut one. **Fixed** on all seven.
- *The "not the wide" claim overreached.* The anchor's home angle is its wide **and** its operated camera, so it cannot tell the two readings apart — the evidence is entry 2 alone. **Downgraded** to `[believed, unverified]` with the reason written out.
- *Two result paths were globs*, which cannot be resolved back to the run that produced them. **Fixed** with the real cache keys.
- *`given` alignment reported `matched: true` with no audio named.* **Fixed** — nothing to have recognised.
- *`GetMediaPoolItem` fetched three times per item* (~1575 round trips on the anchor) inside the pass that exists to be single. **Fixed** — `angle_of` takes the clip the caller already holds.

Fake tier green, `mypy --strict` clean over 150 files, `ruff check` clean.

### Not done, and filed rather than fixed here

**#110** — `analyze_music` refuses 32-bit float WAVs (entry 3's master is one), and its `fix` line tells the caller to delete the file, which is the director's own master on a media drive. Worked around by transcoding to PCM with duration preserved to the sample, rather than growing this ticket's code scope a third time.

Review: clean
