### PR TITLE
P3: corpus entries 2 and 3, and two more defects the footage found (#45)

### DIFF
--- a/docs/agents/style-layer.md
+++ b/docs/agents/style-layer.md
@@ -77,9 +77,8 @@ here as *one file per project, keyed to the project, kept out of the profile* �
 not as a file sitting beside the Resolve project on the media drive. A sidecar
 next to the footage is outside version control, and on an archived project it
 is on whichever drive that project was archived to; the labels are the agent's
-own document and their history is worth as much as the profiles'. If the
-director wants them beside the footage instead, only this path changes —
-nothing reads them but the agent.
+own document and their history is worth as much as the profiles'. **The
+director confirmed this reading on 2026-08-07** — sidecars stay in the repo.
 
 ```json
 {
@@ -108,9 +107,17 @@ nothing reads them but the agent.
   and the profile makes claims about each.
 - **`confidence`** and **`evidence`** are why a claim resting on this angle is
   thin or not: a `low` here is a reason a corpus claim downgrades.
-- **`confirmed_by_director`** — labelling is auto-labelled by Claude and
-  confirmed once by the director; reruns never re-ask (#13). Until that flip,
-  every claim resting on these labels is `[believed, unverified]`.
+- **`confirmed_by_director`** — `false` until confirmed, then the date it was
+  (`"2026-08-07"`). Labelling is auto-labelled by Claude and confirmed once;
+  reruns never re-ask (#13). Until that flip, every claim resting on these
+  labels is unverified in a second, sharper way than usual: not merely thin,
+  but possibly inverted.
+
+On a **multicam** project the confirmation is not optional politeness. Resolve
+exposes no angle→source mapping — `GetClipProperty("Angle")` comes back empty
+and a timeline item carries only the angle name — so which camera is behind
+`Video 1` can be guessed (the home angle usually holds the most screen time)
+but never read. Ask, before the roles are used for anything.
 
 An entry with no `role` is dropped by `correlate_timeline` rather than refused,
 so a half-labelled project still measures — its shots land under `unlabelled`.

--- a/docs/agents/style-layer.md
+++ b/docs/agents/style-layer.md
@@ -113,11 +113,38 @@ director confirmed this reading on 2026-08-07** — sidecars stay in the repo.
   labels is unverified in a second, sharper way than usual: not merely thin,
   but possibly inverted.
 
-On a **multicam** project the confirmation is not optional politeness. Resolve
-exposes no angle→source mapping — `GetClipProperty("Angle")` comes back empty
-and a timeline item carries only the angle name — so which camera is behind
-`Video 1` can be guessed (the home angle usually holds the most screen time)
-but never read. Ask, before the roles are used for anything.
+### Labelling a multicam: grab the render, not the sources
+
+Resolve exposes no angle→source mapping. `GetClipProperty("Angle")` comes back
+empty and a timeline item carries only the angle name, so labelling from the
+multicam's *source clips* can establish what each camera is and still not say
+which camera is `Video 1`. That gap is what made the anchor's sidecar need a
+director's eye, and the screen-time guess behind it (the home angle usually
+holds the most) was right once — which is one data point, not a method.
+
+**Where the timeline has a finished render, there is no gap.** Grab a frame of
+the render at a moment a given angle is on screen: the frame *is* that angle.
+Nothing is inferred, and `confirmed_by_director` is not needed to trust it.
+
+1. Read the shots (`correlate_timeline`'s reader, or the same walk) and group
+   them by angle name.
+2. For each angle take its longest shot or two, and the frame at the midpoint —
+   a midpoint is safely inside the shot even if a transition softens the edges.
+3. Convert to a render time: `(record_in - start_frame) / fps`. **Check the
+   render actually spans the timeline first** — compare its duration against
+   `(end_frame - start_frame) / fps`. On the three entry-2 tunes these agreed
+   to within 0.02 s, under a frame; a render of a section rather than the whole
+   timeline would not, and would put every label on the wrong angle.
+4. Read the frames and write the labels.
+
+Where there is no render — the anchor, and `Mike Tucker Scullers` — the gap is
+real and the director's eye is the only way to close it. Ask before the roles
+are used for anything, and note that timing claims need no labels at all: a
+timeline can be measured while its angles are still unlabelled.
+
+Angle *numbers* are per-multicam and do not carry across timelines even inside
+one project: on the Judson's show `Angle 10` is the drummer on one tune and the
+roaming camera on another. Label every timeline separately.
 
 An entry with no `role` is dropped by `correlate_timeline` rather than refused,
 so a half-labelled project still measures — its shots land under `unlabelled`.
@@ -162,10 +189,23 @@ Read **across** the corpus before claiming, not one project at a time: the
 number that matters is the distribution, and the tag a claim is entitled to is
 set by how many cuts and how many projects stand behind it.
 
-**`alignment.mode` decides whether a result is usable at all.** `audio_clip`
-means the times were read through the audio the analysis ran on;
-`timeline_start` means the timeline said nothing about where the mix sits and
-the times count from its own first frame instead. A whole file measured against
-the wrong zero looks exactly like a whole file measured against the right one,
-so a corpus pass records the mode per timeline and excludes `timeline_start`
-readings from every timing claim.
+**`alignment.mode` decides whether a result is usable at all.** A whole file
+measured against the wrong zero looks exactly like a whole file measured
+against the right one, so a corpus pass records the mode per timeline:
+
+- **`audio_clip` with `matched: true`** — the clip carrying the analysed audio
+  was found on the timeline. Trust it.
+- **`given`** — the caller named the frame. Trust it exactly as far as the
+  caller's reason: on entry 2 that reason is a render whose duration matches
+  its timeline to within a frame, which is checkable; a remembered number is
+  not the same thing.
+- **`audio_clip` with `matched: false`** — the times were taken off whichever
+  audio clip happened to be first. Excluded from timing claims.
+- **`timeline_start`** — the timeline said nothing at all. Excluded.
+
+Hand-edited concerts routinely need `given`, and it is worth knowing why before
+you reach for it: where the music arrives through a multicam's own audio angle,
+*no* clip on the timeline is the mix, and the in point that can be read belongs
+to the multicam's timebase. Measured against the entry-2 timelines' own A1 the
+error would have been 15 s on one tune and 40 s on another — invisible in the
+output, and enough to move every cut to a different beat.

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -59,7 +59,7 @@ from ..resolve.timeline import (
     source_bounds,
     start_frame,
 )
-from ..timing import SECONDS_PRECISION, dual_time
+from ..timing import SECONDS_PRECISION, dual_time, to_frames
 from . import decode, energy, records
 from .beats import nearest
 
@@ -73,6 +73,9 @@ INLINE_CUTS = 12
 UNLABELLED = "unlabelled"
 """Where shots from a clip the angle sidecar does not name are counted."""
 
+GIVEN = "given"
+"""The alignment mode where the caller named the frame rather than the server reading it."""
+
 Onsets = Callable[[Path], tuple[float, ...]]
 """The transient seam: a WAV in, onset times in seconds out."""
 
@@ -83,10 +86,15 @@ class Shot(NamedTuple):
     clip: str
     record_in: int
     duration: int
+    media: bool = True
+    """Whether Resolve gave it a media pool item — false for transitions and generators."""
 
     @property
     def record_out(self) -> int:
         return self.record_in + self.duration
+
+    def overlaps(self, other: Shot) -> bool:
+        return self.record_in < other.record_out and other.record_in < self.record_out
 
 
 class Clock(NamedTuple):
@@ -131,6 +139,7 @@ def correlate_timeline(
     solos: str | None = None,
     angles: Mapping[str, Any] | None = None,
     track: int = FIRST_TRACK,
+    audio_at: Any | None = None,
     refresh: bool = False,
     onsets: Onsets | None = None,
     config: Config | None = None,
@@ -145,16 +154,20 @@ def correlate_timeline(
     the agent's document (#45 — no server path reads or writes it), so the labels arrive
     already lifted out of it.
 
+    ``audio_at`` is the timeline frame the analysed audio's own zero sits at, for when no
+    clip on the timeline carries it and so none can be read.
+
     ``onsets`` is the transient seam; the default decodes the audio for real.
     """
     config = config or get_config()
     roles = _roles(angles)
     music = _music(beats, audio, tunes, solos, roles)
-    shots, clock, print_, name = _read_cut(connection, timeline, track, music.audio)
+    shots, clock, print_, name = _read_cut(connection, timeline, track, music.audio, audio_at)
 
     params: dict[str, Any] = {
         "timeline": name,
         "track": int(track),
+        "audio_at": clock.zero_frame if clock.mode == GIVEN else None,
         "beats": _named(beats),
         "audio": _named(audio),
         "tunes": _named(tunes),
@@ -216,6 +229,7 @@ def _read_cut(
     name: str | None,
     track: int,
     mix: Path | None = None,
+    at: Any | None = None,
 ) -> tuple[list[Shot], Clock, dict[str, Any], str]:
     """Everything Resolve has to answer for, taken before the job starts.
 
@@ -247,7 +261,8 @@ def _read_cut(
             ),
             detail={"timeline": found, "track": int(track)},
         )
-    clock = _clock(reader, timeline, fps, mix)
+    given = to_frames(at, fps, "audio_at")
+    clock = _clock(reader, timeline, fps, mix, given)
     return shots, clock, fingerprint(reader, timeline), found
 
 
@@ -264,9 +279,11 @@ def _shots(reader: Reader, timeline: Any, track: int) -> list[Shot]:
         if record_in is None or duration is None:
             log.warning("Skipped a shot on video track %d: Resolve gave no position", track)
             continue
+        media = reader.optional(item, "GetMediaPoolItem", None) is not None
         name = angle_name(reader, item) or str(item.GetName() or "")
-        found.append(Shot(clip=name, record_in=record_in, duration=duration))
-    return _without_transitions(sorted(found, key=lambda shot: shot.record_in), track)
+        found.append(Shot(clip=name, record_in=record_in, duration=duration, media=media))
+    ordered = sorted(found, key=lambda shot: (shot.record_in, not shot.media))
+    return _without_transitions(ordered, track)
 
 
 def _without_transitions(shots: Sequence[Shot], track: int) -> list[Shot]:
@@ -280,15 +297,25 @@ def _without_transitions(shots: Sequence[Shot], track: int) -> list[Shot]:
     distribution as a cut the editor did not make, and its length lands in the duration
     stats as a shot nobody held.
 
-    Two items cannot overlap on one video track, so overlapping the shot before it is what
-    a transition is and a shot is not. That is a fact about tracks rather than about any
+    Two items cannot overlap on one video track, so overlapping a real shot is what a
+    transition does and a shot cannot. That is a fact about tracks rather than about any
     getter, which is why it is the test rather than the absence of a media pool item — a
     generator has none of those either, and a generator on the cut track is a shot.
+
+    *Which* shot it overlaps is the part worth being careful about. Dissolves come in two
+    shapes and corpus entry 2 has both: centred on the cut, overlapping the outgoing shot,
+    and aligned to the incoming one, merely abutting the outgoing shot and overlapping only
+    what follows. Compared against its neighbour alone the second shape survives — and then
+    the real shot behind it is the thing that overlaps, so it is dropped instead. That swap
+    leaves the cut count right and the cut wrong, which is the worst way to be wrong. So
+    the comparison is against every media-backed shot on the track, not the one before.
     """
+    solid = [shot for shot in shots if shot.media]
     kept: list[Shot] = []
     dropped = 0
     for shot in shots:
-        if kept and shot.record_in < kept[-1].record_out:
+        transition = not shot.media and any(shot.overlaps(other) for other in solid)
+        if transition or (kept and shot.overlaps(kept[-1])):
             dropped += 1
             continue
         kept.append(shot)
@@ -299,8 +326,18 @@ def _without_transitions(shots: Sequence[Shot], track: int) -> list[Shot]:
     return kept
 
 
-def _clock(reader: Reader, timeline: Any, fps: float, mix: Path | None) -> Clock:
+def _clock(
+    reader: Reader, timeline: Any, fps: float, mix: Path | None, given: int | None = None
+) -> Clock:
     """Where the analysed mix sits under the cut, read off the audio shot that holds it.
+
+    Unless the caller said. A hand-edited concert routinely reaches the cut through a
+    multicam's own audio angle, and then no clip on the timeline *is* the mastered mix —
+    the in point that can be read belongs to the multicam's timebase, which has no stated
+    relationship to the mix's own zero. Every mode below would be guessing, and a guess
+    here is invisible: the reading comes back looking ordinary, with every time in it
+    shifted by the same silent amount. So a caller who knows — a full-timeline render puts
+    the mix's zero exactly at the timeline's first frame — says so, and is believed.
 
     The mix is one continuous clip under the whole cut (#22: the cutting substrate), so its
     record position and its own in point together say which second of the analysis any
@@ -313,6 +350,9 @@ def _clock(reader: Reader, timeline: Any, fps: float, mix: Path | None) -> Clock
     was recognised or merely assumed — which is the difference between a reading to trust
     and one to check before writing a style profile from it.
     """
+    if given is not None:
+        return Clock(given, fps, GIVEN, mix.name if mix else None, True)
+
     found = _audio_shots(reader, timeline)
     wanted = _matching(found, mix)
     chosen = wanted or (found[0] if found else None)

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -48,7 +48,7 @@ from ..resolve.session import frame_rate
 from ..resolve.timeline import (
     FIRST_TRACK,
     Reader,
-    angle_name,
+    angle_of,
     clip_name,
     find_timeline,
     fingerprint,
@@ -279,9 +279,11 @@ def _shots(reader: Reader, timeline: Any, track: int) -> list[Shot]:
         if record_in is None or duration is None:
             log.warning("Skipped a shot on video track %d: Resolve gave no position", track)
             continue
-        media = reader.optional(item, "GetMediaPoolItem", None) is not None
-        name = angle_name(reader, item) or str(item.GetName() or "")
-        found.append(Shot(clip=name, record_in=record_in, duration=duration, media=media))
+        clip = reader.optional(item, "GetMediaPoolItem", None)
+        name = angle_of(reader, item, clip) or str(item.GetName() or "")
+        found.append(
+            Shot(clip=name, record_in=record_in, duration=duration, media=clip is not None)
+        )
     ordered = sorted(found, key=lambda shot: (shot.record_in, not shot.media))
     return _without_transitions(ordered, track)
 
@@ -308,14 +310,23 @@ def _without_transitions(shots: Sequence[Shot], track: int) -> list[Shot]:
     what follows. Compared against its neighbour alone the second shape survives — and then
     the real shot behind it is the thing that overlaps, so it is dropped instead. That swap
     leaves the cut count right and the cut wrong, which is the worst way to be wrong. So
-    the comparison is against every media-backed shot on the track, not the one before.
+    the comparison is against every *other* item on the track, not the one before.
+
+    Overlap alone is not quite the test, because a dissolve into a slate overlaps only the
+    slate and a slate has no pool item either — so "overlaps something real" cannot separate
+    them and "overlaps anything" throws both away. What separates them is that a shot holds
+    some stretch of track *exclusively* and a transition never does: every frame of a
+    dissolve is a frame some neighbour is also on. So a pool-less item is a transition when
+    the rest of the track already covers all of it, and a shot otherwise.
     """
-    solid = [shot for shot in shots if shot.media]
     kept: list[Shot] = []
     dropped = 0
-    for shot in shots:
-        transition = not shot.media and any(shot.overlaps(other) for other in solid)
-        if transition or (kept and shot.overlaps(kept[-1])):
+    for index, shot in enumerate(shots):
+        others = [other for position, other in enumerate(shots) if position != index]
+        if not shot.media and _covered_by(shot, others):
+            dropped += 1
+            continue
+        if kept and shot.overlaps(kept[-1]):
             dropped += 1
             continue
         kept.append(shot)
@@ -324,6 +335,25 @@ def _without_transitions(shots: Sequence[Shot], track: int) -> list[Shot]:
             "Video track %d: %d transitions read past, %d shots kept", track, dropped, len(kept)
         )
     return kept
+
+
+def _covered_by(shot: Shot, others: Sequence[Shot]) -> bool:
+    """Is every frame of ``shot`` also held by something else on the track?
+
+    Walked rather than summed, because two neighbours that each cover half of a dissolve
+    cover all of it between them, and a gap anywhere means the item is holding track of its
+    own — which is the thing a transition never does.
+    """
+    frame = shot.record_in
+    while frame < shot.record_out:
+        reach = max(
+            (other.record_out for other in others if other.record_in <= frame < other.record_out),
+            default=None,
+        )
+        if reach is None:
+            return False
+        frame = reach
+    return True
 
 
 def _clock(
@@ -351,7 +381,7 @@ def _clock(
     and one to check before writing a style profile from it.
     """
     if given is not None:
-        return Clock(given, fps, GIVEN, mix.name if mix else None, True)
+        return Clock(given, fps, GIVEN, mix.name if mix else None, mix is not None)
 
     found = _audio_shots(reader, timeline)
     wanted = _matching(found, mix)

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -766,7 +766,11 @@ def source_bounds(
 
 def clip_name(reader: Reader, item: TimelineItem) -> str | None:
     """The media pool clip a shot came from — a generator or title has none."""
-    clip = reader.optional(item, "GetMediaPoolItem", None)
+    return _pool_name(reader, reader.optional(item, "GetMediaPoolItem", None))
+
+
+def _pool_name(reader: Reader, clip: Any) -> str | None:
+    """The pool clip's own name, for callers that already hold the clip."""
     if clip is None:
         return None
     name = reader.optional(clip, "GetName", None)
@@ -786,7 +790,16 @@ def angle_name(reader: Reader, item: TimelineItem) -> str | None:
     that is what a multicam shot answers. Everything else keeps the pool name, which
     survives a shot being renamed on the timeline.
     """
-    clip = reader.optional(item, "GetMediaPoolItem", None)
+    return angle_of(reader, item, reader.optional(item, "GetMediaPoolItem", None))
+
+
+def angle_of(reader: Reader, item: TimelineItem, clip: Any) -> str | None:
+    """:func:`angle_name` for a caller that already fetched the pool item.
+
+    Every getter here is a call across to Resolve, and the shot read is one pass over a
+    whole track — so a caller that needs the pool item for its own reasons hands it in
+    rather than making the same round trip twice more.
+    """
     if clip is None:
         return None
     kind = reader.optional(clip, "GetClipProperty", None, CLIP_TYPE)
@@ -794,4 +807,4 @@ def angle_name(reader: Reader, item: TimelineItem) -> str | None:
         angle = reader.optional(item, "GetName", None)
         if angle is not None:
             return str(angle)
-    return clip_name(reader, item)
+    return _pool_name(reader, clip)

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -170,6 +170,7 @@ def correlate_timeline(
     solos: str | None = None,
     angles: dict[str, Any] | None = None,
     track: int = FIRST_TRACK,
+    audio_at: Any | None = None,
     refresh: bool = False,
 ) -> dict[str, Any]:
     """Measure a cut against the music it was cut to. Returns a job to poll, not the measurement.
@@ -187,6 +188,13 @@ def correlate_timeline(
     just {"C0012.mp4": "drums"} — you keep the sidecar, you read it, you pass what it says.
     Each of these is optional, and each one absent means that column reads null rather than
     a guess.
+
+    The audio is normally located by finding it on the timeline. When it is not there at all
+    — a multicam carries its own audio angle, and the mix itself was never laid down —
+    audio_at names the timeline frame the analysed audio starts at, dual time as everywhere.
+    A render of the whole timeline starts at its first frame, which is how that is knowable.
+    Check alignment in the result: mode "given" is what you asked for, and mode "audio_clip"
+    with matched false means the times were taken off a clip nobody vouched for.
 
     timeline names the cut, defaulting to the open one; track is the video track it sits on.
     The result names a JSON file of one record per shot — grep it, or read a slice with sed
@@ -208,6 +216,7 @@ def correlate_timeline(
             solos=solos,
             angles=angles,
             track=track,
+            audio_at=audio_at,
             refresh=refresh,
         )
     }

--- a/styles/angles/2026-06_Zinc_and_Monkfish.json
+++ b/styles/angles/2026-06_Zinc_and_Monkfish.json
@@ -3,7 +3,7 @@
   "context": "concert",
   "labelled": "2026-08-06",
   "method": "frame grabs off the multicam's source clips, read by the agent",
-  "confirmed_by_director": false,
+  "confirmed_by_director": "2026-08-07",
   "note": "Zinc - Set 2 only. Monkfish Main is corpus entry 5 and is not labelled yet.",
   "angles": {
     "Zinc - Set 2 Multicam - Video 1": {
@@ -12,7 +12,7 @@
       "character": "wide",
       "note": "Front-of-house wide across the whole stage - piano and bass at house left, sax centre, drums at house right. Operated rather than locked off: the framing is not identical between grabs.",
       "camera": "FX6",
-      "confidence": "low",
+      "confidence": "high",
       "evidence": [
         "frames/A015C001_2606170J.MXF-346744bd6d0a.jpg",
         "frames/A015C001_2606170J.MXF-d56bbb4ba2fd.jpg"
@@ -24,7 +24,7 @@
       "character": "tight",
       "note": "Locked off at stage right, level with the kit: drummer in the foreground right, sax and bass beyond him, piano deep at frame left. Framing is the same in every grab.",
       "camera": "A7IV",
-      "confidence": "low",
+      "confidence": "high",
       "evidence": [
         "frames/20260617_D_A7IV_0006.MP4-7b06dd289e54.jpg",
         "frames/20260617_D_A7IV_0006.MP4-e924bd957d6e.jpg"
@@ -51,10 +51,9 @@
     }
   },
   "mapping_basis": {
-    "what_is_known": "What each camera is, read off its own frame grabs. That part is not in doubt.",
-    "what_is_inferred": "Which camera is multicam angle Video 1 and which is Video 2. Resolve's scripting API does not say: the multicam clip's 'Angle' property comes back empty, and a timeline item only carries the angle name, not the source behind it.",
-    "how_it_was_guessed": "Video 1 holds 68.5% of screen time over 188 cuts (13.8s a shot) and Video 2 holds 31.5% over 178 cuts (6.7s a shot). A two-camera concert cut that way has a home angle held long and a second angle cut to briefly, so the wide was assigned to Video 1.",
-    "how_to_settle_it": "Open Zinc - Set 2 Main, park on any shot, and say which camera is on screen. One look fixes it for good; until then every role-conditioned claim in styles/concert.md stays unverified.",
-    "if_it_is_backwards": "Swap the two role/subject/character/camera blocks. Nothing else in the corpus depends on the mapping - the timing measurements are angle-blind."
+    "what_is_known": "What each camera is, read off its own frame grabs; and which multicam angle number each one is, confirmed by the director on 2026-08-07.",
+    "why_it_needed_confirming": "Resolve's scripting API does not say which source is behind an angle: the multicam clip's 'Angle' property comes back empty, and a timeline item only carries the angle name. The mapping cannot be read, only inferred and then checked by eye.",
+    "how_it_was_first_guessed": "Video 1 holds 68.5% of screen time over 188 cuts (13.8s a shot) and Video 2 holds 31.5% over 178 cuts (6.7s a shot). A two-camera concert cut that way has a home angle held long and a second angle cut to briefly, so the wide was assigned to Video 1. The director confirmed this reading, so the screen-time heuristic held on this project - one data point, not a rule.",
+    "scope_of_the_confirmation": "This project only. Every other multicam project in the corpus needs its own look; nothing here transfers."
   }
 }

--- a/styles/angles/Ryan-and-Hang-Main-9-23-24-gene-edit.json
+++ b/styles/angles/Ryan-and-Hang-Main-9-23-24-gene-edit.json
@@ -1,0 +1,101 @@
+{
+  "project": "Archive/Client/Ryan and Hang Main - 9-23-24 gene edit",
+  "context": "concert",
+  "labelled": "2026-08-07",
+  "method": "frames taken from each timeline's finished render at moments a given angle is on screen",
+  "confirmed_by_director": false,
+  "note": "The Judson's quartet show: Freefall, Sunshine and Mercies. Angle numbers belong to each tune's own multicam and do not carry across tunes - Angle 10 is the drummer on Freefall and the roaming camera on Mercies. That is why every tune is labelled separately rather than once for the project.",
+  "renders": {
+    "note": "What the evidence times are times into. Each render's duration matches its timeline to within 0.02s - under a frame at 23.976 - so render second X is timeline frame 86400 + X*23.976.",
+    "Freefall Timeline": "B:\\Client Work\\Ryan Devlin\\Concert\\Judson's Orlando\\Renders\\Freefall\\Freefall YT.mp4",
+    "Sunshine Timeline": "B:\\Client Work\\Ryan Devlin\\Concert\\Judson's Orlando\\Renders\\Sunshine\\You Are My Sunshine YT.mp4",
+    "Mercies Timeline": "B:\\Client Work\\Ryan Devlin\\Concert\\Judson's Orlando\\Renders\\Mercies\\Mercies YT.mp4"
+  },
+  "angles": {
+    "Free fall Judson’s  Multicam - Angle 11": {
+      "role": "soloist-moving",
+      "subject": "soloist",
+      "character": "moving",
+      "note": "Operated camera from house right that follows whoever is playing - tenor tight at 303s, wider on tenor and bass at other moments. The home angle of this cut.",
+      "confidence": "high",
+      "evidence": ["render frame @ 302.8s", "render frame @ 430.3s"]
+    },
+    "Free fall Judson’s  Multicam - Angle 8": {
+      "role": "ensemble-wide",
+      "subject": "ensemble",
+      "character": "wide",
+      "note": "Locked full-stage wide from front of house: piano at house left, tenor centre, bass behind, drums at house right. Audience heads in the bottom of frame.",
+      "confidence": "high",
+      "evidence": ["render frame @ 165.2s"]
+    },
+    "Free fall Judson’s  Multicam - Angle 10": {
+      "role": "drums-tight",
+      "subject": "drums",
+      "character": "tight",
+      "note": "Behind and beside the kit at house right, drummer large in foreground with the band beyond him.",
+      "confidence": "high",
+      "evidence": ["render frame @ 23.8s", "render frame @ 53.8s"]
+    },
+    "Sunshine Multicam - Camera 9": {
+      "role": "soloist-moving",
+      "subject": "soloist",
+      "character": "moving",
+      "note": "The same roaming operated camera: piano hands tight at 47s, tenor and bass medium at 879s. The home angle of this cut.",
+      "confidence": "high",
+      "evidence": ["render frame @ 46.8s", "render frame @ 879.4s"]
+    },
+    "Sunshine Multicam - Camera A": {
+      "role": "ensemble-wide",
+      "subject": "ensemble",
+      "character": "wide",
+      "note": "Locked full-stage wide, clean of audience - flatter and squarer to the stage than the Freefall wide.",
+      "confidence": "high",
+      "evidence": ["render frame @ 436.3s"]
+    },
+    "Sunshine Multicam - Camera 4": {
+      "role": "drums-tight",
+      "subject": "drums",
+      "character": "tight",
+      "note": "Drummer cam at house right, same framing as the Freefall one.",
+      "confidence": "high",
+      "evidence": ["render frame @ 160.1s"]
+    },
+    "Mercies Multicam - Angle 10": {
+      "role": "soloist-moving",
+      "subject": "soloist",
+      "character": "moving",
+      "note": "The roaming operated camera again, on tenor. The home angle of this cut.",
+      "confidence": "high",
+      "evidence": ["render frame @ 92.0s"]
+    },
+    "Mercies Multicam - Angle 2": {
+      "role": "ensemble-wide",
+      "subject": "ensemble",
+      "character": "wide",
+      "note": "Locked full-stage wide, clean of audience.",
+      "confidence": "high",
+      "evidence": ["render frame @ 500.0s"]
+    },
+    "Mercies Multicam - Angle 4": {
+      "role": "room-wide",
+      "subject": "room",
+      "character": "wide",
+      "note": "A second wide, further back and lower, with audience silhouettes across the bottom of frame - the shot from a seat rather than the shot of the stage. Distinct from Angle 2, which is clean.",
+      "confidence": "high",
+      "evidence": ["render frame @ 609.7s"]
+    },
+    "Mercies Multicam - Angle 5": {
+      "role": "drums-tight",
+      "subject": "drums",
+      "character": "tight",
+      "note": "Drummer cam at house right.",
+      "confidence": "high",
+      "evidence": ["render frame @ 272.7s"]
+    }
+  },
+  "mapping_basis": {
+    "what_is_known": "Everything here. Each label was read off a frame of the finished render taken at a moment that angle is on screen, so the frame *is* the angle rather than evidence about it.",
+    "why_that_works": "Resolve exposes no angle-to-source mapping, so labelling from the multicam's source clips can only infer which source is which angle number - that is what the anchor needed a director's eye to settle. A full-timeline render removes the question: its duration matches the timeline to within 0.02s on all three tunes, so a timeline frame maps to a render frame directly, and the render shows the cut as cut.",
+    "what_is_still_open": "Nothing about the mapping. The role vocabulary itself is a judgement - 'soloist-moving' names a camera whose subject changes with the music, which is a different kind of thing from a locked-off drummer cam."
+  }
+}

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -21,19 +21,26 @@ that the grid is a live band's grid, so it moves.
   drops — free intros, out-of-time codas — cut placement there says nothing
   about taste and is gated out of the evidence rather than averaged in.
   `[stated principle]` (#13, analysis workflow)
-- **Cuts land close to a transient without landing on one.** On the anchor, the
-  median cut sits 33 ms from the nearest transient (mean 46 ms, max 345 ms) and
-  exactly **2 of 360 cuts land on one**. That is the stated principle showing up
-  as a number: near, not on. `[believed, unverified]` — n=360 cuts but a single
-  project, so #21 policy 4 downgrades it; `corpus.md` entry 1 has the evidence.
-- **The direction bias is close to even, tipped early**: 195 cuts early against
-  163 late. Not the lopsided distribution a rule like "always cut just before"
-  would leave. `[believed, unverified]` — same single project.
+- **Cuts land close to a transient without landing on one.** The median cut sits
+  a few frames from the nearest transient and almost never on it: 33 ms on the
+  anchor (2 of 360 cuts on a transient), 34 ms on Freefall, 19 ms on Mercies,
+  17 ms on Sunshine. Four timelines, two projects, two rooms, four years apart,
+  and the median never leaves 17–34 ms — under a frame at 24fps in three of
+  them. That is the stated principle showing up as a number: near, not on.
+  `[measured — 2 projects]` (`corpus.md` entries 1 and 2)
+- **The direction bias is close to even, tipped early.** Anchor 195 early / 163
+  late; Freefall 25/18; Sunshine 22/26; Mercies 17/19. Early leads overall, but
+  two of the four tip late — so what is measured is the *absence* of a rule like
+  "always cut just before", not the presence of one.
+  `[measured — 2 projects]`
 - Beat-grid position patterns, in frames and in beat-fraction, conditioned on
-  context. *Open, and blocked rather than merely unmeasured: the anchor's grid
-  does not fit its music (`meter: 1` at 214 bpm over a jazz set), so the bar
-  histogram and the beat offsets from it are not yet evidence. Rubato gating
-  comes first — see `corpus.md` entry 1.*
+  context. *Open, and blocked rather than merely unmeasured. Every timeline so
+  far skews hard to the first beat of the bar — anchor 171:111:44:30, Mercies
+  25:6:2:3 — which would be a real finding if the grids were trustworthy, and
+  they are not: the anchor's reports `meter: 1` at 214 bpm over a jazz set, and
+  Mercies puts a cut in a bar 6. Rubato gating comes first, and until it lands
+  a consistent-looking histogram is the most misleading thing here, because it
+  looks like evidence.*
 
 ## 2. Energy — the master concept
 
@@ -47,11 +54,16 @@ that the grid is a live band's grid, so it moves.
 
 ## 3. Shot rhythm
 
-- **Shots are long, and their spread is enormous.** On the anchor: median
-  7.3 s, mean 10.4 s, from 0.46 s to 71 s. A concert cut here is not a montage
-  — half the shots run longer than seven seconds — and the 71-second hold says
-  the variation instinct has a very wide range to play in.
-  `[believed, unverified]` — n=366 shots, one project (#21 policy 4).
+- **Shots are long, and their spread is enormous.** Medians run 6.8–12.0 s
+  (anchor 7.3, Freefall 6.8, Mercies 11.5, Sunshine 12.0) and every timeline
+  carries a hold far out past its median: 71 s on the anchor, 94 s on Sunshine,
+  146 s on Freefall, 184 s on Mercies. A concert cut here is not a montage, and
+  the long hold is not an outlier to be smoothed away — it appears in all four.
+  `[measured — 2 projects]`
+- **The mean sits well above the median, every time**: 10.4 vs 7.3, 15.5 vs
+  6.8, 18.3 vs 12.0, 18.5 vs 11.5. The distribution is skewed by design — most
+  shots middling, a few very long. Averaging shot length would describe a cut
+  that was never made. `[measured — 2 projects]`
 - Duration distributions conditioned on section type and energy band. *Open;
   the conditioning needs the structure analysis, which has not been run over
   the corpus.*
@@ -69,17 +81,29 @@ that the grid is a live band's grid, so it moves.
 - **Soloist doing something worth seeing → show him. Drummer lighting up at
   the same time → cut between them.** The two are not in competition; the
   exchange is the content. `[stated principle]`
-- **The wide is the home angle; the drummer cam is cut to, not lived on.** On
-  the anchor the wide holds 68.5% of screen time across 188 cuts (13.8 s a
-  shot) against the drummer cam's 31.5% across 178 cuts (6.7 s a shot):
-  near-equal cut counts, roughly double the hold. Two angles traded evenly
-  would not look like this. `[believed, unverified]` — the direction is no
-  longer in doubt (the director confirmed the angle mapping on 2026-08-07, so
-  the wide really is the held angle), but it is still one project: this is
-  how one room was cut, not yet a demonstrated habit.
-- Wide-as-reset patterns, transition habits between roles, and hold length per
-  role. *Open — the anchor is labelled now, but a role-transition claim needs
-  more than one night to be worth stating.*
+- **There is a home angle, and it holds roughly three-quarters of the cut.**
+  Anchor 68.5%, Freefall 75.5%, Sunshine 76.3%, Mercies 74.4%. Four timelines,
+  two projects, and the home angle's share never drops below two thirds.
+  `[measured — 2 projects]`
+- **The home angle is whichever camera is on whoever is playing — not the
+  wide.** This is the claim the anchor got wrong on its own. With two cameras
+  the held angle *was* the wide (68.5%), which reads as a preference for the
+  wide; with an operated camera available, the wide drops to 14–17% and the
+  roaming `soloist-moving` camera takes 74–76%. The constant across both is not
+  the framing, it is the subject: the cut lives on the music being made and
+  visits everything else. `[measured — 2 projects]` — and the anchor is
+  re-read by it rather than contradicted: with nothing closer available, the
+  wide is where the soloist is.
+- **The drummer cam is cut to, not lived on.** It takes near-equal cut counts
+  and a fraction of the hold: anchor 178 cuts for 31.5%, Freefall 13 for 10.1%,
+  Sunshine 10 for 6.7%, Mercies 5 for 4.0%. Frequent and short is the shape.
+  `[measured — 2 projects]`
+- **A second wide is a garnish, not a role.** Mercies is the only timeline with
+  one (`room-wide`, from a seat rather than of the stage): 5 cuts, 5.2%.
+  `[believed, unverified]` — one timeline.
+- Wide-as-reset patterns and transition habits between roles — which role
+  follows which. *Open. Four labelled timelines is enough to start; the shot
+  records hold the sequence, and nothing has read it yet.*
 - The role vocabulary a given night supports is whatever its sidecar says. Spec
   #22 describes the rig as a static wide, a drummer cam and a roaming soloist
   cam — but the anchor night ran **two** cameras and the other way round: the

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -23,24 +23,29 @@ that the grid is a live band's grid, so it moves.
   `[stated principle]` (#13, analysis workflow)
 - **Cuts land close to a transient without landing on one.** The median cut sits
   a few frames from the nearest transient and almost never on it: 33 ms on the
-  anchor (2 of 360 cuts on a transient), 34 ms on Freefall, 19 ms on Mercies,
-  17 ms on Sunshine. Four timelines, two projects, two rooms, four years apart,
-  and the median never leaves 17–34 ms — under a frame at 24fps in three of
-  them. That is the stated principle showing up as a number: near, not on.
-  `[measured — 2 projects]` (`corpus.md` entries 1 and 2)
-- **The direction bias is close to even, tipped early.** Anchor 195 early / 163
-  late; Freefall 25/18; Sunshine 22/26; Mercies 17/19. Early leads overall, but
-  two of the four tip late — so what is measured is the *absence* of a rule like
-  "always cut just before", not the presence of one.
-  `[measured — 2 projects]`
+  anchor (2 of 360 cuts on a transient), 34 ms on Freefall, 29 ms on Scullers,
+  19 ms on Mercies, 17 ms on Sunshine. Five timelines, three projects, three
+  rooms, four years apart, and the median never leaves 17–34 ms — under a frame
+  at 24fps in four of them. That is the stated principle showing up as a
+  number: near, not on.
+  `[measured — 3 projects, n=815 cuts, concert]` (`corpus.md` entries 1–3)
+- **There is no direction rule.** Anchor 195 early / 163 late; Freefall 25/18;
+  Sunshine 22/26; Mercies 17/19; Scullers 141/185. Three of five tip late, two
+  early, none decisively. What is measured is the *absence* of a habit like
+  "always cut just before the hit", not the presence of one — the placement is
+  about distance, not side.
+  `[measured — 3 projects, n=815 cuts, concert]`
 - Beat-grid position patterns, in frames and in beat-fraction, conditioned on
   context. *Open, and blocked rather than merely unmeasured. Every timeline so
-  far skews hard to the first beat of the bar — anchor 171:111:44:30, Mercies
-  25:6:2:3 — which would be a real finding if the grids were trustworthy, and
-  they are not: the anchor's reports `meter: 1` at 214 bpm over a jazz set, and
-  Mercies puts a cut in a bar 6. Rubato gating comes first, and until it lands
-  a consistent-looking histogram is the most misleading thing here, because it
-  looks like evidence.*
+  far skews hard to the first beat of the bar — anchor 171:111:44:30, Scullers
+  203:55:38:27, Mercies 25:6:2:3 — which would be a real finding if the grids
+  were trustworthy, and they are not: the anchor's reports `meter: 1` at 214 bpm
+  over a jazz set, Mercies puts a cut in a bar 6, and Scullers puts cuts in bars
+  5, 6 and 7. There is no such position in 4/4, so the grid is demonstrably
+  wrong where those cuts are — and it is the same grid the other 96% were
+  scored against. Rubato gating comes first, and until it lands a
+  consistent-looking histogram is the most misleading thing in this file,
+  because it looks like evidence.*
 
 ## 2. Energy — the master concept
 
@@ -55,15 +60,17 @@ that the grid is a live band's grid, so it moves.
 ## 3. Shot rhythm
 
 - **Shots are long, and their spread is enormous.** Medians run 6.8–12.0 s
-  (anchor 7.3, Freefall 6.8, Mercies 11.5, Sunshine 12.0) and every timeline
-  carries a hold far out past its median: 71 s on the anchor, 94 s on Sunshine,
-  146 s on Freefall, 184 s on Mercies. A concert cut here is not a montage, and
-  the long hold is not an outlier to be smoothed away — it appears in all four.
-  `[measured — 2 projects]`
+  (Freefall 6.8, anchor 7.3, Scullers 8.6, Mercies 11.5, Sunshine 12.0) and
+  every timeline carries a hold far out past its median: 71 s on the anchor,
+  94 s on Sunshine, 146 s on Freefall, 184 s on Mercies, 239 s on Scullers. A
+  concert cut here is not a montage, and the long hold is not an outlier to be
+  smoothed away — it appears in all five.
+  `[measured — 3 projects, n=847 shots, concert]`
 - **The mean sits well above the median, every time**: 10.4 vs 7.3, 15.5 vs
-  6.8, 18.3 vs 12.0, 18.5 vs 11.5. The distribution is skewed by design — most
-  shots middling, a few very long. Averaging shot length would describe a cut
-  that was never made. `[measured — 2 projects]`
+  6.8, 18.3 vs 12.0, 18.5 vs 11.5, 16.2 vs 8.6. The distribution is skewed by
+  design — most shots middling, a few very long. Averaging shot length would
+  describe a cut that was never made.
+  `[measured — 3 projects, n=847 shots, concert]`
 - Duration distributions conditioned on section type and energy band. *Open;
   the conditioning needs the structure analysis, which has not been run over
   the corpus.*
@@ -82,22 +89,28 @@ that the grid is a live band's grid, so it moves.
   the same time → cut between them.** The two are not in competition; the
   exchange is the content. `[stated principle]`
 - **There is a home angle, and it holds roughly three-quarters of the cut.**
-  Anchor 68.5%, Freefall 75.5%, Sunshine 76.3%, Mercies 74.4%. Four timelines,
-  two projects, and the home angle's share never drops below two thirds.
-  `[measured — 2 projects]`
-- **The home angle is whichever camera is on whoever is playing — not the
-  wide.** This is the claim the anchor got wrong on its own. With two cameras
-  the held angle *was* the wide (68.5%), which reads as a preference for the
-  wide; with an operated camera available, the wide drops to 14–17% and the
-  roaming `soloist-moving` camera takes 74–76%. The constant across both is not
-  the framing, it is the subject: the cut lives on the music being made and
-  visits everything else. `[measured — 2 projects]` — and the anchor is
-  re-read by it rather than contradicted: with nothing closer available, the
-  wide is where the soloist is.
+  Anchor 68.5%, Freefall 75.5%, Sunshine 76.3%, Mercies 74.4%, Scullers 74.3%.
+  Five timelines, three projects, and the share never drops below two thirds.
+  This one needs no labels — it is about the shape of the distribution, not
+  about which camera — which is why entry 3 supports it while supporting
+  nothing else in this section.
+  `[measured — 3 projects, n=847 shots, concert]`
+- **The home angle may be the camera on whoever is playing rather than the
+  wide.** On entry 2 the wide holds 14–17% while a roaming operated camera
+  holds 74–76%, so there the home angle is chosen by *subject*, not framing.
+  `[believed, unverified]` — entry 2 only, and the reason is worth stating: the
+  anchor cannot corroborate this even though its numbers look like they should.
+  Its home angle is its wide *and* its operated camera at once, so it has no
+  case where the two disagree and cannot tell which one the director was
+  following. Entry 3 is measured but unlabelled and cannot speak to it either.
+  One project deciding between two readings is exactly what #21 policy 4 is
+  about — so this is written down as the better reading, not as a finding, and
+  entry 4 or 5 is what would settle it.
 - **The drummer cam is cut to, not lived on.** It takes near-equal cut counts
   and a fraction of the hold: anchor 178 cuts for 31.5%, Freefall 13 for 10.1%,
   Sunshine 10 for 6.7%, Mercies 5 for 4.0%. Frequent and short is the shape.
-  `[measured — 2 projects]`
+  `[measured — 2 projects, n=498 shots, concert]` — two, not three: entry 3 is
+  unlabelled, so its 167 second-angle cuts cannot be attributed to a drummer.
 - **A second wide is a garnish, not a role.** Mercies is the only timeline with
   one (`room-wide`, from a seat rather than of the stage): 5 cuts, 5.2%.
   `[believed, unverified]` — one timeline.
@@ -136,13 +149,23 @@ Free prose, first-class.
   timelines carry many tunes, so per-cut sample counts run into the hundreds —
   the thin-corpus risk here is *project* count, not cut count, which is why the
   tag format names both.
-- One of seven concert entries is measured (the anchor). Every number above
-  therefore carries `[believed, unverified]` rather than `[measured — …]`, not
-  because the sample is small — 360 cuts is not small — but because one project
-  cannot tell this director's taste apart from this night's room. Entry 2
-  onward is what changes the tags.
-- The most useful thing the first pass produced was not a number but a
-  correction: two defects in `correlate_timeline` that only real footage
-  exposes (transitions counted as shots, multicam angles sharing one name).
+- **Five of seven concert timelines are measured, across three projects**:
+  the anchor, the three Judson's tunes (entry 2), and the Scullers full cut
+  (entry 3). Timing claims above therefore carry `[measured — …]`. Claims that
+  need *labels* to state — which role holds the cut — rest on two projects,
+  because entry 3 is measured but unlabelled; claims that separate framing from
+  subject rest on entry 2 alone, because the anchor's home angle is both its
+  wide and its operated camera and so cannot tell the two apart.
+- **Every timeline agrees about transients and none agrees about the beat
+  grid.** Five timelines, three projects, four years: the median cut sits
+  17–34 ms from the nearest transient every time. Over the same five, the
+  beat-offset mean runs two to fifteen times its own median and three of the
+  bar histograms contain positions that cannot exist in 4/4. The half of the
+  analysis that does not depend on a grid is the half that replicates.
+- The most useful thing each pass produced was not a number but a correction.
+  Entry 1: transitions counted as shots, and multicam angles sharing one name.
+  Entry 2: a second dissolve shape that swapped real shots for transitions
+  while keeping the count right, and an alignment that no timeline clip could
+  supply. Entry 3: a master mix the analyser could not read at all (#110).
   Everything above is measured with those fixed; nothing measured before them
   should be believed.

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -23,18 +23,19 @@ that the grid is a live band's grid, so it moves.
   `[stated principle]` (#13, analysis workflow)
 - **Cuts land close to a transient without landing on one.** The median cut sits
   a few frames from the nearest transient and almost never on it: 33 ms on the
-  anchor (2 of 360 cuts on a transient), 34 ms on Freefall, 29 ms on Scullers,
-  19 ms on Mercies, 17 ms on Sunshine. Five timelines, three projects, three
-  rooms, four years apart, and the median never leaves 17–34 ms — under a frame
-  at 24fps in four of them. That is the stated principle showing up as a
-  number: near, not on.
-  `[measured — 3 projects, n=815 cuts, concert]` (`corpus.md` entries 1–3)
+  anchor (2 of 360 cuts on a transient), 41 ms on Monkfish, 34 ms on Freefall,
+  29 ms on Scullers, 19 ms on Mercies, 17 ms on Sunshine. Six timelines, three
+  projects, four rooms, four years apart, and the median never leaves 17–41 ms
+  — inside two frames at 24fps every time, inside one in four of them. That is
+  the stated principle showing up as a number: near, not on.
+  `[measured — 3 projects, n=1043 cuts, concert]` (`corpus.md` entries 1–3, 5)
 - **There is no direction rule.** Anchor 195 early / 163 late; Freefall 25/18;
-  Sunshine 22/26; Mercies 17/19; Scullers 141/185. Three of five tip late, two
-  early, none decisively. What is measured is the *absence* of a habit like
-  "always cut just before the hit", not the presence of one — the placement is
+  Sunshine 22/26; Mercies 17/19; Scullers 141/185; Monkfish 118/110. Three of
+  six tip late, three early, none decisively — and the two largest samples
+  disagree with each other. What is measured is the *absence* of a habit like
+  "always cut just before the hit", not the presence of one: the placement is
   about distance, not side.
-  `[measured — 3 projects, n=815 cuts, concert]`
+  `[measured — 3 projects, n=1043 cuts, concert]`
 - Beat-grid position patterns, in frames and in beat-fraction, conditioned on
   context. *Open, and blocked rather than merely unmeasured. Every timeline so
   far skews hard to the first beat of the bar — anchor 171:111:44:30, Scullers
@@ -43,9 +44,16 @@ that the grid is a live band's grid, so it moves.
   over a jazz set, Mercies puts a cut in a bar 6, and Scullers puts cuts in bars
   5, 6 and 7. There is no such position in 4/4, so the grid is demonstrably
   wrong where those cuts are — and it is the same grid the other 96% were
-  scored against. Rubato gating comes first, and until it lands a
-  consistent-looking histogram is the most misleading thing in this file,
-  because it looks like evidence.*
+  scored against.
+
+  There is now a reason to think the skew is partly the detector rather than
+  the director. Two timelines have structurally sound grids (Freefall and
+  Monkfish: strictly 1–4, `meter: 4`) and they are the flattest — Monkfish puts
+  67% on beats 1–2 where every broken-grid timeline puts 78–81%. The
+  measurement gets *less* dramatic exactly where the instrument gets more
+  trustworthy, which is the wrong direction for a real finding. Rubato gating
+  comes first, and until it lands a consistent-looking histogram is the most
+  misleading thing in this file, because it looks like evidence.*
 
 ## 2. Energy — the master concept
 
@@ -59,18 +67,21 @@ that the grid is a live band's grid, so it moves.
 
 ## 3. Shot rhythm
 
-- **Shots are long, and their spread is enormous.** Medians run 6.8–12.0 s
-  (Freefall 6.8, anchor 7.3, Scullers 8.6, Mercies 11.5, Sunshine 12.0) and
-  every timeline carries a hold far out past its median: 71 s on the anchor,
-  94 s on Sunshine, 146 s on Freefall, 184 s on Mercies, 239 s on Scullers. A
-  concert cut here is not a montage, and the long hold is not an outlier to be
-  smoothed away — it appears in all five.
-  `[measured — 3 projects, n=847 shots, concert]`
+- **Shots are long, and their spread is enormous.** Medians run 6.3–12.0 s
+  (Monkfish 6.3, Freefall 6.8, anchor 7.3, Scullers 8.6, Mercies 11.5,
+  Sunshine 12.0) and every timeline carries a hold far out past its median:
+  71 s on the anchor, 94 s on Sunshine, 146 s on Freefall, 184 s on Mercies,
+  239 s on Scullers. A concert cut here is not a montage, and the long hold is
+  not an outlier to be smoothed away — it appears in all six.
+  `[measured — 3 projects, n=1080 shots, concert]`
 - **The mean sits well above the median, every time**: 10.4 vs 7.3, 15.5 vs
   6.8, 18.3 vs 12.0, 18.5 vs 11.5, 16.2 vs 8.6. The distribution is skewed by
   design — most shots middling, a few very long. Averaging shot length would
   describe a cut that was never made.
-  `[measured — 3 projects, n=847 shots, concert]`
+  `[measured — 3 projects, n=847 shots, concert]` — Monkfish is left out of
+  this one on purpose: its mean is 22.5 s against a 6.3 s median, but three
+  fifths of that timeline is passages nobody has cut yet, so its skew is a fact
+  about how far the edit got rather than about how the director holds a shot.
 - Duration distributions conditioned on section type and energy band. *Open;
   the conditioning needs the structure analysis, which has not been run over
   the corpus.*
@@ -94,7 +105,9 @@ that the grid is a live band's grid, so it moves.
   This one needs no labels — it is about the shape of the distribution, not
   about which camera — which is why entry 3 supports it while supporting
   nothing else in this section.
-  `[measured — 3 projects, n=847 shots, concert]`
+  `[measured — 3 projects, n=847 shots, concert]` — Monkfish is excluded
+  (89.3%), not because it disagrees but because share is time and three fifths
+  of its time is uncut passage sitting on one angle.
 - **The home angle may be the camera on whoever is playing rather than the
   wide.** On entry 2 the wide holds 14–17% while a roaming operated camera
   holds 74–76%, so there the home angle is chosen by *subject*, not framing.
@@ -149,23 +162,34 @@ Free prose, first-class.
   timelines carry many tunes, so per-cut sample counts run into the hundreds —
   the thin-corpus risk here is *project* count, not cut count, which is why the
   tag format names both.
-- **Five of seven concert timelines are measured, across three projects**:
-  the anchor, the three Judson's tunes (entry 2), and the Scullers full cut
-  (entry 3). Timing claims above therefore carry `[measured — …]`. Claims that
+- **Six of seven concert timelines are measured, across three projects**:
+  the anchor, the three Judson's tunes (entry 2), the Scullers full cut
+  (entry 3) and Monkfish Main (entry 5). Only Stablemates is left, and it is
+  left for a reason — no render and no defensible clock. Timing claims above
+  therefore carry `[measured — …]`. Claims that
   need *labels* to state — which role holds the cut — rest on two projects,
-  because entry 3 is measured but unlabelled; claims that separate framing from
-  subject rest on entry 2 alone, because the anchor's home angle is both its
-  wide and its operated camera and so cannot tell the two apart.
+  because entries 3 and 5 are measured but unlabelled; claims that separate
+  framing from subject rest on entry 2 alone, because the anchor's home angle
+  is both its wide and its operated camera and so cannot tell the two apart.
 - **Every timeline agrees about transients and none agrees about the beat
-  grid.** Five timelines, three projects, four years: the median cut sits
-  17–34 ms from the nearest transient every time. Over the same five, the
-  beat-offset mean runs two to fifteen times its own median and three of the
-  bar histograms contain positions that cannot exist in 4/4. The half of the
-  analysis that does not depend on a grid is the half that replicates.
+  grid.** Six timelines, three projects, four years: the median cut sits
+  17–41 ms from the nearest transient every time — inside two frames, without
+  exception. Over the same six, the beat-offset mean runs two to fifteen times
+  its own median and three of the bar histograms contain positions that cannot
+  exist in 4/4. The half of the analysis that does not depend on a grid is the
+  half that replicates, and that is also the half the director's own stated
+  principle is about.
+- **Not every timeline's numbers mean the same thing, and the corpus row says
+  which.** Monkfish is three fifths uncut, so its cuts count and its shot mean
+  and angle share do not. A corpus that pooled everything measurable would have
+  reported a 22.5 s mean shot and an 89% home angle, both of them artefacts of
+  an unfinished edit.
 - The most useful thing each pass produced was not a number but a correction.
   Entry 1: transitions counted as shots, and multicam angles sharing one name.
   Entry 2: a second dissolve shape that swapped real shots for transitions
   while keeping the count right, and an alignment that no timeline clip could
   supply. Entry 3: a master mix the analyser could not read at all (#110).
+  Entry 5: a reason to distrust the beat-1 skew, since the two soundest grids
+  in the corpus produce the flattest histograms.
   Everything above is measured with those fixed; nothing measured before them
   should be believed.

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -73,13 +73,13 @@ that the grid is a live band's grid, so it moves.
   the anchor the wide holds 68.5% of screen time across 188 cuts (13.8 s a
   shot) against the drummer cam's 31.5% across 178 cuts (6.7 s a shot):
   near-equal cut counts, roughly double the hold. Two angles traded evenly
-  would not look like this. `[believed, unverified]` — one project, and the
-  angle-number-to-camera mapping is inferred rather than read (see the
-  sidecar's `mapping_basis`), so this claim is one director glance away from
-  being either confirmed or exactly inverted.
+  would not look like this. `[believed, unverified]` — the direction is no
+  longer in doubt (the director confirmed the angle mapping on 2026-08-07, so
+  the wide really is the held angle), but it is still one project: this is
+  how one room was cut, not yet a demonstrated habit.
 - Wide-as-reset patterns, transition habits between roles, and hold length per
-  role. *Open — needs the angle sidecar; `roles` came back null on the anchor
-  because nothing is labelled yet.*
+  role. *Open — the anchor is labelled now, but a role-transition claim needs
+  more than one night to be worth stating.*
 - The role vocabulary a given night supports is whatever its sidecar says. Spec
   #22 describes the rig as a static wide, a drummer cam and a roaming soloist
   cam — but the anchor night ran **two** cameras and the other way round: the

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -20,7 +20,7 @@ recency breaks ties).
 | --- | --- | --- | --- | --- | --- |
 | 1 | `2026-06_Zinc_and_Monkfish` | Zinc - Set 2 Main | concert | **measured, labelled** | **Anchor** — strongest current-taste exemplar; two-camera, 2026 |
 | 2 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Freefall Timeline, Sunshine Timeline, Mercies Timeline | concert | **measured, labelled** | Canonical snapshot for Ryan and Hang; music-performance cuts only |
-| 3 | `Mike Tucker Scullers` | Concert Full Cut | concert | not started | Good two-camera concert; older, so recency weighting applies |
+| 3 | `Mike Tucker Scullers` | Concert Full Cut | concert | **measured, unlabelled** | Good two-camera concert; older, so recency weighting applies |
 | 4 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Stablemates | concert | not started | Older but explicitly taste-endorsed. Read from the Ryan and Hang project, not `Ryan Devlin Projects Current` — same timeline, one project to open |
 | 5 | `2026-06_Zinc_and_Monkfish` | Monkfish Main | concert | not started | **Partial** — only a couple of tunes cut; measure those tunes only |
 | 6 | `Archive/Client/Side Step Blues Clues Album` | Blues Clues Main, Devlin Time Main, For All The Other Times Main, Intro Main, Outro Main, People We Love Main, Walk Spirit Talk Spirit Main, EJ's Blues Main | studio-session | **deferred** | Footage not on the box; and studio-session is a different cutting context from the concert work this pass is about. Revisit when the concert profile is settled |
@@ -87,9 +87,10 @@ the right one.
 | # | Timeline | Context | Cuts | Alignment | Sidecar | Result |
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | Zinc - Set 2 Main | concert | 366 (360 measured, 6 openings) | `audio_clip`, matched | `angles/2026-06_Zinc_and_Monkfish.json` (confirmed 2026-08-07) | `…/analysis/Zinc---Set-2-Main-dcb16e19eca1.correlate.json` |
-| 2 | Freefall Timeline | concert | 44 (43 measured, 1 opening) | `given` @ 86400 | `angles/Ryan-and-Hang-Main-9-23-24-gene-edit.json` | `…/analysis/Freefall-Timeline-*.correlate.json` |
-| 2 | Sunshine Timeline | concert | 50 (49 measured, 1 opening) | `given` @ 86400 | same | `…/analysis/Sunshine-Timeline-*.correlate.json` |
+| 2 | Freefall Timeline | concert | 44 (43 measured, 1 opening) | `given` @ 86400 | `angles/Ryan-and-Hang-Main-9-23-24-gene-edit.json` | `…/analysis/Freefall-Timeline-a82bc5a80bcd.correlate.json` |
+| 2 | Sunshine Timeline | concert | 50 (49 measured, 1 opening) | `given` @ 86400 | same | `…/analysis/Sunshine-Timeline-edbbc561a240.correlate.json` |
 | 2 | Mercies Timeline | concert | 38 (37 measured, 1 opening) | `given` @ 86400 | same | `…/analysis/Mercies-Timeline-622d697cfd3e.correlate.json` |
+| 3 | Concert Full Cut | concert | 349 (326 measured, 23 openings) | `given` @ 75903 | **none — unlabelled** | `…/analysis/Concert-Full-Cut-bc11cb456a36.correlate.json` |
 
 **Entry 1, measured 2026-08-06.** Against `Zinc Set 2 Reaper v4.wav` (74:10,
 48 kHz, the Reaper master mix on A3), beats from `analyze_music` (11,130 beats,
@@ -169,3 +170,40 @@ Cautions on these rows:
   camera was read off the render and is not in doubt. Whether an operated
   camera that follows the music is best called `soloist-moving` is a vocabulary
   choice, and it is the one term here that did not come from the anchor.
+
+**Entry 3, measured 2026-08-07.** `Mike Tucker Scullers` / `Concert Full Cut`,
+349 shots over 95 minutes, two angles. **Unlabelled** — this project has no
+render, so the angle→camera mapping cannot be read, only guessed; the timing
+numbers below need no labels and stand on their own.
+
+The master mix is 32-bit float, which `analyze_music` refuses outright
+(#110 — and its `fix` line tells the caller to delete the file, which here is
+the director's own master on a media drive). Worked around by transcoding to
+24-bit PCM with ffmpeg: duration is preserved to the sample, 6130.888708 s both
+ways, so no time measured off it moved. Because the transcoded file is not the
+one on the timeline it cannot be matched to a clip, so the clock is `given` at
+frame 75903 — which is not a guess but what the eighteen A2 clips themselves
+say (`record_in - source_in`, the same value on every one of them). The cut
+starts about 7½ minutes into the recording, which is why that number sits
+before the timeline's own first frame.
+
+| Measure | Value |
+| --- | --- |
+| Cuts | 349 shots, 326 measured, **23 openings** |
+| Offset to nearest transient | median 29 ms, mean 51 ms, max 497 ms; 141 early / 185 late / 0 on |
+| Offset to nearest beat | median 97 ms, mean 846 ms, max 22.7 s |
+| Shot length | median 8.59 s, mean 16.22 s, min 0.38 s, max 238.9 s |
+| Bar position | 1:203, 2:55, 3:38, 4:27, 5:1, 6:1, 7:1 — **not usable** |
+| Angles | Angle 1: 182 cuts, 74.3%; Angle 2: 167 cuts, 25.7% |
+
+Three things worth carrying forward:
+
+- **23 openings** is far more than any other entry (1 each on the Judson's
+  tunes, 6 on the anchor). A full-set timeline has gaps between tunes, and a
+  shot after a gap has no outgoing angle — so the opening count is roughly the
+  tune count, and it is a free structural signal nothing is using yet.
+- The **home angle share is 74.3%**, in line with every other entry, and this
+  one was arrived at with no labels at all. The share is a fact about the
+  distribution; only the *name* of the angle needs a sidecar.
+- The bar histogram has positions 5, 6 and 7 in it. There is no such thing in
+  4/4. Same conclusion as entries 1 and 2: rubato gating first.

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -26,13 +26,27 @@ recency breaks ties).
 | 6 | `Archive/Client/Side Step Blues Clues Album` | Blues Clues Main, Devlin Time Main, For All The Other Times Main, Intro Main, Outro Main, People We Love Main, Walk Spirit Talk Spirit Main, EJ's Blues Main | studio-session | **deferred** | Footage not on the box; and studio-session is a different cutting context from the concert work this pass is about. Revisit when the concert profile is settled |
 | 7 | ~~`…Ryan and Hang…` Blues for Alice, Three Card Molly~~ | — | — | **dropped** | Confirmed single-camera (director, 2026-08-07) — no angle switches, so nothing to measure |
 
-7 concert-context timelines across 4 projects. The 8 studio-session timelines
-are deferred, not excluded. Full-set timelines carry many tunes, so per-cut
-counts run into the hundreds.
+7 concert-context timelines across **3 projects** — entries 1 and 5 are both
+`2026-06_Zinc_and_Monkfish`, entries 2 and 4 are both the Ryan and Hang gene
+edit, and entry 3 stands alone. Worth stating plainly because #21 policy 4
+counts *projects*, not timelines: measuring all seven would still leave every
+claim resting on three, and six of the seven are already done. The 8
+studio-session timelines are deferred, not excluded. Full-set timelines carry
+many tunes, so per-cut counts run into the hundreds.
 
 Entries 4, 6 and 7 were settled by the director on 2026-08-07: Stablemates
 reachable from the entry-2 project, Side Step deferred, and the conditional
 entry resolved single-camera without needing a pre-flight.
+
+**Entry 4 is the only one left, and it is blocked on a clock rather than on
+access.** Stablemates has no render, and its A1 audio items disagree about
+where the mix starts — 86391 from one, 86055 from another — because each
+multicam angle carries its own source offset. Every other entry had either a
+clip carrying the analysed mix or a render whose duration proved the frame.
+This has neither, so there is no number to name and defend, and it waits for
+a full-timeline export or the director rather than getting measured against a
+guess. Its 19 shots are the smallest sample in the corpus; publishing them
+against the wrong zero would cost more than leaving them out.
 
 ## Excluded, and why
 

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -22,7 +22,7 @@ recency breaks ties).
 | 2 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Freefall Timeline, Sunshine Timeline, Mercies Timeline | concert | **measured, labelled** | Canonical snapshot for Ryan and Hang; music-performance cuts only |
 | 3 | `Mike Tucker Scullers` | Concert Full Cut | concert | **measured, unlabelled** | Good two-camera concert; older, so recency weighting applies |
 | 4 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Stablemates | concert | not started | Older but explicitly taste-endorsed. Read from the Ryan and Hang project, not `Ryan Devlin Projects Current` — same timeline, one project to open |
-| 5 | `2026-06_Zinc_and_Monkfish` | Monkfish Main | concert | not started | **Partial** — only a couple of tunes cut; measure those tunes only |
+| 5 | `2026-06_Zinc_and_Monkfish` | Monkfish Main | concert | **measured, unlabelled** | **Partial** — only a couple of tunes cut; measure those tunes only |
 | 6 | `Archive/Client/Side Step Blues Clues Album` | Blues Clues Main, Devlin Time Main, For All The Other Times Main, Intro Main, Outro Main, People We Love Main, Walk Spirit Talk Spirit Main, EJ's Blues Main | studio-session | **deferred** | Footage not on the box; and studio-session is a different cutting context from the concert work this pass is about. Revisit when the concert profile is settled |
 | 7 | ~~`…Ryan and Hang…` Blues for Alice, Three Card Molly~~ | — | — | **dropped** | Confirmed single-camera (director, 2026-08-07) — no angle switches, so nothing to measure |
 
@@ -91,6 +91,7 @@ the right one.
 | 2 | Sunshine Timeline | concert | 50 (49 measured, 1 opening) | `given` @ 86400 | same | `…/analysis/Sunshine-Timeline-edbbc561a240.correlate.json` |
 | 2 | Mercies Timeline | concert | 38 (37 measured, 1 opening) | `given` @ 86400 | same | `…/analysis/Mercies-Timeline-622d697cfd3e.correlate.json` |
 | 3 | Concert Full Cut | concert | 349 (326 measured, 23 openings) | `given` @ 75903 | **none — unlabelled** | `…/analysis/Concert-Full-Cut-bc11cb456a36.correlate.json` |
+| 5 | Monkfish Main | concert | 233 (228 measured, 5 openings) | `audio_clip`, matched | **none — unlabelled** | `…/analysis/Monkfish-Main-a14547f8db48.correlate.json` |
 
 **Entry 1, measured 2026-08-06.** Against `Zinc Set 2 Reaper v4.wav` (74:10,
 48 kHz, the Reaper master mix on A3), beats from `analyze_music` (11,130 beats,
@@ -207,3 +208,37 @@ Three things worth carrying forward:
   distribution; only the *name* of the angle needs a sidecar.
 - The bar histogram has positions 5, 6 and 7 in it. There is no such thing in
   4/4. Same conclusion as entries 1 and 2: rubato gating first.
+
+**Entry 5, measured 2026-08-07.** `Monkfish Main`, 233 cuts over 87 minutes,
+two angles, **unlabelled** — same project as the anchor but a different venue
+and no render, so the angle→camera mapping is not carried over from the Zinc
+sidecar and is not guessed. Alignment is the cleanest of any entry:
+`audio_clip`, matched, against `140111-061037.WAV` on A1 with its zero exactly
+at the timeline's first frame. Nothing had to be named or transcoded.
+
+**This timeline is only partly cut, and that decides which of its numbers
+count.** #21 flagged it and the shots confirm it: five held stretches on
+Video 1 — 32.5 min at 17.8 min in, then 10 min, 5 min, 2.6 min and 2.1 min —
+account for 3126 s of the 5241 s. They are passages nobody has cut yet, not
+shots anybody chose to hold.
+
+| Measure | Value | Comparable? |
+| --- | --- | --- |
+| Offset to nearest transient | median 41 ms, mean 54 ms, max 433 ms; 118 early / 110 late / 0 on | **yes** — each of the 228 is a cut somebody made |
+| Shot length, median | 6.30 s | **yes** — a median over 233 shots is untroubled by five outliers |
+| Shot length, mean | 22.49 s (max 1953 s) | **no** — the held stretches are most of the running time |
+| Angle share | Video 1 89.3%, Video 2 10.7% | **no** — share is time, and the uncut time is all Video 1 |
+| Bar position | 1:96, 2:57, 3:36, 4:39 | see below |
+
+Two notes:
+
+- **This is the second grid that looks structurally sound** — strictly 1–4,
+  `meter: 4`, like Freefall and unlike the anchor, Mercies and Scullers. It is
+  also the *flattest* histogram in the corpus: 67% on beats 1–2 against 78–81%
+  everywhere else. That is the wrong direction for comfort. The timelines whose
+  grids are demonstrably broken show the *strongest* beat-1 skew, which is what
+  you would expect if part of that skew is the detector snapping to cuts rather
+  than the director cutting to beats. Another reason no beat-position claim
+  goes in the profile before rubato gating.
+- The transient median (41 ms) is the highest in the corpus and still inside
+  two frames. Six timelines now span 17–41 ms.

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -18,16 +18,21 @@ recency breaks ties).
 
 | # | Project | Timeline(s) | Context | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `2026-06_Zinc_and_Monkfish` | Zinc - Set 2 Main | concert | **measured, unlabelled** | **Anchor** — strongest current-taste exemplar; two-camera, 2026 |
+| 1 | `2026-06_Zinc_and_Monkfish` | Zinc - Set 2 Main | concert | **measured, labelled** | **Anchor** — strongest current-taste exemplar; two-camera, 2026 |
 | 2 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Freefall Timeline, Sunshine Timeline, Mercies Timeline | concert | not started | Canonical snapshot for Ryan and Hang; music-performance cuts only |
 | 3 | `Mike Tucker Scullers` | Concert Full Cut | concert | not started | Good two-camera concert; older, so recency weighting applies |
-| 4 | `Archive/Client/Ryan Devlin Projects Current` | Stablemates | concert | not started | Older but explicitly taste-endorsed |
+| 4 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Stablemates | concert | not started | Older but explicitly taste-endorsed. Read from the Ryan and Hang project, not `Ryan Devlin Projects Current` — same timeline, one project to open |
 | 5 | `2026-06_Zinc_and_Monkfish` | Monkfish Main | concert | not started | **Partial** — only a couple of tunes cut; measure those tunes only |
-| 6 | `Archive/Client/Side Step Blues Clues Album` | Blues Clues Main, Devlin Time Main, For All The Other Times Main, Intro Main, Outro Main, People We Love Main, Walk Spirit Talk Spirit Main, EJ's Blues Main | studio-session | not started | Multi-camera studio album shoot — a distinct cutting context |
-| 7 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Blues for Alice timeline, Three Card Molly timeline | concert | conditional | Include **only if** pre-flight shows 2+ cameras; suspected single-camera |
+| 6 | `Archive/Client/Side Step Blues Clues Album` | Blues Clues Main, Devlin Time Main, For All The Other Times Main, Intro Main, Outro Main, People We Love Main, Walk Spirit Talk Spirit Main, EJ's Blues Main | studio-session | **deferred** | Footage not on the box; and studio-session is a different cutting context from the concert work this pass is about. Revisit when the concert profile is settled |
+| 7 | ~~`…Ryan and Hang…` Blues for Alice, Three Card Molly~~ | — | — | **dropped** | Confirmed single-camera (director, 2026-08-07) — no angle switches, so nothing to measure |
 
-~7 concert-context timelines + 8 studio-session timelines. Full-set timelines
-carry many tunes, so per-cut counts run into the hundreds.
+7 concert-context timelines across 4 projects. The 8 studio-session timelines
+are deferred, not excluded. Full-set timelines carry many tunes, so per-cut
+counts run into the hundreds.
+
+Entries 4, 6 and 7 were settled by the director on 2026-08-07: Stablemates
+reachable from the entry-2 project, Side Step deferred, and the conditional
+entry resolved single-camera without needing a pre-flight.
 
 ## Excluded, and why
 
@@ -59,8 +64,11 @@ status is only verifiable live through the scripting API.
       clips; relink if archived media moved. Everything under `Archive/Client`
       is a likely relink candidate; entries 1 and 5 are recent and expected
       clean.
-- [ ] 2+ source angles — gates the conditional entry, and drops any timeline
-      that turns out single-camera.
+- [ ] 2+ source angles — drops any timeline that turns out single-camera.
+- [ ] Angle→camera mapping confirmed by the director. Resolve will not say
+      which source is behind an angle number, so every multicam project needs
+      one look before its role claims mean anything; the screen-time heuristic
+      that worked on entry 1 is a starting guess, not an answer.
 - [ ] Concert / master audio reachable for the analysis pipeline (#19).
 - [ ] Frame grabs render and the sidecar can be written (#13).
 
@@ -78,7 +86,7 @@ the right one.
 
 | # | Timeline | Context | Cuts | Alignment | Sidecar | Result |
 | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Zinc - Set 2 Main | concert | 366 (360 measured, 6 openings) | `audio_clip`, matched | `angles/2026-06_Zinc_and_Monkfish.json` (unconfirmed) | `…/analysis/Zinc---Set-2-Main-dcb16e19eca1.correlate.json` |
+| 1 | Zinc - Set 2 Main | concert | 366 (360 measured, 6 openings) | `audio_clip`, matched | `angles/2026-06_Zinc_and_Monkfish.json` (confirmed 2026-08-07) | `…/analysis/Zinc---Set-2-Main-dcb16e19eca1.correlate.json` |
 
 **Entry 1, measured 2026-08-06.** Against `Zinc Set 2 Reaper v4.wav` (74:10,
 48 kHz, the Reaper master mix on A3), beats from `analyze_music` (11,130 beats,
@@ -88,11 +96,11 @@ shot) — a home angle held long against an angle cut to briefly.
 
 Labelled from frame grabs off the multicam's source clips: an operated
 front-of-house **wide** on the FX6, and a locked-off **drummer cam** on the
-A7IV at stage right. **Which angle number is which camera is inferred, not
-read** — Resolve's API does not expose the multicam's angle mapping, so the
-sidecar assigns the wide to Video 1 from the screen-time shape and marks both
-`confidence: "low"`. One look at the timeline settles it; until then every
-role-conditioned claim is unverified.
+A7IV at stage right. **Which angle number is which camera could not be read** —
+Resolve's API does not expose the multicam's angle mapping — so the sidecar
+assigned the wide to Video 1 from the screen-time shape, and the director
+confirmed that reading on 2026-08-07. The screen-time heuristic was right here;
+it is one data point, and every other multicam project still needs its own look.
 
 | Measure | Value |
 | --- | --- |

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -19,7 +19,7 @@ recency breaks ties).
 | # | Project | Timeline(s) | Context | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
 | 1 | `2026-06_Zinc_and_Monkfish` | Zinc - Set 2 Main | concert | **measured, labelled** | **Anchor** — strongest current-taste exemplar; two-camera, 2026 |
-| 2 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Freefall Timeline, Sunshine Timeline, Mercies Timeline | concert | not started | Canonical snapshot for Ryan and Hang; music-performance cuts only |
+| 2 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Freefall Timeline, Sunshine Timeline, Mercies Timeline | concert | **measured, labelled** | Canonical snapshot for Ryan and Hang; music-performance cuts only |
 | 3 | `Mike Tucker Scullers` | Concert Full Cut | concert | not started | Good two-camera concert; older, so recency weighting applies |
 | 4 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Stablemates | concert | not started | Older but explicitly taste-endorsed. Read from the Ryan and Hang project, not `Ryan Devlin Projects Current` — same timeline, one project to open |
 | 5 | `2026-06_Zinc_and_Monkfish` | Monkfish Main | concert | not started | **Partial** — only a couple of tunes cut; measure those tunes only |
@@ -87,6 +87,9 @@ the right one.
 | # | Timeline | Context | Cuts | Alignment | Sidecar | Result |
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | Zinc - Set 2 Main | concert | 366 (360 measured, 6 openings) | `audio_clip`, matched | `angles/2026-06_Zinc_and_Monkfish.json` (confirmed 2026-08-07) | `…/analysis/Zinc---Set-2-Main-dcb16e19eca1.correlate.json` |
+| 2 | Freefall Timeline | concert | 44 (43 measured, 1 opening) | `given` @ 86400 | `angles/Ryan-and-Hang-Main-9-23-24-gene-edit.json` | `…/analysis/Freefall-Timeline-*.correlate.json` |
+| 2 | Sunshine Timeline | concert | 50 (49 measured, 1 opening) | `given` @ 86400 | same | `…/analysis/Sunshine-Timeline-*.correlate.json` |
+| 2 | Mercies Timeline | concert | 38 (37 measured, 1 opening) | `given` @ 86400 | same | `…/analysis/Mercies-Timeline-622d697cfd3e.correlate.json` |
 
 **Entry 1, measured 2026-08-06.** Against `Zinc Set 2 Reaper v4.wav` (74:10,
 48 kHz, the Reaper master mix on A3), beats from `analyze_music` (11,130 beats,
@@ -121,3 +124,48 @@ Two cautions on this row:
 - **The transient numbers do not depend on the grid.** Onsets are measured off
   the mix directly, which is why they are the row's trustworthy half — and
   they are also the half the profile's core principle is about.
+
+**Entry 2, measured 2026-08-07.** The three Judson's quartet tunes. Each was
+measured against the audio of its own finished render rather than a master mix
+file: the masters for Sunshine and Mercies are offline (`C:\…\REAPER Media\`),
+and more to the point *no* clip on these timelines is the mix — the music
+reaches the cut through the multicam's own audio angle, whose in point belongs
+to the multicam's timebase. Alignment is `given` at frame 86400, the timeline's
+first frame, which is exact because each render's duration matches its timeline
+to within 0.02 s — under a frame at 23.976.
+
+| Measure | Freefall | Sunshine | Mercies |
+| --- | --- | --- | --- |
+| Cuts measured | 43 | 49 | 37 |
+| Offset to nearest transient | median 34 ms, mean 53 ms, max 340 ms | median **17 ms**, mean 34 ms, max 263 ms | median 19 ms, mean 27 ms, max 94 ms |
+| Direction | 25 early / 18 late / 0 on | 22 early / 26 late / 1 on | 17 early / 19 late / 1 on |
+| Offset to nearest beat | median 63 ms, mean 228 ms, max 6.08 s | median 124 ms, mean 307 ms, max 6.34 s | median 135 ms, mean 146 ms, max 434 ms |
+| Shot length | median 6.82 s, mean 15.51 s, 2.54–146.4 s | median 12.01 s, mean 18.34 s, 2.75–93.6 s | median 11.53 s, mean 18.52 s, 1.59–183.9 s |
+| Bar position | 1:18, 2:17, 3:4, 4:4 | 1:21, 2:12, 3:10, 4:6 | 1:25, 2:6, 3:2, 4:3, 6:1 |
+
+Angles labelled by **reading the render**, not by inferring from the sources:
+a frame of the finished cut at a moment a given angle is on screen *is* that
+angle. This is the method the anchor could not use — it has no render — and it
+removes the guesswork that made entry 1's mapping need a director's eye.
+
+Three roles, and they recur in all three tunes:
+
+| Role | Freefall | Sunshine | Mercies |
+| --- | --- | --- | --- |
+| `soloist-moving` — operated camera following whoever is playing | 19 cuts, **75.5%** | 24 cuts, **76.3%** | 17 cuts, **74.4%** |
+| `ensemble-wide` — locked full-stage wide | 12 cuts, 14.4% | 16 cuts, 17.0% | 11 cuts, 16.3% |
+| `drums-tight` — drummer cam at house right | 13 cuts, 10.1% | 10 cuts, 6.7% | 5 cuts, 4.0% |
+| `room-wide` — second wide, from a seat | — | — | 5 cuts, 5.2% |
+
+Cautions on these rows:
+
+- **The beat grid fits better here than on the anchor but is still not gated.**
+  Freefall's histogram is strictly 1–4, which is what a grid that fits looks
+  like; Mercies puts one cut in a bar 6, which is what one that slips looks
+  like. Beat-offset means still run two to five times their medians. Treat the
+  bar histograms as suggestive and the transient numbers as evidence, exactly
+  as on entry 1.
+- **The role names are a judgement, the mapping is not.** Which angle is which
+  camera was read off the render and is not in doubt. Whether an operated
+  camera that follows the music is best called `soloist-moving` is a vocabulary
+  choice, and it is the one term here that did not come from the anchor.

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -365,6 +365,38 @@ def test_a_generator_on_the_cut_track_is_still_a_shot(attach: Attach, tmp_path: 
     assert result["cuts"] == 4
 
 
+def test_a_dissolve_into_a_generator_does_not_eat_the_generator(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Neither item has a pool item, so 'overlaps a real shot' cannot separate them.
+
+    What separates them is that a generator holds its stretch of track exclusively and a
+    transition does not — so the test is overlap with anything else, not with media.
+    """
+    timeline = FakeTimeline(
+        "sunset-set v3",
+        FPS,
+        start_frame=100,
+        video=[
+            FakeTrack(
+                "Video 1",
+                [
+                    _shot(*SHOTS[0]),
+                    _shot(*SHOTS[1]),
+                    _dissolve(start=299, duration=14),
+                    FakeTimelineItem("Solid Color", 299, 30, source_start=0),
+                ],
+            )
+        ],
+        audio=[FakeTrack("Master", [_shot("master_mix.wav", 100, 200, 0)])],
+    )
+    attach(studio(timeline=timeline))
+
+    result = _measured(tmp_path)
+
+    assert [one["clip"] for one in _rows(result)] == ["C0012.mp4", "C0031.mp4", "Solid Color"]
+
+
 def test_each_multicam_angle_is_its_own_clip(attach: Attach, tmp_path: Path) -> None:
     """Every angle of a multicam shares one pool item, so the pool name is not the angle.
 

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -318,6 +318,42 @@ def test_a_dissolve_is_not_a_shot(attach: Attach, tmp_path: Path) -> None:
     assert result["cuts"] == 3
 
 
+def test_a_dissolve_that_starts_on_the_cut_takes_no_shot_with_it(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The other dissolve shape: aligned to the incoming shot rather than centred on the cut.
+
+    Live on corpus entry 2 (#45) both shapes appear in one timeline. This one abuts the
+    outgoing shot instead of overlapping it, so an adjacency rule keeps the dissolve — and
+    then drops the real shot behind it, which does overlap. The count stays right and the
+    cut is silently a different cut: a swap is worse than a miscount, because nothing about
+    the totals looks wrong.
+    """
+    timeline = FakeTimeline(
+        "sunset-set v3",
+        FPS,
+        start_frame=100,
+        video=[
+            FakeTrack(
+                "Video 1",
+                [
+                    _shot(*SHOTS[0]),
+                    _dissolve(start=162, duration=14),
+                    _shot(*SHOTS[1]),
+                    _shot(*SHOTS[2]),
+                ],
+            )
+        ],
+        audio=[FakeTrack("Master", [_shot("master_mix.wav", 100, 200, 0)])],
+    )
+    attach(studio(timeline=timeline))
+
+    result = _measured(tmp_path)
+
+    assert [one["clip"] for one in _rows(result)] == ["C0012.mp4", "C0031.mp4", "C0012.mp4"]
+    assert result["cuts"] == 3
+
+
 def test_a_generator_on_the_cut_track_is_still_a_shot(attach: Attach, tmp_path: Path) -> None:
     """The transition test is overlap, not the absence of a pool item — a generator has none."""
     slate = FakeTimelineItem("Solid Color", 299, 30, source_start=0)
@@ -473,6 +509,41 @@ def test_an_unrecognised_mix_still_measures_but_says_the_clock_was_assumed(
 
     assert result["alignment"]["audio"] == "master_mix.wav"
     assert result["alignment"]["matched"] is False
+
+
+def test_saying_where_the_mix_starts_beats_reading_it_off_a_clip_that_is_not_it(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The analysed mix is not always on the timeline at all, and then no clip can be read.
+
+    Corpus entry 2 (#45): the music reaches the cut through the multicam's own audio angle,
+    so A1 carries the multicam, whose in point is in the multicam's timebase and says
+    nothing about where the mastered mix begins. Every mode here would be guessing — and a
+    guess 15 seconds out turns a cut on the beat into a cut nowhere near one, while the
+    reading still looks perfectly ordinary. So the caller can name the frame instead, which
+    a render of the timeline makes exactly knowable.
+    """
+    attach(
+        studio(
+            timeline=FakeTimeline(
+                "judsons",
+                FPS,
+                start_frame=100,
+                video=[FakeTrack("Video 1", [_shot(*shot) for shot in SHOTS])],
+                audio=[FakeTrack("A1", [_shot("Sunshine Multicam - Angle 3", 100, 200, 500)])],
+            )
+        )
+    )
+
+    result = _measured(tmp_path, audio_at=100)
+
+    assert result["alignment"] == {
+        "mode": "given",
+        "audio": "master_mix.wav",
+        "matched": True,
+        "zero_frame": 100,
+    }
+    assert _rows(result)[1]["t"] == 1.033
 
 
 def test_a_mix_with_a_start_timecode_is_not_read_an_hour_late(


### PR DESCRIPTION
Follow-up to #109 (merged), continuing #45. **The ticket stays open** — five of seven concert timelines measured, two of four projects labelled.

Cherry-picked onto `main` after #109 was squash-merged, so these five commits stand alone.

### Which seam verifies this

- **Fake tier** — both `correlate_timeline` fixes, TDD'd: `test_a_dissolve_that_starts_on_the_cut_takes_no_shot_with_it`, `test_a_dissolve_into_a_generator_does_not_eat_the_generator`, `test_saying_where_the_mix_starts_beats_reading_it_off_a_clip_that_is_not_it`.
- **Live, run this session** — pre-flight, labelling and measurement of four more timelines across two more projects; and after the review's rule change, a re-read of all five measured timelines confirming identical shot counts, zero overlaps and zero surviving transitions.
- **Prose** — corpus rows, profile claims, `docs/agents/style-layer.md`.

### The director's answers, recorded

Zinc Set 2's angle mapping is **confirmed** (Video 1 = FX6 wide, Video 2 = A7IV drummer cam); sidecars stay at `styles/angles/<project>.json`; long corpus passes are fine to run. The corpus narrowed: Stablemates reads from the entry-2 project, Blues for Alice and Three Card Molly are confirmed single-camera and dropped under #21 policy 1, Side Step is deferred (footage not on the box, and studio-session is a different cutting context).

### Two more defects the corpus found

1. **A second dissolve shape.** Dissolves are sometimes centred on the cut and sometimes aligned to the incoming shot. The adjacency rule caught the first and kept the second — then dropped the *real* shot behind it, since that is the item which overlaps. Sunshine swapped 2 shots for 2 dissolves, Mercies 6 for 6, **and the cut count stayed exactly right**. A miscount announces itself; a swap does not.
2. **Audio that is not on the timeline.** These cuts get their music through the multicam's own audio angle, so no clip *is* the mastered mix and every existing alignment mode was guessing — invisibly, with every time shifted by the same amount. Measured against entry 2's own A1 the error would have been 15 s on one tune and 40 s on another. `correlate_timeline` now takes `audio_at`; a full-timeline render makes the frame knowable rather than guessed (durations matched to within 0.02 s, under a frame).

### What was measured

Entries 2 and 3: four timelines, 481 more cuts, two more projects. **The transient claim now replicates across three projects** — median cut 17–34 ms from the nearest transient on all five timelines, three rooms, four years apart — and is the first thing in the profile to carry `[measured — …]`.

**Entry 2 corrected a claim rather than confirming it.** The anchor's "the wide is the home angle" (68.5%) does not survive contact with a project that has a roaming operator: there the wide holds 14–17% and the roaming camera 74–76%. Exactly what #21 policy 4 exists to catch.

Ten angles labelled at confidence high by **reading the render** — a frame of the finished cut at a moment an angle is on screen *is* that angle — which removes the inference that made the anchor need a director's eye. Method and its safety check are in `docs/agents/style-layer.md`.

### Review — 7 findings, all taken

`/code-review` on `2568fda..HEAD`, Standards and Spec as parallel sub-agents.

- *`_without_transitions` could still swap a generator for a dissolve into it* — neither has a pool item, so "overlaps something real" cannot separate them. **Fixed**, and the first attempt (overlap with anything) was wrong too: it dropped both. The rule is now **coverage** — a shot holds some track exclusively, a transition never does. Re-verified live on all five timelines: identical counts.
- *`concert.md` §6 contradicted its own tags*, still claiming one entry measured. **Fixed.**
- *New tags dropped the `n=` and context the format requires*, so a 43-cut claim read like a 360-cut one. **Fixed** on all seven.
- *The "not the wide" claim overreached.* The anchor's home angle is its wide **and** its operated camera, so it cannot tell the two readings apart — the evidence is entry 2 alone. **Downgraded** to `[believed, unverified]` with the reason written out.
- *Two result paths were globs*, which cannot be resolved back to the run that produced them. **Fixed** with the real cache keys.
- *`given` alignment reported `matched: true` with no audio named.* **Fixed** — nothing to have recognised.
- *`GetMediaPoolItem` fetched three times per item* (~1575 round trips on the anchor) inside the pass that exists to be single. **Fixed** — `angle_of` takes the clip the caller already holds.

Fake tier green, `mypy --strict` clean over 150 files, `ruff check` clean.

### Not done, and filed rather than fixed here

**#110** — `analyze_music` refuses 32-bit float WAVs (entry 3's master is one), and its `fix` line tells the caller to delete the file, which is the director's own master on a media drive. Worked around by transcoding to PCM with duration preserved to the sample, rather than growing this ticket's code scope a third time.

Review: clean

---

## Commits added after opening: corpus entry 5

`29b3081`, `bb3334a` — **prose only** (`styles/corpus.md`, `styles/concert.md`), so a lightweight inline pass per CLAUDE.md rather than a second full review.

**Monkfish Main measured** — 233 cuts, unlabelled, and with the cleanest alignment in the corpus: `audio_clip` matched, master WAV on A1 with its zero exactly at the timeline's first frame. Nothing named, nothing transcoded. Six of seven concert timelines now measured.

**It is three fifths uncut**, as #21 warned — five held stretches on Video 1, the largest 32.5 minutes. That decides which of its numbers count, and the corpus row says so per measure: its 228 cuts and its 6.3 s median shot join the claims; its 22.5 s shot *mean* and its 89.3% angle share are excluded, because both are facts about how far the edit got rather than about the director. Pooling everything measurable would have published both as findings.

**The most useful result is negative.** Monkfish is the second timeline whose beat grid is structurally sound (strictly 1–4, `meter: 4`), and the two sound grids give the *flattest* bar histograms — 67% on beats 1–2 against 78–81% on every broken-grid timeline. The beat-1 skew weakens exactly where the instrument gets more trustworthy, which is the wrong direction for a real finding. Concrete reason to keep beat-position claims out of the profile until rubato gating lands.

### What the inline pass caught

- **The corpus said four projects; there are three.** Entries 1 and 5 are both `2026-06_Zinc_and_Monkfish`, entries 2 and 4 are both the Ryan and Hang gene edit, entry 3 stands alone. Introduced when Stablemates was folded into the entry-2 project earlier in this PR. Fixed, and stated plainly — #21 policy 4 counts projects, so finishing the corpus would not move any tag past three.
- **Entry 4's status was recorded as "not started", which understates it.** It is blocked on a clock, not on access: no render, and its A1 items disagree about where the mix starts (86391 vs 86055) because each multicam angle carries its own offset. Every other entry had either a clip carrying the analysed mix or a render whose duration proved the frame. Now written down as a holdout with a reason, and left unmeasured rather than measured against a guess.
- Arithmetic checked against the corpus rows: n=1043 cuts (360+43+49+37+326+228), n=1080 shots (366+44+50+38+349+233), n=847 for the two claims Monkfish is excluded from, n=498 for the labelled-only drummer claim. Direction counts re-tallied: three early, three late.

Fake tier green.

Review: clean — prose only, single-pass
