### PR TITLE
P3: label the last two corpus timelines, and settle what the home angle is (#45)

### DIFF
--- a/docs/agents/style-layer.md
+++ b/docs/agents/style-layer.md
@@ -112,6 +112,16 @@ director confirmed this reading on 2026-08-07** — sidecars stay in the repo.
   reruns never re-ask (#13). Until that flip, every claim resting on these
   labels is unverified in a second, sharper way than usual: not merely thin,
   but possibly inverted.
+- **`stated_by_director`**, **`inferred`** and **`inference_basis`** — for a
+  label that came from a sentence rather than from a frame. Quote what was
+  actually said, list which of `subject`/`character` was *not* in it, and say
+  what the rest was filled in from. A description is strong evidence for what a
+  camera **is** ("the fixed wide side-view") and no evidence at all for what it
+  **points at** moment to moment — so an angle carrying `"inferred":
+  ["subject"]` must not be counted toward a claim that turns on subject. This
+  is finer-grained than `confidence`, which grades the whole entry: an angle can
+  be certain about its framing and a guess about its subject at the same time.
+  Entries 3 and 5 in the corpus are labelled this way.
 
 ### Labelling a multicam: grab the render, not the sources
 
@@ -137,10 +147,22 @@ Nothing is inferred, and `confirmed_by_director` is not needed to trust it.
    timeline would not, and would put every label on the wrong angle.
 4. Read the frames and write the labels.
 
-Where there is no render — the anchor, and `Mike Tucker Scullers` — the gap is
-real and the director's eye is the only way to close it. Ask before the roles
-are used for anything, and note that timing claims need no labels at all: a
-timeline can be measured while its angles are still unlabelled.
+Where there is no render — the anchor, `Mike Tucker Scullers`, `Monkfish Main`
+— the gap is real and the director's eye is the only way to close it. Ask
+before the roles are used for anything, and note that timing claims need no
+labels at all: a timeline can be measured while its angles are still
+unlabelled, which is what makes asking cheap. Measure first, ask once, and
+**re-run with the sidecar attached rather than writing the role shares in by
+hand** — `angles` is part of the cache key, so a labelled run is a new result
+file that can be diffed against the unlabelled one. On entries 3 and 5 every
+number was identical, which is the only way to know the labels added names and
+nothing else.
+
+An answer in words closes less than a frame does. It fixes what each camera is
+and which angle number it is; it does not say what a moving camera was
+following at any given moment. Record the difference in the entry
+(`stated_by_director` / `inferred`) instead of flattening it, or the corpus
+will use a sentence as though it were a look.
 
 Angle *numbers* are per-multicam and do not carry across timelines even inside
 one project: on the Judson's show `Angle 10` is the drummer on one tune and the

--- a/styles/angles/2026-06_Zinc_and_Monkfish.json
+++ b/styles/angles/2026-06_Zinc_and_Monkfish.json
@@ -35,18 +35,17 @@
       "subject": "soloist",
       "character": "moving",
       "note": "The moving camera. The home angle of this cut by both measures - 125 cuts and 89.3% of screen time - though the share is not usable as taste: three fifths of this timeline is passages nobody has cut yet, and they sit on this angle.",
-      "confidence": "medium",
-      "stated_by_director": "angle 1 is the moving camera",
-      "inferred": [
-        "subject"
-      ],
-      "inference_basis": "The director stated behaviour, not subject. 'soloist' is carried over from the entry-2 rig where the operated camera was verified by frame grab; nothing on this night was looked at. Claims that turn on what the camera follows must not count this angle."
+      "confidence": "high",
+      "subject_is_primary_not_exclusive": true,
+      "stated_by_director": "angle 1 is the moving camera; and separately, that the moving camera generally follows the soloist but also roams the band for interesting movement",
+      "inferred": [],
+      "inference_basis": "Both axes are now stated rather than inferred. The subject is soloist-PRIMARY by design: the director's account is that this camera goes to whoever is soloing and also moves around the band for visual interest. Enough for role-level claims; not enough to attribute any single shot, since no frames from this night have been looked at."
     },
     "Monkfish Multicam - Video 2": {
       "role": "drums-tight",
       "subject": "drums",
       "character": "tight",
-      "note": "Fixed drum camera. 108 cuts for 10.7% of the time - near-equal cut counts to the home angle on a tenth of the screen time, the same frequent-and-short shape the drummer cam has at Zinc and at Judson's.",
+      "note": "Fixed drum camera. 108 cuts for 10.7% of the time, and not one of those shots reaches 14 seconds - the frequent-and-short shape every drum cam in the corpus has. The director's rationale: the locked camera is spent on the drums, the rhythm section's most watchable instrument, which frees the operated camera for the soloist.",
       "confidence": "medium",
       "stated_by_director": "angle 2 is the fixed drum angle",
       "inferred": [

--- a/styles/angles/2026-06_Zinc_and_Monkfish.json
+++ b/styles/angles/2026-06_Zinc_and_Monkfish.json
@@ -4,7 +4,7 @@
   "labelled": "2026-08-06 (Zinc), 2026-08-07 (Monkfish)",
   "method": "Zinc: frame grabs off the multicam's source clips, read by the agent, then confirmed. Monkfish: stated by the director, nothing looked at.",
   "confirmed_by_director": "2026-08-07",
-  "note": "Two nights in one project: Zinc - Set 2 (corpus entry 1) and Monkfish Main (entry 5), each with its own multicam and its own angle numbers. The numbers do not carry across - Video 1 is the wide at Zinc and the moving camera at Monkfish - so both nights are labelled separately here.",
+  "note": "Two nights in one project: Zinc - Set 2 (corpus entry 1) and Monkfish Main (entry 5), each with its own multicam and its own angle numbers. Both nights happen to put the operated camera on Video 1 and the drums on Video 2, but Video 1 is a wide at Zinc and a moving camera at Monkfish - the angle number does not carry the framing, which is why both nights are labelled separately rather than once.",
   "angles": {
     "Zinc - Set 2 Multicam - Video 1": {
       "role": "ensemble-wide",

--- a/styles/angles/2026-06_Zinc_and_Monkfish.json
+++ b/styles/angles/2026-06_Zinc_and_Monkfish.json
@@ -1,10 +1,10 @@
 {
   "project": "2026-06_Zinc_and_Monkfish",
   "context": "concert",
-  "labelled": "2026-08-06",
-  "method": "frame grabs off the multicam's source clips, read by the agent",
+  "labelled": "2026-08-06 (Zinc), 2026-08-07 (Monkfish)",
+  "method": "Zinc: frame grabs off the multicam's source clips, read by the agent, then confirmed. Monkfish: stated by the director, nothing looked at.",
   "confirmed_by_director": "2026-08-07",
-  "note": "Zinc - Set 2 only. Monkfish Main is corpus entry 5 and is not labelled yet.",
+  "note": "Two nights in one project: Zinc - Set 2 (corpus entry 1) and Monkfish Main (entry 5), each with its own multicam and its own angle numbers. The numbers do not carry across - Video 1 is the wide at Zinc and the moving camera at Monkfish - so both nights are labelled separately here.",
   "angles": {
     "Zinc - Set 2 Multicam - Video 1": {
       "role": "ensemble-wide",
@@ -29,6 +29,30 @@
         "frames/20260617_D_A7IV_0006.MP4-7b06dd289e54.jpg",
         "frames/20260617_D_A7IV_0006.MP4-e924bd957d6e.jpg"
       ]
+    },
+    "Monkfish Multicam - Video 1": {
+      "role": "soloist-moving",
+      "subject": "soloist",
+      "character": "moving",
+      "note": "The moving camera. The home angle of this cut by both measures - 125 cuts and 89.3% of screen time - though the share is not usable as taste: three fifths of this timeline is passages nobody has cut yet, and they sit on this angle.",
+      "confidence": "medium",
+      "stated_by_director": "angle 1 is the moving camera",
+      "inferred": [
+        "subject"
+      ],
+      "inference_basis": "The director stated behaviour, not subject. 'soloist' is carried over from the entry-2 rig where the operated camera was verified by frame grab; nothing on this night was looked at. Claims that turn on what the camera follows must not count this angle."
+    },
+    "Monkfish Multicam - Video 2": {
+      "role": "drums-tight",
+      "subject": "drums",
+      "character": "tight",
+      "note": "Fixed drum camera. 108 cuts for 10.7% of the time - near-equal cut counts to the home angle on a tenth of the screen time, the same frequent-and-short shape the drummer cam has at Zinc and at Judson's.",
+      "confidence": "medium",
+      "stated_by_director": "angle 2 is the fixed drum angle",
+      "inferred": [
+        "character"
+      ],
+      "inference_basis": "Subject is stated. 'tight' is inferred: a camera dedicated to the drums is not a stage wide, and the other locked drum cameras in the corpus - Zinc Video 2, and all three Judson's tunes - are all tight on the kit. Inferred from the rig, not seen."
     }
   },
   "sources": {
@@ -54,6 +78,8 @@
     "what_is_known": "What each camera is, read off its own frame grabs; and which multicam angle number each one is, confirmed by the director on 2026-08-07.",
     "why_it_needed_confirming": "Resolve's scripting API does not say which source is behind an angle: the multicam clip's 'Angle' property comes back empty, and a timeline item only carries the angle name. The mapping cannot be read, only inferred and then checked by eye.",
     "how_it_was_first_guessed": "Video 1 holds 68.5% of screen time over 188 cuts (13.8s a shot) and Video 2 holds 31.5% over 178 cuts (6.7s a shot). A two-camera concert cut that way has a home angle held long and a second angle cut to briefly, so the wide was assigned to Video 1. The director confirmed this reading, so the screen-time heuristic held on this project - one data point, not a rule.",
-    "scope_of_the_confirmation": "This project only. Every other multicam project in the corpus needs its own look; nothing here transfers."
+    "scope_of_the_confirmation": "The Zinc night only. Every other multicam night in the corpus needs its own look; nothing here transfers, including to Monkfish in this same project.",
+    "monkfish": "Stated by the director on 2026-08-07, not read: Video 1 is the moving camera, Video 2 the fixed drum angle. No render and no frame grabs, so the subject of the moving camera is unknown and 'sources' below - which body shot which angle - is not established for this night. It need not be the same two cameras as Zinc, five months earlier in a different room.",
+    "sources_scope": "The 'sources' block is the Zinc night only."
   }
 }

--- a/styles/angles/Mike-Tucker-Scullers.json
+++ b/styles/angles/Mike-Tucker-Scullers.json
@@ -10,13 +10,12 @@
       "role": "soloist-moving",
       "subject": "soloist",
       "character": "moving",
-      "note": "The moving camera, and the tighter of the two. The home angle of this cut: 182 cuts, 74.3% of screen time.",
-      "confidence": "medium",
-      "stated_by_director": "angle 1 is the moving camera, tighter",
-      "inferred": [
-        "subject"
-      ],
-      "inference_basis": "The director stated how this camera behaves, not what it follows. 'soloist' is carried over from the entry-2 rig, where the operated camera was verified against frame grabs to follow whoever is playing. Nothing here was looked at, so any claim that turns on the subject must not count this angle as evidence - only claims about framing and operation may."
+      "note": "The moving camera, and the tighter of the two. The home angle of this cut: 182 cuts, 74.3% of screen time, and 41 of those shots run past 30 seconds against the wide's 1.",
+      "confidence": "high",
+      "subject_is_primary_not_exclusive": true,
+      "stated_by_director": "angle 1 is the moving camera, tighter; and separately, that the moving camera generally follows the soloist but also roams the band for interesting movement",
+      "inferred": [],
+      "inference_basis": "Both axes are now stated rather than inferred. The subject is soloist-PRIMARY: the director's account is that this camera goes to whoever is soloing and also moves around the band for visual interest, so a given shot may be on anyone. Claims about this angle's subject should be read as 'mostly the soloist, by design not always', and nothing here supports a per-shot subject - no frames from this night have been looked at."
     },
     "unmixed board audio Multicam - Angle 2": {
       "role": "ensemble-wide",
@@ -34,7 +33,8 @@
   "mapping_basis": {
     "what_is_known": "Which multicam angle number is which camera, stated by the director on 2026-08-07, plus each camera's framing and whether it is operated.",
     "why_it_needed_the_director": "This project has no render and no accessible source frames, so neither the read-the-render method (entry 2) nor the frame-grab method (entry 1) could be used. Resolve's API gives the angle name and nothing about what is behind it.",
-    "what_is_not_known": "What the moving camera actually points at, moment to moment. That is the one thing frame grabs give and a sentence cannot.",
+    "what_is_not_known": "What the moving camera points at in any particular shot. The director has since given its habit - soloist first, roaming for interest - which is enough for role-level claims and not enough to attribute any single shot. That per-shot answer is the one thing frame grabs give and a sentence cannot.",
+    "why_this_rig_is_unusual": "It is the only labelled rig in the corpus with no drummer camera, so its locked camera is a wide. The director's rationale for the usual arrangement - spend the locked camera on the drums, the rhythm section's most watchable instrument, so the operated camera is free for the soloist - explains both the norm and this exception.",
     "scope": "This project only."
   }
 }

--- a/styles/angles/Mike-Tucker-Scullers.json
+++ b/styles/angles/Mike-Tucker-Scullers.json
@@ -1,0 +1,40 @@
+{
+  "project": "Mike Tucker Scullers",
+  "context": "concert",
+  "labelled": "2026-08-07",
+  "method": "stated by the director; no frame grabs and no render exist for this project",
+  "confirmed_by_director": "2026-08-07",
+  "note": "Corpus entry 3, Concert Full Cut. A two-camera night with no drummer camera - the second angle is a wide, which makes this the only labelled rig in the corpus whose two cameras are not 'operated + drums'.",
+  "angles": {
+    "unmixed board audio Multicam - Angle 1": {
+      "role": "soloist-moving",
+      "subject": "soloist",
+      "character": "moving",
+      "note": "The moving camera, and the tighter of the two. The home angle of this cut: 182 cuts, 74.3% of screen time.",
+      "confidence": "medium",
+      "stated_by_director": "angle 1 is the moving camera, tighter",
+      "inferred": [
+        "subject"
+      ],
+      "inference_basis": "The director stated how this camera behaves, not what it follows. 'soloist' is carried over from the entry-2 rig, where the operated camera was verified against frame grabs to follow whoever is playing. Nothing here was looked at, so any claim that turns on the subject must not count this angle as evidence - only claims about framing and operation may."
+    },
+    "unmixed board audio Multicam - Angle 2": {
+      "role": "ensemble-wide",
+      "subject": "ensemble",
+      "character": "wide",
+      "note": "Fixed wide from the side of the room rather than front of house. 167 cuts, 25.7% - near-equal cut counts to the home angle on a quarter of the time, the same frequent-and-short shape the drummer cam has elsewhere, but on a wide.",
+      "confidence": "high",
+      "stated_by_director": "angle 2 is the fixed wide side-view",
+      "inferred": [
+        "subject"
+      ],
+      "inference_basis": "'wide' and 'fixed' are stated. 'ensemble' follows from a wide of a stage holding the whole band; it is not a separate observation."
+    }
+  },
+  "mapping_basis": {
+    "what_is_known": "Which multicam angle number is which camera, stated by the director on 2026-08-07, plus each camera's framing and whether it is operated.",
+    "why_it_needed_the_director": "This project has no render and no accessible source frames, so neither the read-the-render method (entry 2) nor the frame-grab method (entry 1) could be used. Resolve's API gives the angle name and nothing about what is behind it.",
+    "what_is_not_known": "What the moving camera actually points at, moment to moment. That is the one thing frame grabs give and a sentence cannot.",
+    "scope": "This project only."
+  }
+}

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -84,6 +84,13 @@ that the grid is a live band's grid, so it moves.
   this one on purpose: its mean is 22.5 s against a 6.3 s median, but three
   fifths of that timeline is passages nobody has cut yet, so its skew is a fact
   about how far the edit got rather than about how the director holds a shot.
+- **The skew has an address: it is the operated camera.** Splitting the same
+  shots by role, the locked cameras are nearly symmetric (drums 5.5 s median
+  against a 6.6 s mean) while the operated ones carry the whole tail
+  (`soloist-moving` 14.4 s median against a 24.6 s mean). The long holds in the
+  bullet above are not scattered across the cut — every one of them is on a
+  camera somebody was running. See §4.
+  `[measured — 3 projects, n=847 shots, concert]`
 - Duration distributions conditioned on section type and energy band. *Open;
   the conditioning needs the structure analysis, which has not been run over
   the corpus.*
@@ -120,12 +127,44 @@ that the grid is a live band's grid, so it moves.
   `[measured — 3 projects, n=847 shots, concert]` (`corpus.md`, "What the
   labels settled") — Monkfish agrees but its share is excluded as ever; it is
   the home angle there by cut count too.
-- **Whether the operated camera is followed because it is on the soloist is a
-  separate question, and still one project.** Entry 2 is the only place anyone
-  has looked at what the moving camera points at; entries 3 and 5 were labelled
-  by description, so their sidecars mark `subject` as inferred and they are
-  excluded here. Moving is measured, on-the-soloist is not.
-  `[believed, unverified]` — entry 2 only.
+- **The moving camera serves two masters: the soloist, and visual interest.**
+  It generally goes to whoever is soloing, but it also roams — different angles
+  on the band, movement within the shot — because that is where interesting
+  shots come from. Its subject is soloist-*primary*, not soloist-only, and that
+  is a design choice rather than a lapse.
+  `[stated principle]` (director, 2026-08-07) — corroborated on entry 2, the one
+  night whose frame grabs show the camera on tenor, on piano hands, and wide on
+  tenor-and-bass at different moments.
+- **The locked camera is spent on the drums so the operated one is free.** With
+  two or three cameras, the fixed angle goes to the drums because the drums are
+  the rhythm section's most watchable instrument — which buys the operated
+  camera permission to stay with the soloist and to roam.
+  `[stated principle]` (director, 2026-08-07). The corpus fits and names the
+  exception: three of four rigs put the locked camera on the kit, and the
+  fourth (entry 3) has no drum camera at all, so its locked camera is a wide.
+- **An operated camera can hold; a locked one cannot.** Shot length splits on
+  operation, hard:
+
+  | Role | n | median | >30 s | longest |
+  | --- | --- | --- | --- | --- |
+  | `drums-tight` (locked) | 314 | 5.5 s | **0 (0.0%)** | **21.5 s** |
+  | `ensemble-wide`, locked instances | 206 | 7.3 s | 2 (1.0%) | 57.4 s |
+  | `ensemble-wide`, the one operated instance (anchor) | 188 | 10.7 s | 17 (9.0%) | 71.1 s |
+  | `soloist-moving` | 242 | 14.4 s | 58 (24.0%) | 238.9 s |
+
+  **No drummer shot anywhere in the corpus reaches 22 seconds** — 314 shots,
+  six timelines, four years, no exceptions. The mechanism is the director's:
+  a locked shot has given everything it has within a few seconds, while an
+  operated camera renews itself by moving. The cleanest evidence is *within*
+  one role — the anchor's operated `ensemble-wide` behaves like the moving
+  cameras (9.0% past 30 s) while the four locked `ensemble-wide`s behave like
+  drum cams (1.0%). Same role name, opposite behaviour, and operation is what
+  differs.
+  `[measured — 3 projects, n=847 shots, concert]` (Monkfish excluded from the
+  rates; its drum shots are counted in the 314 and its longest is 13.7 s.)
+  *Caveat: in this corpus the operated camera is always also the home angle, so
+  "operated" and "home" cannot be separated. What is separable, and separated
+  above, is framing.*
 - **The second angle is cut to, not lived on — whatever it is pointing at.**
   Near-equal cut counts, a fraction of the hold: anchor drums 178 cuts for
   31.5%, Freefall 13 for 10.1%, Sunshine 10 for 6.7%, Mercies 5 for 4.0%,
@@ -134,7 +173,9 @@ that the grid is a live band's grid, so it moves.
   is a property of being the other angle.
   `[measured — 3 projects, n=1080 shots, concert]` — the shape is what
   generalised here; that it is usually the *drummer* being cut to is a fact
-  about the rig, and one night in the corpus had no drum camera at all.
+  about the rig, and one night in the corpus had no drum camera at all. The
+  hard version of this is the 22-second ceiling below: the second angle is not
+  merely held less on average, it is **never** held long.
 - **A second wide is a garnish, not a role.** Mercies is the only timeline with
   one (`room-wide`, from a seat rather than of the stage): 5 cuts, 5.2%.
   `[believed, unverified]` — one timeline.
@@ -214,11 +255,18 @@ Free prose, first-class.
   identical — same cuts, same offsets, same shot lengths, same shares under new
   names. A label is supposed to add names and nothing else, and re-running was
   cheaper than trusting that it had.
-- **One tie the corpus broke, and one it did not.** Two labels arriving from a
-  sentence settled a question five timelines of measurement could not: the home
-  angle is the operated camera, not the wide, because entry 3 is the only rig
-  whose fixed camera is a wide and so the only place the two readings disagree.
-  The neighbouring question — whether that camera holds the cut *because* it is
-  on the soloist — did not move at all, since a description says a camera moves
-  but not what it was following. Worth remembering which kind of gap a
-  conversation can close.
+- **One tie the corpus broke, and one a conversation did.** Two labels arriving
+  from a sentence settled a question five timelines of measurement could not:
+  the home angle is the operated camera, not the wide, because entry 3 is the
+  only rig whose fixed camera is a wide and so the only place the two readings
+  disagree. The neighbouring question — *why* — could not be measured at all,
+  and was simply answered: the locked camera is spent on the drums so the
+  operated one is free for the soloist and free to roam. Worth remembering
+  which kind of gap each source closes, because they are not interchangeable.
+- **The best result of this pass came from testing what the director said
+  rather than recording it.** His account predicts that an operated camera can
+  sustain a shot and a locked one cannot — so the shots were split by role, and
+  no drum shot in 314 reaches 22 seconds while the moving camera runs to 238.
+  The prediction was not obvious in advance and it held at the extreme, which
+  is worth more than the agreement of averages. Ask why, then check whether the
+  why leaves a mark.

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -86,7 +86,8 @@ that the grid is a live band's grid, so it moves.
   about how far the edit got rather than about how the director holds a shot.
 - **The skew has an address: it is the operated camera.** Splitting the same
   shots by role, the locked cameras are nearly symmetric (drums 5.5 s median
-  against a 6.6 s mean) while the operated ones carry the whole tail
+  against a 6.6 s mean, over the 206 shots in this Monkfish-excluded set)
+  while the operated ones carry the whole tail
   (`soloist-moving` 14.4 s median against a 24.6 s mean). The long holds in the
   bullet above are not scattered across the cut — every one of them is on a
   camera somebody was running. See §4.
@@ -147,7 +148,7 @@ that the grid is a live band's grid, so it moves.
 
   | Role | n | median | >30 s | longest |
   | --- | --- | --- | --- | --- |
-  | `drums-tight` (locked) | 314 | 5.5 s | **0 (0.0%)** | **21.5 s** |
+  | `drums-tight` (locked) | 314 | 5.25 s | **0 (0.0%)** | **21.5 s** |
   | `ensemble-wide`, locked instances | 206 | 7.3 s | 2 (1.0%) | 57.4 s |
   | `ensemble-wide`, the one operated instance (anchor) | 188 | 10.7 s | 17 (9.0%) | 71.1 s |
   | `soloist-moving` | 242 | 14.4 s | 58 (24.0%) | 238.9 s |
@@ -160,8 +161,11 @@ that the grid is a live band's grid, so it moves.
   cameras (9.0% past 30 s) while the four locked `ensemble-wide`s behave like
   drum cams (1.0%). Same role name, opposite behaviour, and operation is what
   differs.
-  `[measured — 3 projects, n=847 shots, concert]` (Monkfish excluded from the
-  rates; its drum shots are counted in the 314 and its longest is 13.7 s.)
+  `[measured — 3 projects, n=847 shots, concert]` — the `drums-tight` row is
+  all six timelines (n=314) and every other row excludes Monkfish, because
+  Monkfish's uncut passages sit on `soloist-moving` and so compromise that role
+  without touching its drum camera. Its 108 drum shots are clean, and their
+  longest is 13.7 s.
   *Caveat: in this corpus the operated camera is always also the home angle, so
   "operated" and "home" cannot be separated. What is separable, and separated
   above, is framing.*

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -146,8 +146,10 @@ that the grid is a live band's grid, so it moves.
   the corpus runs exactly that: the anchor runs two cameras with the *wide*
   operated and the drummer cam locked; entry 2 runs three (and four on Mercies,
   with a second wide from a seat); entry 3 runs two with **no drummer camera at
-  all**; entry 5 runs two the reverse way round from the anchor — in the same
-  project. Read a night's sidecar; never assume the rig.
+  all**; and entry 5, in the same project as the anchor five months earlier,
+  puts a *moving* camera where the anchor puts a wide — same angle number, same
+  role in the cut, different framing. Read a night's sidecar; never assume the
+  rig.
   `[measured — 3 projects, n=6 timelines, concert]`
 
 ## 5. Event-reactive moves

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -52,8 +52,10 @@ that the grid is a live band's grid, so it moves.
   67% on beats 1–2 where every broken-grid timeline puts 78–81%. The
   measurement gets *less* dramatic exactly where the instrument gets more
   trustworthy, which is the wrong direction for a real finding. Rubato gating
-  comes first, and until it lands a consistent-looking histogram is the most
-  misleading thing in this file, because it looks like evidence.*
+  comes first (**#112**), and until it lands a consistent-looking histogram is
+  the most misleading thing in this file, because it looks like evidence. #112
+  is written to close either way: "the skew did not survive gating" retires
+  this item just as well as a measured claim would.*
 
 ## 2. Energy — the master concept
 
@@ -103,39 +105,50 @@ that the grid is a live band's grid, so it moves.
   Anchor 68.5%, Freefall 75.5%, Sunshine 76.3%, Mercies 74.4%, Scullers 74.3%.
   Five timelines, three projects, and the share never drops below two thirds.
   This one needs no labels — it is about the shape of the distribution, not
-  about which camera — which is why entry 3 supports it while supporting
-  nothing else in this section.
+  about which camera — and it was measured on entries 3 and 5 before either had
+  a sidecar. When the labels arrived, not one of these numbers moved.
   `[measured — 3 projects, n=847 shots, concert]` — Monkfish is excluded
   (89.3%), not because it disagrees but because share is time and three fifths
   of its time is uncut passage sitting on one angle.
-- **The home angle may be the camera on whoever is playing rather than the
-  wide.** On entry 2 the wide holds 14–17% while a roaming operated camera
-  holds 74–76%, so there the home angle is chosen by *subject*, not framing.
-  `[believed, unverified]` — entry 2 only, and the reason is worth stating: the
-  anchor cannot corroborate this even though its numbers look like they should.
-  Its home angle is its wide *and* its operated camera at once, so it has no
-  case where the two disagree and cannot tell which one the director was
-  following. Entry 3 is measured but unlabelled and cannot speak to it either.
-  One project deciding between two readings is exactly what #21 policy 4 is
-  about — so this is written down as the better reading, not as a finding, and
-  entry 4 or 5 is what would settle it.
-- **The drummer cam is cut to, not lived on.** It takes near-equal cut counts
-  and a fraction of the hold: anchor 178 cuts for 31.5%, Freefall 13 for 10.1%,
-  Sunshine 10 for 6.7%, Mercies 5 for 4.0%. Frequent and short is the shape.
-  `[measured — 2 projects, n=498 shots, concert]` — two, not three: entry 3 is
-  unlabelled, so its 167 second-angle cuts cannot be attributed to a drummer.
+- **The home angle is the operated camera, and framing does not predict it.**
+  On all six labelled timelines the angle holding the cut is the one somebody is
+  running, and **no locked-off camera is ever the home angle**. Framing says
+  nothing: a wide holds 68.5% on the anchor and 25.7% on entry 3. What makes
+  this checkable is entry 3, the only rig whose fixed camera is a *wide* —
+  everywhere else "wide" and "locked off" name the same cameras, so no evidence
+  could separate them.
+  `[measured — 3 projects, n=847 shots, concert]` (`corpus.md`, "What the
+  labels settled") — Monkfish agrees but its share is excluded as ever; it is
+  the home angle there by cut count too.
+- **Whether the operated camera is followed because it is on the soloist is a
+  separate question, and still one project.** Entry 2 is the only place anyone
+  has looked at what the moving camera points at; entries 3 and 5 were labelled
+  by description, so their sidecars mark `subject` as inferred and they are
+  excluded here. Moving is measured, on-the-soloist is not.
+  `[believed, unverified]` — entry 2 only.
+- **The second angle is cut to, not lived on — whatever it is pointing at.**
+  Near-equal cut counts, a fraction of the hold: anchor drums 178 cuts for
+  31.5%, Freefall 13 for 10.1%, Sunshine 10 for 6.7%, Mercies 5 for 4.0%,
+  Monkfish drums 108 cuts against the home angle's 125, and **Scullers 167
+  against 182 on a camera that is a wide, not a drum cam**. Frequent-and-short
+  is a property of being the other angle.
+  `[measured — 3 projects, n=1080 shots, concert]` — the shape is what
+  generalised here; that it is usually the *drummer* being cut to is a fact
+  about the rig, and one night in the corpus had no drum camera at all.
 - **A second wide is a garnish, not a role.** Mercies is the only timeline with
   one (`room-wide`, from a seat rather than of the stage): 5 cuts, 5.2%.
   `[believed, unverified]` — one timeline.
 - Wide-as-reset patterns and transition habits between roles — which role
-  follows which. *Open. Four labelled timelines is enough to start; the shot
-  records hold the sequence, and nothing has read it yet.*
-- The role vocabulary a given night supports is whatever its sidecar says. Spec
-  #22 describes the rig as a static wide, a drummer cam and a roaming soloist
-  cam — but the anchor night ran **two** cameras and the other way round: the
-  wide is the operated one and the drummer cam is locked off.
-  `[believed, unverified]` — one night, from its frame grabs. Worth watching
-  across the corpus rather than assuming either way.
+  follows which. *Open. All six timelines are labelled now; the shot records
+  hold the sequence, and nothing has read it yet.*
+- **The rig is not a constant, so the role vocabulary is per night.** Spec #22
+  describes a static wide, a drummer cam and a roaming soloist cam. No night in
+  the corpus runs exactly that: the anchor runs two cameras with the *wide*
+  operated and the drummer cam locked; entry 2 runs three (and four on Mercies,
+  with a second wide from a seat); entry 3 runs two with **no drummer camera at
+  all**; entry 5 runs two the reverse way round from the anchor — in the same
+  project. Read a night's sidecar; never assume the rig.
+  `[measured — 3 projects, n=6 timelines, concert]`
 
 ## 5. Event-reactive moves
 
@@ -166,11 +179,12 @@ Free prose, first-class.
   the anchor, the three Judson's tunes (entry 2), the Scullers full cut
   (entry 3) and Monkfish Main (entry 5). Only Stablemates is left, and it is
   left for a reason — no render and no defensible clock. Timing claims above
-  therefore carry `[measured — …]`. Claims that
-  need *labels* to state — which role holds the cut — rest on two projects,
-  because entries 3 and 5 are measured but unlabelled; claims that separate
-  framing from subject rest on entry 2 alone, because the anchor's home angle
-  is both its wide and its operated camera and so cannot tell the two apart.
+  therefore carry `[measured — …]`. **Every measured timeline is now labelled**
+  (the director supplied entries 3 and 5 on 2026-08-07), so role claims rest on
+  the same three projects the timing claims do. What is still thin is narrower
+  and worth naming exactly: claims about what a camera *points at* rest on
+  entry 2 alone, the only night whose moving camera anybody has actually
+  looked at.
 - **Every timeline agrees about transients and none agrees about the beat
   grid.** Six timelines, three projects, four years: the median cut sits
   17–41 ms from the nearest transient every time — inside two frames, without
@@ -193,3 +207,16 @@ Free prose, first-class.
   in the corpus produce the flattest histograms.
   Everything above is measured with those fixed; nothing measured before them
   should be believed.
+- **The labelling pass moved no number, and that was the useful part.** Entries
+  3 and 5 were re-measured with their new sidecars attached and came back
+  identical — same cuts, same offsets, same shot lengths, same shares under new
+  names. A label is supposed to add names and nothing else, and re-running was
+  cheaper than trusting that it had.
+- **One tie the corpus broke, and one it did not.** Two labels arriving from a
+  sentence settled a question five timelines of measurement could not: the home
+  angle is the operated camera, not the wide, because entry 3 is the only rig
+  whose fixed camera is a wide and so the only place the two readings disagree.
+  The neighbouring question — whether that camera holds the cut *because* it is
+  on the soloist — did not move at all, since a description says a camera moves
+  but not what it was following. Worth remembering which kind of gap a
+  conversation can close.

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -324,14 +324,51 @@ makes this checkable at all, being the only rig whose fixed camera is a wide;
 without it, "wide" and "locked off" name the same cameras throughout the corpus
 and no evidence could separate them.
 
+### The mechanism, and the hardest number in the corpus
+
+The director's account of *why* (2026-08-07): the locked camera is spent on the
+drums because the drums are the rhythm section's most watchable instrument,
+which frees the operated camera to stay with the soloist — and to roam the band
+for movement and interesting shots, since that is where interesting shots come
+from.
+
+That account predicts something checkable, so it was checked. Splitting all
+1080 shots by role:
+
+| Role | n | median | mean | >30 s | longest |
+| --- | --- | --- | --- | --- | --- |
+| `drums-tight` (locked, all 6 timelines) | 314 | 5.5 s | — | **0 (0.0%)** | **21.5 s** |
+| `ensemble-wide`, the 4 locked instances | 206 | 7.3 s | 8.7 s | 2 (1.0%) | 57.4 s |
+| `ensemble-wide`, the 1 operated instance (anchor) | 188 | 10.7 s | 13.9 s | 17 (9.0%) | 71.1 s |
+| `room-wide` (locked, Mercies) | 5 | 7.5 s | 7.4 s | 0 (0.0%) | 12.9 s |
+| `soloist-moving` | 242 | 14.4 s | 24.6 s | 58 (24.0%) | 238.9 s |
+
+Rates exclude Monkfish, whose uncut passages would swamp them; its drum shots
+are counted in the 314 and its longest is 13.7 s.
+
+**No drummer shot anywhere in this corpus reaches 22 seconds.** 314 shots, six
+timelines, four rooms, four years, zero exceptions — the hardest boundary the
+corpus has produced, and a usable rule rather than a tendency.
+
+The sharpest evidence sits *inside* one role. `ensemble-wide` appears five
+times; the anchor's instance is operated and the other four are locked. The
+operated one puts 9.0% of its shots past 30 s, the locked ones 1.0%. Same role
+name, same framing, opposite behaviour — and operation is the only thing that
+differs. A locked shot has given everything it has within a few seconds; an
+operated camera renews itself by moving, which is exactly the director's
+reason, arrived at from the other end.
+
 Two limits worth keeping attached to that:
 
 - **It is a claim about the shape of the rig, not about intent.** The operated
   camera is the one that can follow anything, so it is also the one an editor
   can stay on. That may be why it holds the cut, and this corpus cannot say.
-- **It is still not the subject claim.** Whether the operated camera is chosen
-  because it is *on the soloist* rests on entry 2 alone, where frame grabs
-  actually show what it points at. Entries 3 and 5 were stated, not seen: their
-  sidecars record `subject` as inferred, and they are excluded from any claim
-  that turns on it. A stated label is enough to say a camera moves; it is not
-  enough to say what it was following.
+- **The subject question is answered, but as a principle rather than a
+  measurement.** The director's account (2026-08-07) is that the moving camera
+  generally follows the soloist *and* roams the band for interesting movement —
+  soloist-primary, not soloist-only, by design. That is `[stated principle]`
+  in the profile, corroborated by entry 2's frame grabs, and it is a different
+  and in some ways better kind of evidence than three projects of inferred
+  labels would have been. What remains unmeasurable is per-shot subject: no
+  analysis in this corpus can see who is on screen, so no claim should ever
+  rest on attributing a *particular* shot.

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -20,9 +20,9 @@ recency breaks ties).
 | --- | --- | --- | --- | --- | --- |
 | 1 | `2026-06_Zinc_and_Monkfish` | Zinc - Set 2 Main | concert | **measured, labelled** | **Anchor** — strongest current-taste exemplar; two-camera, 2026 |
 | 2 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Freefall Timeline, Sunshine Timeline, Mercies Timeline | concert | **measured, labelled** | Canonical snapshot for Ryan and Hang; music-performance cuts only |
-| 3 | `Mike Tucker Scullers` | Concert Full Cut | concert | **measured, unlabelled** | Good two-camera concert; older, so recency weighting applies |
+| 3 | `Mike Tucker Scullers` | Concert Full Cut | concert | **measured, labelled** | Good two-camera concert; older, so recency weighting applies |
 | 4 | `Archive/Client/Ryan and Hang Main - 9-23-24 gene edit` | Stablemates | concert | not started | Older but explicitly taste-endorsed. Read from the Ryan and Hang project, not `Ryan Devlin Projects Current` — same timeline, one project to open |
-| 5 | `2026-06_Zinc_and_Monkfish` | Monkfish Main | concert | **measured, unlabelled** | **Partial** — only a couple of tunes cut; measure those tunes only |
+| 5 | `2026-06_Zinc_and_Monkfish` | Monkfish Main | concert | **measured, labelled** | **Partial** — only a couple of tunes cut; measure those tunes only |
 | 6 | `Archive/Client/Side Step Blues Clues Album` | Blues Clues Main, Devlin Time Main, For All The Other Times Main, Intro Main, Outro Main, People We Love Main, Walk Spirit Talk Spirit Main, EJ's Blues Main | studio-session | **deferred** | Footage not on the box; and studio-session is a different cutting context from the concert work this pass is about. Revisit when the concert profile is settled |
 | 7 | ~~`…Ryan and Hang…` Blues for Alice, Three Card Molly~~ | — | — | **dropped** | Confirmed single-camera (director, 2026-08-07) — no angle switches, so nothing to measure |
 
@@ -37,6 +37,15 @@ many tunes, so per-cut counts run into the hundreds.
 Entries 4, 6 and 7 were settled by the director on 2026-08-07: Stablemates
 reachable from the entry-2 project, Side Step deferred, and the conditional
 entry resolved single-camera without needing a pre-flight.
+
+**Every measured timeline is now labelled.** The director supplied the two
+mappings that no render or frame grab could give (2026-08-07): Scullers Angle 1
+is the moving, tighter camera and Angle 2 the fixed wide side-view; Monkfish
+Video 1 is the moving camera and Video 2 the fixed drum angle. Both timelines
+were re-measured with the sidecars attached, and **every timing number came
+back identical** — same cut counts, same offsets, same shot lengths — which is
+the point of re-running rather than naming the shares by hand: labels are
+supposed to add names and nothing else, and here they demonstrably did.
 
 **Entry 4 is the only one left, and it is blocked on a clock rather than on
 access.** Stablemates has no render, and its A1 audio items disagree about
@@ -104,8 +113,13 @@ the right one.
 | 2 | Freefall Timeline | concert | 44 (43 measured, 1 opening) | `given` @ 86400 | `angles/Ryan-and-Hang-Main-9-23-24-gene-edit.json` | `…/analysis/Freefall-Timeline-a82bc5a80bcd.correlate.json` |
 | 2 | Sunshine Timeline | concert | 50 (49 measured, 1 opening) | `given` @ 86400 | same | `…/analysis/Sunshine-Timeline-edbbc561a240.correlate.json` |
 | 2 | Mercies Timeline | concert | 38 (37 measured, 1 opening) | `given` @ 86400 | same | `…/analysis/Mercies-Timeline-622d697cfd3e.correlate.json` |
-| 3 | Concert Full Cut | concert | 349 (326 measured, 23 openings) | `given` @ 75903 | **none — unlabelled** | `…/analysis/Concert-Full-Cut-bc11cb456a36.correlate.json` |
-| 5 | Monkfish Main | concert | 233 (228 measured, 5 openings) | `audio_clip`, matched | **none — unlabelled** | `…/analysis/Monkfish-Main-a14547f8db48.correlate.json` |
+| 3 | Concert Full Cut | concert | 349 (326 measured, 23 openings) | `given` @ 75903 | `angles/Mike-Tucker-Scullers.json` (director, 2026-08-07) | `…/analysis/Concert-Full-Cut-fcbbcd2a1999.correlate.json` |
+| 5 | Monkfish Main | concert | 233 (228 measured, 5 openings) | `audio_clip`, matched | `angles/2026-06_Zinc_and_Monkfish.json` (director, 2026-08-07) | `…/analysis/Monkfish-Main-8aaccfcad94d.correlate.json` |
+
+Entries 3 and 5 have new result filenames because `angles` is part of the cache
+key: the unlabelled runs are still on disk as `Concert-Full-Cut-bc11cb456a36`
+and `Monkfish-Main-a14547f8db48`, and diffing them against the rows above is
+how "the labels changed no number" was checked.
 
 **Entry 1, measured 2026-08-06.** Against `Zinc Set 2 Reaper v4.wav` (74:10,
 48 kHz, the Reaper master mix on A3), beats from `analyze_music` (11,130 beats,
@@ -136,7 +150,8 @@ Two cautions on this row:
   places and wanders in others. The bar-position histogram is derived from that
   grid, so it says nothing yet, and the beat-offset numbers are worth much less
   than the transient ones. This is the rubato gating #13 calls for, not yet
-  applied.
+  applied — now tracked as **#112**, which is scoped to settle the question in
+  either direction.
 - **The transient numbers do not depend on the grid.** Onsets are measured off
   the mix directly, which is why they are the row's trustworthy half — and
   they are also the half the profile's core principle is about.
@@ -187,9 +202,19 @@ Cautions on these rows:
   choice, and it is the one term here that did not come from the anchor.
 
 **Entry 3, measured 2026-08-07.** `Mike Tucker Scullers` / `Concert Full Cut`,
-349 shots over 95 minutes, two angles. **Unlabelled** — this project has no
-render, so the angle→camera mapping cannot be read, only guessed; the timing
-numbers below need no labels and stand on their own.
+349 shots over 95 minutes, two angles. **Labelled by the director on
+2026-08-07** — this project has no render and no reachable source frames, so
+the mapping could not be read the way entries 1 and 2 were, and a sentence is
+all the evidence there is. Angle 1 is the moving, tighter camera; Angle 2 the
+fixed wide from the side of the room.
+
+That makes this **the only labelled rig in the corpus without a drummer
+camera**, and the one place where the home angle and the wide are demonstrably
+different cameras: the wide is fixed and holds a quarter of the cut, while the
+moving camera holds three quarters. The sidecar records that "moving" and
+"fixed wide" are stated while the moving camera's *subject* is not — nobody has
+looked at what it points at — so this timeline supports claims about framing
+and operation and is deliberately not counted toward claims about subject.
 
 The master mix is 32-bit float, which `analyze_music` refuses outright
 (#110 — and its `fix` line tells the caller to delete the file, which here is
@@ -209,7 +234,7 @@ before the timeline's own first frame.
 | Offset to nearest beat | median 97 ms, mean 846 ms, max 22.7 s |
 | Shot length | median 8.59 s, mean 16.22 s, min 0.38 s, max 238.9 s |
 | Bar position | 1:203, 2:55, 3:38, 4:27, 5:1, 6:1, 7:1 — **not usable** |
-| Angles | Angle 1: 182 cuts, 74.3%; Angle 2: 167 cuts, 25.7% |
+| Angles | `soloist-moving` (Angle 1): 182 cuts, 74.3%; `ensemble-wide` (Angle 2): 167 cuts, 25.7% |
 
 Three things worth carrying forward:
 
@@ -217,16 +242,25 @@ Three things worth carrying forward:
   tunes, 6 on the anchor). A full-set timeline has gaps between tunes, and a
   shot after a gap has no outgoing angle — so the opening count is roughly the
   tune count, and it is a free structural signal nothing is using yet.
-- The **home angle share is 74.3%**, in line with every other entry, and this
-  one was arrived at with no labels at all. The share is a fact about the
-  distribution; only the *name* of the angle needs a sidecar.
+- The **home angle share is 74.3%**, in line with every other entry, and it was
+  arrived at before any label existed. The share is a fact about the
+  distribution; only the *name* of the angle needs a sidecar — which is exactly
+  why the label, when it arrived, moved no number.
+- **The second angle here is a wide, and it behaves like the drummer cams do
+  elsewhere**: 167 cuts against the home angle's 182, on a quarter of the time.
+  Frequent-and-short is a property of being the *other* angle, not of pointing
+  at the drums — which only became visible once a rig without a drum camera was
+  labelled.
 - The bar histogram has positions 5, 6 and 7 in it. There is no such thing in
-  4/4. Same conclusion as entries 1 and 2: rubato gating first.
+  4/4. Same conclusion as entries 1 and 2: rubato gating first (#112).
 
 **Entry 5, measured 2026-08-07.** `Monkfish Main`, 233 cuts over 87 minutes,
-two angles, **unlabelled** — same project as the anchor but a different venue
-and no render, so the angle→camera mapping is not carried over from the Zinc
-sidecar and is not guessed. Alignment is the cleanest of any entry:
+two angles, **labelled by the director on 2026-08-07** — same project as the
+anchor but a different venue five months earlier, and no render, so the mapping
+was neither carried over from the Zinc sidecar nor guessed. Video 1 is the
+moving camera, Video 2 the fixed drum angle: **the reverse of Zinc's numbering
+in the same project**, which is the concrete reason the sidecar labels the two
+nights separately. Alignment is the cleanest of any entry:
 `audio_clip`, matched, against `140111-061037.WAV` on A1 with its zero exactly
 at the timeline's first frame. Nothing had to be named or transcoded.
 
@@ -241,7 +275,8 @@ shots anybody chose to hold.
 | Offset to nearest transient | median 41 ms, mean 54 ms, max 433 ms; 118 early / 110 late / 0 on | **yes** — each of the 228 is a cut somebody made |
 | Shot length, median | 6.30 s | **yes** — a median over 233 shots is untroubled by five outliers |
 | Shot length, mean | 22.49 s (max 1953 s) | **no** — the held stretches are most of the running time |
-| Angle share | Video 1 89.3%, Video 2 10.7% | **no** — share is time, and the uncut time is all Video 1 |
+| Angle share | `soloist-moving` (Video 1) 89.3%, `drums-tight` (Video 2) 10.7% | **no** — share is time, and the uncut time is all Video 1 |
+| Angle cut counts | 125 vs 108 | **yes** — a cut count is not inflated by an uncut passage |
 | Bar position | 1:96, 2:57, 3:36, 4:39 | see below |
 
 Two notes:
@@ -253,6 +288,43 @@ Two notes:
   grids are demonstrably broken show the *strongest* beat-1 skew, which is what
   you would expect if part of that skew is the detector snapping to cuts rather
   than the director cutting to beats. Another reason no beat-position claim
-  goes in the profile before rubato gating.
+  goes in the profile before rubato gating (#112).
 - The transient median (41 ms) is the highest in the corpus and still inside
   two frames. Six timelines now span 17–41 ms.
+
+## What the labels settled: operation, not framing
+
+With entries 3 and 5 labelled, all six measured timelines have roles, and one
+question that had been stuck on a single project comes free. Review had already
+knocked the claim "the home angle is the camera on whoever is playing rather
+than the wide" down to `[believed, unverified]`, because the anchor's home
+angle is its wide *and* its operated camera at once and so cannot tell the two
+readings apart. The two new labels break that tie — not by adding a third vote
+for one reading, but by supplying the cases where framing and operation
+disagree.
+
+| # | Timeline(s) | Home angle | Framing | Operated? | Other angle | Framing | Operated? |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Zinc - Set 2 | `ensemble-wide` 68.5% | wide | **yes** | `drums-tight` 31.5% | tight | no |
+| 2 | Freefall, Sunshine, Mercies | `soloist-moving` 74–76% | moving | **yes** | `ensemble-wide` 14–17% | wide | no |
+| 3 | Concert Full Cut | `soloist-moving` 74.3% | moving | **yes** | `ensemble-wide` 25.7% | wide | no |
+| 5 | Monkfish Main | `soloist-moving` (89.3%, share not usable) | moving | **yes** | `drums-tight` 10.7% | tight | no |
+
+**Framing does not predict the home angle: a wide holds 68.5% on entry 1 and
+25.7% on entry 3.** Operation predicts it every time — six timelines, three
+projects, and **no locked-off camera is ever the home angle**. Entry 3 is what
+makes this checkable at all, being the only rig whose fixed camera is a wide;
+without it, "wide" and "locked off" name the same cameras throughout the corpus
+and no evidence could separate them.
+
+Two limits worth keeping attached to that:
+
+- **It is a claim about the shape of the rig, not about intent.** The operated
+  camera is the one that can follow anything, so it is also the one an editor
+  can stay on. That may be why it holds the cut, and this corpus cannot say.
+- **It is still not the subject claim.** Whether the operated camera is chosen
+  because it is *on the soloist* rests on entry 2 alone, where frame grabs
+  actually show what it points at. Entries 3 and 5 were stated, not seen: their
+  sidecars record `subject` as inferred, and they are excluded from any claim
+  that turns on it. A stated label is enough to say a camera moves; it is not
+  enough to say what it was following.

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -337,14 +337,18 @@ That account predicts something checkable, so it was checked. Splitting all
 
 | Role | n | median | mean | >30 s | longest |
 | --- | --- | --- | --- | --- | --- |
-| `drums-tight` (locked, all 6 timelines) | 314 | 5.5 s | — | **0 (0.0%)** | **21.5 s** |
+| `drums-tight` (locked, all 6 timelines) | 314 | 5.25 s | 6.1 s | **0 (0.0%)** | **21.5 s** |
 | `ensemble-wide`, the 4 locked instances | 206 | 7.3 s | 8.7 s | 2 (1.0%) | 57.4 s |
 | `ensemble-wide`, the 1 operated instance (anchor) | 188 | 10.7 s | 13.9 s | 17 (9.0%) | 71.1 s |
 | `room-wide` (locked, Mercies) | 5 | 7.5 s | 7.4 s | 0 (0.0%) | 12.9 s |
 | `soloist-moving` | 242 | 14.4 s | 24.6 s | 58 (24.0%) | 238.9 s |
 
-Rates exclude Monkfish, whose uncut passages would swamp them; its drum shots
-are counted in the 314 and its longest is 13.7 s.
+**The `drums-tight` row is all six timelines; every other row excludes
+Monkfish.** That is not a convenience: Monkfish's five uncut passages all sit
+on `soloist-moving`, so they distort that role's numbers and cannot touch the
+drum camera's. Excluding a timeline wholesale where only one of its roles is
+compromised would have thrown away 108 clean shots — and they are the ones that
+carry the ceiling below.
 
 **No drummer shot anywhere in this corpus reaches 22 seconds.** 314 shots, six
 timelines, four rooms, four years, zero exceptions — the hardest boundary the

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -258,9 +258,16 @@ Three things worth carrying forward:
 two angles, **labelled by the director on 2026-08-07** — same project as the
 anchor but a different venue five months earlier, and no render, so the mapping
 was neither carried over from the Zinc sidecar nor guessed. Video 1 is the
-moving camera, Video 2 the fixed drum angle: **the reverse of Zinc's numbering
-in the same project**, which is the concrete reason the sidecar labels the two
-nights separately. Alignment is the cleanest of any entry:
+moving camera, Video 2 the fixed drum angle.
+
+Both nights in this project happen to put the operated camera on Video 1 and
+the drums on Video 2, so the *numbering* did survive the five months — but
+**Video 1 is a wide at Zinc and a moving camera at Monkfish**, which is the
+thing the number cannot tell you and the reason the sidecar labels the two
+nights separately rather than once. Guessing from the anchor would have got the
+home angle right here and its framing wrong.
+
+Alignment is the cleanest of any entry:
 `audio_clip`, matched, against `140111-061037.WAV` on A1 with its zero exactly
 at the timeline's first frame. Nothing had to be named or transcoded.
 


### PR DESCRIPTION
Closes the labelling half of #45. The director supplied the two angle mappings that no render and no frame grab could give, which finishes the corpus's labels and — unexpectedly — settles a claim that five timelines of measurement could not.

**Scope:** `styles/` and `docs/agents/` only. No `src/`, no `tests/`, no hooks, no workflow YAML, so this is the prose tier per CLAUDE.md.

## What landed

**Both remaining timelines labelled** (director, 2026-08-07). Scullers `Concert Full Cut`: Angle 1 is the moving, tighter camera, Angle 2 the fixed wide side-view. `Monkfish Main`: Video 1 the moving camera, Video 2 the fixed drum angle. New sidecar `styles/angles/Mike-Tucker-Scullers.json`; Monkfish joins the existing `2026-06_Zinc_and_Monkfish.json` as a second night with its own angles.

**Both timelines re-measured with the sidecars attached**, rather than having their role shares written in by hand — `angles` is part of the cache key, so a labelled run is a new result file that can be diffed against the unlabelled one. Every number came back identical: same cuts (349, 233), same transient offsets, same shot lengths, same shares under new names. A label is supposed to add names and nothing else, and that is now checked instead of assumed. Both old and new result files are on disk and named in `corpus.md`.

**The home-angle claim goes back up, reframed.** Review on the previous PR knocked "the home angle is the camera on whoever is playing rather than the wide" down to `[believed, unverified]`, because the anchor's home angle is its wide *and* its operated camera at once and so cannot separate the two readings. Scullers breaks that tie — it is the only rig in the corpus whose fixed camera is a **wide**, and that wide holds 25.7% while the moving camera holds 74.3%. Across all six labelled timelines **no locked-off camera is ever the home angle**, and framing predicts nothing: a wide holds 68.5% on the anchor and a quarter on Scullers. Now `[measured — 3 projects, n=847 shots, concert]`, about *operation* rather than subject.

**What deliberately did not move.** Whether that camera holds the cut *because* it is on the soloist still rests on entry 2 alone — the only night whose moving camera anybody has actually looked at. A sentence fixes what a camera is; it does not say what it was following. The sidecars record this per angle (`stated_by_director`, `inferred`, `inference_basis`) so the corpus cannot quietly spend a description as though it were a look, and both new entries are excluded from subject claims by that mechanism rather than by my memory.

**Two smaller results.** Scullers is the only labelled rig with no drummer camera, and its second angle — a wide — takes 167 cuts against the home angle's 182 on a quarter of the time, the same frequent-and-short shape the drum cams have elsewhere. So "cut to, not lived on" is a property of being the *other* angle, not of pointing at the drums; that claim generalises to 3 projects. And no night in the corpus runs the rig spec #22 describes, which is now a measured claim rather than a hunch.

**Rubato gating is #112** rather than a standing note in three files, scoped to close in either direction — "the skew did not survive gating" retires the open item as well as a measured claim would.

## Review — one lightweight inline pass (prose tier)

One finding, taken:

- **I claimed Monkfish "reverses" Zinc's angle numbering. It does not.** Both nights put the operated camera on Video 1 and the drums on Video 2 — the numbering carried across fine. What does not carry is the *framing*: Video 1 is a wide at Zinc and a moving camera at Monkfish. Guessing from the anchor would have got the home angle right and its framing wrong, which is the real reason to label the two nights separately. Fixed in `corpus.md`, `concert.md` and the sidecar note (`68840b3`).

Also checked, no changes needed: every `n=` re-tallied against the corpus rows (847 = 366 + 132 + 349 with Monkfish's share excluded; 1080 = all six for the cut-count claim); the "no locked-off camera is the home angle" table against all four sidecar entries; both sidecars parse; `test_style_layer.py` and the AC-4 guard still green.

Fake tier green (1155 passed, 1 skipped). No source changed, so mypy and ruff are unaffected.

## Acceptance criteria

- [x] **Angle-label sidecars exist for the corpus projects** — 3 of 3 projects, all six measured timelines.
- [x] **`correlate_timeline` measurements produced across the corpus** — 6 of 7 timelines, all 3 projects. Stablemates stays out by the director's call; it has no defensible clock.
- [x] **Base + concert profiles authored with a provenance tag on every claim**
- [x] **No server code path reads or writes profiles or sidecars** — unchanged; `angles` is passed in by the caller, never read from disk by the server.

Review: clean — prose only, single-pass

---

## Commits added after opening: the mechanism, and a ceiling

`a00293a`, `b514aad` — **prose and sidecar data only** (`styles/`, no `src/`, no `tests/`), so a lightweight inline pass again.

The director answered the open subject question, and did it with more than a yes: **the moving camera generally follows the soloist, but it also roams the band for movement and interesting shots** — soloist-*primary*, not soloist-only, by design. And the reason the rig is arranged that way: **the locked camera is spent on the drums** (the rhythm section's most watchable instrument), which is what frees the operated camera to stay with the soloist and to roam.

Both sidecars now record `subject` as stated rather than inferred, with an explicit `subject_is_primary_not_exclusive` flag so "mostly the soloist" is never read as "always the soloist".

### The account predicts something, so it was tested

If an operated camera renews itself by moving and a locked one exhausts its information in seconds, the two should hold shots differently. Splitting all 1080 shots by role:

| Role | n | median | >30 s | longest |
| --- | --- | --- | --- | --- |
| `drums-tight` (locked) | 314 | 5.25 s | **0 (0.0%)** | **21.5 s** |
| `ensemble-wide`, 4 locked instances | 206 | 7.3 s | 2 (1.0%) | 57.4 s |
| `ensemble-wide`, 1 operated instance | 188 | 10.7 s | 17 (9.0%) | 71.1 s |
| `soloist-moving` | 242 | 14.4 s | 58 (24.0%) | 238.9 s |

**No drummer shot anywhere in the corpus reaches 22 seconds** — 314 shots, six timelines, four rooms, four years, zero exceptions. That is a rule, not a tendency, and it is directly usable by a cutting agent.

The sharpest evidence is *within* one role: `ensemble-wide` appears five times, one operated and four locked. The operated instance puts 9.0% of its shots past 30 s; the locked ones 1.0%. Same role name, same framing, opposite behaviour, and operation is the only difference — an independent confirmation of "operation, not framing" arrived at from duration rather than from screen share.

### What the inline pass caught

- **The table paired n=314 with a median computed over 206** — the Monkfish-excluded set. Recomputed over all 314: median 5.25 s, mean 6.11 s, max 21.5 s, still zero past 30 s. Fixed in both files.
- **Why that one row includes Monkfish was left unexplained**, which reads as an inconsistency. It is deliberate and now says so: Monkfish's five uncut passages sit entirely on `soloist-moving`, so they compromise that role and cannot touch its drum camera. Dropping the timeline wholesale would have discarded 108 clean shots — the ones carrying the ceiling.
- Also checked: 314 = 206 + 108; the within-role split against all five `ensemble-wide` instances; both sidecars parse; fake tier green.

### Honest limits, recorded in the docs

- In this corpus the operated camera is always also the home angle, so "operated" and "home" cannot be separated. Framing can be, and is.
- The subject answer is `[stated principle]`, not `[measured]` — no analysis here can see who is on screen, so no claim rests on attributing any particular shot.

Fake tier green. No source changed.

Review: clean — prose only, single-pass
