### PR TITLE
fix(audio): read IEEE float and extensible WAVs (#110)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,7 +149,10 @@ a dissolve), `tests/text_plus_probe.py` (Text+ probe fixtures).
 
 Test files pair 1:1 with the module they cover (`test_cut_validate.py` ↔
 `cut/validate.py`, `test_timeline_tools.py` ↔ `tools/timeline.py` +
-`resolve/timeline.py`, …). Live tier: `test_live_smoke.py` (module-level
+`resolve/timeline.py`, …). `test_wav_container.py` ↔ `audio/riff.py` is the
+exception that earns its keep: the headers it covers are read by `audio/wav.py`,
+`analysis/decode.py` and `analysis/silence.py` alike, and #110 was a bug in what
+all three agreed about. Live tier: `test_live_smoke.py` (module-level
 `pytest.mark.live`) and two `@pytest.mark.live` tests in
 `test_live_analysis.py`; everything else is fake-tier.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,7 +63,7 @@ Top level:
 `analysis/` — compute jobs that read audio and write findings to disk:
 `applause` (bursts → tune boundaries), `beats` (grid + downbeats, model
 injected per ADR 0002), `correlate` (measure a cut against its music),
-`decode` (WAV → numpy, stdlib only), `drums` (hits per stem), `energy`
+`decode` (WAV → numpy, no third-party decoder), `drums` (hits per stem), `energy`
 (loudness curves), `fills` (drum-fill candidates), `halves` (shared
 identify/cache/write pattern), `music` (beats + energy + gist job),
 `records` (sliceable record files), `silence` (RMS spans), `solos` (front
@@ -72,8 +72,10 @@ of band changes), `structure` (tunes + solo changes job), `transcribe`
 `whisper` (default backend: faster-whisper large-v3).
 
 `audio/` — concert audio out of Resolve onto disk: `acquire` (both routes),
-`ffmpeg` (per-source-clip route), `separator` (python-audio-separator out
-of process), `stems` (two-pass separation), `wav` (read back written WAVs).
+`ffmpeg` (per-source-clip route), `riff` (the WAV container itself: PCM,
+IEEE float and extensible headers, because stdlib `wave` opens PCM only),
+`separator` (python-audio-separator out of process), `stems` (two-pass
+separation), `wav` (header facts + the one unreadable-WAV error).
 
 `cut/` — cut-file schema v1: `document` (read off disk), `schema`
 (verbatim, served by `get_cut_schema`), `validate` (11 errors + 2
@@ -131,7 +133,9 @@ module, not the package, and never the whole package at once:
 - `connection.py` — `FakeResolve`, `FakeConnector`, `EXPORT_TYPES`
 - `separator.py` — `FakeSeparator`
 - `fixtures.py` — `write_wav`/`write_clicks`/`write_hits`/`write_sections`/
-  `write_jpeg`, `ffmpeg_absent`, `ffmpeg_refusing`
+  `write_jpeg`, `ffmpeg_absent`, `ffmpeg_refusing`; and the headers stdlib
+  `wave` cannot write, built by hand — `write_float_wav`,
+  `write_extensible_pcm_wav`, `write_tagged_wav`
 - `builders.py` — `studio()`, `sync_reference()`, `with_a_mix()`
 
 `__init__.py` re-exports every public name, so `from .fakes import X` works

--- a/src/resolve_mcp/analysis/decode.py
+++ b/src/resolve_mcp/analysis/decode.py
@@ -62,7 +62,7 @@ def read(path: Path | str) -> Audio:
     """Decode a WAV, or say which file could not be decoded and why."""
     target = Path(path)
     try:
-        found, raw = riff.read(target)
+        header, raw = riff.read(target)
     except (OSError, riff.RiffError) as exc:
         raise AudioExtractionError(
             cause=f"{target.name} is not a readable WAV file ({exc}).",
@@ -74,35 +74,34 @@ def read(path: Path | str) -> Audio:
             detail={"path": str(target)},
         ) from exc
 
-    if not found.is_float and found.sample_width not in SUPPORTED_WIDTHS:
+    if not header.is_float and header.sample_width not in SUPPORTED_WIDTHS:
         raise AudioExtractionError(
-            cause=f"{target.name} is {found.bit_depth}-bit PCM, which is not supported.",
+            cause=f"{target.name} is {header.bit_depth}-bit PCM, which is not supported.",
             fix="Convert it to 16-, 24- or 32-bit PCM WAV and analyse that.",
-            detail={"path": str(target), "bit_depth": found.bit_depth},
+            detail={"path": str(target), "bit_depth": header.bit_depth},
         )
 
-    samples = _samples(raw, found.sample_width, found.is_float)
-    usable = samples.size - samples.size % found.channels
-    reshaped = samples[:usable].reshape(-1, found.channels).T
-    return Audio(samples=reshaped.copy(), sample_rate=found.sample_rate)
+    samples = _samples(raw, header)
+    usable = samples.size - samples.size % header.channels
+    reshaped = samples[:usable].reshape(-1, header.channels).T
+    return Audio(samples=reshaped.copy(), sample_rate=header.sample_rate)
 
 
-def _samples(raw: bytes, width: int, is_float: bool) -> NDArray[np.float32]:
-    """Interleaved sample bytes to interleaved floats.
+def _samples(raw: bytes, header: riff.Format) -> NDArray[np.float32]:
+    """Interleaved sample bytes to interleaved floats, in full-scale units.
 
-    Float sources are already in full-scale units, so they are only narrowed to float32 —
-    dividing by anything would be scaling a signal that is already scaled.
+    Float sources are only narrowed to float32: they are already stored in those units, so
+    the header's full scale is 1.0 and the division is the no-op that says so.
     """
-    if is_float:
-        precision = np.dtype("<f4") if width == riff.FLOAT32_BYTES else np.dtype("<f8")
-        return np.asarray(np.frombuffer(raw, dtype=precision), dtype=np.float32)
-    if width == 3:
+    if header.is_float:
+        precision = "<f4" if header.sample_width == riff.FLOAT32_BYTES else "<f8"
+        return np.asarray(np.frombuffer(raw, dtype=np.dtype(precision)), dtype=np.float32)
+    if header.sample_width == 3:
         ints = _from_24_bit(raw)
     else:
-        signed = np.dtype("<i2") if width == 2 else np.dtype("<i4")
+        signed = np.dtype("<i2") if header.sample_width == 2 else np.dtype("<i4")
         ints = np.frombuffer(raw, dtype=signed).astype(np.int32)
-    full_scale = float(2 ** (width * riff.BITS_PER_BYTE - 1))
-    return np.asarray(ints.astype(np.float32) / full_scale, dtype=np.float32)
+    return np.asarray(ints.astype(np.float32) / header.full_scale, dtype=np.float32)
 
 
 def _from_24_bit(raw: bytes) -> NDArray[np.int32]:

--- a/src/resolve_mcp/analysis/decode.py
+++ b/src/resolve_mcp/analysis/decode.py
@@ -1,29 +1,34 @@
 """WAV on disk to samples in memory.
 
 Everything analysed here is a WAV this server acquired or the director handed over, so the
-standard library opens it and numpy does the arithmetic — no soundfile, no librosa, no third
-decoder to disagree with the two the repo already depends on.
+container is parsed in-repo by ``audio.riff`` and numpy does the arithmetic — no soundfile,
+no librosa, no third decoder to disagree with the two the repo already depends on. ``riff``
+rather than the standard library's ``wave`` because ``wave`` opens PCM and nothing else, and
+a 32-bit float master is what a mastering chain hands you (#110).
 
-Samples are ``float32`` in [-1, 1], shaped ``(channels, frames)``. float32 rather than
-float64 because an hour of 48k stereo is 173 million frames: 1.4 GB of the former is already
-a lot to hold, and 2.8 GB of the latter is a lot to hold twice. The loudness filter widens
-one channel at a time to float64 where the arithmetic wants the headroom.
+Samples are ``float32``, shaped ``(channels, frames)``. float32 rather than float64 because
+an hour of 48k stereo is 173 million frames: 1.4 GB of the former is already a lot to hold,
+and 2.8 GB of the latter is a lot to hold twice. The loudness filter widens one channel at a
+time to float64 where the arithmetic wants the headroom.
+
+Fixed-point sources land in [-1, 1] because that is the whole range they have. Float sources
+are passed through unscaled and may exceed it: a float master is allowed peaks above full
+scale, and clamping them here would report a true peak, and a loudness, that the master does
+not have.
 """
 
 from __future__ import annotations
 
-import contextlib
-import wave
 from pathlib import Path
 from typing import NamedTuple
 
 import numpy as np
 from numpy.typing import NDArray
 
+from ..audio import riff
 from ..errors import AudioExtractionError
 
 SUPPORTED_WIDTHS = (2, 3, 4)
-BITS_PER_BYTE = 8
 
 
 class Audio(NamedTuple):
@@ -57,41 +62,46 @@ def read(path: Path | str) -> Audio:
     """Decode a WAV, or say which file could not be decoded and why."""
     target = Path(path)
     try:
-        with contextlib.closing(wave.open(str(target), "rb")) as handle:
-            width = handle.getsampwidth()
-            channels = handle.getnchannels()
-            rate = handle.getframerate()
-            raw = handle.readframes(handle.getnframes())
-    except (OSError, wave.Error, EOFError) as exc:
+        found, raw = riff.read(target)
+    except (OSError, riff.RiffError) as exc:
         raise AudioExtractionError(
             cause=f"{target.name} is not a readable WAV file ({exc}).",
             fix=(
-                "Analysis reads WAV only. Acquire the audio with acquire_timeline_audio, or "
-                "convert the master mix to WAV first."
+                "Analysis reads PCM and IEEE float WAV. Acquire the audio with "
+                "acquire_timeline_audio, or convert a copy of the master mix to PCM WAV "
+                "and analyse that."
             ),
             detail={"path": str(target)},
         ) from exc
 
-    if width not in SUPPORTED_WIDTHS:
+    if not found.is_float and found.sample_width not in SUPPORTED_WIDTHS:
         raise AudioExtractionError(
-            cause=f"{target.name} is {width * BITS_PER_BYTE}-bit PCM, which is not supported.",
+            cause=f"{target.name} is {found.bit_depth}-bit PCM, which is not supported.",
             fix="Convert it to 16-, 24- or 32-bit PCM WAV and analyse that.",
-            detail={"path": str(target), "bit_depth": width * BITS_PER_BYTE},
+            detail={"path": str(target), "bit_depth": found.bit_depth},
         )
 
-    samples = _samples(raw, width)
-    usable = samples.size - samples.size % channels
-    return Audio(samples=samples[:usable].reshape(-1, channels).T.copy(), sample_rate=rate)
+    samples = _samples(raw, found.sample_width, found.is_float)
+    usable = samples.size - samples.size % found.channels
+    reshaped = samples[:usable].reshape(-1, found.channels).T
+    return Audio(samples=reshaped.copy(), sample_rate=found.sample_rate)
 
 
-def _samples(raw: bytes, width: int) -> NDArray[np.float32]:
-    """Interleaved PCM bytes to interleaved floats, scaled by the depth's full scale."""
+def _samples(raw: bytes, width: int, is_float: bool) -> NDArray[np.float32]:
+    """Interleaved sample bytes to interleaved floats.
+
+    Float sources are already in full-scale units, so they are only narrowed to float32 —
+    dividing by anything would be scaling a signal that is already scaled.
+    """
+    if is_float:
+        precision = np.dtype("<f4") if width == riff.FLOAT32_BYTES else np.dtype("<f8")
+        return np.asarray(np.frombuffer(raw, dtype=precision), dtype=np.float32)
     if width == 3:
         ints = _from_24_bit(raw)
     else:
-        dtype = np.dtype("<i2") if width == 2 else np.dtype("<i4")
-        ints = np.frombuffer(raw, dtype=dtype).astype(np.int32)
-    full_scale = float(2 ** (width * BITS_PER_BYTE - 1))
+        signed = np.dtype("<i2") if width == 2 else np.dtype("<i4")
+        ints = np.frombuffer(raw, dtype=signed).astype(np.int32)
+    full_scale = float(2 ** (width * riff.BITS_PER_BYTE - 1))
     return np.asarray(ints.astype(np.float32) / full_scale, dtype=np.float32)
 
 

--- a/src/resolve_mcp/analysis/silence.py
+++ b/src/resolve_mcp/analysis/silence.py
@@ -57,16 +57,16 @@ def levels(path: Path | str, window_seconds: float = DEFAULT_WINDOW_SECONDS) -> 
     """RMS per window in dBFS, oldest first — the curve everything else here reads."""
     target = Path(path)
     with wav.opened(target) as handle:
-        found = handle.format
-        _refuse_unsigned(target, found)
-        per_window = max(1, round(window_seconds * found.sample_rate))
+        header = handle.format
+        _refuse_unsigned(target, header)
+        per_window = max(1, round(window_seconds * header.sample_rate))
         measured: list[float] = []
         while True:
             raw = handle.read_frames(per_window)
             if not raw:
                 return measured
-            measured.append(_window_db(raw, found))
-            if len(raw) < per_window * found.block_align:
+            measured.append(_window_db(raw, header))
+            if len(raw) < per_window * header.block_align:
                 return measured
 
 
@@ -109,7 +109,7 @@ def _span(
     }
 
 
-def _window_db(raw: bytes, found: riff.Format) -> float:
+def _window_db(raw: bytes, header: riff.Format) -> float:
     """One window's RMS in dBFS, from a decimated read of its samples.
 
     The stride walks *interleaved* samples, so it has to be coprime with the channel count
@@ -119,24 +119,24 @@ def _window_db(raw: bytes, found: riff.Format) -> float:
     carrying the band. Stepping up to the next coprime stride costs at most a few samples
     of the 64 and visits every channel in turn.
     """
-    count = len(raw) // found.sample_width
+    count = len(raw) // header.sample_width
     if count == 0:
         return SILENT_FLOOR_DB
     stride = max(1, count // MAX_SAMPLES_PER_WINDOW)
-    while found.channels > 1 and math.gcd(stride, found.channels) != 1:
+    while header.channels > 1 and math.gcd(stride, header.channels) != 1:
         stride += 1
-    read_one = _sample_reader(found)
+    read_one = _sample_reader(header)
     total = 0.0
     taken = 0
     for index in range(0, count, stride):
-        sample = read_one(raw, index * found.sample_width)
+        sample = read_one(raw, index * header.sample_width)
         total += sample * sample
         taken += 1
     rms = math.sqrt(total / taken)
     return SILENT_FLOOR_DB if rms <= 0.0 else max(SILENT_FLOOR_DB, 20.0 * math.log10(rms))
 
 
-def _sample_reader(found: riff.Format) -> Callable[[bytes, int], float]:
+def _sample_reader(header: riff.Format) -> Callable[[bytes, int], float]:
     """One sample as a fraction of full scale, however the file happens to store them.
 
     A float WAV's bytes read as a signed integer are not a quiet version of the signal, they
@@ -144,26 +144,26 @@ def _sample_reader(found: riff.Format) -> Callable[[bytes, int], float]:
     as noise and digital silence reads as full scale. Picking the reader once per window
     keeps that branch out of the decimation loop, which runs per sample over a whole concert.
     """
-    if found.is_float:
-        code = "<f" if found.sample_width == riff.FLOAT32_BYTES else "<d"
+    if header.is_float:
+        code = "<f" if header.sample_width == riff.FLOAT32_BYTES else "<d"
         return lambda raw, offset: float(struct.unpack_from(code, raw, offset)[0])
-    width = found.sample_width
-    full_scale = float(1 << (found.bit_depth - 1))
+    width = header.sample_width
+    full_scale = header.full_scale
     return lambda raw, offset: (
         int.from_bytes(raw[offset : offset + width], "little", signed=True) / full_scale
     )
 
 
-def _refuse_unsigned(target: Path, found: riff.Format) -> None:
+def _refuse_unsigned(target: Path, header: riff.Format) -> None:
     """8-bit WAV samples are unsigned, and reading them as signed inverts loud and quiet.
 
     Nothing this server acquires is 8-bit — both acquisition routes write 16, 24 or 32 —
     so this is a file someone else put in the cache, and guessing at it would report a loud
     tone as breathing room. Float depths are never 8-bit, so this only ever catches PCM.
     """
-    if found.sample_width == 1:
+    if header.sample_width == 1:
         raise AudioExtractionError(
             cause=f"{target.name} is 8-bit audio, which this reader does not measure.",
             fix="Re-acquire the audio (the acquisition jobs write 24-bit WAV) and retry.",
-            detail={"path": str(target), "bit_depth": found.bit_depth},
+            detail={"path": str(target), "bit_depth": header.bit_depth},
         )

--- a/src/resolve_mcp/analysis/silence.py
+++ b/src/resolve_mcp/analysis/silence.py
@@ -20,9 +20,11 @@ Two implementation constraints shape this module:
 from __future__ import annotations
 
 import math
+import struct
+from collections.abc import Callable
 from pathlib import Path
 
-from ..audio import wav
+from ..audio import riff, wav
 from ..errors import AudioExtractionError
 
 DEFAULT_WINDOW_SECONDS = 0.05
@@ -55,18 +57,16 @@ def levels(path: Path | str, window_seconds: float = DEFAULT_WINDOW_SECONDS) -> 
     """RMS per window in dBFS, oldest first — the curve everything else here reads."""
     target = Path(path)
     with wav.opened(target) as handle:
-        width = handle.getsampwidth()
-        rate = handle.getframerate()
-        channels = handle.getnchannels()
-        _refuse_unsigned(target, width)
-        per_window = max(1, round(window_seconds * rate))
+        found = handle.format
+        _refuse_unsigned(target, found)
+        per_window = max(1, round(window_seconds * found.sample_rate))
         measured: list[float] = []
         while True:
-            raw = handle.readframes(per_window)
+            raw = handle.read_frames(per_window)
             if not raw:
                 return measured
-            measured.append(_window_db(raw, width, channels))
-            if len(raw) < per_window * width * channels:
+            measured.append(_window_db(raw, found))
+            if len(raw) < per_window * found.block_align:
                 return measured
 
 
@@ -109,7 +109,7 @@ def _span(
     }
 
 
-def _window_db(raw: bytes, width: int, channels: int) -> float:
+def _window_db(raw: bytes, found: riff.Format) -> float:
     """One window's RMS in dBFS, from a decimated read of its samples.
 
     The stride walks *interleaved* samples, so it has to be coprime with the channel count
@@ -119,34 +119,51 @@ def _window_db(raw: bytes, width: int, channels: int) -> float:
     carrying the band. Stepping up to the next coprime stride costs at most a few samples
     of the 64 and visits every channel in turn.
     """
-    count = len(raw) // width
+    count = len(raw) // found.sample_width
     if count == 0:
         return SILENT_FLOOR_DB
     stride = max(1, count // MAX_SAMPLES_PER_WINDOW)
-    while channels > 1 and math.gcd(stride, channels) != 1:
+    while found.channels > 1 and math.gcd(stride, found.channels) != 1:
         stride += 1
+    read_one = _sample_reader(found)
     total = 0.0
     taken = 0
     for index in range(0, count, stride):
-        offset = index * width
-        sample = int.from_bytes(raw[offset : offset + width], "little", signed=True)
-        total += float(sample) * float(sample)
+        sample = read_one(raw, index * found.sample_width)
+        total += sample * sample
         taken += 1
-    full_scale = float(1 << (width * wav.BITS_PER_BYTE - 1))
-    rms = math.sqrt(total / taken) / full_scale
+    rms = math.sqrt(total / taken)
     return SILENT_FLOOR_DB if rms <= 0.0 else max(SILENT_FLOOR_DB, 20.0 * math.log10(rms))
 
 
-def _refuse_unsigned(target: Path, width: int) -> None:
+def _sample_reader(found: riff.Format) -> Callable[[bytes, int], float]:
+    """One sample as a fraction of full scale, however the file happens to store them.
+
+    A float WAV's bytes read as a signed integer are not a quiet version of the signal, they
+    are a different signal — the exponent bits land in the high bytes, so a steady tone reads
+    as noise and digital silence reads as full scale. Picking the reader once per window
+    keeps that branch out of the decimation loop, which runs per sample over a whole concert.
+    """
+    if found.is_float:
+        code = "<f" if found.sample_width == riff.FLOAT32_BYTES else "<d"
+        return lambda raw, offset: float(struct.unpack_from(code, raw, offset)[0])
+    width = found.sample_width
+    full_scale = float(1 << (found.bit_depth - 1))
+    return lambda raw, offset: (
+        int.from_bytes(raw[offset : offset + width], "little", signed=True) / full_scale
+    )
+
+
+def _refuse_unsigned(target: Path, found: riff.Format) -> None:
     """8-bit WAV samples are unsigned, and reading them as signed inverts loud and quiet.
 
     Nothing this server acquires is 8-bit — both acquisition routes write 16, 24 or 32 —
     so this is a file someone else put in the cache, and guessing at it would report a loud
-    tone as breathing room.
+    tone as breathing room. Float depths are never 8-bit, so this only ever catches PCM.
     """
-    if width == 1:
+    if found.sample_width == 1:
         raise AudioExtractionError(
             cause=f"{target.name} is 8-bit audio, which this reader does not measure.",
             fix="Re-acquire the audio (the acquisition jobs write 24-bit WAV) and retry.",
-            detail={"path": str(target), "bit_depth": width * wav.BITS_PER_BYTE},
+            detail={"path": str(target), "bit_depth": found.bit_depth},
         )

--- a/src/resolve_mcp/audio/riff.py
+++ b/src/resolve_mcp/audio/riff.py
@@ -1,0 +1,202 @@
+"""The WAV container, read here because the standard library only opens half of them.
+
+``wave`` parses RIFF perfectly well and then refuses any format tag that is not PCM, so a
+32-bit float master — what a mastering chain hands you by default — raises "unknown format:
+3" and reaches the caller looking like a damaged file (#110). The two tags it leaves out are
+the two that turn up most: ``WAVE_FORMAT_IEEE_FLOAT``, and ``WAVE_FORMAT_EXTENSIBLE``, which
+carries its real tag in a GUID and is what a professional tool writes for anything above two
+channels.
+
+This module reads the container for *every* WAV the server touches rather than falling back
+to it for the ones ``wave`` rejects. One reader, because two readers on one format is two
+sets of edge cases that will eventually disagree about the same file — and the disagreement
+would show up as a duration that changes depending on which analysis job asked.
+
+It stays standard-library-only, for the reason ``decode`` gives: soundfile and librosa each
+bring a second decoder along, and neither is installed on the machine that runs the server.
+
+Nothing here raises a server error. A parse failure is a ``RiffError``, and the caller — the
+one that knows whether this file came out of the cache or off the director's drive — turns
+it into an ``AudioExtractionError`` with advice that fits where the file came from.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import struct
+from collections.abc import Iterator
+from pathlib import Path
+from typing import BinaryIO, NamedTuple
+
+PCM = 0x0001
+IEEE_FLOAT = 0x0003
+EXTENSIBLE = 0xFFFE
+
+BITS_PER_BYTE = 8
+HEADER_BYTES = 12
+CHUNK_HEADER_BYTES = 8
+FMT_BYTES = 16
+EXTENSIBLE_FMT_BYTES = 40
+FLOAT32_BYTES = 4
+FLOAT64_BYTES = 8
+FLOAT_WIDTHS = (FLOAT32_BYTES, FLOAT64_BYTES)
+STREAMED_SIZE = 0xFFFFFFFF
+
+
+class RiffError(ValueError):
+    """This file is not a WAV this module can read, and the message says which part failed."""
+
+
+class Format(NamedTuple):
+    """What the ``fmt `` chunk says, once the extensible indirection is resolved."""
+
+    sample_rate: int
+    channels: int
+    sample_width: int
+    is_float: bool
+    frames: int
+
+    @property
+    def bit_depth(self) -> int:
+        return self.sample_width * BITS_PER_BYTE
+
+    @property
+    def block_align(self) -> int:
+        """Bytes per frame — one sample for each channel."""
+        return self.sample_width * self.channels
+
+    @property
+    def encoding(self) -> str:
+        """``pcm`` or ``float``, as the caller reports it and the sample maths branches on it."""
+        return "float" if self.is_float else "pcm"
+
+    @property
+    def duration_seconds(self) -> float:
+        return self.frames / self.sample_rate if self.sample_rate else 0.0
+
+
+class Reader:
+    """An open WAV positioned on its first sample.
+
+    ``read_frames`` is the whole surface, because the one caller that does not want the file
+    in memory at once — silence, which walks a two-hour concert a window at a time — wants
+    exactly that and nothing else.
+    """
+
+    def __init__(self, stream: BinaryIO, layout: Format, start: int) -> None:
+        self.format = layout
+        self._stream = stream
+        self._remaining = layout.frames * layout.block_align
+        stream.seek(start)
+
+    def read_frames(self, count: int) -> bytes:
+        """Up to ``count`` whole frames, or ``b""`` once the data chunk is spent."""
+        wanted = min(count * self.format.block_align, self._remaining)
+        if wanted <= 0:
+            return b""
+        raw = self._stream.read(wanted)
+        self._remaining -= len(raw)
+        return raw
+
+    def read_all(self) -> bytes:
+        """Every frame left, which for every caller but silence means the whole file."""
+        return self.read_frames(self.format.frames)
+
+
+@contextlib.contextmanager
+def opened(path: Path | str) -> Iterator[Reader]:
+    """A WAV open on its samples, its header already parsed."""
+    with Path(path).open("rb") as stream:
+        layout, start = _parse(stream)
+        yield Reader(stream, layout, start)
+
+
+def header(path: Path | str) -> Format:
+    """The header alone — no samples read, which matters when the file is gigabytes."""
+    with Path(path).open("rb") as stream:
+        return _parse(stream)[0]
+
+
+def read(path: Path | str) -> tuple[Format, bytes]:
+    """The header and every frame behind it."""
+    with opened(path) as handle:
+        return handle.format, handle.read_all()
+
+
+def _parse(stream: BinaryIO) -> tuple[Format, int]:
+    """Walk the chunks to the ``fmt `` and ``data`` pair, and report where the samples start."""
+    prologue = stream.read(HEADER_BYTES)
+    if len(prologue) < HEADER_BYTES or prologue[8:12] != b"WAVE":
+        raise RiffError("not a RIFF/WAVE file")
+    if prologue[0:4] == b"RF64":
+        raise RiffError(
+            "this is an RF64 file, the 64-bit variant of WAV written past the 4 GB "
+            "limit, which this reader does not decode"
+        )
+    if prologue[0:4] != b"RIFF":
+        raise RiffError(f"unexpected container {prologue[0:4]!r}, expected RIFF")
+
+    fmt: bytes | None = None
+    while True:
+        head = stream.read(CHUNK_HEADER_BYTES)
+        if len(head) < CHUNK_HEADER_BYTES:
+            raise RiffError("no data chunk" if fmt else "no fmt chunk")
+        name, declared = head[0:4], struct.unpack("<I", head[4:8])[0]
+        if name == b"data":
+            return _format(fmt, _data_bytes(stream, declared)), stream.tell()
+        if name == b"fmt ":
+            fmt = stream.read(declared)
+        else:
+            stream.seek(declared, 1)
+        stream.seek(declared % 2, 1)  # every chunk is padded to an even length
+
+
+def _data_bytes(stream: BinaryIO, declared: int) -> int:
+    """The data chunk's real length, which is not always the one in its header.
+
+    A WAV ffmpeg piped, or one whose writer died mid-render, declares a size it never wrote —
+    sometimes ``0xFFFFFFFF``, sometimes the size the finished file would have had. Believing
+    it would report a duration the file does not hold, so the rest of the file wins.
+    """
+    start = stream.tell()
+    available = stream.seek(0, 2) - start
+    stream.seek(start)
+    return available if declared in (0, STREAMED_SIZE) else min(declared, available)
+
+
+def _format(fmt: bytes | None, data_bytes: int) -> Format:
+    if fmt is None:
+        raise RiffError("no fmt chunk before the data chunk")
+    if len(fmt) < FMT_BYTES:
+        raise RiffError(f"fmt chunk is {len(fmt)} bytes, too short to describe a format")
+    tag, channels, rate, _, _, bits = struct.unpack("<HHIIHH", fmt[:FMT_BYTES])
+    if tag == EXTENSIBLE:
+        tag = _subformat(fmt)
+    if tag not in (PCM, IEEE_FLOAT):
+        raise RiffError(f"format tag {tag} is neither PCM ({PCM}) nor IEEE float ({IEEE_FLOAT})")
+
+    width = bits // BITS_PER_BYTE
+    if bits % BITS_PER_BYTE or width == 0:
+        raise RiffError(f"{bits}-bit samples do not fall on a byte boundary")
+    if channels < 1 or rate < 1:
+        raise RiffError(f"header claims {channels} channels at {rate} Hz")
+    if tag == IEEE_FLOAT and width not in FLOAT_WIDTHS:
+        raise RiffError(f"{bits}-bit floating point is neither single nor double precision")
+
+    align = width * channels
+    return Format(
+        sample_rate=rate,
+        channels=channels,
+        sample_width=width,
+        is_float=tag == IEEE_FLOAT,
+        frames=data_bytes // align,
+    )
+
+
+def _subformat(fmt: bytes) -> int:
+    """An extensible header's real tag: the first two bytes of its SubFormat GUID."""
+    if len(fmt) < EXTENSIBLE_FMT_BYTES:
+        raise RiffError(
+            f"extensible fmt chunk is {len(fmt)} bytes, too short to hold a SubFormat GUID"
+        )
+    return int(struct.unpack("<H", fmt[24:26])[0])

--- a/src/resolve_mcp/audio/riff.py
+++ b/src/resolve_mcp/audio/riff.py
@@ -71,6 +71,17 @@ class Format(NamedTuple):
         return "float" if self.is_float else "pcm"
 
     @property
+    def full_scale(self) -> float:
+        """What one sample reads at the top of its range — the divisor that normalises it.
+
+        A float file is already stored in those units, so its full scale is 1.0 and dividing
+        by it is the no-op that says so. Both readers take the number from here rather than
+        each spelling out the fixed-point arithmetic: they had drifted into two spellings of
+        it already, and two spellings are two chances to be wrong about one file.
+        """
+        return 1.0 if self.is_float else float(1 << (self.bit_depth - 1))
+
+    @property
     def duration_seconds(self) -> float:
         return self.frames / self.sample_rate if self.sample_rate else 0.0
 
@@ -83,10 +94,10 @@ class Reader:
     exactly that and nothing else.
     """
 
-    def __init__(self, stream: BinaryIO, layout: Format, start: int) -> None:
-        self.format = layout
+    def __init__(self, stream: BinaryIO, header: Format, start: int) -> None:
+        self.format = header
         self._stream = stream
-        self._remaining = layout.frames * layout.block_align
+        self._remaining = header.frames * header.block_align
         stream.seek(start)
 
     def read_frames(self, count: int) -> bytes:
@@ -98,29 +109,19 @@ class Reader:
         self._remaining -= len(raw)
         return raw
 
-    def read_all(self) -> bytes:
-        """Every frame left, which for every caller but silence means the whole file."""
-        return self.read_frames(self.format.frames)
-
 
 @contextlib.contextmanager
 def opened(path: Path | str) -> Iterator[Reader]:
-    """A WAV open on its samples, its header already parsed."""
+    """A WAV open on its samples, its header already parsed and no sample read yet."""
     with Path(path).open("rb") as stream:
-        layout, start = _parse(stream)
-        yield Reader(stream, layout, start)
-
-
-def header(path: Path | str) -> Format:
-    """The header alone — no samples read, which matters when the file is gigabytes."""
-    with Path(path).open("rb") as stream:
-        return _parse(stream)[0]
+        header, start = _parse(stream)
+        yield Reader(stream, header, start)
 
 
 def read(path: Path | str) -> tuple[Format, bytes]:
     """The header and every frame behind it."""
     with opened(path) as handle:
-        return handle.format, handle.read_all()
+        return handle.format, handle.read_frames(handle.format.frames)
 
 
 def _parse(stream: BinaryIO) -> tuple[Format, int]:
@@ -165,6 +166,12 @@ def _data_bytes(stream: BinaryIO, declared: int) -> int:
 
 
 def _format(fmt: bytes | None, data_bytes: int) -> Format:
+    """The ``fmt `` chunk's bytes, checked and resolved into what the samples actually are.
+
+    Every refusal here names the thing that is wrong rather than the file, because the
+    caller turns these into advice and "not a readable WAV file" was the message that sent
+    someone toward deleting a perfectly good master (#110).
+    """
     if fmt is None:
         raise RiffError("no fmt chunk before the data chunk")
     if len(fmt) < FMT_BYTES:

--- a/src/resolve_mcp/audio/wav.py
+++ b/src/resolve_mcp/audio/wav.py
@@ -50,13 +50,15 @@ def describe(path: Path | str) -> dict[str, Any]:
     """Duration, sample rate, channels, bit depth and encoding of a WAV on disk."""
     target = Path(path)
     with opened(target) as handle:
-        found = handle.format
+        header = handle.format
     return {
         "path": str(target),
-        "duration_seconds": round(found.duration_seconds, 3) if found.sample_rate else None,
-        "sample_rate": found.sample_rate,
-        "channels": found.channels,
-        "bit_depth": found.bit_depth,
-        "encoding": found.encoding,
+        "duration_seconds": round(header.duration_seconds, 3) if header.sample_rate else None,
+        "sample_rate": header.sample_rate,
+        "channels": header.channels,
+        "bit_depth": header.bit_depth,
+        # Depth alone stopped identifying a file the moment float became readable: 32-bit
+        # PCM and 32-bit float are different audio behind the same number (#110).
+        "encoding": header.encoding,
         "bytes": target.stat().st_size,
     }

--- a/src/resolve_mcp/audio/wav.py
+++ b/src/resolve_mcp/audio/wav.py
@@ -1,57 +1,62 @@
-"""Reading back what we just wrote.
+"""Reading back what we just wrote — and what the director handed over.
 
-Everything this server acquires is a WAV, and the standard library reads WAV headers — so
-duration, sample rate and channel count come from ``wave`` rather than from shelling out to
-ffprobe. One less external binary on the critical path, and it works for the render-queue
-route on a machine with no ffmpeg at all.
+Everything this server acquires is a WAV, so duration, sample rate and channel count come
+off the header rather than out of ffprobe: one less external binary on the critical path,
+and it works for the render-queue route on a machine with no ffmpeg at all. The header is
+parsed by ``riff`` rather than by the standard library, which opens PCM only (#110).
+
+The reading is left to the caller; what lives here is the one failure every reader of a WAV
+has to report, phrased for a file this server did not necessarily write.
 """
 
 from __future__ import annotations
 
 import contextlib
-import wave
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 from ..errors import AudioExtractionError
-
-BITS_PER_BYTE = 8
+from . import riff
 
 
 @contextlib.contextmanager
-def opened(path: Path | str) -> Iterator[wave.Wave_read]:
+def opened(path: Path | str) -> Iterator[riff.Reader]:
     """An open WAV, or the one failure every reader of one should report.
 
-    Anything that reads a WAV this server wrote reads a file the server can also delete and
-    make again, so the advice is the same wherever the read happens — which is why the
-    reading itself is the only part left to the caller.
+    The advice deliberately does not say to delete the file. This path reads two kinds of
+    WAV — one the server cached and can make again, and one the caller passed in with
+    ``audio_at``, which is their own master sitting on a media drive — and it cannot tell
+    them apart from here. Telling an agent to delete the second is worse than saying nothing
+    at all, so the fix names the check that is safe either way (#110).
     """
     target = Path(path)
     try:
-        with contextlib.closing(wave.open(str(target), "rb")) as handle:
+        with riff.opened(target) as handle:
             yield handle
-    except (OSError, wave.Error) as exc:
+    except (OSError, riff.RiffError) as exc:
         raise AudioExtractionError(
             cause=f"{target.name} is not a readable WAV file ({exc}).",
-            fix="Delete it from the cache directory and run the job again.",
+            fix=(
+                "Check the path points at a WAV this reader decodes — PCM or IEEE float. "
+                "If the server acquired this file, run the acquisition again to rewrite it; "
+                "if it is your own master, convert a copy to PCM WAV and analyse that."
+            ),
             detail={"path": str(target)},
         ) from exc
 
 
 def describe(path: Path | str) -> dict[str, Any]:
-    """Duration, sample rate, channels and bit depth of a WAV on disk."""
+    """Duration, sample rate, channels, bit depth and encoding of a WAV on disk."""
     target = Path(path)
     with opened(target) as handle:
-        frames = handle.getnframes()
-        rate = handle.getframerate()
-        channels = handle.getnchannels()
-        width = handle.getsampwidth()
+        found = handle.format
     return {
         "path": str(target),
-        "duration_seconds": round(frames / rate, 3) if rate else None,
-        "sample_rate": rate,
-        "channels": channels,
-        "bit_depth": width * BITS_PER_BYTE,
+        "duration_seconds": round(found.duration_seconds, 3) if found.sample_rate else None,
+        "sample_rate": found.sample_rate,
+        "channels": found.channels,
+        "bit_depth": found.bit_depth,
+        "encoding": found.encoding,
         "bytes": target.stat().st_size,
     }

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -55,9 +55,12 @@ from .core import DroppedHandleError as DroppedHandleError
 from .fixtures import ffmpeg_absent as ffmpeg_absent
 from .fixtures import ffmpeg_refusing as ffmpeg_refusing
 from .fixtures import write_clicks as write_clicks
+from .fixtures import write_extensible_pcm_wav as write_extensible_pcm_wav
+from .fixtures import write_float_wav as write_float_wav
 from .fixtures import write_hits as write_hits
 from .fixtures import write_jpeg as write_jpeg
 from .fixtures import write_sections as write_sections
+from .fixtures import write_tagged_wav as write_tagged_wav
 from .fixtures import write_wav as write_wav
 from .fusion import FakeFusionComp as FakeFusionComp
 from .fusion import FakeFusionInput as FakeFusionInput

--- a/tests/fakes/fixtures.py
+++ b/tests/fakes/fixtures.py
@@ -18,6 +18,7 @@ from resolve_mcp.ffmpeg import Completed, Runner
 PCM_TAG = 0x0001
 FLOAT_TAG = 0x0003
 EXTENSIBLE_TAG = 0xFFFE
+FLOAT32_BITS = 32
 
 # The tail of KSDATAFORMAT_SUBTYPE_*, the GUID an extensible header carries in place of a tag.
 SUBFORMAT_TAIL = b"\x00\x00\x10\x00\x80\x00\x00\xaa\x00\x38\x9b\x71"
@@ -218,6 +219,7 @@ def write_tagged_wav(
 
 
 def _interleaved_ints(samples: list[int], bit_depth: int, channels: int) -> bytes:
+    """One mono signal laid out as interleaved fixed-point frames: every channel the same."""
     width = bit_depth // 8
     frames = bytearray()
     for sample in samples:
@@ -226,7 +228,8 @@ def _interleaved_ints(samples: list[int], bit_depth: int, channels: int) -> byte
 
 
 def _interleaved_floats(samples: list[float], bit_depth: int, channels: int) -> bytes:
-    code = "<f" if bit_depth == 32 else "<d"
+    """The same, in single or double precision — the layouts ``wave`` will not write."""
+    code = "<f" if bit_depth == FLOAT32_BITS else "<d"
     frames = bytearray()
     for sample in samples:
         frames.extend(struct.pack(code, sample) * channels)

--- a/tests/fakes/fixtures.py
+++ b/tests/fakes/fixtures.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 import contextlib
 import math
 import random
+import struct
 import wave
 from collections.abc import Sequence
 from pathlib import Path
 
 from resolve_mcp.ffmpeg import Completed, Runner
+
+# The format tags a WAV header can carry, spelled out again rather than imported from
+# resolve_mcp.audio.riff: a fixture that took its constants from the parser under test would
+# agree with that parser about a wrong number, and prove nothing.
+PCM_TAG = 0x0001
+FLOAT_TAG = 0x0003
+EXTENSIBLE_TAG = 0xFFFE
+
+# The tail of KSDATAFORMAT_SUBTYPE_*, the GUID an extensible header carries in place of a tag.
+SUBFORMAT_TAIL = b"\x00\x00\x10\x00\x80\x00\x00\xaa\x00\x38\x9b\x71"
 
 
 def write_wav(
@@ -134,6 +145,137 @@ def write_sections(
     return _write_samples(path, samples, sample_rate, bit_depth, channels)
 
 
+def write_float_wav(
+    path: Path,
+    seconds: float = 2.0,
+    sample_rate: int = 48_000,
+    bit_depth: int = 32,
+    channels: int = 2,
+    frequency: float = 440.0,
+    amplitude: float = 0.3,
+    silence: Sequence[tuple[float, float]] = (),
+    extensible: bool = False,
+) -> Path:
+    """``write_wav``'s tone, written as IEEE float — what a mastering chain hands you.
+
+    The standard library cannot write one of these any more than it can read one, so the
+    header is built by hand. ``amplitude`` is in full-scale units and is *not* clamped:
+    passing more than 1.0 writes the above-full-scale peaks a float master is allowed to
+    carry, which is the thing a fixed-point fixture cannot express.
+    """
+    quiet = [(start * sample_rate, end * sample_rate) for start, end in silence]
+    samples = [
+        0.0
+        if any(start <= index < end for start, end in quiet)
+        else amplitude * math.sin(2 * math.pi * frequency * index / sample_rate)
+        for index in range(int(seconds * sample_rate))
+    ]
+    frames = _interleaved_floats(samples, bit_depth, channels)
+    return _write_riff(path, frames, sample_rate, bit_depth, channels, FLOAT_TAG, extensible)
+
+
+def write_extensible_pcm_wav(
+    path: Path,
+    seconds: float = 2.0,
+    sample_rate: int = 48_000,
+    bit_depth: int = 24,
+    channels: int = 2,
+    frequency: float = 440.0,
+    amplitude: float = 0.3,
+) -> Path:
+    """PCM samples behind an extensible header — ordinary audio the standard library refuses.
+
+    Anything with more than two channels, and plenty of two-channel exports besides, comes
+    out of a professional tool tagged ``WAVE_FORMAT_EXTENSIBLE`` with PCM named in a GUID.
+    The samples are the same ones ``write_wav`` writes; only the header differs.
+    """
+    peak = 2 ** (bit_depth - 1) * amplitude
+    samples = [
+        int(peak * math.sin(2 * math.pi * frequency * index / sample_rate))
+        for index in range(int(seconds * sample_rate))
+    ]
+    frames = _interleaved_ints(samples, bit_depth, channels)
+    return _write_riff(path, frames, sample_rate, bit_depth, channels, PCM_TAG, extensible=True)
+
+
+def write_tagged_wav(
+    path: Path,
+    tag: int,
+    bit_depth: int = 16,
+    sample_rate: int = 48_000,
+    channels: int = 2,
+    frames: bytes = b"\x00" * 64,
+    riff_id: bytes = b"RIFF",
+) -> Path:
+    """A structurally sound WAV carrying whatever format tag is asked for.
+
+    For the refusals: a compressed tag the readers cannot decode, and an ``RF64`` file,
+    both of which have to be told apart from a damaged file rather than lumped in with one.
+    """
+    return _write_riff(
+        path, frames, sample_rate, bit_depth, channels, tag, extensible=False, riff_id=riff_id
+    )
+
+
+def _interleaved_ints(samples: list[int], bit_depth: int, channels: int) -> bytes:
+    width = bit_depth // 8
+    frames = bytearray()
+    for sample in samples:
+        frames.extend(sample.to_bytes(width, "little", signed=True) * channels)
+    return bytes(frames)
+
+
+def _interleaved_floats(samples: list[float], bit_depth: int, channels: int) -> bytes:
+    code = "<f" if bit_depth == 32 else "<d"
+    frames = bytearray()
+    for sample in samples:
+        frames.extend(struct.pack(code, sample) * channels)
+    return bytes(frames)
+
+
+def _write_riff(
+    path: Path,
+    frames: bytes,
+    sample_rate: int,
+    bit_depth: int,
+    channels: int,
+    tag: int,
+    extensible: bool,
+    riff_id: bytes = b"RIFF",
+) -> Path:
+    """A WAV assembled chunk by chunk, including the ``fact`` chunk a non-PCM file carries.
+
+    ``fact`` is here because it sits *between* ``fmt `` and ``data`` in a real float export:
+    a reader that assumed the samples follow the header immediately would pass every test
+    written without it and fail on the first file off a mastering desk.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    block_align = bit_depth // 8 * channels
+    header = struct.pack(
+        "<HHIIHH",
+        EXTENSIBLE_TAG if extensible else tag,
+        channels,
+        sample_rate,
+        sample_rate * block_align,
+        block_align,
+        bit_depth,
+    )
+    if extensible:
+        header += struct.pack("<HHI", 22, bit_depth, 0) + struct.pack("<I", tag) + SUBFORMAT_TAIL
+    body = (
+        _chunk(b"fmt ", header)
+        + _chunk(b"fact", struct.pack("<I", len(frames) // max(block_align, 1)))
+        + _chunk(b"data", frames)
+    )
+    path.write_bytes(riff_id + struct.pack("<I", 4 + len(body)) + b"WAVE" + body)
+    return path
+
+
+def _chunk(name: bytes, body: bytes) -> bytes:
+    """One RIFF chunk, padded to an even length the way the container requires."""
+    return name + struct.pack("<I", len(body)) + body + (b"\x00" if len(body) % 2 else b"")
+
+
 def _write_samples(
     path: Path,
     samples: list[int],
@@ -142,15 +284,11 @@ def _write_samples(
     channels: int,
 ) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
-    width = bit_depth // 8
-    frames = bytearray()
-    for sample in samples:
-        frames.extend(sample.to_bytes(width, "little", signed=True) * channels)
     with contextlib.closing(wave.open(str(path), "wb")) as handle:
         handle.setnchannels(channels)
-        handle.setsampwidth(width)
+        handle.setsampwidth(bit_depth // 8)
         handle.setframerate(sample_rate)
-        handle.writeframes(bytes(frames))
+        handle.writeframes(_interleaved_ints(samples, bit_depth, channels))
     return path
 
 

--- a/tests/test_wav_container.py
+++ b/tests/test_wav_container.py
@@ -14,6 +14,7 @@ this repo does not own.
 
 from __future__ import annotations
 
+import math
 import struct
 from collections.abc import Callable
 from pathlib import Path
@@ -21,7 +22,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from resolve_mcp.analysis import decode, silence
+from resolve_mcp.analysis import decode, energy, music, silence
 from resolve_mcp.audio import riff, wav
 from resolve_mcp.errors import AudioExtractionError
 
@@ -91,7 +92,10 @@ def test_describe_reports_a_float_wav(tmp_path: Path) -> None:
 
     described = wav.describe(path)
 
-    assert described["duration_seconds"] == pytest.approx(0.5)
+    # Exact, not approximate: #45 leaned on a float master and its transcode agreeing to the
+    # sample (6130.888708 both ways), so a frame lost in the header read would matter.
+    assert described["duration_seconds"] == 0.5
+    assert decode.read(path).frames == 22_050
     assert described["sample_rate"] == 44_100
     assert described["channels"] == 2
     assert described["bit_depth"] == 32
@@ -101,7 +105,7 @@ def test_describe_reports_a_float_wav(tmp_path: Path) -> None:
 def test_describe_still_reports_pcm_as_pcm(tmp_path: Path) -> None:
     described = wav.describe(write_wav(tmp_path / "tone.wav", seconds=0.5, bit_depth=24))
 
-    assert described["duration_seconds"] == pytest.approx(0.5)
+    assert described["duration_seconds"] == 0.5
     assert described["bit_depth"] == 24
     assert described["encoding"] == "pcm"
 
@@ -203,4 +207,36 @@ def test_the_reader_walks_past_chunks_it_does_not_know(tmp_path: Path) -> None:
     path = write_float_wav(tmp_path / "master.wav", seconds=0.1)
 
     assert b"fact" in path.read_bytes()
-    assert riff.header(path).frames == 4_800
+    with riff.opened(path) as handle:
+        assert handle.format.frames == 4_800
+
+
+def test_analyze_music_measures_a_float_master(tmp_path: Path) -> None:
+    """#110's own headline, at the tool the ticket names rather than a layer below it.
+
+    Beats are switched off because the detector is a model this tier does not install
+    (ADR 0002); the energy half reads the samples, which is the half the bug was in.
+    """
+    path = write_float_wav(tmp_path / "master.wav", seconds=2.0, sample_rate=8_000)
+    settings = {"beats": False, "energy": True, "window_seconds": 0.5, "hop_seconds": 0.25}
+
+    output = music.analyze(path, settings, lambda fraction, step: None)
+
+    assert output.result["audio"]["duration_seconds"] == 2.0
+    assert output.result["audio"]["sample_rate"] == 8_000
+    assert output.result["energy"]["count"] > 1
+
+
+def test_loudness_survives_a_master_that_peaks_above_full_scale(tmp_path: Path) -> None:
+    """The unclamped samples reach the loudness maths, which has to stay finite on them.
+
+    Passing peaks through is only right if what reads them can take it: BS.1770 is a log of
+    a mean square, so an above-full-scale file must measure *louder*, not overflow or clip.
+    """
+    quiet = decode.read(write_float_wav(tmp_path / "quiet.wav", seconds=0.5, amplitude=0.3))
+    hot = decode.read(write_float_wav(tmp_path / "hot.wav", seconds=0.5, amplitude=1.4))
+
+    measured = energy.integrated_lufs(hot)
+
+    assert math.isfinite(measured)
+    assert measured > energy.integrated_lufs(quiet)

--- a/tests/test_wav_container.py
+++ b/tests/test_wav_container.py
@@ -1,0 +1,206 @@
+"""The WAV container itself: the headers the standard library will not open.
+
+``wave`` reads RIFF but refuses every format tag except PCM, so a 32-bit float master — the
+default output of a mastering chain, and one of the four concert masters in the #21 corpus —
+came back as "unknown format: 3" and was reported as a damaged file (#110). The tests here
+pin both halves of that: the float and extensible headers now decode, and a file that really
+cannot be read says so without telling the caller to delete their own media.
+
+The fixtures build these headers by hand because the standard library cannot write them
+either; the PCM fixtures still go through ``wave``, which makes them an independent control —
+where a test compares a float file against a PCM one, the PCM side was written by a decoder
+this repo does not own.
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from resolve_mcp.analysis import decode, silence
+from resolve_mcp.audio import riff, wav
+from resolve_mcp.errors import AudioExtractionError
+
+from .fakes import (
+    write_extensible_pcm_wav,
+    write_float_wav,
+    write_tagged_wav,
+    write_wav,
+)
+
+ADPCM_TAG = 0x0011
+
+
+@pytest.mark.parametrize("bit_depth", [32, 64])
+def test_decode_reads_ieee_float(tmp_path: Path, bit_depth: int) -> None:
+    path = write_float_wav(tmp_path / f"float{bit_depth}.wav", seconds=0.2, bit_depth=bit_depth)
+
+    audio = decode.read(path)
+
+    assert audio.sample_rate == 48_000
+    assert audio.channels == 2
+    assert audio.frames == 9_600
+    assert float(np.max(np.abs(audio.samples))) == pytest.approx(0.3, abs=0.01)
+
+
+def test_decode_reads_an_extensible_header(tmp_path: Path) -> None:
+    """Anything above two channels, and plenty of stereo besides, is tagged extensible."""
+    path = write_extensible_pcm_wav(tmp_path / "extensible.wav", seconds=0.2)
+
+    audio = decode.read(path)
+
+    assert audio.sample_rate == 48_000
+    assert audio.channels == 2
+    assert float(np.max(np.abs(audio.samples))) == pytest.approx(0.3, abs=0.01)
+
+
+def test_float_and_pcm_of_one_tone_decode_alike(tmp_path: Path) -> None:
+    """The whole point of the fix: the same music measures the same whichever way it is stored.
+
+    The PCM side is written by the standard library, so this compares the new reader against
+    a decoder the repo does not own rather than against itself.
+    """
+    fixed = decode.read(write_wav(tmp_path / "fixed.wav", seconds=0.2, bit_depth=24))
+    floating = decode.read(write_float_wav(tmp_path / "floating.wav", seconds=0.2))
+
+    assert floating.samples.shape == fixed.samples.shape
+    assert floating.sample_rate == fixed.sample_rate
+    # 24-bit quantisation is the only difference left, and it lands well under a thousandth.
+    assert float(np.max(np.abs(floating.mono() - fixed.mono()))) < 1e-3
+
+
+def test_decode_keeps_peaks_above_full_scale(tmp_path: Path) -> None:
+    """Float WAVs carry peaks over 1.0, and clamping them would under-report loudness.
+
+    A fixed-point file cannot express this, so nothing before #110 had to decide; measuring
+    a clipped copy of a master would report a peak the master does not have.
+    """
+    path = write_float_wav(tmp_path / "hot.wav", seconds=0.05, amplitude=1.4)
+
+    audio = decode.read(path)
+
+    assert float(np.max(np.abs(audio.samples))) == pytest.approx(1.4, abs=0.01)
+
+
+def test_describe_reports_a_float_wav(tmp_path: Path) -> None:
+    path = write_float_wav(tmp_path / "master.wav", seconds=0.5, sample_rate=44_100)
+
+    described = wav.describe(path)
+
+    assert described["duration_seconds"] == pytest.approx(0.5)
+    assert described["sample_rate"] == 44_100
+    assert described["channels"] == 2
+    assert described["bit_depth"] == 32
+    assert described["encoding"] == "float"
+
+
+def test_describe_still_reports_pcm_as_pcm(tmp_path: Path) -> None:
+    described = wav.describe(write_wav(tmp_path / "tone.wav", seconds=0.5, bit_depth=24))
+
+    assert described["duration_seconds"] == pytest.approx(0.5)
+    assert described["bit_depth"] == 24
+    assert described["encoding"] == "pcm"
+
+
+def test_silence_is_measured_in_a_float_wav(tmp_path: Path) -> None:
+    """The streaming reader reads float samples too, or it calls a loud file silent.
+
+    Making ``describe`` accept a float file without teaching this path the same thing would
+    turn a clean refusal into a wrong answer — the one outcome worse than the bug in #110.
+    """
+    path = write_float_wav(tmp_path / "gap.wav", seconds=2.0, silence=[(0.6, 1.4)])
+
+    found = silence.measure(path, min_seconds=0.3)
+
+    assert len(found) == 1
+    assert found[0]["start"] == pytest.approx(0.6, abs=0.1)
+    assert found[0]["end"] == pytest.approx(1.4, abs=0.1)
+
+
+def test_a_float_wav_is_not_called_silent(tmp_path: Path) -> None:
+    """Float bytes read as signed integers measure as noise or as nothing, never as a tone."""
+    path = write_float_wav(tmp_path / "tone.wav", seconds=0.5)
+
+    levels = silence.levels(path)
+
+    assert levels
+    assert max(levels) > -20.0
+
+
+def test_an_unreadable_file_is_not_answered_by_deleting_the_callers_media(
+    tmp_path: Path,
+) -> None:
+    """#110's second half: the ``fix`` line pointed at the wrong file and the wrong action.
+
+    ``describe`` reads the caller's own source when it is passed through ``audio_at``, not
+    only the server's cache, and these errors are read by agents that act on them.
+    """
+    path = tmp_path / "notes.txt"
+    path.write_text("not audio", encoding="utf-8")
+
+    with pytest.raises(AudioExtractionError) as raised:
+        wav.describe(path)
+
+    assert "delete" not in raised.value.fix.lower()
+    assert "notes.txt" in raised.value.cause
+
+
+@pytest.mark.parametrize("reader", [wav.describe, decode.read])
+def test_a_compressed_wav_is_refused_by_its_name(
+    tmp_path: Path, reader: Callable[[Path], object]
+) -> None:
+    """A tag neither reader can decode is a different fault from a damaged file, and says so."""
+    path = write_tagged_wav(tmp_path / "adpcm.wav", tag=ADPCM_TAG)
+
+    with pytest.raises(AudioExtractionError) as raised:
+        reader(path)
+
+    assert str(ADPCM_TAG) in raised.value.cause
+    assert "delete" not in raised.value.fix.lower()
+
+
+def test_rf64_is_named_rather_than_called_damaged(tmp_path: Path) -> None:
+    """A concert master past 4 GB is RF64, which is a real format and not a broken RIFF."""
+    path = write_tagged_wav(tmp_path / "long.wav", tag=1, riff_id=b"RF64")
+
+    with pytest.raises(AudioExtractionError) as raised:
+        wav.describe(path)
+
+    assert "RF64" in raised.value.cause
+
+
+def test_a_data_chunk_that_runs_past_the_file_is_read_to_its_end(tmp_path: Path) -> None:
+    """A WAV piped from ffmpeg, or one still being written, declares a size it does not have.
+
+    ``wave`` reports the declared frame count and then hands back short reads; trusting the
+    header here would report a duration the file does not hold.
+    """
+    path = write_float_wav(tmp_path / "cut.wav", seconds=0.4)
+    whole = path.read_bytes()
+    path.write_bytes(whole[: len(whole) // 2])
+
+    described = wav.describe(path)
+
+    assert 0.0 < described["duration_seconds"] < 0.4
+    decoded = decode.read(path).duration_seconds
+    assert decoded == pytest.approx(described["duration_seconds"], abs=0.01)
+
+
+def test_a_truncated_header_is_refused(tmp_path: Path) -> None:
+    path = tmp_path / "stub.wav"
+    path.write_bytes(b"RIFF" + struct.pack("<I", 4) + b"WAVE")
+
+    with pytest.raises(AudioExtractionError):
+        wav.describe(path)
+
+
+def test_the_reader_walks_past_chunks_it_does_not_know(tmp_path: Path) -> None:
+    """The fixtures write a ``fact`` chunk between ``fmt `` and ``data``, as a real export does."""
+    path = write_float_wav(tmp_path / "master.wav", seconds=0.1)
+
+    assert b"fact" in path.read_bytes()
+    assert riff.header(path).frames == 4_800


### PR DESCRIPTION
Closes #110.

`analyze_music` refused a 32-bit float master with `unknown format: 3` and told the caller to *"Delete it from the cache directory and run the job again"* — advice written for a corrupt cached extraction, handed to someone whose own master was sitting on a media drive. Both halves are fixed.

## What changed

`analysis/decode` and `audio/wav` both read through stdlib `wave`, which parses RIFF and then accepts PCM only. A new `audio/riff` parses the container in-repo and resolves the two tags `wave` leaves out: `WAVE_FORMAT_IEEE_FLOAT`, and `WAVE_FORMAT_EXTENSIBLE`, which hides its real tag in a SubFormat GUID and is what professional tools write for anything above two channels.

It is one reader for every WAV, not a fallback for the ones `wave` rejects. Two decoders on one format eventually disagree about a file, and here the disagreement would surface as a duration that changes depending on which analysis job asked.

**On not using `soundfile`:** the issue suggested it, but `decode`'s own module docstring carries the repo rule — *"no soundfile, no librosa, no third decoder to disagree with the two the repo already depends on"* — and `soundfile` is not installed on the machine that runs the server (it is hand-installed for the beats path only). Taking that route would have shipped a fix that does not run. The issue's wording is *"Read WAVs through something that handles float, **or** transcode to PCM internally"*, under `## Suggested fix`; the outcome it asks for is delivered.

Three things follow from parsing the container ourselves:

- **`silence.levels` had to learn float too.** It streams bytes and read them as signed integers. Left alone, teaching only `describe` and `decode` about float would have turned a clean refusal into a wrong answer — float bytes read as integers make a steady tone measure as noise and digital silence measure as full scale.
- **Float samples pass through unscaled and unclamped.** A float master is allowed peaks above full scale; clipping them would report a true peak, and a loudness, the master does not have.
- **A data chunk declaring more bytes than the file holds is read to the end of the file.** A WAV piped from ffmpeg, or one whose writer died mid-render, declares a size it never wrote. This also removes a pre-existing disagreement: `describe` used to trust the declared frame count while `decode` already got a short read.

`describe` now reports `encoding` (`pcm` or `float`) beside `bit_depth`, because depth alone stopped identifying a file the moment float became readable — 32-bit PCM and 32-bit float are different audio behind the same number.

## Test seam

Fake tier, as the ticket specifies. Float, double, extensible, compressed-tag and RF64 headers are written by hand in `tests/fakes/fixtures.py`, since the standard library cannot write them either; the PCM fixtures still go through `wave`, which makes them an independent control for the float-vs-PCM comparison test. Verified the fixture reproduces the exact reported symptom (`wave.Error: unknown format: 3`) before the fix reads it.

Full tier: 1172 passed, mypy strict clean, ruff clean.

## Review

Two-axis review (`/code-review`, Standards + Spec as parallel sub-agents) against `origin/main`. No hard standards violations and no correctness bugs; findings and their resolutions:

**Standards**
- *Duplicated Code* — full scale spelled two ways (`2 ** (width * 8 - 1)` in decode, `1 << (bit_depth - 1)` in silence). **Fixed:** both take `riff.Format.full_scale`, which answers 1.0 for float so the two paths share one expression.
- *Data Clump / Feature Envy* — `decode.read` unbundled the `Format` it had just received, then re-branched on the pieces. **Fixed:** `_samples` takes the whole `Format`.
- *Speculative Generality* — `riff.header()` had no production caller; `Reader.read_all()` only one that could inline it. **Fixed:** both deleted.
- *Mysterious Name* — the `Format` value was `layout` in one module and `found` in two others, where `found` elsewhere names silence spans. **Fixed:** `header` everywhere.
- Missing docstrings on `riff._format` and the two `_interleaved_*` fixture helpers. **Fixed.**
- Test-map pairing note in `CONTEXT.md` not extended. **Fixed.**
- Not actioned: `fixtures.py` re-declaring the format tags rather than importing `riff`'s. Deliberate and commented — a fixture taking its constants from the parser under test would agree with that parser about a wrong number.

**Spec**
- Sub-agent verified end-to-end that `music.analyze`'s only two audio reads both now go through `riff`, and ran it on a float WAV successfully.
- *Missing coverage* — the regression was pinned one layer below `analyze_music`, the tool the ticket names. **Fixed:** added a test through `music.analyze` (beats off — the detector is a model this tier does not install, ADR 0002; energy is the half that reads samples).
- *Missing coverage* — above-full-scale float now reaches the LUFS path untested. **Fixed:** added a test that loudness stays finite and reads the hot file louder.
- *Sample-exact duration not pinned* — the ticket turns on a master and its transcode agreeing to the sample. **Fixed:** two duration assertions moved from approx to exact, plus an exact frame count.
- *Scope* — `encoding` on `describe`, the declared-size override, and extensible/RF64/64-bit float going past "format 3" were each flagged as beyond the literal ask. Kept, with the reasoning above; the extensible case is the same bug class (`wave` refuses it identically), and RF64 is an honest refusal rather than a feature.
- No requirements found implemented wrongly.

Fix diff re-checked on its own (focused pass, not a second full review): full-scale consolidation confirmed behaviour-identical for widths 2/3/4, rename complete with no shadowing, `riff.read()` still reads every frame, no weakened assertions.

Review: clean — two-axis review against origin/main; all Standards and Spec findings fixed, fix diff re-checked clean.
