### PR TITLE
Default render preset: config key + optional preset argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,13 @@ against the media all the same. `detect_scene_cuts` decodes the whole clip, so i
 the catalog of every cut and shot goes to the cache in dual-time JSON and only a gist (how
 many cuts, the shot lengths, the first few times, the path) comes back inline.
 
-Deliverables come off one timeline the same way: `render_timeline` takes a **preset** by
-name — what a preset renders was decided in the Deliver page and saved there, so the server
-overrides only where the file goes and which frames it covers — plus an optional half-open
+Deliverables come off one timeline the same way: `render_timeline` renders with a **preset**
+— what a preset renders was decided in the Deliver page and saved there, so the server
+overrides only where the file goes and which frames it covers. Name none and the configured
+default is used (`H.265 Master`, a Resolve built-in; `RESOLVE_MCP_DEFAULT_RENDER_PRESET`
+points it elsewhere), and the job says which preset ran and whether it was the default or
+explicit. An unknown name is refused with the list of names that exist, never swapped for a
+near-enough preset. On top of that goes an optional half-open
 `[start, end)` range in the timeline's own frames, the numbers `inspect_timeline` and
 `list_markers` report. That is a per-song file out of a concert set. Without a `target_dir`
 the file lands in the cache's `renders` folder, which the server replaces freely on a

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Zero-config by default; every path has an environment override.
 | `RESOLVE_MCP_AUDIO_SEPARATOR` | `audio-separator` (found on PATH) | python-audio-separator CLI used for stem separation |
 | `RESOLVE_MCP_STEM_MODEL` | `htdemucs_ft.yaml` | Pass one: the 4-stem model (vocals, drums, bass, other) |
 | `RESOLVE_MCP_DRUM_MODEL` | `MDX23C-DrumSep-aufr33-jarredou.ckpt` | Pass two: the drum decomposition model (kick, snare, toms) |
+| `RESOLVE_MCP_DEFAULT_RENDER_PRESET` | `H.265 Master` | Render preset `render_timeline` uses when the call names none. Must be a preset the project offers — an unknown name is refused, never swapped for another |
 | `RESOLVE_MCP_LOG_LEVEL` | `INFO` | Log level for the stderr logger |
 | `RESOLVE_MCP_ALLOW_ANY_PYTHON` | unset | Bypass the interpreter check (see ADR 0001) |
 

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -22,6 +22,9 @@ DEFAULT_STEM_MODEL = "htdemucs_ft.yaml"
 # The name audio-separator 0.44.5 lists for the six-stem MDX23C drum model; the
 # "MDX23C-DrumSep-6stem-FT.ckpt" spelling is not in its catalog and fails to load.
 DEFAULT_DRUM_MODEL = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
+# A Resolve built-in, present on every install, so a bare render works before anyone has
+# saved a preset. The director's own presets are named explicitly or set here.
+DEFAULT_RENDER_PRESET = "H.265 Master"
 
 
 TRUTHY = {"1", "true", "yes", "on"}
@@ -39,6 +42,7 @@ class Config:
     audio_separator: str = DEFAULT_AUDIO_SEPARATOR
     stem_model: str = DEFAULT_STEM_MODEL
     drum_model: str = DEFAULT_DRUM_MODEL
+    default_render_preset: str = DEFAULT_RENDER_PRESET
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> Config:
@@ -57,6 +61,9 @@ class Config:
             audio_separator=env.get("RESOLVE_MCP_AUDIO_SEPARATOR") or DEFAULT_AUDIO_SEPARATOR,
             stem_model=env.get("RESOLVE_MCP_STEM_MODEL") or DEFAULT_STEM_MODEL,
             drum_model=env.get("RESOLVE_MCP_DRUM_MODEL") or DEFAULT_DRUM_MODEL,
+            default_render_preset=(
+                env.get("RESOLVE_MCP_DEFAULT_RENDER_PRESET") or DEFAULT_RENDER_PRESET
+            ),
         )
 
     @property

--- a/src/resolve_mcp/deliver.py
+++ b/src/resolve_mcp/deliver.py
@@ -6,8 +6,9 @@ A concert set is one timeline and a dozen files. That shape drives every decisio
   their own leave resolution, bit rate and colour at whatever the project was last set to.
   What those should be is the director's call, made once in the Deliver page and saved; this
   server picks a saved preset by name and overrides only where the file goes and which
-  frames it covers. That is also why the preset catalog was never specified in the spec —
-  it belongs to the project, not to the server.
+  frames it covers. That is also why the spec never said what a preset *contains* — the
+  settings belong to the project, not to the server. Which presets there are is the fourth
+  decision below.
 
 * **A range is the same half-open ``[in, out)`` as everywhere else, on the timeline's own
   clock.** The numbers ``inspect_timeline`` and ``list_markers`` report are the numbers to
@@ -21,6 +22,21 @@ A concert set is one timeline and a dozen files. That shape drives every decisio
   render directory is cleared before rendering, and a directory the caller named is refused
   unless ``refresh`` says otherwise. A deliverable the director already sent out is not this
   server's to overwrite on a guess.
+
+* **The catalog is one changeable default plus explicitly named extras** (#71). The default
+  is ``config.default_render_preset``, shipped as the Resolve built-in ``H.265 Master`` and
+  overridable like any other key, so "render this" means render with the preset the server
+  knows and a name in the call is the override. What comes out of here are streaming uploads
+  — YouTube, Instagram — rendered per song off one concert timeline; there is no standing
+  review or master role for a preset to fill, and no per-platform roles either: a vertical
+  Instagram deliverable is a timeline and a cut, not a preset. Extra presets (a future review
+  preset, ``h.265 NVIDIA``) are names the director saves in the GUI and passes explicitly.
+
+  This catalog records a name and a one-line purpose, never a settings table: presets are GUI
+  state the director owns and re-tunes as the methodology moves, and a copy of their settings
+  here would be a second version of the truth that nothing updates. For the same reason the
+  cut file never names a preset — delivery format is a render-time parameter, so one cut can
+  go out to two platforms without being rewritten.
 
 Caching is the timeline fingerprint plus these parameters, so a re-render of an unchanged
 song is instant and a cut that moved renders again — see ``resolve.timeline.fingerprint``
@@ -75,7 +91,7 @@ def list_presets(connection: ResolveConnection) -> dict[str, Any]:
 
 def render_timeline(
     connection: ResolveConnection,
-    preset: str,
+    preset: str | None = None,
     timeline: str | None = None,
     name: str | None = None,
     target_dir: str | None = None,
@@ -90,6 +106,10 @@ def render_timeline(
     a job exists: a preset that is not in the project, a range that runs off the end of the
     timeline, a file already sitting where this one would land. Those are the caller's
     mistakes, and a raised error names them a poll earlier than a failed job would.
+
+    Omitting ``preset`` renders with ``config.default_render_preset``. A default the project
+    does not have refuses exactly like a name that was typed out: there is no second preset
+    to fall back to, only a wrong-shaped file that would go out under a right-sounding name.
     """
     config = config or get_config()
     project = current_project(connection, "No project is open, so there is nothing to render.")
@@ -98,16 +118,19 @@ def render_timeline(
     fps = frame_rate(project, found)
     span = _span(start, end, found, fps)
 
+    using = config.default_render_preset if preset is None else preset
+
     # Reading the preset list is cheap and does not disturb the queue; loading it is what
     # changes project state, and that waits for the job's turn under the Resolve lock.
-    render.require_preset(project, preset)
+    render.require_preset(project, using)
 
     covered = span or (int(found.GetStartFrame()), int(found.GetEndFrame()))
     stem = _stem(name, timeline_name, span)
     directory = Path(target_dir) if target_dir is not None else config.render_dir
     params: dict[str, Any] = {
         "timeline": timeline_name,
-        "preset": preset,
+        "preset": using,
+        "preset_source": "default" if preset is None else "explicit",
         "name": stem,
         "target_dir": str(directory),
         "whole_timeline": span is None,
@@ -115,7 +138,12 @@ def render_timeline(
         "end": covered[1],
         "fps": fps,
     }
-    key = cache.cache_key(KIND, [fingerprint(Reader(connection), found)], params)
+
+    # How the preset was chosen is reported, not keyed on: it does not change a frame of the
+    # file, and a concert render costs minutes to hours. Keying on it would re-render the
+    # whole song the first time a caller spelled out the name it had been defaulting to.
+    keyed = {field: value for field, value in params.items() if field != "preset_source"}
+    key = cache.cache_key(KIND, [fingerprint(Reader(connection), found)], keyed)
 
     # The lookup start_job is about to make, made a moment early: a cache hit renders
     # nothing, so it is the one case where a file already at the target is this job's own
@@ -211,6 +239,10 @@ def _result(
     The range is reported whether or not one was asked for: a whole-timeline render covers
     the timeline's own bounds, and a deliverable that will not say what it holds is one the
     agent has to open Resolve to identify.
+
+    ``preset_source`` says whether that preset was named in the call or came from the config
+    default, so a file that came out the wrong shape leads back to the thing that chose it
+    rather than to a guess about which of the two was in play.
     """
     fps = params["fps"]
     start = int(params["start"])
@@ -220,6 +252,7 @@ def _result(
         "size_bytes": expecting.stat().st_size,
         "timeline": params["timeline"],
         "preset": params["preset"],
+        "preset_source": params["preset_source"],
         "format": format_and_codec.get("format"),
         "codec": format_and_codec.get("codec"),
         "whole_timeline": params["whole_timeline"],

--- a/src/resolve_mcp/deliver.py
+++ b/src/resolve_mcp/deliver.py
@@ -77,6 +77,18 @@ not a stalled render at ninety minutes, and killing it would waste the whole thi
 RENDER_FLOOR = 0.05
 RENDER_CEILING = 0.98
 
+# Where the preset came from: the config default, or a name the caller spelled out.
+DEFAULTED = "default"
+EXPLICIT = "explicit"
+
+REPORTED_ONLY = frozenset({"preset_source"})
+"""Params that describe the call rather than the file, so they stay out of the cache key.
+
+Two calls that differ only in these produce the same bytes; keying on them would re-render
+a whole song to answer a question about how it was asked for. Anything added here has to be
+read the same way, or a real difference will start sharing one cache entry.
+"""
+
 
 def list_presets(connection: ResolveConnection) -> dict[str, Any]:
     """The render presets this project offers, and the format it would render with now."""
@@ -110,6 +122,8 @@ def render_timeline(
     Omitting ``preset`` renders with ``config.default_render_preset``. A default the project
     does not have refuses exactly like a name that was typed out: there is no second preset
     to fall back to, only a wrong-shaped file that would go out under a right-sounding name.
+    Which of the two happened is ``preset_source`` on the job's params — see ``_result`` for
+    why the marker sits there and not on the result.
     """
     config = config or get_config()
     project = current_project(connection, "No project is open, so there is nothing to render.")
@@ -118,19 +132,22 @@ def render_timeline(
     fps = frame_rate(project, found)
     span = _span(start, end, found, fps)
 
-    using = config.default_render_preset if preset is None else preset
+    if preset is None:
+        chosen, source = config.default_render_preset, DEFAULTED
+    else:
+        chosen, source = preset, EXPLICIT
 
     # Reading the preset list is cheap and does not disturb the queue; loading it is what
     # changes project state, and that waits for the job's turn under the Resolve lock.
-    render.require_preset(project, using)
+    render.require_preset(project, chosen)
 
     covered = span or (int(found.GetStartFrame()), int(found.GetEndFrame()))
     stem = _stem(name, timeline_name, span)
     directory = Path(target_dir) if target_dir is not None else config.render_dir
     params: dict[str, Any] = {
         "timeline": timeline_name,
-        "preset": using,
-        "preset_source": "default" if preset is None else "explicit",
+        "preset": chosen,
+        "preset_source": source,
         "name": stem,
         "target_dir": str(directory),
         "whole_timeline": span is None,
@@ -142,7 +159,7 @@ def render_timeline(
     # How the preset was chosen is reported, not keyed on: it does not change a frame of the
     # file, and a concert render costs minutes to hours. Keying on it would re-render the
     # whole song the first time a caller spelled out the name it had been defaulting to.
-    keyed = {field: value for field, value in params.items() if field != "preset_source"}
+    keyed = {field: value for field, value in params.items() if field not in REPORTED_ONLY}
     key = cache.cache_key(KIND, [fingerprint(Reader(connection), found)], keyed)
 
     # The lookup start_job is about to make, made a moment early: a cache hit renders
@@ -240,9 +257,11 @@ def _result(
     the timeline's own bounds, and a deliverable that will not say what it holds is one the
     agent has to open Resolve to identify.
 
-    ``preset_source`` says whether that preset was named in the call or came from the config
-    default, so a file that came out the wrong shape leads back to the thing that chose it
-    rather than to a guess about which of the two was in play.
+    The preset is named here and how it was chosen is not: ``preset_source`` lives on the
+    job's params, which always describe *this* call, while a result can be replayed from
+    cache. A render started on the default and asked for again by name is one file and one
+    cache entry, and a result that carried the marker would answer the second call with the
+    first call's word for it.
     """
     fps = params["fps"]
     start = int(params["start"])
@@ -252,7 +271,6 @@ def _result(
         "size_bytes": expecting.stat().st_size,
         "timeline": params["timeline"],
         "preset": params["preset"],
-        "preset_source": params["preset_source"],
         "format": format_and_codec.get("format"),
         "codec": format_and_codec.get("codec"),
         "whole_timeline": params["whole_timeline"],

--- a/src/resolve_mcp/tools/render.py
+++ b/src/resolve_mcp/tools/render.py
@@ -40,7 +40,7 @@ def render_timeline(
     except where it goes and which frames it covers.
 
     Leave preset out and the server's configured default is used, which is the normal way to
-    render: the result says which preset ran and whether it was the default or explicit. Name
+    render: the job's params name the preset that ran and mark it default or explicit. Name
     one — spelled as list_render_presets spells it — only to override that for this render.
     Either way an unknown name is refused with the list of names that exist; nothing falls
     back to another preset, because a wrong-shaped file under a right-sounding name is worse

--- a/src/resolve_mcp/tools/render.py
+++ b/src/resolve_mcp/tools/render.py
@@ -24,7 +24,7 @@ def list_render_presets() -> dict[str, Any]:
 
 @tool
 def render_timeline(
-    preset: str,
+    preset: str | None = None,
     timeline: str | None = None,
     name: str | None = None,
     target_dir: str | None = None,
@@ -36,8 +36,15 @@ def render_timeline(
 
     A render is the longest thing this server does, so it hands back a job straight away and
     get_job reports it — progress while it runs, the file's path and size when it finishes,
-    a cause and a fix if the queue refused it. preset must be one list_render_presets names;
-    it decides everything about the file except where it goes and which frames it covers.
+    a cause and a fix if the queue refused it. A preset decides everything about the file
+    except where it goes and which frames it covers.
+
+    Leave preset out and the server's configured default is used, which is the normal way to
+    render: the result says which preset ran and whether it was the default or explicit. Name
+    one — spelled as list_render_presets spells it — only to override that for this render.
+    Either way an unknown name is refused with the list of names that exist; nothing falls
+    back to another preset, because a wrong-shaped file under a right-sounding name is worse
+    than a refusal you can act on.
 
     start and end cut one deliverable out of a longer timeline — a song off a concert set.
     They are frames on the timeline's own clock, the numbers inspect_timeline and

--- a/tests/fakes/project.py
+++ b/tests/fakes/project.py
@@ -50,8 +50,12 @@ class FakeProject:
         self.render_writes_the_file = True
         # A preset carries the format and codec with it — loading one is what sets them,
         # which is why the deliver route never sets a format of its own.
+        # "H.265 Master" is here because Resolve ships it on every install: it is the
+        # config's default preset, so a fake without it would make every bare render fail
+        # for a reason no real machine has.
         self.render_presets: dict[str, tuple[str, str]] = {
             "H.264 Master": ("mp4", "H.264"),
+            "H.265 Master": ("mp4", "H.265"),
             "ProRes 422 HQ": ("mov", "ProRes422HQ"),
         }
         self.loaded_presets: list[str] = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,6 +96,19 @@ def test_the_separator_and_its_two_models_are_overridable() -> None:
     assert config.drum_model == "drumsep.ckpt"
 
 
+def test_the_default_render_preset_is_a_resolve_built_in_and_overridable() -> None:
+    """Shipped as a preset every install has, so a bare render works before anyone configures.
+
+    A preset saved on the director's machine cannot be the shipped value — it would not be
+    on a fresh install, and the first render would refuse with nothing to point at.
+    """
+    assert Config.from_env({}).default_render_preset == "H.265 Master"
+    assert (
+        Config.from_env({"RESOLVE_MCP_DEFAULT_RENDER_PRESET": "Concert 4K"}).default_render_preset
+        == "Concert 4K"
+    )
+
+
 def test_ffmpeg_is_a_bare_name_on_path_until_told_otherwise() -> None:
     assert Config.from_env({}).ffmpeg == "ffmpeg"
     assert Config.from_env({"RESOLVE_MCP_FFMPEG": r"D:\tools\ffmpeg.exe"}).ffmpeg == (

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -911,9 +911,9 @@ def test_the_shipped_default_preset_is_a_built_in_on_this_machine(tmp_path: Path
     record = wait_for(started["job"]["job_id"], timeout=1800.0)
 
     assert record.state == "completed", record.error
+    assert record.params["preset_source"] == "default"
     assert record.result is not None
     assert record.result["preset"] == default
-    assert record.result["preset_source"] == "default"
     written = Path(record.result["path"])
     assert written.exists() and written.stat().st_size > 0
     print(f"\ndefault preset {default!r} rendered {written} ({written.stat().st_size} bytes)")

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -876,6 +876,49 @@ def test_the_preset_list_is_the_one_in_the_deliver_page() -> None:
     print(f"\nrender presets: {reply['presets']}")
 
 
+def test_the_shipped_default_preset_is_a_built_in_on_this_machine(tmp_path: Path) -> None:
+    """#96: whether ``H.265 Master`` is really a name a stock Resolve offers.
+
+    The fakes prove that an omitted preset resolves to the config default, that the marker
+    says which of the two it was, and that an unknown name refuses. What only Resolve can
+    say is whether the *shipped* default is spelled the way this project spells it — get
+    that wrong and every render that names no preset refuses on a fresh install, which is
+    exactly the call this ticket made the normal one. Slow: it renders a two-second span.
+    """
+    if get_status()["context"]["timeline"] is None:
+        pytest.skip("No timeline open in Resolve")
+    default = get_config().default_render_preset
+    listed = list_render_presets()
+    assert listed["ok"] is True, listed.get("error")
+    assert default in listed["presets"], (
+        f"the default preset {default!r} is not in {listed['presets']} — a bare "
+        "render_timeline would refuse on this install"
+    )
+
+    whole = inspect_timeline(detail="summary")
+    assert whole["ok"] is True
+    first = whole["timeline"]["start"]["frames"]
+    fps = whole["timeline"]["fps"] or 24
+    if whole["timeline"]["duration"]["frames"] < int(fps * 4):
+        pytest.skip("The open timeline is too short to render a span out of")
+
+    started = render_timeline(
+        name="resolve-mcp-smoke-default",
+        target_dir=str(tmp_path),
+        start=first + int(fps),
+        end=first + int(fps * 3),
+    )
+    record = wait_for(started["job"]["job_id"], timeout=1800.0)
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert record.result["preset"] == default
+    assert record.result["preset_source"] == "default"
+    written = Path(record.result["path"])
+    assert written.exists() and written.stat().st_size > 0
+    print(f"\ndefault preset {default!r} rendered {written} ({written.stat().st_size} bytes)")
+
+
 def test_a_range_render_covers_the_frames_it_was_given(tmp_path: Path) -> None:
     """#33: the AC no fake can answer — that MarkIn/MarkOut are read on the timeline's clock.
 

--- a/tests/test_render_tools.py
+++ b/tests/test_render_tools.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import pytest
 
-from resolve_mcp.config import get_config
+from resolve_mcp.config import Config, get_config, set_config
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.tools.jobs import get_job
 from resolve_mcp.tools.render import list_render_presets, render_timeline
@@ -23,6 +23,8 @@ from .conftest import Attach
 from .fakes import FakeProject, FakeResolve, FakeTimeline, studio
 
 PRESET = "H.264 Master"
+DEFAULT_PRESET = "H.265 Master"
+PRESETS_ON_THIS_PROJECT = ["H.264 Master", "H.265 Master", "ProRes 422 HQ"]
 
 
 # --- presets -------------------------------------------------------------------------------
@@ -34,8 +36,8 @@ def test_the_preset_list_names_what_the_deliver_page_offers(attach: Attach) -> N
     reply = list_render_presets()
 
     assert reply["ok"] is True
-    assert reply["presets"] == ["H.264 Master", "ProRes 422 HQ"]
-    assert reply["count"] == 2
+    assert reply["presets"] == ["H.264 Master", "H.265 Master", "ProRes 422 HQ"]
+    assert reply["count"] == 3
 
 
 def test_the_preset_list_reports_the_format_currently_loaded(attach: Attach) -> None:
@@ -55,6 +57,83 @@ def test_no_project_open_is_a_failure_not_an_empty_preset_list(attach: Attach) -
 
     assert reply["ok"] is False
     assert reply["error"]["code"] == "no_project_open"
+
+
+# --- the default preset --------------------------------------------------------------------
+
+
+def test_a_render_with_no_preset_named_uses_the_configured_default(attach: Attach) -> None:
+    """"Render this" means render with the preset the server knows — #96's whole point."""
+    resolve = studio(timeline=FakeTimeline("sunset-set v3", "24"))
+    attach(resolve)
+
+    started = render_timeline()
+    record = wait_for(started["job"]["job_id"])
+
+    assert started["job"]["params"]["preset"] == DEFAULT_PRESET
+    assert started["job"]["params"]["preset_source"] == "default"
+    assert record.state == "completed"
+    assert record.result is not None
+    assert record.result["preset"] == DEFAULT_PRESET
+    assert record.result["preset_source"] == "default"
+    assert record.result["codec"] == "H.265"
+    assert _project(resolve).loaded_presets == [DEFAULT_PRESET]
+
+
+def test_the_env_override_changes_which_preset_a_bare_render_uses(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The default is config like any other key, so a machine can be pointed elsewhere."""
+    set_config(
+        Config.from_env(
+            {
+                "RESOLVE_MCP_CACHE": str(tmp_path / "cache"),
+                "RESOLVE_MCP_DEFAULT_RENDER_PRESET": "ProRes 422 HQ",
+            }
+        )
+    )
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    record = wait_for(render_timeline()["job"]["job_id"])
+
+    assert record.state == "completed"
+    assert record.result is not None
+    assert record.result["preset"] == "ProRes 422 HQ"
+    assert record.result["preset_source"] == "default"
+    assert _project(resolve).loaded_presets == ["ProRes 422 HQ"]
+
+
+def test_a_named_preset_is_marked_explicit_and_beats_the_default(attach: Attach) -> None:
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    started = render_timeline(preset=PRESET)
+    record = wait_for(started["job"]["job_id"])
+
+    assert started["job"]["params"]["preset_source"] == "explicit"
+    assert record.result is not None
+    assert record.result["preset"] == PRESET
+    assert record.result["preset_source"] == "explicit"
+    assert _project(resolve).loaded_presets == [PRESET]
+
+
+def test_defaulting_to_a_preset_and_naming_it_are_one_cache_entry(attach: Attach) -> None:
+    """How the preset was chosen does not change a frame of the file, so it is not in the key.
+
+    A concert render costs minutes to hours; re-running one because the second call spelled
+    out the name the first call defaulted to would be the expensive kind of wrong. The
+    replayed result still reports the render that actually happened — ``default``.
+    """
+    resolve = studio(timeline=_concert())
+    attach(resolve)
+
+    first = wait_for(render_timeline(name="Blue Monk")["job"]["job_id"])
+    again = render_timeline(preset=DEFAULT_PRESET, name="Blue Monk")["job"]
+
+    assert again["cached"] is True
+    assert again["result"] == first.result
+    assert len(_project(resolve).render_jobs) == 1
 
 
 # --- the whole timeline --------------------------------------------------------------------
@@ -271,6 +350,27 @@ def test_an_unknown_preset_names_the_ones_that_exist(attach: Attach) -> None:
 
     assert reply["ok"] is False
     assert reply["error"]["code"] == "render_preset_not_found"
+    assert reply["error"]["detail"]["available"] == PRESETS_ON_THIS_PROJECT
+    assert _project(resolve).render_jobs == []
+
+
+def test_a_default_preset_this_project_lacks_refuses_rather_than_falling_back(
+    attach: Attach,
+) -> None:
+    """No fallback, ever (#71 Q4): a missing default is a question for the director.
+
+    Rendering the nearest other preset would hand back a file of the wrong shape under a
+    name that says it is right, and nothing downstream would catch it.
+    """
+    resolve = studio(timeline=_concert())
+    del _project(resolve).render_presets[DEFAULT_PRESET]
+    attach(resolve)
+
+    reply = render_timeline()
+
+    assert reply["ok"] is False
+    assert reply["error"]["code"] == "render_preset_not_found"
+    assert reply["error"]["detail"]["requested"] == DEFAULT_PRESET
     assert reply["error"]["detail"]["available"] == ["H.264 Master", "ProRes 422 HQ"]
     assert _project(resolve).render_jobs == []
 

--- a/tests/test_render_tools.py
+++ b/tests/test_render_tools.py
@@ -36,7 +36,7 @@ def test_the_preset_list_names_what_the_deliver_page_offers(attach: Attach) -> N
     reply = list_render_presets()
 
     assert reply["ok"] is True
-    assert reply["presets"] == ["H.264 Master", "H.265 Master", "ProRes 422 HQ"]
+    assert reply["presets"] == PRESETS_ON_THIS_PROJECT
     assert reply["count"] == 3
 
 
@@ -73,9 +73,9 @@ def test_a_render_with_no_preset_named_uses_the_configured_default(attach: Attac
     assert started["job"]["params"]["preset"] == DEFAULT_PRESET
     assert started["job"]["params"]["preset_source"] == "default"
     assert record.state == "completed"
+    assert record.params["preset_source"] == "default"
     assert record.result is not None
     assert record.result["preset"] == DEFAULT_PRESET
-    assert record.result["preset_source"] == "default"
     assert record.result["codec"] == "H.265"
     assert _project(resolve).loaded_presets == [DEFAULT_PRESET]
 
@@ -98,9 +98,9 @@ def test_the_env_override_changes_which_preset_a_bare_render_uses(
     record = wait_for(render_timeline()["job"]["job_id"])
 
     assert record.state == "completed"
+    assert record.params["preset_source"] == "default"
     assert record.result is not None
     assert record.result["preset"] == "ProRes 422 HQ"
-    assert record.result["preset_source"] == "default"
     assert _project(resolve).loaded_presets == ["ProRes 422 HQ"]
 
 
@@ -112,9 +112,9 @@ def test_a_named_preset_is_marked_explicit_and_beats_the_default(attach: Attach)
     record = wait_for(started["job"]["job_id"])
 
     assert started["job"]["params"]["preset_source"] == "explicit"
+    assert record.params["preset_source"] == "explicit"
     assert record.result is not None
     assert record.result["preset"] == PRESET
-    assert record.result["preset_source"] == "explicit"
     assert _project(resolve).loaded_presets == [PRESET]
 
 
@@ -122,8 +122,11 @@ def test_defaulting_to_a_preset_and_naming_it_are_one_cache_entry(attach: Attach
     """How the preset was chosen does not change a frame of the file, so it is not in the key.
 
     A concert render costs minutes to hours; re-running one because the second call spelled
-    out the name the first call defaulted to would be the expensive kind of wrong. The
-    replayed result still reports the render that actually happened — ``default``.
+    out the name the first call defaulted to would be the expensive kind of wrong.
+
+    Which is why the marker is on the params and not on the result: the result is replayed
+    from the earlier render, and one carrying ``default`` would answer this explicit call
+    with the other call's word for it.
     """
     resolve = studio(timeline=_concert())
     attach(resolve)
@@ -134,6 +137,9 @@ def test_defaulting_to_a_preset_and_naming_it_are_one_cache_entry(attach: Attach
     assert again["cached"] is True
     assert again["result"] == first.result
     assert len(_project(resolve).render_jobs) == 1
+    assert again["params"]["preset_source"] == "explicit"
+    assert first.params["preset_source"] == "default"
+    assert "preset_source" not in again["result"]
 
 
 # --- the whole timeline --------------------------------------------------------------------


### PR DESCRIPTION
Closes #96.

`render_timeline`'s `preset` becomes optional. Omitted, it renders with `config.default_render_preset` — shipped as the Resolve built-in `H.265 Master`, overridable through `RESOLVE_MCP_DEFAULT_RENDER_PRESET` like every other key. A name in the call is the override. An unknown name refuses with `render_preset_not_found` and the list it was checked against, whether it was defaulted or typed out (#71 Q4): there is no second preset to fall back to, only a wrong-shaped file going out under a right-sounding name.

The #71 catalog is appended to `deliver.py`'s module docstring as the fourth decision, next to #33's three.

**Test seams.** Everything that is a decision verifies at the fake tier — default resolution, the env override end to end, the defaulted/explicit marker, the no-fallback refusal, and that the two ways of naming one preset share one cache entry. The fake project gains `H.265 Master`, because a fake without the built-in every install has would fail bare renders for a reason no real machine has. The live tier answers the one thing no fake can: whether a stock Resolve really spells the shipped default that way.

**Two decisions the ticket did not spell out:**

- `preset_source` is reported but kept out of the cache key (`REPORTED_ONLY`). It does not change a frame of the file, and a concert render costs minutes to hours — keying on it would re-render a whole song the first time a caller spelled out the name it had been defaulting to. The filtered dict is byte-identical to the pre-#96 params, so existing cache entries stay valid.
- The marker sits on the job's params, not on the result. A cache hit builds a record from *this* call's params and answers it with the *earlier* render's stored result, so a marker on the result would answer an explicit call with the previous call's word for it. The result still names the preset, which is in the key and so is always this call's own.

## Review

`/code-review` (two-axis: Standards and Spec as parallel sub-agents), run on the branch against `origin/main` before this PR existed.

**Spec axis — 4 findings, all resolved:**

1. *(wrong)* On a cache hit the envelope contradicted itself: `params.preset_source` said `explicit` while the replayed `result.preset_source` said `default`. Fixed — the marker now lives only on the params, and a test asserts both the replayed result and the two records' markers.
2. *(missing)* `README.md`'s prose still said `render_timeline` "takes a **preset** by name". Fixed — it now describes the default, the override, and the refusal.
3. *(scope)* The cache-key exclusion is a decision the ticket did not ask for. Kept, and named above rather than only in a code comment.
4. *(process)* The live AC must be run and recorded, not assumed. Run — see below.

**Standards axis — no hard violations; 5 judgement calls, 4 taken:**

- `using` was a verb form, not the thing held → `chosen`.
- `preset is None` was decided twice three lines apart → one derivation of `chosen, source`.
- The cache-key exclusion keyed on a bare string literal → `REPORTED_ONLY`, documented so the next report-only param does not silently join the key.
- `PRESETS_ON_THIS_PROJECT` was introduced but the same literal stayed spelled out at the other site → constant at both.
- Declined: typing `preset_source` as `Literal["default", "explicit"]`. The params dict is `dict[str, Any]`, so mypy would not police it, and the repo's envelope fields are consistently plain strings.

Fix diff re-checked in a focused pass (not a second full review): full fake tier 1181 passed, mypy strict clean over 152 files, ruff clean, and the live preset tests re-run against the final code.

**Live tier (this box — Windows 11, Resolve Studio 21.0.3, python.org 3.11):** `uv run pytest -m live tests/test_live_smoke.py -k preset -s` → **2 passed** in 13.41s. `H.265 Master` is in `list_render_presets` on this install, and a bare `render_timeline()` loaded it and rendered a 98,910-byte `.mov`. Note for the catalog: `H.265 Master` reports `mov`, not `mp4`.

Review: clean — findings above resolved on the branch; fix diff re-checked, fake tier 1181 passed, mypy strict and ruff clean, live preset tier 2 passed.
