### PR TITLE
Gate the beat statistics on whether the grid can describe the music (#112)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,7 +62,9 @@ Top level:
 
 `analysis/` — compute jobs that read audio and write findings to disk:
 `applause` (bursts → tune boundaries), `beats` (grid + downbeats, model
-injected per ADR 0002), `correlate` (measure a cut against its music),
+injected per ADR 0002; `trust` says which beats the grid describes well enough
+to count, #112), `correlate` (measure a cut against its music, gating the beat
+statistics on `trust` and leaving the transient ones ungated),
 `decode` (WAV → numpy, no third-party decoder), `drums` (hits per stem), `energy`
 (loudness curves), `fills` (drum-fill candidates), `halves` (shared
 identify/cache/write pattern), `music` (beats + energy + gist job),

--- a/src/resolve_mcp/analysis/beats.py
+++ b/src/resolve_mcp/analysis/beats.py
@@ -27,7 +27,7 @@ INSTALL = "uv pip install 'beat_this @ git+https://github.com/CPJKU/beat_this'"
 DOWNBEAT_TOLERANCE = 0.005
 """How far a downbeat may sit from the beat it marks before it is a different beat."""
 
-UNSTEADY_INTERVAL = 0.15
+UNSTEADY_FRACTION = 0.15
 """How far a beat-to-beat interval may sit from its neighbours before the grid is guessing.
 
 Fifteen percent is roughly a swung eighth against a straight one: wide enough that ordinary
@@ -35,7 +35,7 @@ human time-keeping and the model's own rounding stay inside it, narrow enough th
 ballad head — where the interval wanders by half again — falls outside on the first beat.
 """
 
-DESCRIBES_BARS = 2
+MINIMUM_METER = 2
 """The smallest meter that is a meter at all.
 
 A grid reporting bars one beat long has not found a slow tune; it has marked every beat a
@@ -185,14 +185,13 @@ def gist(grid: BeatGrid, records: Sequence[dict[str, Any]]) -> dict[str, Any]:
         if later > earlier
     ]
     tempos = sorted(60.0 / interval for interval in intervals)
-    lengths = list(Counter(record["bar"] for record in records).values())
     return {
         "count": len(grid.beats),
         "downbeat_count": sum(1 for record in records if record["downbeat"]),
         "tempo_bpm": round(statistics.median(tempos), 2) if tempos else None,
         "tempo_min_bpm": round(tempos[0], 2) if tempos else None,
         "tempo_max_bpm": round(tempos[-1], 2) if tempos else None,
-        "meter": statistics.mode(lengths) if lengths else None,
+        "meter": _meter(records),
         "first_seconds": round(grid.beats[0], 3) if grid.beats else None,
         "last_seconds": round(grid.beats[-1], 3) if grid.beats else None,
     }
@@ -213,7 +212,7 @@ def trust(records: Sequence[dict[str, Any]]) -> GridTrust:
     its own (it returns two lists of times), so steadiness is derived from the intervals.
     """
     meter = _meter(records)
-    describes_bars = meter is not None and meter >= DESCRIBES_BARS
+    describes_bars = meter is not None and meter >= MINIMUM_METER
     steady = _steady_flags([float(record["t"]) for record in records])
     reasons: Counter[str] = Counter()
     trusted: list[bool] = []
@@ -234,7 +233,11 @@ def trust(records: Sequence[dict[str, Any]]) -> GridTrust:
 
 
 def _meter(records: Sequence[dict[str, Any]]) -> int | None:
-    """The meter the grid behaves as if it is in — the same statistic the gist reports."""
+    """The meter the grid behaves as if it is in: the commonest bar length it produced.
+
+    One definition, shared by the gist that reports it and the gate that judges bar positions
+    against it, so a grid can never be described as one meter and gated against another.
+    """
     lengths = list(Counter(record["bar"] for record in records).values())
     return statistics.mode(lengths) if lengths else None
 
@@ -266,4 +269,9 @@ def _local(intervals: Sequence[float], index: int) -> float:
 
 
 def _wanders(interval: float, local: float) -> bool:
-    return local <= 0 or abs(interval - local) > UNSTEADY_INTERVAL * local
+    """Whether one interval is too far from the tempo around it to be the same tempo.
+
+    A window with no length at all — a grid reporting the same time twice — is treated as
+    wandering rather than divided by, since nothing can be judged against it.
+    """
+    return local <= 0 or abs(interval - local) > UNSTEADY_FRACTION * local

--- a/src/resolve_mcp/analysis/beats.py
+++ b/src/resolve_mcp/analysis/beats.py
@@ -27,12 +27,53 @@ INSTALL = "uv pip install 'beat_this @ git+https://github.com/CPJKU/beat_this'"
 DOWNBEAT_TOLERANCE = 0.005
 """How far a downbeat may sit from the beat it marks before it is a different beat."""
 
+UNSTEADY_INTERVAL = 0.15
+"""How far a beat-to-beat interval may sit from its neighbours before the grid is guessing.
+
+Fifteen percent is roughly a swung eighth against a straight one: wide enough that ordinary
+human time-keeping and the model's own rounding stay inside it, narrow enough that a rubato
+ballad head — where the interval wanders by half again — falls outside on the first beat.
+"""
+
+DESCRIBES_BARS = 2
+"""The smallest meter that is a meter at all.
+
+A grid reporting bars one beat long has not found a slow tune; it has marked every beat a
+downbeat, which is the failure the anchor timeline shows at 214bpm over a jazz set (#112).
+Such a grid is refused whole rather than filtered against its own meter: keeping only the
+beats whose position is ``1`` would leave a histogram that is 100% beat one by construction
+and would read as the strongest possible evidence for the very skew being tested.
+"""
+
+STEADINESS_WINDOW = 9
+"""Intervals used as the local reference for one interval.
+
+The comparison is local rather than against the whole mix because a two-hour set has tunes
+at different tempos, and a grid measured against the set-wide median would call the fast
+tune untrustworthy for no better reason than that it is fast. Nine intervals is a little
+over two bars in four: long enough to have a median worth the name, short enough that the
+reference moves with the music.
+"""
+
 
 class BeatGrid(NamedTuple):
     """Beat times and the subset of them that start a bar, both in seconds."""
 
     beats: tuple[float, ...]
     downbeats: tuple[float, ...]
+
+
+class GridTrust(NamedTuple):
+    """Which beats the grid describes well enough to draw a statistic from, and why not.
+
+    ``trusted`` is parallel to the beat records it was computed from. ``reasons`` counts the
+    beats each check refused, so a result can say what it dropped rather than quietly
+    returning a smaller n (#112).
+    """
+
+    trusted: tuple[bool, ...]
+    meter: int | None
+    reasons: dict[str, int]
 
 
 Detector = Callable[[Path], BeatGrid]
@@ -155,3 +196,74 @@ def gist(grid: BeatGrid, records: Sequence[dict[str, Any]]) -> dict[str, Any]:
         "first_seconds": round(grid.beats[0], 3) if grid.beats else None,
         "last_seconds": round(grid.beats[-1], 3) if grid.beats else None,
     }
+
+
+def trust(records: Sequence[dict[str, Any]]) -> GridTrust:
+    """How far the grid may be trusted, beat by beat.
+
+    A grid is fitted over the whole mix, including the stretches that are not in time at all
+    — free intros, rubato heads, out-of-time codas — and the fit succeeds there anyway. Cuts
+    scored against those stretches are measuring the detector rather than the director, so
+    #112 gates them out of the beat statistics instead of averaging them in.
+
+    Two checks, deliberately independent. The first is free: a bar position outside
+    ``1..meter`` is the grid contradicting its own meter, and needs no confidence signal to
+    spot. The second is the one that matters, because rubato carries perfectly legal bar
+    positions and only the timing gives it away. beat_this exposes no per-beat confidence of
+    its own (it returns two lists of times), so steadiness is derived from the intervals.
+    """
+    meter = _meter(records)
+    describes_bars = meter is not None and meter >= DESCRIBES_BARS
+    steady = _steady_flags([float(record["t"]) for record in records])
+    reasons: Counter[str] = Counter()
+    trusted: list[bool] = []
+    for record, holds_time in zip(records, steady, strict=True):
+        in_bar = record.get("in_bar")
+        placed = (
+            describes_bars
+            and meter is not None
+            and isinstance(in_bar, int)
+            and 1 <= in_bar <= meter
+        )
+        if not placed:
+            reasons["bar_position"] += 1
+        if not holds_time:
+            reasons["tempo"] += 1
+        trusted.append(placed and holds_time)
+    return GridTrust(tuple(trusted), meter, dict(reasons))
+
+
+def _meter(records: Sequence[dict[str, Any]]) -> int | None:
+    """The meter the grid behaves as if it is in — the same statistic the gist reports."""
+    lengths = list(Counter(record["bar"] for record in records).values())
+    return statistics.mode(lengths) if lengths else None
+
+
+def _steady_flags(times: Sequence[float]) -> tuple[bool, ...]:
+    """Whether each beat sits between intervals that match the tempo around them.
+
+    A beat is judged by the intervals either side of it, so an interval that does not belong
+    discredits both of the beats it joins rather than one arbitrary end of it.
+    """
+    intervals = [later - earlier for earlier, later in zip(times, times[1:], strict=False)]
+    if len(intervals) < 2:
+        # One interval has no neighbours to be judged against; refusing it would be inventing
+        # a verdict rather than reaching one.
+        return tuple(True for _ in times)
+    unsteady = [
+        _wanders(interval, _local(intervals, index)) for index, interval in enumerate(intervals)
+    ]
+    return tuple(
+        not any(unsteady[near] for near in (position - 1, position) if 0 <= near < len(unsteady))
+        for position in range(len(times))
+    )
+
+
+def _local(intervals: Sequence[float], index: int) -> float:
+    """The tempo around one interval, as the median of the window it sits in."""
+    start = max(0, index - STEADINESS_WINDOW // 2)
+    return statistics.median(intervals[start : start + STEADINESS_WINDOW])
+
+
+def _wanders(interval: float, local: float) -> bool:
+    return local <= 0 or abs(interval - local) > UNSTEADY_INTERVAL * local

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -61,7 +61,7 @@ from ..resolve.timeline import (
 )
 from ..timing import SECONDS_PRECISION, dual_time, to_frames
 from . import decode, energy, records
-from .beats import nearest
+from .beats import nearest, trust
 
 log = get_logger("analysis")
 
@@ -587,11 +587,13 @@ def measure(
     tune_times = [float(row["t"]) for row in (music.tunes or ())]
     solo_times = [float(row["t"]) for row in (music.solos or ())]
     roles = music.roles or {}
+    trusted = trust(music.beats).trusted
 
     rows: list[dict[str, Any]] = []
     for index, shot in enumerate(shots, start=1):
         seconds = clock.seconds(shot.record_in)
-        beat = _beat_at(music.beats, times, seconds)
+        found = nearest(times, seconds)
+        beat = None if found is None else music.beats[found]
         rows.append(
             {
                 "cut": index,
@@ -609,6 +611,10 @@ def measure(
                 "beat": None if beat is None else beat.get("beat"),
                 "bar": None if beat is None else beat.get("bar"),
                 "in_bar": None if beat is None else beat.get("in_bar"),
+                # Whether the grid describes the music here at all (#112). The measurement
+                # itself is kept either way — a marked cut is a fact about the detector, and
+                # dropping the row would hide the very thing the gate exists to report.
+                "in_grid": found is not None and trusted[found],
                 "transient_offset": _offset(transients, seconds),
                 "tune": _tune_at(music.tunes, tune_times, seconds),
                 "front": _front_at(music.solos, solo_times, seconds),
@@ -627,15 +633,6 @@ def _opens(index: int, shot: Shot, shots: Sequence[Shot]) -> bool:
     measurement, and the records say which shots were left out of the statistics.
     """
     return index == 1 or shot.record_in != shots[index - 2].record_out
-
-
-def _beat_at(
-    rows: Sequence[dict[str, Any]],
-    times: Sequence[float],
-    seconds: float,
-) -> dict[str, Any] | None:
-    found = nearest(times, seconds)
-    return None if found is None else rows[found]
 
 
 def _offset(times: Sequence[float] | None, seconds: float) -> float | None:
@@ -699,6 +696,10 @@ def _summary(
     file and averages the column gets the number it was already told.
     """
     cut_to_music = [row for row in rows if not row["opening"]]
+    # The gate is applied here and nowhere else (#112). Transients need no grid, so they are
+    # measured over every cut; the beat and bar statistics are taken over the cuts the grid
+    # can actually describe, and the count of the rest is reported rather than swallowed.
+    in_grid = [row for row in cut_to_music if row["in_grid"]]
     transient_offsets = (
         None if transients is None else _offsets([row["transient_offset"] for row in cut_to_music])
     )
@@ -708,9 +709,10 @@ def _summary(
         "cuts": len(rows),
         "openings": sum(1 for row in rows if row["opening"]),
         "outside_grid": _outside(rows, grid),
-        "beat_offsets": _offsets([row["beat_offset"] for row in cut_to_music]),
+        "gated": len(cut_to_music) - len(in_grid),
+        "beat_offsets": _offsets([row["beat_offset"] for row in in_grid]),
         "transient_offsets": transient_offsets,
-        "bars": _histogram(row["in_bar"] for row in cut_to_music),
+        "bars": _histogram(row["in_bar"] for row in in_grid),
         "tunes": _spread("tune", cut_to_music) if _measured("tune", rows) else None,
         "solos": _spread("front", cut_to_music) if _measured("front", rows) else None,
         "shot_seconds": _lengths([row["seconds"] for row in rows]),

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -61,7 +61,7 @@ from ..resolve.timeline import (
 )
 from ..timing import SECONDS_PRECISION, dual_time, to_frames
 from . import decode, energy, records
-from .beats import nearest, trust
+from .beats import GridTrust, nearest, trust
 
 log = get_logger("analysis")
 
@@ -201,8 +201,9 @@ def correlate(
     transients = _transients(music.audio, onsets)
 
     progress(0.7, "measuring the cut against the music")
-    rows = measure(shots, clock, music, transients)
-    summary = _summary(rows, clock, transients, [float(one["t"]) for one in music.beats])
+    grid = trust(music.beats)
+    rows = measure(shots, clock, music, transients, grid)
+    summary = _summary(rows, clock, transients, [float(one["t"]) for one in music.beats], grid)
 
     target = config.analysis_dir / keyed_name(name, key, ".correlate.json", "correlate")
     # "count", not "cuts": the records themselves are the file's ``cuts`` field, and a header
@@ -575,6 +576,7 @@ def measure(
     clock: Clock,
     music: Music,
     transients: Sequence[float] | None,
+    grid: GridTrust | None = None,
 ) -> list[dict[str, Any]]:
     """One record per shot: where it starts in the music, and how far off everything it is.
 
@@ -587,7 +589,7 @@ def measure(
     tune_times = [float(row["t"]) for row in (music.tunes or ())]
     solo_times = [float(row["t"]) for row in (music.solos or ())]
     roles = music.roles or {}
-    trusted = trust(music.beats).trusted
+    trusted = (grid if grid is not None else trust(music.beats)).trusted
 
     rows: list[dict[str, Any]] = []
     for index, shot in enumerate(shots, start=1):
@@ -688,6 +690,7 @@ def _summary(
     clock: Clock,
     transients: Sequence[float] | None,
     grid: Sequence[float],
+    trusted: GridTrust,
 ) -> dict[str, Any]:
     """The list-free reading: what a style profile is written from, and a self-review read.
 
@@ -708,8 +711,14 @@ def _summary(
         "alignment": clock.reading(),
         "cuts": len(rows),
         "openings": sum(1 for row in rows if row["opening"]),
+        # ``outside_grid`` and ``gated`` are different refusals and neither implies the other:
+        # the first is a cut beyond the ends of the analysed span, which means the times and
+        # the audio are not the same recording; the second is a cut inside the span that the
+        # grid describes badly. A misaligned clock shows in the first, rubato in the second.
         "outside_grid": _outside(rows, grid),
         "gated": len(cut_to_music) - len(in_grid),
+        "grid_meter": trusted.meter,
+        "grid_refused": trusted.reasons,
         "beat_offsets": _offsets([row["beat_offset"] for row in in_grid]),
         "transient_offsets": transient_offsets,
         "bars": _histogram(row["in_bar"] for row in in_grid),

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -46,31 +46,23 @@ that the grid is a live band's grid, so it moves.
   wrong where those cuts are — and it is the same grid the other 96% were
   scored against.
 
-  **Gated (#112). Half the corpus turned out to have no bar positions at all,
-  and the number did not survive.** Three of the six grids — the anchor,
-  Sunshine and Mercies — report `meter: 1`: the detector marked every beat a
-  downbeat, so those grids never described a bar position in the first place.
-  All three are now refused whole rather than filtered, because keeping only
-  their position-1 beats would leave a histogram that is 100% beat one by
-  construction and would read as the strongest evidence in the file for the
-  very thing under test. Every one of the 78–84% figures quoted above came
-  from those three timelines. They are not weak evidence; they are not
-  evidence.
+  **The gate is built (#112); the pass that would settle this has not run.**
+  `correlate_timeline` now refuses a beat whose bar position its own meter
+  cannot hold, or whose interval does not match the tempo around it, and
+  refuses whole any grid whose meter comes out as 1 — filtering such a grid
+  against its own meter would keep exactly its position-1 beats and leave a
+  histogram that is 100% beat one *by construction*, which is a gate
+  manufacturing the very skew it was built to test. Cuts are marked
+  `in_grid: false` and counted, never silently dropped.
 
-  Three grids survive gating with a real meter of 4, and they do not agree:
-  Freefall 82.9% on beats 1–2 (8 of 43 cuts gated), Scullers 77.1% (108 of
-  326), Monkfish 63.9% (26 of 228). All three sit above the 50% an
-  indifferent director would produce, so the *direction* is real and
-  replicates. The magnitude does not: 19 points separate the three, gating
-  moved each by under 4 points, and the largest sample is the flattest. The
-  disagreement was never the rubato — it is between timelines, and the gate
-  removed the stretches without closing the gap.
-
-  So: cuts do favour the front of the bar, and no number describes by how
-  much. A conditioned beat-position pattern stays **open** — but no longer
-  blocked, since the instrument now says when it cannot be trusted.
-  `[measured — 3 projects, n=455 cuts surviving the gate, concert; direction
-  only, no magnitude]`*
+  What that changes here: the instrument can now say when it cannot be
+  trusted, so this item is **open but no longer blocked**. What it does not
+  change: still no beat-position claim, because a claim needs numbers out of
+  `correlate_timeline` over the six corpus timelines, and that pass needs each
+  project open in Resolve. A provisional offline check suggests three of the
+  six grids will produce no bar histogram at all under the gate. If that
+  holds, half the histograms quoted above were never evidence — but it is a
+  prediction until the tool has been run.*
 
 ## 2. Energy — the master concept
 

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -46,16 +46,31 @@ that the grid is a live band's grid, so it moves.
   wrong where those cuts are — and it is the same grid the other 96% were
   scored against.
 
-  There is now a reason to think the skew is partly the detector rather than
-  the director. Two timelines have structurally sound grids (Freefall and
-  Monkfish: strictly 1–4, `meter: 4`) and they are the flattest — Monkfish puts
-  67% on beats 1–2 where every broken-grid timeline puts 78–81%. The
-  measurement gets *less* dramatic exactly where the instrument gets more
-  trustworthy, which is the wrong direction for a real finding. Rubato gating
-  comes first (**#112**), and until it lands a consistent-looking histogram is
-  the most misleading thing in this file, because it looks like evidence. #112
-  is written to close either way: "the skew did not survive gating" retires
-  this item just as well as a measured claim would.*
+  **Gated (#112). Half the corpus turned out to have no bar positions at all,
+  and the number did not survive.** Three of the six grids — the anchor,
+  Sunshine and Mercies — report `meter: 1`: the detector marked every beat a
+  downbeat, so those grids never described a bar position in the first place.
+  All three are now refused whole rather than filtered, because keeping only
+  their position-1 beats would leave a histogram that is 100% beat one by
+  construction and would read as the strongest evidence in the file for the
+  very thing under test. Every one of the 78–84% figures quoted above came
+  from those three timelines. They are not weak evidence; they are not
+  evidence.
+
+  Three grids survive gating with a real meter of 4, and they do not agree:
+  Freefall 82.9% on beats 1–2 (8 of 43 cuts gated), Scullers 77.1% (108 of
+  326), Monkfish 63.9% (26 of 228). All three sit above the 50% an
+  indifferent director would produce, so the *direction* is real and
+  replicates. The magnitude does not: 19 points separate the three, gating
+  moved each by under 4 points, and the largest sample is the flattest. The
+  disagreement was never the rubato — it is between timelines, and the gate
+  removed the stretches without closing the gap.
+
+  So: cuts do favour the front of the bar, and no number describes by how
+  much. A conditioned beat-position pattern stays **open** — but no longer
+  blocked, since the instrument now says when it cannot be trusted.
+  `[measured — 3 projects, n=455 cuts surviving the gate, concert; direction
+  only, no magnitude]`*
 
 ## 2. Energy — the master concept
 

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -299,47 +299,32 @@ Two notes:
 - The transient median (41 ms) is the highest in the corpus and still inside
   two frames. Six timelines now span 17–41 ms.
 
-## What the gate settled: half these grids never described a bar (#112)
+## Rubato gating exists; the corpus pass that uses it is still to run (#112)
 
-All six timelines re-scored with the rubato/confidence gate on. The gate refuses
-a beat on either of two independent grounds: a bar position its own meter cannot
-hold, or an interval that does not match the tempo around it. Cuts landing on a
-refused beat stay in the records, marked `in_grid: false`, and are counted out of
-the bar and beat-offset statistics only — the transient numbers are computed over
-every cut and are untouched by any of this.
+`correlate_timeline` now gates the beat statistics. A beat is refused on either
+of two independent grounds — a bar position its own meter cannot hold, or an
+interval that does not match the tempo around it — and a grid whose meter comes
+out as 1 is refused whole rather than filtered, since keeping only its
+position-1 beats would leave a histogram reading 100% beat one *by
+construction*. Cuts landing on a refused beat stay in the records marked
+`in_grid: false` and are counted out of the bar and beat-offset statistics only;
+the transient numbers are computed over every cut and are untouched.
 
-| Timeline | Meter | Cuts measured | Gated | Bar histogram, gate on | Beats 1–2 |
-| --- | --- | --- | --- | --- | --- |
-| Anchor (Zinc Set 2) | **1** | 360 | 360 (100%) | — | — |
-| Sunshine | **1** | 49 | 49 (100%) | — | — |
-| Mercies | **1** | 37 | 37 (100%) | — | — |
-| Scullers | 4 | 326 | 108 (33.1%) | 1:128, 2:40, 3:27, 4:23 | 77.1% |
-| Freefall | 4 | 43 | 8 (18.6%) | 1:15, 2:14, 3:2, 4:4 | 82.9% |
-| Monkfish | 4 | 228 | 26 (11.4%) | 1:80, 2:49, 3:34, 4:39 | 63.9% |
+**No gated histogram is recorded here yet, deliberately.** A number in this file
+is evidence, and evidence comes from the tool: step 4 of the analysis workflow
+in `docs/agents/style-layer.md` is explicit that `correlate_timeline` is the one
+tested measurement path and that statistics are never recomputed ad hoc. The six
+gated rows therefore need a live re-run through the tool, which needs each
+project open in Resolve. Until that pass runs, the ungated bar histograms
+recorded in the entries above stand as they are — already marked, in entries 1,
+2 and 4, as saying nothing.
 
-Three notes:
-
-- **Three of the six grids report `meter: 1`** — the detector marked every beat
-  a downbeat, so those grids never described a bar position at all. They are
-  refused whole rather than filtered against their own meter: keeping only the
-  beats at position 1 would leave a histogram reading 100% beat one *by
-  construction*, which would look like the strongest evidence in the corpus for
-  precisely the effect under test. Every 78–84% figure recorded above came from
-  these three timelines, and none of it was ever evidence.
-- **The three surviving grids do not agree.** 63.9%, 77.1% and 82.9% on beats
-  1–2, all above the 50% an indifferent director gives, so the direction
-  replicates across every timeline that can speak. The magnitude does not: 19
-  points of spread, and gating moved each timeline by under 4 points. The
-  disagreement was never the rubato — it is between timelines, and the gate
-  removed the out-of-time stretches without narrowing the gap.
-- **The #45 artefact hypothesis is half-retired.** The prediction was that
-  broken grids skew harder; those grids now produce no histogram at all, so the
-  comparison cannot be made. Among the survivors the pattern still leans the
-  wrong way — Monkfish, the largest sample at 228 cuts, remains the flattest.
-
-Recomputed from the cut records and beat grids already in the analysis cache
-using the shipped `beats.trust`, not re-read out of Resolve: the cut times and
-bar positions are the ones #45 wrote, and only the gating arithmetic is new.
+A provisional offline pass over the cut records and grids in the analysis cache
+was run to size the job, and is recorded on the ticket rather than here. Its one
+result worth acting on: three of the six grids look likely to report `meter: 1`
+and so to produce no bar histogram at all under the gate, which would mean half
+the corpus never described a bar position in the first place. Treat that as a
+prediction about what the live pass will show, not as a measurement.
 
 ## What the labels settled: operation, not framing
 

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -299,6 +299,48 @@ Two notes:
 - The transient median (41 ms) is the highest in the corpus and still inside
   two frames. Six timelines now span 17–41 ms.
 
+## What the gate settled: half these grids never described a bar (#112)
+
+All six timelines re-scored with the rubato/confidence gate on. The gate refuses
+a beat on either of two independent grounds: a bar position its own meter cannot
+hold, or an interval that does not match the tempo around it. Cuts landing on a
+refused beat stay in the records, marked `in_grid: false`, and are counted out of
+the bar and beat-offset statistics only — the transient numbers are computed over
+every cut and are untouched by any of this.
+
+| Timeline | Meter | Cuts measured | Gated | Bar histogram, gate on | Beats 1–2 |
+| --- | --- | --- | --- | --- | --- |
+| Anchor (Zinc Set 2) | **1** | 360 | 360 (100%) | — | — |
+| Sunshine | **1** | 49 | 49 (100%) | — | — |
+| Mercies | **1** | 37 | 37 (100%) | — | — |
+| Scullers | 4 | 326 | 108 (33.1%) | 1:128, 2:40, 3:27, 4:23 | 77.1% |
+| Freefall | 4 | 43 | 8 (18.6%) | 1:15, 2:14, 3:2, 4:4 | 82.9% |
+| Monkfish | 4 | 228 | 26 (11.4%) | 1:80, 2:49, 3:34, 4:39 | 63.9% |
+
+Three notes:
+
+- **Three of the six grids report `meter: 1`** — the detector marked every beat
+  a downbeat, so those grids never described a bar position at all. They are
+  refused whole rather than filtered against their own meter: keeping only the
+  beats at position 1 would leave a histogram reading 100% beat one *by
+  construction*, which would look like the strongest evidence in the corpus for
+  precisely the effect under test. Every 78–84% figure recorded above came from
+  these three timelines, and none of it was ever evidence.
+- **The three surviving grids do not agree.** 63.9%, 77.1% and 82.9% on beats
+  1–2, all above the 50% an indifferent director gives, so the direction
+  replicates across every timeline that can speak. The magnitude does not: 19
+  points of spread, and gating moved each timeline by under 4 points. The
+  disagreement was never the rubato — it is between timelines, and the gate
+  removed the out-of-time stretches without narrowing the gap.
+- **The #45 artefact hypothesis is half-retired.** The prediction was that
+  broken grids skew harder; those grids now produce no histogram at all, so the
+  comparison cannot be made. Among the survivors the pattern still leans the
+  wrong way — Monkfish, the largest sample at 228 cuts, remains the flattest.
+
+Recomputed from the cut records and beat grids already in the analysis cache
+using the shipped `beats.trust`, not re-read out of Resolve: the cut times and
+bar positions are the ones #45 wrote, and only the gating arithmetic is new.
+
 ## What the labels settled: operation, not framing
 
 With entries 3 and 5 labelled, all six measured timelines have roles, and one

--- a/tests/test_beat_grid.py
+++ b/tests/test_beat_grid.py
@@ -8,6 +8,7 @@ start on the one, so neither assumption is allowed to go unchecked.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -113,3 +114,89 @@ def test_a_structured_failure_from_a_detector_is_passed_through_unchanged() -> N
 
     with pytest.raises(AnalysisDependencyError):
         beats.detect(Path("concert.wav"), missing)
+
+
+# --- how far the grid may be trusted (#112) ---------------------------------------------------
+
+
+def _rubato(steady: int = 12, free: Sequence[float] = (0.9, 1.4, 0.7, 1.3)) -> BeatGrid:
+    """A grid that keeps time and then stops keeping it — a ballad head after an in-time tune."""
+    times = [round(index * 0.5, 6) for index in range(steady)]
+    for interval in free:
+        times.append(round(times[-1] + interval, 6))
+    return BeatGrid(beats=tuple(times), downbeats=tuple(times[::4]))
+
+
+def test_a_grid_that_keeps_time_in_four_is_trusted_end_to_end() -> None:
+    """The gate has to be inert on the timelines whose grids are already sound."""
+    found = beats.trust(beats.numbered(_steady(13)))
+
+    assert found.meter == 4
+    assert all(found.trusted)
+    assert found.reasons == {}
+
+
+def test_a_bar_position_the_meter_cannot_hold_is_not_trusted() -> None:
+    """A bar 6 in a grid whose bars are fours is the grid refuting itself — #112 AC3."""
+    grid = BeatGrid(
+        beats=tuple(round(index * 0.5, 6) for index in range(17)),
+        downbeats=(0.0, 3.0, 5.0, 7.0),
+    )
+
+    found = beats.trust(beats.numbered(grid))
+
+    assert found.meter == 4
+    # The opening bar runs to six beats, so its fifth and sixth are positions 4/4 cannot hold.
+    assert found.trusted[:6] == (True, True, True, True, False, False)
+    assert found.trusted[6:10] == (True, True, True, True)
+    assert found.reasons == {"bar_position": 2}
+
+
+def test_beats_either_side_of_an_out_of_time_stretch_are_not_trusted() -> None:
+    """Rubato carries perfectly legal bar positions, so only the timing gives it away."""
+    found = beats.trust(beats.numbered(_rubato()))
+
+    assert found.trusted[:10] == (True,) * 10
+    assert not all(found.trusted[11:])
+    assert found.reasons.get("tempo", 0) > 0
+
+
+def test_a_steady_grid_that_changes_tempo_once_is_not_gated_wholesale() -> None:
+    """A set has tunes at different tempos; only the change itself is untrustworthy, not both."""
+    slow = [round(index * 0.5, 6) for index in range(12)]
+    fast = [round(slow[-1] + (index + 1) * 0.35, 6) for index in range(12)]
+    grid = BeatGrid(beats=tuple(slow + fast), downbeats=tuple((slow + fast)[::4]))
+
+    found = beats.trust(beats.numbered(grid))
+
+    assert all(found.trusted[:9])
+    assert all(found.trusted[-9:])
+
+
+def test_a_grid_too_short_to_judge_is_left_alone_rather_than_gated_blind() -> None:
+    """Two beats give one interval and no local reference; refusing them all would invent a gate."""
+    found = beats.trust(beats.numbered(BeatGrid(beats=(0.0, 0.5), downbeats=(0.0,))))
+
+    assert all(found.trusted)
+
+
+def test_a_grid_that_calls_every_beat_a_downbeat_describes_no_bar_position_at_all() -> None:
+    """The anchor's failure: `meter: 1` over a jazz set, every beat marked as starting a bar.
+
+    Filtering such a grid against its own meter would keep exactly the beats at position one
+    and throw the rest away, leaving a histogram that is 100% beat one by construction. That
+    is not a gate finding a skew, it is a gate manufacturing one, so the grid is refused whole.
+    """
+    times = tuple(round(index * 0.5, 6) for index in range(16))
+    found = beats.trust(beats.numbered(BeatGrid(beats=times, downbeats=times)))
+
+    assert found.meter == 1
+    assert not any(found.trusted)
+    assert found.reasons["bar_position"] == 16
+
+
+def test_an_empty_grid_has_nothing_to_trust_and_no_meter() -> None:
+    found = beats.trust(beats.numbered(BeatGrid((), ())))
+
+    assert found.trusted == ()
+    assert found.meter is None

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -37,6 +37,15 @@ BEAT_SECONDS = tuple(index * 0.5 for index in range(13))
 ONSETS = (1.05, 2.48)
 """Two transients, one either side of the beat the cuts near them are measured against."""
 
+BAD_BAR_SECONDS = tuple(round(index * 0.5, 6) for index in range(17))
+BAD_BAR_DOWNBEATS = (0.0, 3.0, 5.0, 7.0)
+"""A grid whose bars are mostly fours but whose first runs to six — the #112 self-refuting case.
+
+Beats stay at 120bpm throughout, so the steadiness check is inert here and the bar-position
+check is the only thing that can gate: the second measured cut lands on beat six of a bar
+that a meter of four cannot hold, and the first lands on a position four can.
+"""
+
 SHOTS = (
     ("C0012.mp4", 100, 62, 1000),
     ("C0031.mp4", 162, 87, 4200),
@@ -96,16 +105,21 @@ def _dissolve(start: int, duration: int) -> FakeTimelineItem:
     return FakeTimelineItem("Cross Dissolve", start, duration)
 
 
-def beats_file(tmp_path: Path, seconds: Sequence[float] = BEAT_SECONDS) -> Path:
+def beats_file(
+    tmp_path: Path,
+    seconds: Sequence[float] = BEAT_SECONDS,
+    downbeats: Sequence[float] | None = None,
+    name: str = "concert-beats.json",
+) -> Path:
     """A beats file in the shape analyze_music writes: header, then one record per line.
 
     Written once per test: the cache keys off the file's mtime, so a second identical write
     would look like new analysis and no rerun would ever be answered from cache.
     """
-    target = tmp_path / "concert-beats.json"
+    target = tmp_path / name
     if target.exists():
         return target
-    grid = BeatGrid(tuple(seconds), tuple(seconds[::4]))
+    grid = BeatGrid(tuple(seconds), tuple(seconds[::4] if downbeats is None else downbeats))
     return records.write(
         target,
         {"kind": "beats", "audio": "concert.wav", "duration_seconds": 6.0},
@@ -205,6 +219,7 @@ def test_every_shot_lands_on_disk_with_its_offsets_bar_and_section(
         "beat": 3,
         "bar": 1,
         "in_bar": 3,
+        "in_grid": True,
         "transient_offset": -0.017,
         "tune": 1,
         "front": "drums",
@@ -771,3 +786,81 @@ def test_a_handle_that_dies_mid_read_never_measures_half_a_cut(
         assert _result(envelope["job"])["cuts"] == 3
     else:
         assert envelope["error"]["code"] in {"resolve_unavailable", "internal_error"}
+
+
+# --- gating the cuts the grid cannot describe (#112) -------------------------------------------
+
+
+def _bad_grid(tmp_path: Path) -> str:
+    return str(
+        beats_file(
+            tmp_path,
+            seconds=BAD_BAR_SECONDS,
+            downbeats=BAD_BAR_DOWNBEATS,
+            name="bad-grid-beats.json",
+        )
+    )
+
+
+def test_a_cut_on_a_bar_position_the_meter_cannot_hold_is_marked_and_counted(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """AC1/AC3: the marker is per cut and the count is inline, so nothing drops silently."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, beats=_bad_grid(tmp_path))
+
+    cuts = _rows(result)
+    assert cuts[1]["in_bar"] == 3
+    assert cuts[1]["in_grid"] is True
+    # Beat six of a bar in a grid whose meter is four: the grid contradicting itself.
+    assert cuts[2]["in_bar"] == 6
+    assert cuts[2]["in_grid"] is False
+    assert result["gated"] == 1
+
+
+def test_a_gated_cut_is_kept_out_of_the_bar_and_beat_statistics(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """AC3: an impossible position is evidence the grid is wrong, not a position to publish."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, beats=_bad_grid(tmp_path))
+
+    assert result["bars"] == {"3": 1}
+    assert "6" not in result["bars"]
+    assert result["beat_offsets"]["measured"] == 1
+
+
+def test_the_gate_leaves_the_transient_measurement_exactly_as_it_was(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """AC2: transients need no grid, so a broken grid must not shrink their n by one cut.
+
+    The two runs are the gate off and on over identical cuts: the sound grid gates nothing,
+    the broken one gates a cut. The beat block moves between them and the transient block
+    may not.
+    """
+    attach(studio(timeline=a_cut()))
+    ungated = _measured(tmp_path)
+
+    attach(studio(timeline=a_cut()))
+    gated = _measured(tmp_path, beats=_bad_grid(tmp_path))
+
+    assert ungated["gated"] == 0
+    assert gated["gated"] == 1
+    assert gated["transient_offsets"] == ungated["transient_offsets"]
+    assert gated["transient_offsets"]["measured"] == 2
+    assert gated["beat_offsets"] != ungated["beat_offsets"]
+
+
+def test_every_cut_carries_the_marker_even_when_the_grid_is_sound(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A reader should not have to guess whether an absent marker means trusted or unmeasured."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path)
+
+    assert [one["in_grid"] for one in _rows(result)] == [True, True, True]
+    assert result["gated"] == 0

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -854,6 +854,31 @@ def test_the_gate_leaves_the_transient_measurement_exactly_as_it_was(
     assert gated["beat_offsets"] != ungated["beat_offsets"]
 
 
+def test_a_cut_in_an_out_of_time_stretch_is_gated_though_its_bar_position_is_legal(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The check that matters at this seam: rubato carries positions 1..4 like anything else.
+
+    The bar-position gate cannot see this one — every position here is legal — so a cut that
+    survives the sound grid and falls out of this one has been gated on timing alone.
+    """
+    attach(studio(timeline=a_cut()))
+
+    # Steady to 1.5s, then the head goes out of time across where the second cut lands.
+    wandering = (0.0, 0.5, 1.0, 1.5, 2.4, 2.6, 3.6, 3.8, 4.9, 5.1, 6.1, 6.3)
+    result = _measured(
+        tmp_path,
+        beats=str(beats_file(tmp_path, seconds=wandering, name="rubato-beats.json")),
+    )
+
+    cuts = _rows(result)
+    assert cuts[2]["in_bar"] in {1, 2, 3, 4}  # nothing a bar-position check could object to
+    assert cuts[2]["in_grid"] is False
+    assert result["gated"] >= 1
+    assert result["grid_refused"].get("tempo", 0) > 0
+    assert result["grid_refused"].get("bar_position", 0) == 0
+
+
 def test_every_cut_carries_the_marker_even_when_the_grid_is_sound(
     attach: Attach, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Closes #112 (partially — see **Not done** below).

`correlate_timeline` scored every cut against a grid fitted over the whole mix, including the stretches that are not in time at all. This gates those cuts out of the bar and beat-offset statistics instead of averaging them in.

## Test seam

**Fake tier** (`uv run pytest -m 'not live'`), which is where ACs 1–3 name their seam. `beats.trust` is pure arithmetic over beat records, and the gate is exercised end to end through `correlate_timeline` against the fake Resolve singleton with real files on disk. AC4 is live/manual and has **not** run — see below.

## What it does

`beats.trust` judges each beat on two independent grounds:

- **Bar position** — a position outside `1..meter` is the grid contradicting its own meter. Free, and needs no confidence signal.
- **Steadiness** — an interval that does not match the tempo around it. This is the one that matters: rubato carries perfectly legal bar positions, so only the timing gives it away. `beat_this` exposes no per-beat confidence (it returns two lists of times), so the signal is derived, against a *local* median so a set with tunes at different tempos does not gate the fast ones.

A grid whose meter comes out as **1** is refused whole rather than filtered. Filtering it against its own meter would keep exactly the beats at position one and leave a histogram that is 100% beat one *by construction* — a gate manufacturing the skew it was built to test. This was found by running the gate over the corpus, not by reasoning about it, and it is the single most important line in the diff.

Cuts are marked `in_grid: false` and counted (`gated`, `grid_meter`, `grid_refused`), never silently dropped. Transient offsets need no grid and are computed over every cut, gate or no gate.

## Review

Two-axis `/code-review` on the branch at 2535703, before this PR existed. Findings and resolutions:

**Spec axis**

1. *AC1 partial — the tempo check was exercised only as a unit, never through `measure`, though the code itself calls it the one that matters.* Fixed: added `test_a_cut_in_an_out_of_time_stretch_is_gated_though_its_bar_position_is_legal` at the correlate seam, on a grid whose bar positions are all legal, so a cut can only fall out of it on timing.
2. *AC4 discharged by an offline recompute rather than a tool run.* Fixed by retracting it — see Standards 1. AC4 is now explicitly unrun.
3. *`GridTrust.reasons` computed and discarded.* Fixed: reported as `grid_refused` in the result.
4. *Two false sentences in the prose* — "every 78–84% figure came from those three timelines" (Scullers survived at meter 4 and was 79.1%) and "Monkfish, the largest sample, remains the flattest" (Scullers had 326 measured / 218 surviving). Both removed with the tables they sat in.
5. *AC2's transient assertion is close to tautological* — `transient_offsets` is computed over ungated rows by construction. Accepted as a known weakness rather than fixed: the test does pin the property the AC protects (transient block identical across a run that gates nothing and a run that gates a cut, while the beat block moves), and the alternative was adding an on/off toggle to the tool purely to be tested. Flagging rather than hiding it.

**Standards axis**

1. **Hard breach.** `docs/agents/style-layer.md` step 4: `correlate_timeline` "is the one tested measurement path: Claude interprets its records and never recomputes statistics ad hoc." The corpus histograms had been computed by a side script over the cached records. Fixed: the gated table is out of `corpus.md`, `concert.md` carries no `[measured — …]` tag resting on it, and both now say the gate exists and the pass has not run. The offline figures survive as a prediction on the ticket, not as evidence in the profile.
2. *`_meter` duplicated `gist`'s meter computation.* Fixed: one shared definition, so a grid can never be described as one meter and gated against another.
3. *`UNSTEADY_INTERVAL` holds a ratio, `DESCRIBES_BARS` holds a minimum.* Fixed: `UNSTEADY_FRACTION`, `MINIMUM_METER`.
4. *`outside_grid` reads as the negation of the new `in_grid` and is not.* Fixed: stated in code — the first is a cut beyond the analysed span (misaligned clock), the second a cut inside it that the grid describes badly (rubato).
5. *`_wanders` missing a docstring.* Fixed.
6. *The "100% by construction" rationale appears in four files.* Accepted: it is the reason the design is what it is, and each audience (code, test, two profile documents) needs it where it stands.

Fix diff re-checked on its own (`2535703..cae0bcf`); all seven fixes confirmed landed, no new findings. Fake tier 1187 passed, mypy strict clean, ruff clean.

## Not done

**AC4 and AC5 are not discharged.** The six corpus timelines must be re-run through `correlate_timeline` itself, which needs each project open in Resolve. A provisional offline pass over the cached records predicts three of the six grids (anchor, Sunshine, Mercies) report `meter: 1` and will produce no bar histogram at all, and that the three survivors disagree by ~19 points on beats 1–2 — but those are predictions, not measurements, and the profile now says so.

Review: clean
