### PR TITLE
Suggested-mode bin defaults for import_media + the #57 convention doc (#94)

### DIFF
--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -64,12 +64,14 @@ BIN_SEPARATOR = "/"
 DEFAULT_LIST_LIMIT = 200
 IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"})
 AUDIO_SUFFIXES = frozenset({".aac", ".aif", ".aiff", ".flac", ".m4a", ".mp3", ".ogg", ".wav"})
+GRAPHIC_SUFFIXES = frozenset({".ai", ".eps", ".psd", ".svg"})
 FOOTAGE_BIN = "02_Footage"
 AUDIO_BIN = "03_Audio"
 ASSETS_BIN = "04_Assets"
-# The metadata field Resolve fills with the recording device's model name. One key on
-# purpose: which fields real cards populate is a live question (#94 live smoke), and an
-# unreadable camera falls back to the bare footage bin rather than guessing.
+# The field Resolve fills with the recording device's model name, consulted in the clip's
+# properties first, then its metadata. One key on purpose: which fields real cards
+# populate is a live question (#94 live smoke), and an unreadable camera falls back to
+# the bare footage bin rather than guessing.
 CAMERA_KEYS = ("Camera Type",)
 SEQUENCE_TOKEN = "%"
 # Resolve paths an imported image sequence by folding the index range into the name —
@@ -494,7 +496,7 @@ def import_media(
     summaries: list[dict[str, Any]] = []
     landed: set[str] = set()
     for clip in imported:
-        summaries.append(_clip_summary(clip, target.path, "explicit", landed))
+        summaries.append(_clip_summary(clip, properties(clip), target.path, "explicit", landed))
 
     refused = _refused_or_fail(items, imported, landed, summaries)
     log.info("Imported %d clip(s) into %r", len(summaries), target.path or "the root")
@@ -521,8 +523,9 @@ def _import_suggested(pool: Pool, items: list[str | dict[str, Any]]) -> dict[str
         arrived = import_into(pool, group, target)
         imported.extend(arrived)
         for clip in arrived:
-            where, source = _placed(pool, clip, target)
-            summaries.append(_clip_summary(clip, where, source, landed))
+            reported = properties(clip)
+            placed = _placed(pool, clip, reported, target)
+            summaries.append(_clip_summary(clip, reported, placed.path, placed.source, landed))
 
     refused = _refused_or_fail(items, imported, landed, summaries)
     bins = sorted({str(summary["bin"]) for summary in summaries})
@@ -539,53 +542,68 @@ def _suggested_bin(item: str | dict[str, Any]) -> str:
     """
     if isinstance(item, dict):
         return ASSETS_BIN
+    if _looks_like_image(item):
+        return ASSETS_BIN
     suffix = Path(item).suffix.lower()
-    if suffix in IMAGE_SUFFIXES:
+    if suffix in GRAPHIC_SUFFIXES:
         return ASSETS_BIN
     if suffix in AUDIO_SUFFIXES:
         return AUDIO_BIN
     return FOOTAGE_BIN
 
 
-def camera_model(clip: Clip) -> str | None:
-    """The camera model the clip's metadata reports, sanitised for bin use, or ``None``.
+def _camera_model(clip: Clip, reported: dict[str, str]) -> str | None:
+    """The camera model the clip reports, sanitised for bin use, or ``None``.
 
-    Read after import — the model is embedded metadata Resolve surfaces, nothing the file
-    path could carry. A slash in a model name would read as a bin separator, so it is
-    folded to a dash.
+    Read after import — the model is embedded data Resolve surfaces, nothing the file
+    path could carry. Properties are consulted before metadata because the spec words the
+    source as clip properties; which dict real cards populate is the #94 live question.
+    A slash in a model name would read as a bin separator, so it is folded to a dash.
     """
     metadata = clip.GetMetadata()
-    if not isinstance(metadata, dict):
-        return None
-    for key in CAMERA_KEYS:
-        value = str(metadata.get(key) or "").strip()
-        if value:
-            return value.replace(BIN_SEPARATOR, "-")
+    dicts = [reported, metadata if isinstance(metadata, dict) else {}]
+    for source in dicts:
+        for key in CAMERA_KEYS:
+            value = str(source.get(key) or "").strip()
+            if value:
+                return value.replace(BIN_SEPARATOR, "-")
     return None
 
 
-def _placed(pool: Pool, clip: Clip, target: LocatedBin) -> tuple[str, str]:
-    """Where a suggested clip ends up, and what the suggestion drew on.
+class Placement(NamedTuple):
+    """Where a suggested-mode clip ended up, and what the suggestion drew on."""
 
-    Footage is the one category with a second hop: the camera leaf can only be known
-    after import, once the clip's metadata is readable.
+    path: str
+    source: str
+
+
+def _placed(pool: Pool, clip: Clip, reported: dict[str, str], target: LocatedBin) -> Placement:
+    """Place one suggested clip: footage gets a second hop into its camera leaf.
+
+    Footage is the one category whose final bin can only be known after import, once the
+    clip's properties and metadata are readable.
     """
     if target.path != FOOTAGE_BIN:
-        return target.path, "media_type"
-    model = camera_model(clip)
+        return Placement(target.path, "media_type")
+    model = _camera_model(clip, reported)
     if model is None:
-        return target.path, "fallback"
+        return Placement(target.path, "fallback")
     leaf = ensure_bin(pool, f"{FOOTAGE_BIN}{BIN_SEPARATOR}{model}")
     if not pool.MoveClips([clip], leaf.folder):
         name = str(clip.GetName() or "")
         log.warning("Camera bin move refused for %r; leaving it in %r", name, target.path)
-        return target.path, "fallback"
-    return leaf.path, "camera_metadata"
+        return Placement(target.path, "fallback")
+    return Placement(leaf.path, "camera_metadata")
 
 
-def _clip_summary(clip: Clip, bin_used: str, source: str, landed: set[str]) -> dict[str, Any]:
+def _clip_summary(
+    clip: Clip,
+    reported: dict[str, str],
+    bin_used: str,
+    source: str,
+    landed: set[str],
+) -> dict[str, Any]:
     """One imported clip's envelope line: the summary, the bin, and how the bin was chosen."""
-    reported = properties(clip)
     landed.add(reported.get(FILE_PATH, ""))
     landed.add(str(clip.GetName() or ""))
     summary = summarise(bin_used, clip, reported)

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -68,11 +68,12 @@ GRAPHIC_SUFFIXES = frozenset({".ai", ".eps", ".psd", ".svg"})
 FOOTAGE_BIN = "02_Footage"
 AUDIO_BIN = "03_Audio"
 ASSETS_BIN = "04_Assets"
-# The field Resolve fills with the recording device's model name, consulted in the clip's
-# properties first, then its metadata. One key on purpose: which fields real cards
-# populate is a live question (#94 live smoke), and an unreadable camera falls back to
-# the bare footage bin rather than guessing.
-CAMERA_KEYS = ("Camera Type",)
+# Camera fields in priority order, each consulted in the clip's properties then its
+# metadata. Live-verified on real FX6 XAVC (2026-08-07, Resolve Studio, #94): the model
+# lives in "Camera TC Type" ("ILME-FX6V") while "Camera Type" holds the manufacturer
+# ("Sony"), so the model key must win or every camera bins as its make. An unreadable
+# camera falls back to the bare footage bin rather than guessing.
+CAMERA_KEYS = ("Camera TC Type", "Camera Type")
 SEQUENCE_TOKEN = "%"
 # Resolve paths an imported image sequence by folding the index range into the name —
 # shot_[0001-0024].png — a label, not a file (#85, Resolve Studio 21.0.3.7).
@@ -556,14 +557,15 @@ def _camera_model(clip: Clip, reported: dict[str, str]) -> str | None:
     """The camera model the clip reports, sanitised for bin use, or ``None``.
 
     Read after import — the model is embedded data Resolve surfaces, nothing the file
-    path could carry. Properties are consulted before metadata because the spec words the
-    source as clip properties; which dict real cards populate is the #94 live question.
-    A slash in a model name would read as a bin separator, so it is folded to a dash.
+    path could carry. Key priority outranks dict priority: a model found anywhere beats a
+    manufacturer found anywhere (see ``CAMERA_KEYS``), with the spec's clip properties
+    consulted before metadata for each key. A slash in a model name would read as a bin
+    separator, so it is folded to a dash.
     """
     metadata = clip.GetMetadata()
     dicts = [reported, metadata if isinstance(metadata, dict) else {}]
-    for source in dicts:
-        for key in CAMERA_KEYS:
+    for key in CAMERA_KEYS:
+        for source in dicts:
             value = str(source.get(key) or "").strip()
             if value:
                 return value.replace(BIN_SEPARATOR, "-")

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -1,6 +1,6 @@
 """Media pool wrappers: import, list, inspect, metadata, bins, relink.
 
-Thin, testable, and MCP-free like the rest of this layer. Four things here are decisions
+Thin, testable, and MCP-free like the rest of this layer. Five things here are decisions
 rather than API calls, and are the reason this file exists at all:
 
 * **Bin paths are slash-separated from the media pool root** (``"Concert/Angles"``), the
@@ -19,6 +19,18 @@ rather than API calls, and are the reason this file exists at all:
 * **Image media gets the still-duration workaround at import.** A one-time
   ``SetClipProperty("Out", …)`` is what makes ``endFrame`` respected on stills later; doing
   it at import means no timeline code ever has to remember.
+* **A no-bin import gets a suggested bin, never an enforced one** (#57). The layout:
+  ``[<Gig>/]01_Timelines``, ``02_Footage/<Camera>`` (B-Roll alongside; angle-description
+  bins allowed when camera metadata is unreadable), ``03_Audio``, ``04_Assets`` (with
+  ``Text/<Song>`` for title assets). The ``<Gig>`` level exists only when a project holds
+  more than one gig, and only the agent can know the gig, so that prefix arrives as an
+  explicit bin. Numbered categories use underscores; gig and song bins use human
+  formatting; clips live in leaf bins. Angle identity is two-layer: bins encode source
+  role (camera, roll class) while the angle sidecars (#13) stay canonical for descriptive
+  semantics — a bin move is an address change (cut files update per the alternates spec)
+  and sidecars keyed on clip name persist. Existing projects are adaptive: the agent reads
+  and follows the structure it finds; the template is for empty ground; nothing is ever
+  reorganized unasked.
 """
 
 from __future__ import annotations
@@ -51,6 +63,14 @@ log = get_logger("media")
 BIN_SEPARATOR = "/"
 DEFAULT_LIST_LIMIT = 200
 IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"})
+AUDIO_SUFFIXES = frozenset({".aac", ".aif", ".aiff", ".flac", ".m4a", ".mp3", ".ogg", ".wav"})
+FOOTAGE_BIN = "02_Footage"
+AUDIO_BIN = "03_Audio"
+ASSETS_BIN = "04_Assets"
+# The metadata field Resolve fills with the recording device's model name. One key on
+# purpose: which fields real cards populate is a live question (#94 live smoke), and an
+# unreadable camera falls back to the bare footage bin rather than guessing.
+CAMERA_KEYS = ("Camera Type",)
 SEQUENCE_TOKEN = "%"
 # Resolve paths an imported image sequence by folding the index range into the name —
 # shot_[0001-0024].png — a label, not a file (#85, Resolve Studio 21.0.3.7).
@@ -458,30 +478,135 @@ def import_media(
     bin_path: str | None = None,
     sequences: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    """Import media into ``bin_path``, creating the bin if needed."""
+    """Import media into ``bin_path``, creating the bin if needed.
+
+    With no ``bin_path`` at all, every item gets a bin suggested by media type — the
+    module docstring's fifth decision (#57). An explicit bin, the root included, bypasses
+    suggestion entirely.
+    """
     pool = media_pool(connection)
     items = _requests(paths, sequences)
+    if bin_path is None:
+        return _import_suggested(pool, items)
     target = ensure_bin(pool, bin_path)
     imported = import_into(pool, items, target)
 
     summaries: list[dict[str, Any]] = []
     landed: set[str] = set()
     for clip in imported:
-        reported = properties(clip)
-        landed.add(reported.get(FILE_PATH, ""))
-        landed.add(str(clip.GetName() or ""))
-        summary = summarise(target.path, clip, reported)
-        summary["still_duration_workaround"] = apply_still_workaround(clip, reported)
-        summaries.append(summary)
+        summaries.append(_clip_summary(clip, target.path, "explicit", landed))
 
+    refused = _refused_or_fail(items, imported, landed, summaries)
+    log.info("Imported %d clip(s) into %r", len(summaries), target.path or "the root")
+    return {"bin": target.path, "imported": summaries, "not_imported": refused}
+
+
+def _import_suggested(pool: Pool, items: list[str | dict[str, Any]]) -> dict[str, Any]:
+    """Import with no bin argument: each item is suggested a bin by media type (#57).
+
+    Suggestion paths are category-from-root; the optional ``<Gig>/`` prefix is the agent's
+    to supply via an explicit bin, because the server cannot know the gig. Suggestion is
+    never enforcement — nothing here refuses a path for being off-convention; an explicit
+    bin simply never reaches this function.
+    """
+    groups: dict[str, list[str | dict[str, Any]]] = {}
+    for item in items:
+        groups.setdefault(_suggested_bin(item), []).append(item)
+
+    summaries: list[dict[str, Any]] = []
+    imported: list[Clip] = []
+    landed: set[str] = set()
+    for category, group in groups.items():
+        target = ensure_bin(pool, category)
+        arrived = import_into(pool, group, target)
+        imported.extend(arrived)
+        for clip in arrived:
+            where, source = _placed(pool, clip, target)
+            summaries.append(_clip_summary(clip, where, source, landed))
+
+    refused = _refused_or_fail(items, imported, landed, summaries)
+    bins = sorted({str(summary["bin"]) for summary in summaries})
+    log.info("Imported %d clip(s) into suggested bin(s) %s", len(summaries), ", ".join(bins))
+    return {"bins": bins, "imported": summaries, "not_imported": refused}
+
+
+def _suggested_bin(item: str | dict[str, Any]) -> str:
+    """Which #57 category an import request belongs to, judged before the import.
+
+    Suffix, not the ``Type`` property, for the same reason as :func:`is_still`: Resolve
+    types a sequence and a movie both ``Video``. A sequence request (a dict) is image
+    frames by construction.
+    """
+    if isinstance(item, dict):
+        return ASSETS_BIN
+    suffix = Path(item).suffix.lower()
+    if suffix in IMAGE_SUFFIXES:
+        return ASSETS_BIN
+    if suffix in AUDIO_SUFFIXES:
+        return AUDIO_BIN
+    return FOOTAGE_BIN
+
+
+def camera_model(clip: Clip) -> str | None:
+    """The camera model the clip's metadata reports, sanitised for bin use, or ``None``.
+
+    Read after import — the model is embedded metadata Resolve surfaces, nothing the file
+    path could carry. A slash in a model name would read as a bin separator, so it is
+    folded to a dash.
+    """
+    metadata = clip.GetMetadata()
+    if not isinstance(metadata, dict):
+        return None
+    for key in CAMERA_KEYS:
+        value = str(metadata.get(key) or "").strip()
+        if value:
+            return value.replace(BIN_SEPARATOR, "-")
+    return None
+
+
+def _placed(pool: Pool, clip: Clip, target: LocatedBin) -> tuple[str, str]:
+    """Where a suggested clip ends up, and what the suggestion drew on.
+
+    Footage is the one category with a second hop: the camera leaf can only be known
+    after import, once the clip's metadata is readable.
+    """
+    if target.path != FOOTAGE_BIN:
+        return target.path, "media_type"
+    model = camera_model(clip)
+    if model is None:
+        return target.path, "fallback"
+    leaf = ensure_bin(pool, f"{FOOTAGE_BIN}{BIN_SEPARATOR}{model}")
+    if not pool.MoveClips([clip], leaf.folder):
+        name = str(clip.GetName() or "")
+        log.warning("Camera bin move refused for %r; leaving it in %r", name, target.path)
+        return target.path, "fallback"
+    return leaf.path, "camera_metadata"
+
+
+def _clip_summary(clip: Clip, bin_used: str, source: str, landed: set[str]) -> dict[str, Any]:
+    """One imported clip's envelope line: the summary, the bin, and how the bin was chosen."""
+    reported = properties(clip)
+    landed.add(reported.get(FILE_PATH, ""))
+    landed.add(str(clip.GetName() or ""))
+    summary = summarise(bin_used, clip, reported)
+    summary["still_duration_workaround"] = apply_still_workaround(clip, reported)
+    summary["bin_source"] = source
+    return summary
+
+
+def _refused_or_fail(
+    items: list[str | dict[str, Any]],
+    imported: list[Clip],
+    landed: set[str],
+    summaries: list[dict[str, Any]],
+) -> list[str]:
     refused = _not_imported(items, imported, landed)
     if not summaries:
         raise ImportFailedError(
             cause=f"Resolve imported none of the {len(items)} path(s) requested.",
             detail={"not_imported": refused},
         )
-    log.info("Imported %d clip(s) into %r", len(summaries), target.path or "the root")
-    return {"bin": target.path, "imported": summaries, "not_imported": refused}
+    return refused
 
 
 def _not_imported(

--- a/src/resolve_mcp/tools/media.py
+++ b/src/resolve_mcp/tools/media.py
@@ -27,6 +27,16 @@ def import_media(
     "end_index": 96}. Image media gets the still-duration workaround applied at import, so
     later timeline appends honour the exact durations you ask for.
 
+    With no bin, each item gets a bin suggested by media type: video into
+    02_Footage/<Camera> (camera model read from clip metadata after import; plain
+    02_Footage when unreadable), audio into 03_Audio, stills and image sequences into
+    04_Assets — bins created on demand. Each imported clip reports the bin used and
+    bin_source (camera_metadata, fallback, media_type, or explicit). Suggestions are
+    category-from-root; in a multi-gig project supply the <Gig>/ prefix yourself via bin=.
+    In a project that already has its own bin structure, check that structure first and
+    pass bin= to follow it rather than accepting a suggestion — a suggestion is never
+    enforcement, and an explicit bin (any path at all) bypasses it entirely.
+
     Returns a summary per imported clip, plus not_imported for anything Resolve refused —
     usually a path that is not readable from the machine Resolve runs on.
     """

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -255,7 +255,7 @@ def test_no_bin_video_lands_in_a_camera_bin_read_from_metadata(
 ) -> None:
     """The camera leaf exists only after import: the model is clip metadata, not the path."""
     video = a_file(tmp_path, "C0012.mp4")
-    clip = FakeMediaPoolItem("C0012.mp4", str(video), metadata={"Camera Type": "ILME-FX6V"})
+    clip = FakeMediaPoolItem("C0012.mp4", str(video), metadata={"Camera TC Type": "ILME-FX6V"})
     pool = media_pool()
     pool.import_result = [clip]
     attach(studio(pool=pool))
@@ -304,7 +304,7 @@ def test_a_camera_model_in_clip_properties_also_lands_the_leaf(
 ) -> None:
     """The spec words the source as clip properties; metadata is the second look."""
     video = a_file(tmp_path, "C0500.mp4")
-    clip = FakeMediaPoolItem("C0500.mp4", str(video), properties={"Camera Type": "ILCE-7M4"})
+    clip = FakeMediaPoolItem("C0500.mp4", str(video), properties={"Camera TC Type": "ILCE-7M4"})
     pool = media_pool()
     pool.import_result = [clip]
     attach(studio(pool=pool))
@@ -312,6 +312,27 @@ def test_a_camera_model_in_clip_properties_also_lands_the_leaf(
     result = import_media(paths=[str(video)])
 
     assert result["imported"][0]["bin"] == "02_Footage/ILCE-7M4"
+    assert result["imported"][0]["bin_source"] == "camera_metadata"
+
+
+def test_the_model_key_beats_the_manufacturer_key(attach: Attach, tmp_path: Path) -> None:
+    """Real FX6 media fills both: "Camera TC Type" holds the model, "Camera Type" only
+    the make (live probe, 2026-08-07) — the make must never name the bin when the model
+    is readable, or every Sony camera collapses into one 02_Footage/Sony."""
+    video = a_file(tmp_path, "A016C008_260618GD.MXF")
+    clip = FakeMediaPoolItem(
+        "A016C008_260618GD.MXF",
+        str(video),
+        properties={"Camera TC Type": "ILME-FX6V", "Camera Type": "Sony"},
+        metadata={"Camera TC Type": "ILME-FX6V", "Camera Type": "Sony"},
+    )
+    pool = media_pool()
+    pool.import_result = [clip]
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["imported"][0]["bin"] == "02_Footage/ILME-FX6V"
     assert result["imported"][0]["bin_source"] == "camera_metadata"
 
 
@@ -335,7 +356,7 @@ def test_a_refused_camera_move_falls_back_to_the_footage_bin(
 ) -> None:
     """A camera model that cannot land its leaf is a fallback, not a lie in the envelope."""
     video = a_file(tmp_path, "C0012.mp4")
-    clip = FakeMediaPoolItem("C0012.mp4", str(video), metadata={"Camera Type": "ILME-FX6V"})
+    clip = FakeMediaPoolItem("C0012.mp4", str(video), metadata={"Camera TC Type": "ILME-FX6V"})
     pool = media_pool()
     pool.import_result = [clip]
     pool.move_result = False

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from resolve_mcp.tools.media import (
     import_media,
@@ -144,7 +145,8 @@ def test_import_applies_the_still_duration_workaround_to_image_media(
 
     assert result["ok"] is True
     assert result["imported"][0]["still_duration_workaround"] is True
-    clip = pool.GetRootFolder().GetClipList()[0]
+    [assets] = [sub for sub in pool.GetRootFolder().GetSubFolderList() if "Assets" in sub.GetName()]
+    clip = assets.GetClipList()[0]
     assert clip.property_writes == [("Out", "0")]
 
 
@@ -155,7 +157,10 @@ def test_import_does_not_touch_the_out_point_of_a_video(attach: Attach, tmp_path
     result = import_media(paths=[str(a_file(tmp_path, "C0012.mp4"))])
 
     assert result["imported"][0]["still_duration_workaround"] is False
-    assert pool.GetRootFolder().GetClipList()[0].property_writes == []
+    [footage] = [
+        sub for sub in pool.GetRootFolder().GetSubFolderList() if "Footage" in sub.GetName()
+    ]
+    assert footage.GetClipList()[0].property_writes == []
 
 
 def test_import_reports_the_paths_resolve_refused_and_keeps_the_rest(
@@ -212,6 +217,112 @@ def test_import_restores_the_folder_that_was_current_before_it(
     assert import_media(paths=[str(a_file(tmp_path, "C0012.mp4"))], bin="Angles")["ok"] is True
 
     assert pool.GetCurrentFolder() is before
+
+
+# --- import: suggested bins (#94) ------------------------------------------------------
+
+
+def bin_named(pool: Any, path: str) -> Any:
+    """Walk a slash path down from the root, or fail the test that asked."""
+    folder = pool.GetRootFolder()
+    for segment in path.split("/"):
+        matches = [sub for sub in folder.GetSubFolderList() if sub.GetName() == segment]
+        assert matches, f"no bin {segment!r} under {folder.GetName()!r}"
+        folder = matches[0]
+    return folder
+
+
+def test_no_bin_import_suggests_a_bin_per_media_type(attach: Attach, tmp_path: Path) -> None:
+    """One call, three media types: each lands in its #57 category, created on demand."""
+    video = a_file(tmp_path, "C0012.mp4")
+    audio = a_file(tmp_path, "mix.wav")
+    still = a_file(tmp_path, "poster.png")
+    pool = media_pool()
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video), str(audio), str(still)])
+
+    assert result["ok"] is True
+    assert result["bins"] == ["02_Footage", "03_Audio", "04_Assets"]
+    placed = {clip["name"]: (clip["bin"], clip["bin_source"]) for clip in result["imported"]}
+    assert placed == {
+        "C0012.mp4": ("02_Footage", "fallback"),
+        "mix.wav": ("03_Audio", "media_type"),
+        "poster.png": ("04_Assets", "media_type"),
+    }
+    assert [clip.GetName() for clip in bin_named(pool, "02_Footage").GetClipList()] == ["C0012.mp4"]
+    assert [clip.GetName() for clip in bin_named(pool, "03_Audio").GetClipList()] == ["mix.wav"]
+    assert [clip.GetName() for clip in bin_named(pool, "04_Assets").GetClipList()] == ["poster.png"]
+
+
+def test_no_bin_video_lands_in_a_camera_bin_read_from_metadata(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The camera leaf exists only after import: the model is clip metadata, not the path."""
+    video = a_file(tmp_path, "C0012.mp4")
+    clip = FakeMediaPoolItem("C0012.mp4", str(video), metadata={"Camera Type": "ILME-FX6V"})
+    pool = media_pool()
+    pool.import_result = [clip]
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["ok"] is True
+    assert result["bins"] == ["02_Footage/ILME-FX6V"]
+    assert result["imported"][0]["bin"] == "02_Footage/ILME-FX6V"
+    assert result["imported"][0]["bin_source"] == "camera_metadata"
+    leaf = bin_named(pool, "02_Footage/ILME-FX6V")
+    assert [found.GetName() for found in leaf.GetClipList()] == ["C0012.mp4"]
+
+
+def test_no_bin_sequence_is_suggested_into_assets(attach: Attach, tmp_path: Path) -> None:
+    for index in range(1, 4):
+        a_file(tmp_path, f"seq/shot_{index:04d}.png")
+    pool = media_pool()
+    attach(studio(pool=pool))
+
+    result = import_media(
+        sequences=[
+            {"path": str(tmp_path / "seq" / "shot_%04d.png"), "start_index": 1, "end_index": 3}
+        ]
+    )
+
+    assert result["ok"] is True
+    assert result["imported"][0]["bin"] == "04_Assets"
+    assert result["imported"][0]["bin_source"] == "media_type"
+
+
+def test_an_explicit_bin_bypasses_suggestion_entirely(attach: Attach, tmp_path: Path) -> None:
+    """No path is ever refused for being off-convention: bin= wins, even for audio."""
+    audio = a_file(tmp_path, "mix.wav")
+    pool = media_pool()
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(audio)], bin="Anywhere/At All")
+
+    assert result["ok"] is True
+    assert result["bin"] == "Anywhere/At All"
+    assert result["imported"][0]["bin"] == "Anywhere/At All"
+    assert result["imported"][0]["bin_source"] == "explicit"
+    assert "bins" not in result
+
+
+def test_a_refused_camera_move_falls_back_to_the_footage_bin(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A camera model that cannot land its leaf is a fallback, not a lie in the envelope."""
+    video = a_file(tmp_path, "C0012.mp4")
+    clip = FakeMediaPoolItem("C0012.mp4", str(video), metadata={"Camera Type": "ILME-FX6V"})
+    pool = media_pool()
+    pool.import_result = [clip]
+    pool.move_result = False
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["ok"] is True
+    assert result["imported"][0]["bin"] == "02_Footage"
+    assert result["imported"][0]["bin_source"] == "fallback"
 
 
 # --- list ------------------------------------------------------------------------------

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
 
 from resolve_mcp.tools.media import (
     import_media,
@@ -16,7 +15,7 @@ from resolve_mcp.tools.media import (
 )
 
 from .conftest import Attach
-from .fakes import FakeMediaPoolItem, media_pool, studio
+from .fakes import FakeFolder, FakeMediaPool, FakeMediaPoolItem, media_pool, studio
 
 AUDIO_MAPPING = json.dumps(
     {
@@ -145,8 +144,7 @@ def test_import_applies_the_still_duration_workaround_to_image_media(
 
     assert result["ok"] is True
     assert result["imported"][0]["still_duration_workaround"] is True
-    [assets] = [sub for sub in pool.GetRootFolder().GetSubFolderList() if "Assets" in sub.GetName()]
-    clip = assets.GetClipList()[0]
+    clip = bin_named(pool, "04_Assets").GetClipList()[0]
     assert clip.property_writes == [("Out", "0")]
 
 
@@ -157,10 +155,7 @@ def test_import_does_not_touch_the_out_point_of_a_video(attach: Attach, tmp_path
     result = import_media(paths=[str(a_file(tmp_path, "C0012.mp4"))])
 
     assert result["imported"][0]["still_duration_workaround"] is False
-    [footage] = [
-        sub for sub in pool.GetRootFolder().GetSubFolderList() if "Footage" in sub.GetName()
-    ]
-    assert footage.GetClipList()[0].property_writes == []
+    assert bin_named(pool, "02_Footage").GetClipList()[0].property_writes == []
 
 
 def test_import_reports_the_paths_resolve_refused_and_keeps_the_rest(
@@ -222,7 +217,7 @@ def test_import_restores_the_folder_that_was_current_before_it(
 # --- import: suggested bins (#94) ------------------------------------------------------
 
 
-def bin_named(pool: Any, path: str) -> Any:
+def bin_named(pool: FakeMediaPool, path: str) -> FakeFolder:
     """Walk a slash path down from the root, or fail the test that asked."""
     folder = pool.GetRootFolder()
     for segment in path.split("/"):
@@ -290,6 +285,34 @@ def test_no_bin_sequence_is_suggested_into_assets(attach: Attach, tmp_path: Path
     assert result["ok"] is True
     assert result["imported"][0]["bin"] == "04_Assets"
     assert result["imported"][0]["bin_source"] == "media_type"
+
+
+def test_no_bin_graphics_are_suggested_into_assets(attach: Attach, tmp_path: Path) -> None:
+    """Graphics ride with stills in #57: a .psd is an asset, not footage."""
+    graphic = a_file(tmp_path, "lower-third.psd")
+    attach(studio(pool=media_pool()))
+
+    result = import_media(paths=[str(graphic)])
+
+    assert result["ok"] is True
+    assert result["imported"][0]["bin"] == "04_Assets"
+    assert result["imported"][0]["bin_source"] == "media_type"
+
+
+def test_a_camera_model_in_clip_properties_also_lands_the_leaf(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The spec words the source as clip properties; metadata is the second look."""
+    video = a_file(tmp_path, "C0500.mp4")
+    clip = FakeMediaPoolItem("C0500.mp4", str(video), properties={"Camera Type": "ILCE-7M4"})
+    pool = media_pool()
+    pool.import_result = [clip]
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["imported"][0]["bin"] == "02_Footage/ILCE-7M4"
+    assert result["imported"][0]["bin_source"] == "camera_metadata"
 
 
 def test_an_explicit_bin_bypasses_suggestion_entirely(attach: Attach, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #94.

## What this does

`import_media` with no `bin` argument now suggests a bin per media type instead of silently using the current folder: video → `02_Footage/<Camera>` (camera model read from the clip after import; bare `02_Footage` when unreadable), audio → `03_Audio`, stills / image sequences / graphics → `04_Assets` — bins created on demand. Every imported clip's envelope line carries `bin` and `bin_source` (`explicit` / `media_type` / `camera_metadata` / `fallback`); suggested-mode replies add a top-level `bins` list, explicit-mode replies keep today's `bin` key and behaviour. An explicit bin bypasses suggestion entirely; nothing is ever refused for being off-convention.

The #57 convention lands as the fifth decision in the `resolve/media.py` module docstring (the canonical evolvable copy), and the tool description carries the adaptive-first instruction: read an existing project's structure and pass `bin=` to follow it rather than accepting a suggestion.

**Seams:** suggestion mapping, envelope shape, on-demand creation, explicit bypass and the camera-key ordering all verify at the fake tier (`tests/test_media_tools.py`, 43 tests in the file). The camera-key choice itself is a live question and was settled by a live probe — below.

## Review record

Two-axis `/code-review` (Standards + Spec as parallel sub-agents) against `origin/main`, run on the branch before this PR existed.

**Standards** — no hard violations. Six judgement-call smells, resolved in `47ba9fa`:

- `_suggested_bin` duplicated the image-suffix check → now delegates to `_looks_like_image`.
- `_placed` returned a bare `tuple[str, str]` in a module whose convention is small NamedTuples → returns `Placement(path, source)`.
- `camera_model` was public with no external caller → private `_camera_model`.
- The two edited tests used ad-hoc substring scans and `Any` types → they reuse the `bin_named` helper with concrete `FakeMediaPool`/`FakeFolder` types.
- `landed`-set mutation through `_clip_summary` — accepted as-is: the accumulator refactor would add churn without changing behaviour; noted here as the residue.
- Docstring bullet longer than the other four decisions — accepted: the spec explicitly asks for the full convention as the canonical evolvable copy.

**Spec** — six findings, resolved in `47ba9fa` and `e32607a`:

- Graphics (`.psd`/`.ai`/`.eps`/`.svg`) fell through to `02_Footage` → new `GRAPHIC_SUFFIXES` routes them to `04_Assets`, with a test.
- Spec words the camera source as clip properties; the code read only metadata → `_camera_model` consults the properties dict first, then metadata, one enumeration per clip.
- `bin_source: "media_type"` is a fourth value beyond the spec's three — kept deliberately: audio/assets suggestions are neither camera-derived nor fallback, and the tool docstring documents all four.
- Refused-`MoveClips` fallback path (unasked-for robustness) — kept: the envelope must not name a bin the clip is not in; logged and tested.
- Envelope shape fork (`bins` list in suggested mode vs `bin` in explicit mode) — kept: explicit mode stays byte-compatible with today per the AC; suggested mode can land in several bins so a single `bin` key would lie.
- Live AC not evidenced in the diff → executed, see below.

Focused re-passes over each fix diff only (per workflow); both clean. Gates after fixes: fake tier 1183 passed, mypy strict clean, ruff clean.

## Live record

Live Windows 11 box, Resolve Studio up, python.org interpreter (the live tier's autouse guard passed).

- **Live tier ran** (not skipped): 21 passed / 4 failed / 9 skipped on this branch. All 4 failures reproduce as wandering open-project state — a full run on detached `origin/main` immediately after failed a *different* set of 3 (including one this branch's run passed), and the two branch-only names pass/skip when run isolated on both refs. None touch the import path; live smoke never calls `import_media`. Pre-existing state, tracked by #62/#79.
- **Camera-key probe** (read-only, open project `2026-06_Zinc_and_Monkfish`): real FX6 XAVC holds the model in `Camera TC Type` (`ILME-FX6V`) and only the make in `Camera Type` (`Sony`) — the original single-key guess would have binned every camera as `02_Footage/Sony`. `CAMERA_KEYS` is now the ordered pair with model first (`e32607a`), and a test pins model-beats-manufacturer with both fields populated exactly as real media populates them.
- **Live AC, FX6 half: PASS.** Through `media.import_media` in a scratch project: no-bin import of `A016C008_260618GD.MXF` → `bin: 02_Footage/ILME-FX6V`, `bin_source: camera_metadata`, `not_imported: []`. The A7IV half cannot run — no A7IV media exists anywhere in the pool — and goes to the human on the ticket. (Resolve refused `DeleteProject` on the scratch project `resolve-mcp-94-camera-smoke`; it is empty and safe to delete by hand.)

Review: clean — two-axis review pre-PR; all findings fixed or resolved above; fake tier, mypy, ruff green; FX6 live AC executed and passing.
