### PR TITLE
P4: rough-cut pillar — read the cut back as the words it will say

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,12 @@ The five canonical triage roles, each label string equal to its role name. See `
 Single-context — `CONTEXT.md` (repo map + vocabulary) and `docs/adr/` at
 the repo root. See `docs/agents/domain.md`.
 
+### The rough-cut pillar
+
+P4: transcript-driven A-roll assembly. The per-project brief and b-roll
+catalog the agent owns, the assembly loop, the `virtual_transcript`
+self-review and the cut report: `docs/agents/rough-cut.md`.
+
 ### The style layer
 
 `styles/` — profiles and angle sidecars, agent-authored and never touched by

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,7 +69,9 @@ identify/cache/write pattern), `music` (beats + energy + gist job),
 `records` (sliceable record files), `silence` (RMS spans), `solos` (front
 of band changes), `structure` (tunes + solo changes job), `transcribe`
 (job), `transcript` (document + Word/Transcription/Transcriber vocabulary),
-`whisper` (default backend: faster-whisper large-v3).
+`virtual` (a cut file read back as the words it will contain — the P4
+self-review, warnings only, touches no Resolve handle), `whisper`
+(default backend: faster-whisper large-v3).
 
 `audio/` — concert audio out of Resolve onto disk: `acquire` (both routes),
 `ffmpeg` (per-source-clip route), `riff` (the WAV container itself: PCM,
@@ -144,15 +146,20 @@ references that exist only in annotations sit under `if TYPE_CHECKING`; that
 is what keeps the runtime import graph acyclic. Installed by the `attach` fixture in
 `tests/conftest.py` (autouse `_clean_globals` resets the seam and pins a
 hermetic `Config` around every test). Other helpers: `tests/cutfile.py`
-(miniature cut file + media pool), `tests/otio.py` (hand-edited OTIO with
-a dissolve), `tests/text_plus_probe.py` (Text+ probe fixtures).
+(miniature concert cut file + media pool), `tests/roughcut.py` (the P4
+substrate: one talking head said twice, its transcript, and the b-roll that
+covers the join), `tests/otio.py` (hand-edited OTIO with a dissolve),
+`tests/text_plus_probe.py` (Text+ probe fixtures).
 
 Test files pair 1:1 with the module they cover (`test_cut_validate.py` ↔
 `cut/validate.py`, `test_timeline_tools.py` ↔ `tools/timeline.py` +
 `resolve/timeline.py`, …). `test_wav_container.py` ↔ `audio/riff.py` is the
 exception that earns its keep: the headers it covers are read by `audio/wav.py`,
 `analysis/decode.py` and `analysis/silence.py` alike, and #110 was a bug in what
-all three agreed about. Live tier: `test_live_smoke.py` (module-level
+all three agreed about. `test_rough_cut_pillar.py` is the other exception: it
+covers no single module, walking the P4 pillar across `cut`, `build`, `takes`
+and `virtual` in one pass because the joins are what a per-module test cannot
+see. Live tier: `test_live_smoke.py` (module-level
 `pytest.mark.live`) and two `@pytest.mark.live` tests in
 `test_live_analysis.py`; everything else is fake-tier.
 
@@ -163,5 +170,7 @@ all three agreed about. Live tier: `test_live_smoke.py` (module-level
   content hash).
 - `docs/agents/` — issue-tracker conventions (wayfinder map ops), triage
   labels, domain-docs usage, the style layer (sidecar + profile formats,
-  provenance tags, how a corpus pass is run).
+  provenance tags, how a corpus pass is run), the rough-cut pillar
+  (`rough-cut.md`: the brief and b-roll catalog the agent owns, the
+  assembly loop, the `virtual_transcript` self-review and the cut report).
 - Wayfinder: map = issue #1, scope = #2, spec = #22, build tickets #23–#47.

--- a/docs/agents/rough-cut.md
+++ b/docs/agents/rough-cut.md
@@ -14,12 +14,19 @@ timeline is as an `overlays[]` entry in the cut file you author, and the only wa
 reaches anything is by changing what you decide. `tests/test_rough_cut_pillar.py` guards
 that — no module under `src/` names a brief or a catalog by path.
 
-They live per project:
+They live per project, in the repo:
 
 ```
 projects/<project>/brief.md      # what the director wants this to be
 projects/<project>/broll.json    # what you have to cover with
 ```
+
+In the repo, one file per project, keyed to the project — the same reading the angle
+sidecar settled, and the director confirmed on 2026-08-07 that sidecars stay in version
+control rather than sitting beside the footage on a media drive
+(`docs/agents/style-layer.md`). They are not under `styles/` because that layer is taste:
+a profile says how you cut, and neither a brief nor a shot list does. If the director would
+rather have one agent-owned root than two, moving them is a rename and a regex.
 
 ### The brief
 
@@ -105,15 +112,21 @@ Then work the warnings. There are no errors; this refuses nothing:
 
 | Rule | What it found | What it usually means |
 | --- | --- | --- |
-| W1 | a word cut in half | the boundary is a frame or two off; the fix hint names the frame |
-| W2 | the same run of words on both sides of a seam | two takes of one line both survived |
-| W3 | a segment's source has no transcript | either transcribe it, or it is silent on purpose |
-| W4 | a low-confidence word survives into the cut | listen to it before delivering |
-| W5 | an uncovered seam between two shots of one source | a jump cut with no b-roll over it |
+| W3 | a word cut in half | the boundary is a frame or two off; the fix hint names the frame |
+| W4 | the same run of words on both sides of a seam | two takes of one line both survived |
+| W5 | a segment's source has no transcript | either transcribe it, or it is silent on purpose |
+| W6 | a low-confidence word survives into the cut | listen to it before delivering |
+| W7 | an uncovered seam between two shots of one source | a jump cut with no b-roll over it |
 
-W2 is the one to take seriously: a cut file that keeps a false start in front of the good
+The numbering starts at W3 because `validate_cut` already owns W1 and W2 **for the same cut
+file**. One document, one numbering — two W2s meaning different things would be a trap in a
+session holding both results.
+
+W4 is the one to take seriously: a cut file that keeps a false start in front of the good
 take is structurally perfect — it validates, it builds, it plays — and only reading the
-words back says the piece stammers.
+words back says the piece stammers. It compares each seam against the one before it, so two
+takes of a line with another shot between them read back clean; the doubling it catches is
+the adjacent kind, which is where a false start actually lands.
 
 Every warning is a reading, not a verdict. A repeat can be deliberate. A mid-word cut can
 be the point. Filler is not flagged at all, because whether an "um" carries thought or
@@ -122,7 +135,9 @@ stalls is exactly the judgement the brief settles and no detector should.
 ## The cut report
 
 What the director gets is the built timeline plus markers on it — uncertainties only, not a
-running commentary. The W4 warnings are the natural contents: each one is a word you are
+running commentary. You write it with `set_markers`; there is no cut-report tool and there
+should not be, because which flags are worth the director's attention is the judgement.
+The W6 warnings are the natural contents: each one is a word you are
 delivering that the transcriber was unsure of, at a frame the director can jump to. Add
 anything you decided against the obvious reading, and leave everything you are confident
 about unmarked. Reviewing a rough cut should take minutes.

--- a/docs/agents/rough-cut.md
+++ b/docs/agents/rough-cut.md
@@ -1,0 +1,132 @@
+# The rough-cut pillar
+
+How a rough cut gets assembled: the two documents you author before cutting, the loop you
+cut in, and the self-review that has to pass before the director sees anything.
+
+This is P4 of spec #22 (stories 51–55). It is the other shape from the concert pillar —
+no continuous master mix, no beat grid, no angle roles. The substrate is one or more
+A-roll cameras talking, and the evidence you cut from is a word-level transcript.
+
+## The two documents you own
+
+Both are yours. The server never reads or writes either one: the only way b-roll reaches a
+timeline is as an `overlays[]` entry in the cut file you author, and the only way the brief
+reaches anything is by changing what you decide. `tests/test_rough_cut_pillar.py` guards
+that — no module under `src/` names a brief or a catalog by path.
+
+They live per project:
+
+```
+projects/<project>/brief.md      # what the director wants this to be
+projects/<project>/broll.json    # what you have to cover with
+```
+
+### The brief
+
+Markdown, short, written with the director before the first assembly. It settles the
+questions that change the shape of the whole cut, not the taste ones you can resolve as you
+go. The one that always matters:
+
+- **Script order or narrative reorder.** Script order means the delivered piece follows the
+  order it was shot in and your job is take selection and tightening. Narrative reorder
+  means you may move material, and the outline you write to do that is an artifact of your
+  working, not a gate — the director does not sign it off before you cut.
+
+Anything else worth stating goes underneath as prose: target length, who the audience is,
+whether filler and breath belong in the register or not, what must survive uncut.
+
+```markdown
+# brief — founder-interview
+
+Order: narrative reorder. The origin story leads; the funding answer moves after it.
+Length: 6–8 minutes, no hard cap.
+Register: conversational. Leave the ums that carry thought; cut the ones that stall.
+Must survive: the answer about the first hire, whole.
+```
+
+### The b-roll catalog
+
+JSON, one entry per b-roll clip, built by grabbing frames and labelling what you see —
+`grab_frames` at a few points per clip, then write down what the clip is *about*. Grab and
+label once per project; the catalog is what makes coverage planned rather than sprinkled.
+
+```jsonc
+{
+  "schema": 1,
+  "clips": [
+    {
+      "alias": "broll_hands",          // the source alias you will use in the cut file
+      "clip": "B012.mp4",              // media-pool clip name
+      "bin": "B-roll",
+      "usable": [{ "in": 0, "out": 240 }],   // ranges worth cutting, source frames
+      "topics": ["typing", "desk", "hands"], // what it is about — how you match it
+      "note": "slow push in; the last 40 frames wobble"
+    }
+  ]
+}
+```
+
+`topics` is the whole point: covering a jump cut means reaching for a clip that is about
+what is being said across that jump, not for whatever is next in the bin. Nothing validates
+these strings — they are notes to yourself, and they are only useful if they describe the
+subject rather than the shot.
+
+## The loop
+
+1. **Transcribe every A-roll source.** `transcribe_audio` per source; keep the paths.
+2. **Read the transcripts.** Word-level, with confidence and silence spans. Flubs, retakes
+   and filler are yours to spot by reading — no tool labels them, deliberately (see
+   `analysis/transcript.py`: "Nothing is called a flub"). Take selection is judgement over
+   evidence.
+3. **Assemble the A-roll** into a cut file of sequential segments, in brief order.
+4. **Park the retakes as alternates.** A line delivered three times is one segment with two
+   `alternates[]`, not three segments. Alternates must match the main frame for frame (E8),
+   so offer the other take at the chosen take's length. That is what lets the director flip
+   a take during review with `swap_take` instead of asking for a rebuild.
+5. **Cover the jump cuts.** Two segments from the same source, back to back, are a visible
+   jump. Anchor an overlay from the catalog over the earlier segment at an offset that puts
+   it across the seam — anchored, so it survives a tightening pass. Cutting from one camera
+   to another is not a jump cut and needs no cover.
+6. **`validate_cut`, then `build_timeline`.** Every revision is a new `<name> v<N>`.
+7. **Self-review with `virtual_transcript`.** Below.
+8. **Fix what it found, rebuild, and mark the rest** as the cut report.
+
+## The self-review
+
+`virtual_transcript` reads the cut file back as the words the built timeline will contain.
+Pass it the cut file and a mapping of source alias to the transcript document for that
+source. Run it before the director sees the cut, every version. It is the P4 counterpart to
+the mandatory `correlate_timeline` pass on a concert cut.
+
+Read `text` first — that is the piece, as prose. If it does not read as something a person
+said, nothing else matters yet.
+
+Then work the warnings. There are no errors; this refuses nothing:
+
+| Rule | What it found | What it usually means |
+| --- | --- | --- |
+| W1 | a word cut in half | the boundary is a frame or two off; the fix hint names the frame |
+| W2 | the same run of words on both sides of a seam | two takes of one line both survived |
+| W3 | a segment's source has no transcript | either transcribe it, or it is silent on purpose |
+| W4 | a low-confidence word survives into the cut | listen to it before delivering |
+| W5 | an uncovered seam between two shots of one source | a jump cut with no b-roll over it |
+
+W2 is the one to take seriously: a cut file that keeps a false start in front of the good
+take is structurally perfect — it validates, it builds, it plays — and only reading the
+words back says the piece stammers.
+
+Every warning is a reading, not a verdict. A repeat can be deliberate. A mid-word cut can
+be the point. Filler is not flagged at all, because whether an "um" carries thought or
+stalls is exactly the judgement the brief settles and no detector should.
+
+## The cut report
+
+What the director gets is the built timeline plus markers on it — uncertainties only, not a
+running commentary. The W4 warnings are the natural contents: each one is a word you are
+delivering that the transcriber was unsure of, at a frame the director can jump to. Add
+anything you decided against the obvious reading, and leave everything you are confident
+about unmarked. Reviewing a rough cut should take minutes.
+
+Then the review round is the ordinary one: the director's notes come back as markers,
+`list_markers` is your queue, take notes are `swap_take` with the cut file kept in sync, and
+everything else is a new version.

--- a/src/resolve_mcp/analysis/virtual.py
+++ b/src/resolve_mcp/analysis/virtual.py
@@ -1,0 +1,401 @@
+"""The transcript a cut will read back as, derived before the cut is built.
+
+The rough-cut pillar assembles A-roll by reading a word-level transcript and choosing
+takes editorially. That leaves one question the agent cannot answer by re-reading its own
+cut file: *what does the assembled cut actually say?* Segments are half-open source ranges;
+the words they contain are somewhere else, in seconds, in another document. Answering it by
+hand means holding two coordinate systems and a running total in your head for every
+segment, which is exactly the arithmetic that goes wrong quietly on a forty-minute cut.
+
+So this derives it. Given a cut file and the transcripts of the sources its segments come
+from, it returns the words the built timeline would contain, in cut order, with the
+timeline position each one lands at — plus the measurements a self-review needs: words the
+cut opens or closes halfway through, a run of words that survives twice because two takes
+of the same line were both kept, low-confidence words that made it into the delivery, and
+seams between two shots of the same source that no overlay covers.
+
+**Nothing here is a judgement.** Following ``transcript.py``: the document reports
+confidence and gaps, and deciding that a word is a flub, that filler should go, or that a
+repeat is a retake rather than a deliberate echo stays the agent's call. Every finding is a
+warning — there is no cut this refuses. It is the P4 counterpart to ``correlate.py``, which
+measures a concert cut against its music and likewise scores nothing.
+
+It touches no Resolve handle: a cut file and some transcripts are both documents on disk,
+so this is a plain reading, verified at the pure-function tier with no seam involved.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from ..config import Config, get_config
+from ..cut.document import read_cut_file
+from ..errors import InvalidRequestError
+from ..findings import Finding, ordered
+from ..spill import spill
+from ..timing import IN_POINT, OUT_POINT, SECONDS_PRECISION, dual_time, frames_from_seconds
+from . import records
+from .transcript import DEFAULT_LOW_CONFIDENCE
+
+INLINE_WORDS: Final = 200
+"""Words returned inline before the whole reading goes to disk instead."""
+
+REPEATED_RUN: Final = 2
+"""How many words either side of a seam must match before a repeat is worth reporting.
+
+One word repeating across a cut is ordinary English — "and", "the", a name. Two in the same
+order is the shape of a line delivered twice with both takes kept.
+"""
+
+RULE_DESCRIPTIONS: Final[dict[str, str]] = {
+    "W1": "a word is cut in half by a segment boundary",
+    "W2": "the same run of words survives on both sides of a seam",
+    "W3": "a segment's source has no transcript, so its words are unknown",
+    "W4": "a low-confidence word survives into the cut",
+    "W5": "two shots of one source meet at a seam no overlay covers",
+}
+
+_FIX_HINTS: Final[dict[str, str]] = {
+    "W1": "Move the boundary to the frame given here, or keep it if the clip is deliberate.",
+    "W2": "Drop one of the two takes, or make the second an alternate of the first.",
+    "W3": "Transcribe the source and pass it in, or accept that this segment reads as silence.",
+    "W4": "Grab the frame and listen, then fix the wording or let the uncertainty stand.",
+    "W5": "Cover the seam with an overlay anchored to the earlier segment, or accept the jump.",
+}
+
+
+def virtual_transcript(
+    cut_file: str,
+    transcripts: Mapping[str, str] | None = None,
+    below: float = DEFAULT_LOW_CONFIDENCE,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Read a cut file back as the words it will contain. Never touches Resolve."""
+    loaded = read_cut_file(cut_file)
+    if loaded.parse_error is not None:
+        raise InvalidRequestError(
+            cause=f"{loaded.path.name} is not readable as a cut file.",
+            fix="Call validate_cut for the parse error, fix it, then read the cut back.",
+            detail={"cut_file": str(loaded.path), "rule": loaded.parse_error.rule},
+        )
+    doc = loaded.doc
+    fps = _fps(doc, loaded.path.name)
+    segments = _segments(doc, loaded.path.name)
+    sources = dict(transcripts or {})
+
+    words_by_source = {alias: _words_of(path) for alias, path in sources.items()}
+    findings: list[Finding] = []
+    rows: list[dict[str, Any]] = []
+    read_back: list[dict[str, Any]] = []
+    at = 0
+
+    for segment in segments:
+        id = str(segment.get("id"))
+        alias = str(segment.get("source"))
+        span = _span(segment, id, loaded.path.name)
+        duration = span[1] - span[0]
+        if alias not in words_by_source:
+            findings.append(
+                _finding("W3", id, f"segment {id} plays {alias!r}, which has no transcript here")
+            )
+            read_back.append(_read(id, alias, at, duration, fps, []))
+            at += duration
+            continue
+
+        kept, clipped = _within(words_by_source[alias], span, fps)
+        for word, edge, frame in clipped:
+            findings.append(
+                _finding(
+                    "W1",
+                    id,
+                    f"segment {id} {edge} halfway through {word['word']!r}",
+                    _FIX_HINTS["W1"].replace("the frame given here", f"frame {frame}"),
+                )
+            )
+        for word, frame in kept:
+            confidence = float(word.get("confidence", 1.0))
+            rows.append(
+                {
+                    "segment": id,
+                    "source": alias,
+                    "word": str(word["word"]),
+                    "confidence": round(confidence, SECONDS_PRECISION),
+                    "at": dual_time(at + frame - span[0], fps),
+                }
+            )
+            if confidence < below:
+                findings.append(
+                    _finding(
+                        "W4",
+                        id,
+                        f"{str(word['word'])!r} is delivered at confidence "
+                        f"{round(confidence, SECONDS_PRECISION)}",
+                    )
+                )
+        read_back.append(_read(id, alias, at, duration, fps, [word for word, _ in kept]))
+        at += duration
+
+    findings.extend(_repeats(read_back))
+    seams = _seams(segments, read_back, doc)
+    findings.extend(_uncovered(seams))
+
+    return _result(loaded, doc, fps, at, read_back, rows, seams, ordered(findings), config)
+
+
+def _result(
+    loaded: Any,
+    doc: Any,
+    fps: float,
+    total: int,
+    read_back: list[dict[str, Any]],
+    rows: list[dict[str, Any]],
+    seams: list[dict[str, Any]],
+    findings: list[Finding],
+    config: Config | None,
+) -> dict[str, Any]:
+    counts = {
+        "words": len(rows),
+        "unsure": sum(1 for finding in findings if finding.rule == "W4"),
+        "clipped": sum(1 for finding in findings if finding.rule == "W1"),
+        "jump_cuts": sum(1 for seam in seams if seam["jump_cut"]),
+        "uncovered": sum(1 for seam in seams if seam["jump_cut"] and seam["covered_by"] is None),
+    }
+    result: dict[str, Any] = {
+        "cut_file": str(loaded.path),
+        "content_hash": loaded.content_hash,
+        "timeline": {"name": _name(doc), "fps": fps},
+        "total": dual_time(total, fps),
+        "text": " ".join(read["text"] for read in read_back if read["text"]),
+        "segments": read_back,
+        "words": rows[:INLINE_WORDS],
+        "truncated": len(rows) > INLINE_WORDS,
+        "spilled_to": None,
+        "seams": seams,
+        "counts": counts,
+        "warnings": [finding.as_dict() for finding in findings],
+    }
+    if result["truncated"]:
+        full = {**result, "words": rows, "truncated": False, "spilled_to": None}
+        result["spilled_to"] = spill(
+            f"{_name(doc)} virtual transcript", full, config or get_config(), fallback="cut"
+        )
+    return result
+
+
+def _read(
+    id: str,
+    alias: str,
+    at: int,
+    duration: int,
+    fps: float,
+    words: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "source": alias,
+        "at": dual_time(at, fps),
+        "duration": dual_time(duration, fps),
+        "words": len(words),
+        "text": " ".join(str(word["word"]).strip() for word in words),
+    }
+
+
+def _within(
+    words: Sequence[Mapping[str, Any]],
+    span: tuple[int, int],
+    fps: float,
+) -> tuple[list[tuple[Mapping[str, Any], int]], list[tuple[Mapping[str, Any], str, int]]]:
+    """Split a source's words against one segment: those wholly inside, and those it cuts.
+
+    A word is kept when both its edges land inside the range, which is the same half-open
+    reading the cut file itself uses. A word overlapping one edge is not silently dropped or
+    silently kept — it is reported, with the frame that would have spared it.
+    """
+    kept: list[tuple[Mapping[str, Any], int]] = []
+    clipped: list[tuple[Mapping[str, Any], str, int]] = []
+    for word in words:
+        start = frames_from_seconds(float(word["start"]), fps, IN_POINT)
+        end = frames_from_seconds(float(word["end"]), fps, OUT_POINT)
+        if end <= span[0] or start >= span[1]:
+            continue
+        if start < span[0]:
+            clipped.append((word, "opens", start))
+        elif end > span[1]:
+            clipped.append((word, "closes", end))
+        else:
+            kept.append((word, start))
+    return kept, clipped
+
+
+def _repeats(read_back: Sequence[Mapping[str, Any]]) -> list[Finding]:
+    """A run of words ending one segment and opening the next — two takes, both kept."""
+    found: list[Finding] = []
+    for earlier, later in zip(read_back, read_back[1:], strict=False):
+        head = _spoken(str(earlier["text"]))
+        tail = _spoken(str(later["text"]))
+        run = next(
+            (
+                length
+                for length in range(min(len(head), len(tail)), 0, -1)
+                if head[-length:] == tail[:length]
+            ),
+            0,
+        )
+        if run >= REPEATED_RUN:
+            said = " ".join(tail[:run])
+            found.append(
+                _finding(
+                    "W2",
+                    str(later["id"]),
+                    f"{said!r} ends {earlier['id']} and opens {later['id']}",
+                )
+            )
+    return found
+
+
+def _seams(
+    segments: Sequence[Mapping[str, Any]],
+    read_back: Sequence[Mapping[str, Any]],
+    doc: Any,
+) -> list[dict[str, Any]]:
+    """Every join between two segments, and whether an overlay rides across it.
+
+    Only a join between two shots of the *same* source is a jump cut: cutting from one
+    camera to another is an ordinary edit, and covering it would be covering nothing.
+    """
+    spans = _overlay_spans(read_back, doc)
+    seams: list[dict[str, Any]] = []
+    for index, (earlier, later) in enumerate(zip(segments, segments[1:], strict=False)):
+        at = int(read_back[index + 1]["at"]["frames"])
+        jump = str(earlier.get("source")) == str(later.get("source"))
+        covering = [id for id, start, end in spans if start < at < end]
+        seams.append(
+            {
+                "between": [str(earlier.get("id")), str(later.get("id"))],
+                "at": read_back[index + 1]["at"],
+                "jump_cut": jump,
+                "covered_by": covering[0] if covering else None,
+            }
+        )
+    return seams
+
+
+def _overlay_spans(
+    read_back: Sequence[Mapping[str, Any]],
+    doc: Any,
+) -> list[tuple[str, int, int]]:
+    """Where each overlay lands on the timeline, resolved through the segment it rides on."""
+    anchors = {str(read["id"]): int(read["at"]["frames"]) for read in read_back}
+    spans: list[tuple[str, int, int]] = []
+    for overlay in doc.get("overlays") or []:
+        if not isinstance(overlay, Mapping):
+            continue
+        over = overlay.get("over")
+        if not isinstance(over, Mapping):
+            continue
+        anchor = anchors.get(str(over.get("segment")))
+        if anchor is None:
+            continue
+        start = anchor + int(over.get("offset", 0))
+        spans.append((str(overlay.get("id")), start, start + _length(overlay)))
+    return spans
+
+
+def _uncovered(seams: Sequence[Mapping[str, Any]]) -> list[Finding]:
+    return [
+        _finding(
+            "W5",
+            str(seam["between"][1]),
+            f"{seam['between'][0]} and {seam['between'][1]} are both one source, uncovered",
+        )
+        for seam in seams
+        if seam["jump_cut"] and seam["covered_by"] is None
+    ]
+
+
+def _length(overlay: Mapping[str, Any]) -> int:
+    return int(overlay.get("out", 0)) - int(overlay.get("in", 0))
+
+
+def _spoken(text: str) -> list[str]:
+    return [word.strip(".,!?").casefold() for word in text.split() if word.strip(".,!?")]
+
+
+def _words_of(path: str) -> list[Mapping[str, Any]]:
+    """A transcript document's words, in the order it wrote them."""
+    document = records.read(_readable(path))
+    words = document.get("words")
+    if not isinstance(words, list):
+        raise InvalidRequestError(
+            cause=f"{path} has no words, so nothing can be read back from it.",
+            fix="Pass the transcript document transcribe_audio wrote, not another job's result.",
+            detail={"transcript": path},
+        )
+    return [word for word in words if isinstance(word, Mapping)]
+
+
+def _readable(path: str) -> Path:
+    found = Path(path)
+    if not found.is_file():
+        raise InvalidRequestError(
+            cause=f"No transcript at {path}.",
+            fix="Call transcribe_audio for the source, then pass the path it reports.",
+            detail={"transcript": path},
+        )
+    return found
+
+
+def _fps(doc: Any, name: str) -> float:
+    timeline = doc.get("timeline") if isinstance(doc, Mapping) else None
+    fps = timeline.get("fps") if isinstance(timeline, Mapping) else None
+    if not isinstance(fps, (int, float)) or isinstance(fps, bool) or fps <= 0:
+        raise InvalidRequestError(
+            cause=f"{name} has no timeline.fps, so words have no frame to land on.",
+            fix="Call validate_cut — timeline.fps is required by the schema.",
+            detail={"cut_file": name},
+        )
+    return float(fps)
+
+
+def _segments(doc: Any, name: str) -> list[Mapping[str, Any]]:
+    segments = doc.get("segments") if isinstance(doc, Mapping) else None
+    if not isinstance(segments, list) or not segments:
+        raise InvalidRequestError(
+            cause=f"{name} has no segments to read back.",
+            fix="Call validate_cut — a cut file needs at least one segment.",
+            detail={"cut_file": name},
+        )
+    return [segment for segment in segments if isinstance(segment, Mapping)]
+
+
+def _span(segment: Mapping[str, Any], id: str, name: str) -> tuple[int, int]:
+    try:
+        span = (int(segment["in"]), int(segment["out"]))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise InvalidRequestError(
+            cause=f"segment {id} in {name} has no readable in/out.",
+            fix="Call validate_cut — in and out are integer frames, half-open [in, out).",
+            detail={"cut_file": name, "segment": id},
+        ) from exc
+    if span[1] <= span[0]:
+        raise InvalidRequestError(
+            cause=f"segment {id} in {name} ends before it starts.",
+            fix="Call validate_cut — ranges are half-open [in, out) with out above in.",
+            detail={"cut_file": name, "segment": id},
+        )
+    return span
+
+
+def _name(doc: Any) -> str:
+    timeline = doc.get("timeline") if isinstance(doc, Mapping) else None
+    name = timeline.get("name") if isinstance(timeline, Mapping) else None
+    return str(name) if name else "cut"
+
+
+def _finding(rule: str, id: str | None, message: str, fix_hint: str | None = None) -> Finding:
+    return Finding(rule=rule, id=id, message=message, fix_hint=fix_hint or _FIX_HINTS[rule])
+
+
+__all__ = ["INLINE_WORDS", "RULE_DESCRIPTIONS", "virtual_transcript"]

--- a/src/resolve_mcp/analysis/virtual.py
+++ b/src/resolve_mcp/analysis/virtual.py
@@ -32,6 +32,8 @@ from typing import Any, Final
 
 from ..config import Config, get_config
 from ..cut.document import read_cut_file
+from ..cut.validate import overlay_positions, positions, total_frames
+from ..document import LoadedDocument
 from ..errors import InvalidRequestError
 from ..findings import Finding, ordered
 from ..spill import spill
@@ -49,21 +51,22 @@ One word repeating across a cut is ordinary English — "and", "the", a name. Tw
 order is the shape of a line delivered twice with both takes kept.
 """
 
-RULE_DESCRIPTIONS: Final[dict[str, str]] = {
-    "W1": "a word is cut in half by a segment boundary",
-    "W2": "the same run of words survives on both sides of a seam",
-    "W3": "a segment's source has no transcript, so its words are unknown",
-    "W4": "a low-confidence word survives into the cut",
-    "W5": "two shots of one source meet at a seam no overlay covers",
-}
-
 _FIX_HINTS: Final[dict[str, str]] = {
-    "W1": "Move the boundary to the frame given here, or keep it if the clip is deliberate.",
-    "W2": "Drop one of the two takes, or make the second an alternate of the first.",
-    "W3": "Transcribe the source and pass it in, or accept that this segment reads as silence.",
-    "W4": "Grab the frame and listen, then fix the wording or let the uncertainty stand.",
-    "W5": "Cover the seam with an overlay anchored to the earlier segment, or accept the jump.",
+    "W3": "Move the boundary to the frame named above, or keep it if the clip is deliberate.",
+    "W4": "Drop one of the two takes, or make the second an alternate of the first.",
+    "W5": "Transcribe the source and pass it in, or accept that this segment reads as silence.",
+    "W6": "Grab the frame and listen, then fix the wording or let the uncertainty stand.",
+    "W7": "Cover the seam with an overlay anchored to the earlier segment, or accept the jump.",
 }
+"""The rules start at W3 because they share a document with ``cut/validate.py``.
+
+That module's rule set already owns W1 and W2 *for the same cut file*, so a second W1
+meaning something else is a trap: an agent holding a validate result and a reading of the
+same file in one session would have two W2s that disagree. One document, one numbering.
+"""
+
+_CLIPPED_HINT: Final = "Move the boundary to frame {frame}, or keep it if the clip is deliberate."
+"""W3 names the frame that would have spared the word, so it is built rather than looked up."""
 
 
 def virtual_transcript(
@@ -86,32 +89,32 @@ def virtual_transcript(
     sources = dict(transcripts or {})
 
     words_by_source = {alias: _words_of(path) for alias, path in sources.items()}
+    spans = {str(segment.get("id")): _span(segment, loaded.path.name) for segment in segments}
+    placed = _placed(doc, loaded.path.name)
     findings: list[Finding] = []
     rows: list[dict[str, Any]] = []
     read_back: list[dict[str, Any]] = []
-    at = 0
 
     for segment in segments:
         id = str(segment.get("id"))
         alias = str(segment.get("source"))
-        span = _span(segment, id, loaded.path.name)
-        duration = span[1] - span[0]
+        span = spans[id]
+        at, duration = placed[id]
         if alias not in words_by_source:
             findings.append(
-                _finding("W3", id, f"segment {id} plays {alias!r}, which has no transcript here")
+                _finding("W5", id, f"segment {id} plays {alias!r}, which has no transcript here")
             )
             read_back.append(_read(id, alias, at, duration, fps, []))
-            at += duration
             continue
 
         kept, clipped = _within(words_by_source[alias], span, fps)
         for word, edge, frame in clipped:
             findings.append(
                 _finding(
-                    "W1",
+                    "W3",
                     id,
                     f"segment {id} {edge} halfway through {word['word']!r}",
-                    _FIX_HINTS["W1"].replace("the frame given here", f"frame {frame}"),
+                    _CLIPPED_HINT.format(frame=frame),
                 )
             )
         for word, frame in kept:
@@ -128,24 +131,24 @@ def virtual_transcript(
             if confidence < below:
                 findings.append(
                     _finding(
-                        "W4",
+                        "W6",
                         id,
                         f"{str(word['word'])!r} is delivered at confidence "
                         f"{round(confidence, SECONDS_PRECISION)}",
                     )
                 )
         read_back.append(_read(id, alias, at, duration, fps, [word for word, _ in kept]))
-        at += duration
 
     findings.extend(_repeats(read_back))
-    seams = _seams(segments, read_back, doc)
+    seams = _seams(segments, placed, doc, fps, loaded.path.name)
     findings.extend(_uncovered(seams))
+    total = total_frames(doc)
 
-    return _result(loaded, doc, fps, at, read_back, rows, seams, ordered(findings), config)
+    return _result(loaded, doc, fps, total, read_back, rows, seams, ordered(findings), config)
 
 
 def _result(
-    loaded: Any,
+    loaded: LoadedDocument,
     doc: Any,
     fps: float,
     total: int,
@@ -157,8 +160,8 @@ def _result(
 ) -> dict[str, Any]:
     counts = {
         "words": len(rows),
-        "unsure": sum(1 for finding in findings if finding.rule == "W4"),
-        "clipped": sum(1 for finding in findings if finding.rule == "W1"),
+        "unsure": sum(1 for finding in findings if finding.rule == "W6"),
+        "clipped": sum(1 for finding in findings if finding.rule == "W3"),
         "jump_cuts": sum(1 for seam in seams if seam["jump_cut"]),
         "uncovered": sum(1 for seam in seams if seam["jump_cut"] and seam["covered_by"] is None),
     }
@@ -247,7 +250,7 @@ def _repeats(read_back: Sequence[Mapping[str, Any]]) -> list[Finding]:
             said = " ".join(tail[:run])
             found.append(
                 _finding(
-                    "W2",
+                    "W4",
                     str(later["id"]),
                     f"{said!r} ends {earlier['id']} and opens {later['id']}",
                 )
@@ -257,24 +260,30 @@ def _repeats(read_back: Sequence[Mapping[str, Any]]) -> list[Finding]:
 
 def _seams(
     segments: Sequence[Mapping[str, Any]],
-    read_back: Sequence[Mapping[str, Any]],
+    placed: Mapping[str, tuple[int, int]],
     doc: Any,
+    fps: float,
+    name: str,
 ) -> list[dict[str, Any]]:
     """Every join between two segments, and whether an overlay rides across it.
 
     Only a join between two shots of the *same* source is a jump cut: cutting from one
     camera to another is an ordinary edit, and covering it would be covering nothing.
+
+    Both sides of the question come from the cut module's own placement — the seam from
+    :func:`positions` and the overlay from :func:`overlay_positions`, the same two functions
+    E9 and the build use. Deriving either here would be measuring a layout nobody builds.
     """
-    spans = _overlay_spans(read_back, doc)
+    spans = _overlay_spans(doc, name)
     seams: list[dict[str, Any]] = []
-    for index, (earlier, later) in enumerate(zip(segments, segments[1:], strict=False)):
-        at = int(read_back[index + 1]["at"]["frames"])
+    for earlier, later in zip(segments, segments[1:], strict=False):
+        at = placed[str(later.get("id"))][0]
         jump = str(earlier.get("source")) == str(later.get("source"))
-        covering = [id for id, start, end in spans if start < at < end]
+        covering = [id for id, (start, length) in spans.items() if start < at < start + length]
         seams.append(
             {
                 "between": [str(earlier.get("id")), str(later.get("id"))],
-                "at": read_back[index + 1]["at"],
+                "at": dual_time(at, fps),
                 "jump_cut": jump,
                 "covered_by": covering[0] if covering else None,
             }
@@ -282,41 +291,28 @@ def _seams(
     return seams
 
 
-def _overlay_spans(
-    read_back: Sequence[Mapping[str, Any]],
-    doc: Any,
-) -> list[tuple[str, int, int]]:
-    """Where each overlay lands on the timeline, resolved through the segment it rides on."""
-    anchors = {str(read["id"]): int(read["at"]["frames"]) for read in read_back}
-    spans: list[tuple[str, int, int]] = []
-    for overlay in doc.get("overlays") or []:
-        if not isinstance(overlay, Mapping):
-            continue
-        over = overlay.get("over")
-        if not isinstance(over, Mapping):
-            continue
-        anchor = anchors.get(str(over.get("segment")))
-        if anchor is None:
-            continue
-        start = anchor + int(over.get("offset", 0))
-        spans.append((str(overlay.get("id")), start, start + _length(overlay)))
-    return spans
+def _overlay_spans(doc: Any, name: str) -> dict[str, tuple[int, int]]:
+    """Where each overlay lands, from the one function that answers that for the build."""
+    try:
+        return overlay_positions(doc)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise InvalidRequestError(
+            cause=f"{name} has an overlay that does not resolve to a position.",
+            fix="Call validate_cut — E9 names the overlay and what is wrong with its anchor.",
+            detail={"cut_file": name},
+        ) from exc
 
 
 def _uncovered(seams: Sequence[Mapping[str, Any]]) -> list[Finding]:
     return [
         _finding(
-            "W5",
+            "W7",
             str(seam["between"][1]),
             f"{seam['between'][0]} and {seam['between'][1]} are both one source, uncovered",
         )
         for seam in seams
         if seam["jump_cut"] and seam["covered_by"] is None
     ]
-
-
-def _length(overlay: Mapping[str, Any]) -> int:
-    return int(overlay.get("out", 0)) - int(overlay.get("in", 0))
 
 
 def _spoken(text: str) -> list[str]:
@@ -370,7 +366,24 @@ def _segments(doc: Any, name: str) -> list[Mapping[str, Any]]:
     return [segment for segment in segments if isinstance(segment, Mapping)]
 
 
-def _span(segment: Mapping[str, Any], id: str, name: str) -> tuple[int, int]:
+def _placed(doc: Any, name: str) -> dict[str, tuple[int, int]]:
+    """Every segment's ``(start, duration)`` — from the cut module, never derived here.
+
+    ``positions`` is what E9 validates against and what the build places against, so a
+    reading that summed its own durations could put a word at a frame no clip occupies.
+    """
+    try:
+        return positions(doc)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise InvalidRequestError(
+            cause=f"{name} has a segment that does not resolve to a position.",
+            fix="Call validate_cut — it names the segment and what is wrong with its range.",
+            detail={"cut_file": name},
+        ) from exc
+
+
+def _span(segment: Mapping[str, Any], name: str) -> tuple[int, int]:
+    id = str(segment.get("id"))
     try:
         span = (int(segment["in"]), int(segment["out"]))
     except (KeyError, TypeError, ValueError) as exc:
@@ -398,4 +411,4 @@ def _finding(rule: str, id: str | None, message: str, fix_hint: str | None = Non
     return Finding(rule=rule, id=id, message=message, fix_hint=fix_hint or _FIX_HINTS[rule])
 
 
-__all__ = ["INLINE_WORDS", "RULE_DESCRIPTIONS", "virtual_transcript"]
+__all__ = ["INLINE_WORDS", "virtual_transcript"]

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..analysis import virtual
+from ..analysis.transcript import DEFAULT_LOW_CONFIDENCE
 from ..resolve import build, cut, takes
 from ..resolve.connection import get_connection
 from .envelope import tool
@@ -39,6 +41,40 @@ def validate_cut(
     """
     connection = get_connection()
     return cut.validate_cut(connection, cut_file, min_segment_frames)
+
+
+@tool
+def virtual_transcript(
+    cut_file: str,
+    transcripts: dict[str, str] | None = None,
+    below: float = DEFAULT_LOW_CONFIDENCE,
+) -> dict[str, Any]:
+    """Read a cut file back as the words it will contain, before building it.
+
+    This is the rough-cut self-review. You assembled A-roll by reading transcripts and
+    choosing takes; this tells you what the assembly now says, so the quality bar is met
+    against the delivered words rather than against your memory of the plan. Needs no
+    project open and touches no timeline — a cut file and its transcripts are documents.
+
+    `transcripts` maps a source alias in the cut file to the transcript document
+    transcribe_audio wrote for that source. Aliases you leave out are reported (W3), not
+    guessed at: a b-roll clip with no speech belongs out of the mapping. `below` is the
+    confidence under which a surviving word is flagged as an uncertainty.
+
+    The result reads the cut back three ways: `text` is the whole thing as prose,
+    `segments` is the same split per shot, and `words` places each word at the frame it
+    lands on (spilled to disk past the inline cap). `seams` reports every join, which ones
+    put two shots of one source together, and the overlay covering each. There is no
+    `errors` list because this cannot produce one — everything it finds is a
+    warning: a word cut in half (W1), a run of words surviving on both sides of a seam
+    because two takes were kept (W2), a source with no transcript (W3), a low-confidence
+    word delivered (W4), and an uncovered same-source seam (W5).
+
+    Nothing here decides anything. Whether a repeat is a retake to drop or an echo you
+    meant, whether filler stays, whether a mid-word cut is sloppy or deliberate — that
+    reading is yours, and no cut is refused on the strength of it.
+    """
+    return virtual.virtual_transcript(cut_file, transcripts, below=below)
 
 
 @tool
@@ -95,8 +131,16 @@ def swap_take(
 TOOLS: tuple[Any, ...] = (
     get_cut_schema,
     validate_cut,
+    virtual_transcript,
     build_timeline,
     swap_take,
 )
 
-__all__ = ["TOOLS", "build_timeline", "get_cut_schema", "swap_take", "validate_cut"]
+__all__ = [
+    "TOOLS",
+    "build_timeline",
+    "get_cut_schema",
+    "swap_take",
+    "validate_cut",
+    "virtual_transcript",
+]

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -65,10 +65,15 @@ def virtual_transcript(
     `segments` is the same split per shot, and `words` places each word at the frame it
     lands on (spilled to disk past the inline cap). `seams` reports every join, which ones
     put two shots of one source together, and the overlay covering each. There is no
-    `errors` list because this cannot produce one — everything it finds is a
-    warning: a word cut in half (W1), a run of words surviving on both sides of a seam
-    because two takes were kept (W2), a source with no transcript (W3), a low-confidence
-    word delivered (W4), and an uncovered same-source seam (W5).
+    `errors` list because this cannot produce one — everything it finds is a warning: a
+    word cut in half (W3), a run of words surviving on both sides of a seam because two
+    takes were kept (W4), a source with no transcript (W5), a low-confidence word
+    delivered (W6), and an uncovered same-source seam (W7). The numbering carries on from
+    validate_cut's W1 and W2 rather than restarting, because both sets of warnings are
+    about the same cut file and a second W1 meaning something else would be a trap.
+
+    W4 compares each seam against the one before it, so two takes of a line separated by
+    another shot read back clean — the doubling this catches is the adjacent kind.
 
     Nothing here decides anything. Whether a repeat is a retake to drop or an echo you
     meant, whether filler stays, whether a mid-word cut is sloppy or deliberate — that

--- a/tests/roughcut.py
+++ b/tests/roughcut.py
@@ -13,13 +13,13 @@ arithmetic disagrees with something readable.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
 from resolve_mcp.analysis import transcript
 from resolve_mcp.analysis.transcript import Word
 
+from . import cutfile
 from .fakes import FakeMediaPoolItem, media_pool, studio
 
 FPS = 24.0
@@ -64,9 +64,8 @@ def a_transcript(tmp_path: Path, words: tuple[Word, ...] = SPOKEN, name: str = "
 
 
 def a_cut(tmp_path: Path, doc: Any, name: str = "interview.cut.json") -> str:
-    path = tmp_path / name
-    path.write_text(json.dumps(doc), encoding="utf-8")
-    return str(path)
+    """The concert fixture's writer, bound to this pillar's file name."""
+    return cutfile.a_cut(tmp_path, doc, name)
 
 
 def delivered(**overrides: Any) -> dict[str, Any]:

--- a/tests/roughcut.py
+++ b/tests/roughcut.py
@@ -1,0 +1,167 @@
+"""The rough-cut substrate the P4 tests share: one talking head, said twice.
+
+The concert fixture in ``cutfile.py`` is three shots over one continuous master mix. A
+rough cut is the other shape — no mix, an A-roll camera that says a line, flubs it, says it
+again, and a b-roll clip that exists only to cover the join. Everything the pillar has to
+prove lives in that one take: a retake to choose between, a jump cut to cover, and a word
+the transcriber was not sure of.
+
+Times are in seconds because transcripts are; frames are 24ths of them because cut files
+are. Both are written out below rather than computed, so a test that disagrees with the
+arithmetic disagrees with something readable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.analysis import transcript
+from resolve_mcp.analysis.transcript import Word
+
+from .fakes import FakeMediaPoolItem, media_pool, studio
+
+FPS = 24.0
+
+SPOKEN: tuple[Word, ...] = (
+    Word("we", 0.0, 0.4, 0.9),
+    Word("start", 0.5, 1.0, 0.9),
+    Word("uh", 1.2, 1.6, 0.8),
+    Word("we", 2.0, 2.4, 0.9),
+    Word("start", 2.5, 3.0, 0.9),
+    Word("here", 3.2, 3.8, 0.9),
+    Word("and", 5.0, 5.4, 0.9),
+    Word("finish", 5.5, 6.2, 0.3),
+)
+"""One pass at camera: a false start, the good take, then a line the model half-heard.
+
+At 24 fps these land on ``we`` [0, 10), ``start`` [12, 24), ``uh`` [28, 39), ``we`` [48,
+58), ``start`` [60, 72), ``here`` [76, 92), ``and`` [120, 130), ``finish`` [132, 149) —
+in-points floored and out-points ceiled, the same snapping the cut file uses.
+"""
+
+GOOD_TAKE = (48, 92)
+"""``we start here`` — the second pass, whole."""
+
+FALSE_START = (0, 26)
+"""``we start`` — the first pass, abandoned."""
+
+CLOSE = (120, 150)
+"""``and finish`` — the line carrying the unsure word."""
+
+
+def a_transcript(tmp_path: Path, words: tuple[Word, ...] = SPOKEN, name: str = "cam_a") -> str:
+    """Write ``words`` as the document ``transcribe_audio`` writes, and return its path."""
+    document = transcript.document(
+        audio={"path": f"D:/media/{name}.mp4", "seconds": 8.0},
+        params={"model": "large-v3"},
+        words=words,
+        silence=[],
+        language="en",
+    )
+    return str(transcript.write(tmp_path / f"{name}.transcript.json", document))
+
+
+def a_cut(tmp_path: Path, doc: Any, name: str = "interview.cut.json") -> str:
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def delivered(**overrides: Any) -> dict[str, Any]:
+    """The rough cut as delivered: the good take, the close, and b-roll over the join.
+
+    The overlay is anchored 36 frames into ``s001`` and runs 16, so it opens before the
+    seam at 44 and closes after it — covering a cut from one camera back to itself.
+    """
+    doc: dict[str, Any] = {
+        "schema": 1,
+        "timeline": {"name": "interview", "fps": FPS},
+        "sources": {
+            "cam_a": {"clip": "A001.mp4", "bin": "A-roll"},
+            "broll_hands": {"clip": "B012.mp4", "bin": "B-roll"},
+        },
+        "segments": [
+            {"id": "s001", "source": "cam_a", "in": GOOD_TAKE[0], "out": GOOD_TAKE[1]},
+            {"id": "s002", "source": "cam_a", "in": CLOSE[0], "out": CLOSE[1]},
+        ],
+        "overlays": [
+            {
+                "id": "b01",
+                "source": "broll_hands",
+                "in": 0,
+                "out": 16,
+                "over": {"segment": "s001", "offset": 36},
+            }
+        ],
+    }
+    doc.update(overrides)
+    return doc
+
+
+def both_takes() -> dict[str, Any]:
+    """The cut before the self-review: the abandoned pass still sitting in front of the good one."""
+    doc = delivered()
+    doc["segments"] = [
+        {"id": "s000", "source": "cam_a", "in": FALSE_START[0], "out": FALSE_START[1]},
+        *doc["segments"],
+    ]
+    doc["overlays"] = []
+    return doc
+
+
+def with_alternate() -> dict[str, Any]:
+    """The delivered cut with the false start kept as a take the director can flip back to.
+
+    An alternate must match its main frame for frame (E8), so the abandoned pass is offered
+    at the good take's length rather than its own.
+    """
+    doc = delivered()
+    length = GOOD_TAKE[1] - GOOD_TAKE[0]
+    doc["segments"][0]["alternates"] = [
+        {"source": "cam_a", "in": 0, "out": length},
+    ]
+    return doc
+
+
+def a_pool(**clips: FakeMediaPoolItem) -> Any:
+    """The pool the rough cut builds against — one A-roll camera, one b-roll clip."""
+    cam = clips.get(
+        "cam_a",
+        FakeMediaPoolItem(
+            "A001.mp4",
+            file_path="D:/media/A001.mp4",
+            properties={"FPS": "24", "Frames": "4000", "Start": "0", "End": "3999"},
+        ),
+    )
+    broll = clips.get(
+        "broll_hands",
+        FakeMediaPoolItem(
+            "B012.mp4",
+            file_path="D:/media/B012.mp4",
+            properties={"FPS": "24", "Frames": "900", "Start": "0", "End": "899"},
+        ),
+    )
+    return media_pool({"A-roll": [cam], "B-roll": [broll]})
+
+
+def a_project(**kwargs: Any) -> Any:
+    """A project holding that pool and no timelines yet."""
+    return studio(timeline=None, timelines=[], pool=a_pool(), **kwargs)
+
+
+__all__ = [
+    "CLOSE",
+    "FALSE_START",
+    "FPS",
+    "GOOD_TAKE",
+    "SPOKEN",
+    "a_cut",
+    "a_pool",
+    "a_project",
+    "a_transcript",
+    "both_takes",
+    "delivered",
+    "with_alternate",
+]

--- a/tests/test_rough_cut_pillar.py
+++ b/tests/test_rough_cut_pillar.py
@@ -1,0 +1,228 @@
+"""The rough-cut pillar, end to end, at the one seam — ticket #47.
+
+Every other test in this suite proves one tool in isolation. This one walks the pillar the
+way a session does, in order, on one cut file: read the transcript, keep the good take,
+offer the abandoned one as an alternate, cover the jump cut with b-roll, validate, build,
+flip the take the way a review round does, read the result back, and mark what the director
+should look at. The value is in the joins — a build that places segments correctly and a
+swap that flips correctly can still not add up to a workflow, and nothing that tests them
+one at a time would notice.
+
+What this cannot prove is the half that is editorial: that the take chosen was the better
+one, that the b-roll is topically right, that the assembly follows the brief. Those are
+judgements over real footage and they go to the director — see the ticket's
+`## Needs from you`. What is provable here is that the mechanism underneath them holds.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.tools import cut as cut_tools
+from resolve_mcp.tools import timeline as timeline_tools
+
+from .conftest import Attach
+from .cutfile import built, placements, selector, shots
+from .roughcut import (
+    CLOSE,
+    FALSE_START,
+    GOOD_TAKE,
+    a_cut,
+    a_project,
+    a_transcript,
+    both_takes,
+    delivered,
+    with_alternate,
+)
+
+TIMELINE = "interview v1"
+
+SOURCE = Path(__file__).resolve().parent.parent / "src" / "resolve_mcp"
+
+PILLAR_DOCUMENTS = re.compile(r"\bbriefs? [/\\] | \bb-?rolls? [/\\]", re.VERBOSE | re.IGNORECASE)
+"""What reading the brief or the catalog would have to look like in source.
+
+The same guard the style layer gets, for the same reason: these two documents are the
+agent's, and the way that breaks is not a failing assertion — it is a convenience landing
+in ``src/`` that opens the catalog "just to check", after which coverage is server
+behaviour. A path shape rather than a word, so prose about b-roll stays allowed.
+"""
+
+
+def test_the_pillars_documents_stay_the_agents() -> None:
+    """No module reaches for a brief or a b-roll catalog by path."""
+    files = sorted(SOURCE.rglob("*.py"))
+    assert len(files) > 20
+
+    for path in files:
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            assert not PILLAR_DOCUMENTS.search(line), f"{path.name}:{number} opens {line!r}"
+
+
+def test_the_assembled_cut_validates_without_a_master_mix(attach: Attach, tmp_path: Path) -> None:
+    """A rough cut has no continuous mix under it — the concert substrate, deliberately absent."""
+    attach(a_project())
+
+    result = cut_tools.validate_cut(a_cut(tmp_path, delivered()))
+
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert result["valid"] is True
+
+
+def test_a_retake_offered_as_an_alternate_validates(attach: Attach, tmp_path: Path) -> None:
+    """E8 is the rule that bites here: an alternate must match its main frame for frame."""
+    attach(a_project())
+
+    result = cut_tools.validate_cut(a_cut(tmp_path, with_alternate()))
+
+    assert result["valid"] is True
+
+
+def test_the_cut_builds_the_a_roll_in_order(attach: Attach, tmp_path: Path) -> None:
+    """AC1's mechanical half: the takes the transcript reading chose, in the order it chose."""
+    resolve = a_project()
+    attach(resolve)
+
+    result = cut_tools.build_timeline(a_cut(tmp_path, delivered()))
+
+    assert result["ok"] is True
+    assert result["timeline"]["name"] == TIMELINE
+    assert placements(built(resolve, TIMELINE)) == [
+        ("A001.mp4", 0, GOOD_TAKE[1] - GOOD_TAKE[0]),
+        ("A001.mp4", GOOD_TAKE[1] - GOOD_TAKE[0], CLOSE[1] - CLOSE[0]),
+    ]
+
+
+def test_the_b_roll_lands_on_v2_across_the_seam(attach: Attach, tmp_path: Path) -> None:
+    """AC3's mechanical half: coverage rides the segment, so it sits over the join at 44."""
+    resolve = a_project()
+    attach(resolve)
+
+    cut_tools.build_timeline(a_cut(tmp_path, delivered()))
+
+    assert placements(built(resolve, TIMELINE), index=2) == [("B012.mp4", 36, 16)]
+
+
+def test_the_retake_is_a_take_the_director_can_flip(attach: Attach, tmp_path: Path) -> None:
+    """AC2: the abandoned pass is not deleted, it is parked in the shot as a second take."""
+    resolve = a_project()
+    attach(resolve)
+    path = a_cut(tmp_path, with_alternate())
+    cut_tools.build_timeline(path)
+
+    first = shots(built(resolve, TIMELINE))[0]
+
+    assert selector(first) == [
+        ("A001.mp4", GOOD_TAKE[0], GOOD_TAKE[1]),
+        ("A001.mp4", FALSE_START[0], GOOD_TAKE[1] - GOOD_TAKE[0]),
+    ]
+
+
+def test_swap_take_flips_the_shot_in_place(attach: Attach, tmp_path: Path) -> None:
+    """AC2 again, from the review round: a note about a take costs one call, not a rebuild."""
+    resolve = a_project()
+    attach(resolve)
+    path = a_cut(tmp_path, with_alternate())
+    cut_tools.build_timeline(path)
+
+    result = cut_tools.swap_take(path, "s001", 2, timeline=TIMELINE)
+
+    assert result["ok"] is True
+    assert shots(built(resolve, TIMELINE))[0].GetSelectedTakeIndex() == 2
+
+
+def test_the_delivered_cut_reads_back_as_one_clean_line(attach: Attach, tmp_path: Path) -> None:
+    """AC4's self-review: the flub is gone, the good take is what the timeline says."""
+    attach(a_project())
+
+    reading = cut_tools.virtual_transcript(
+        a_cut(tmp_path, delivered()),
+        {"cam_a": a_transcript(tmp_path)},
+    )
+
+    assert reading["text"] == "we start here and finish"
+    assert reading["counts"]["uncovered"] == 0
+    assert [one["rule"] for one in reading["warnings"]] == ["W4"]
+
+
+def test_the_self_review_catches_the_assembly_that_kept_both_takes(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The mistake the pillar is most likely to ship: a false start left in front of the take.
+
+    This is the join that matters. Validation passes it — it is a structurally perfect cut
+    file — and the build makes a perfectly good timeline out of it. Only reading the words
+    back says the piece stammers.
+    """
+    attach(a_project())
+    path = a_cut(tmp_path, both_takes())
+
+    assert cut_tools.validate_cut(path)["valid"] is True
+
+    reading = cut_tools.virtual_transcript(path, {"cam_a": a_transcript(tmp_path)})
+
+    assert reading["text"] == "we start we start here and finish"
+    assert [one["rule"] for one in reading["warnings"]] == ["W2", "W4", "W5", "W5"]
+
+
+def test_the_uncertainties_go_onto_the_timeline_as_the_cut_report(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """AC4's other half: the director reads flags on the timeline, not a wall of prose."""
+    resolve = a_project()
+    attach(resolve)
+    path = a_cut(tmp_path, delivered())
+    cut_tools.build_timeline(path)
+    reading = cut_tools.virtual_transcript(path, {"cam_a": a_transcript(tmp_path)})
+
+    result = timeline_tools.set_markers(
+        [_flag(one, reading) for one in reading["warnings"]],
+        timeline=TIMELINE,
+    )
+
+    assert result["ok"] is True
+    marked = timeline_tools.list_markers(timeline=TIMELINE)
+    assert [one["note"] for one in marked["markers"]] == [
+        "'finish' is delivered at confidence 0.3"
+    ]
+
+
+def test_the_whole_pillar_runs_in_one_pass(attach: Attach, tmp_path: Path) -> None:
+    """Assemble, review, fix, rebuild — the loop, with the second version proving the fix.
+
+    The first assembly keeps both takes and reads back stammering; the fix drops the false
+    start and covers the seam; the rebuild is a new version rather than a mutation, and the
+    read-back of that version is the quality bar being met rather than asserted.
+    """
+    resolve = a_project()
+    attach(resolve)
+    path = a_cut(tmp_path, both_takes())
+    cut_tools.build_timeline(path)
+    before = cut_tools.virtual_transcript(path, {"cam_a": a_transcript(tmp_path)})
+
+    assert "W2" in [one["rule"] for one in before["warnings"]]
+
+    fixed = a_cut(tmp_path, delivered(), name="interview.cut.json")
+    result = cut_tools.build_timeline(fixed)
+    after = cut_tools.virtual_transcript(fixed, {"cam_a": a_transcript(tmp_path)})
+
+    assert result["timeline"]["name"] == "interview v2"
+    assert built(resolve, "interview v1") is not None
+    assert "W2" not in [one["rule"] for one in after["warnings"]]
+    assert after["counts"]["uncovered"] == 0
+
+
+def _flag(warning: dict[str, Any], reading: dict[str, Any]) -> dict[str, Any]:
+    """One uncertainty as one marker, at the segment it was found in."""
+    at = next(
+        one["at"]["frames"] for one in reading["segments"] if one["id"] == warning["id"]
+    )
+    return {
+        "frame": at,
+        "color": "Yellow",
+        "name": warning["rule"],
+        "note": warning["message"],
+    }

--- a/tests/test_rough_cut_pillar.py
+++ b/tests/test_rough_cut_pillar.py
@@ -41,14 +41,42 @@ TIMELINE = "interview v1"
 
 SOURCE = Path(__file__).resolve().parent.parent / "src" / "resolve_mcp"
 
-PILLAR_DOCUMENTS = re.compile(r"\bbriefs? [/\\] | \bb-?rolls? [/\\]", re.VERBOSE | re.IGNORECASE)
+PILLAR_DOCUMENTS = re.compile(
+    r"""
+      \bprojects [/\\]     # the per-project directory the two documents live in
+    | \bbriefs? \.md        # or either of them named as the file it is
+    | \bb-?roll \.json
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
 """What reading the brief or the catalog would have to look like in source.
 
 The same guard the style layer gets, for the same reason: these two documents are the
 agent's, and the way that breaks is not a failing assertion — it is a convenience landing
 in ``src/`` that opens the catalog "just to check", after which coverage is server
-behaviour. A path shape rather than a word, so prose about b-roll stays allowed.
+behaviour.
+
+Written against the layout ``docs/agents/rough-cut.md`` documents —
+``projects/<project>/brief.md`` and ``projects/<project>/broll.json`` — because a guard
+matching a shape nothing uses passes forever while proving nothing. It is deliberately a
+path shape: prose about b-roll is what these modules *should* carry, and ``broll_pan`` is
+already a source alias in the schema example.
 """
+
+PROBES = (
+    ('open("projects/demo/broll.json")', True),
+    ('Path("projects") / project / "brief.md"', True),
+    ('"source": "broll_pan"', False),
+    ("b-roll rides the segment it covers", False),
+)
+"""Lines the guard must and must not catch — the assertion that the assertion works."""
+
+
+def test_the_guard_catches_what_it_is_written_for() -> None:
+    """A regex guard that matches nothing is a test that passes for the wrong reason."""
+    assert [bool(PILLAR_DOCUMENTS.search(line)) for line, _ in PROBES] == [
+        caught for _, caught in PROBES
+    ]
 
 
 def test_the_pillars_documents_stay_the_agents() -> None:
@@ -145,7 +173,7 @@ def test_the_delivered_cut_reads_back_as_one_clean_line(attach: Attach, tmp_path
 
     assert reading["text"] == "we start here and finish"
     assert reading["counts"]["uncovered"] == 0
-    assert [one["rule"] for one in reading["warnings"]] == ["W4"]
+    assert [one["rule"] for one in reading["warnings"]] == ["W6"]
 
 
 def test_the_self_review_catches_the_assembly_that_kept_both_takes(
@@ -165,7 +193,7 @@ def test_the_self_review_catches_the_assembly_that_kept_both_takes(
     reading = cut_tools.virtual_transcript(path, {"cam_a": a_transcript(tmp_path)})
 
     assert reading["text"] == "we start we start here and finish"
-    assert [one["rule"] for one in reading["warnings"]] == ["W2", "W4", "W5", "W5"]
+    assert [one["rule"] for one in reading["warnings"]] == ["W4", "W6", "W7", "W7"]
 
 
 def test_the_uncertainties_go_onto_the_timeline_as_the_cut_report(
@@ -203,7 +231,7 @@ def test_the_whole_pillar_runs_in_one_pass(attach: Attach, tmp_path: Path) -> No
     cut_tools.build_timeline(path)
     before = cut_tools.virtual_transcript(path, {"cam_a": a_transcript(tmp_path)})
 
-    assert "W2" in [one["rule"] for one in before["warnings"]]
+    assert "W4" in [one["rule"] for one in before["warnings"]]
 
     fixed = a_cut(tmp_path, delivered(), name="interview.cut.json")
     result = cut_tools.build_timeline(fixed)
@@ -211,7 +239,7 @@ def test_the_whole_pillar_runs_in_one_pass(attach: Attach, tmp_path: Path) -> No
 
     assert result["timeline"]["name"] == "interview v2"
     assert built(resolve, "interview v1") is not None
-    assert "W2" not in [one["rule"] for one in after["warnings"]]
+    assert "W4" not in [one["rule"] for one in after["warnings"]]
     assert after["counts"]["uncovered"] == 0
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -37,6 +37,7 @@ def test_registers_the_p1_session_media_timeline_cut_titling_render_and_job_tool
         "import_timeline",
         "get_cut_schema",
         "validate_cut",
+        "virtual_transcript",
         "build_timeline",
         "get_titles_schema",
         "validate_titles",

--- a/tests/test_virtual_transcript.py
+++ b/tests/test_virtual_transcript.py
@@ -1,0 +1,389 @@
+"""Reading a cut back as the words it will contain.
+
+The measurement is a pure reading of two documents, so almost everything here runs with no
+Resolve in sight; the two tool-level tests exist because the envelope still echoes project
+context, and that is the only part of this that needs a handle at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.analysis import virtual
+from resolve_mcp.analysis.transcript import Word
+from resolve_mcp.config import Config
+from resolve_mcp.errors import InvalidRequestError
+from resolve_mcp.tools import cut as cut_tools
+
+from .conftest import Attach
+from .fakes import studio
+from .roughcut import (
+    CLOSE,
+    FPS,
+    GOOD_TAKE,
+    SPOKEN,
+    a_cut,
+    a_transcript,
+    both_takes,
+    delivered,
+)
+
+
+def a_reading(tmp_path: Path, doc: Any, **kwargs: Any) -> dict[str, Any]:
+    """The cut read back, with cam_a's transcript supplied unless a test says otherwise."""
+    transcripts = kwargs.pop("transcripts", None)
+    if transcripts is None:
+        transcripts = {"cam_a": a_transcript(tmp_path)}
+    return virtual.virtual_transcript(a_cut(tmp_path, doc), transcripts, **kwargs)
+
+
+def rules(reading: dict[str, Any]) -> list[str]:
+    return [finding["rule"] for finding in reading["warnings"]]
+
+
+def messages(reading: dict[str, Any], rule: str) -> list[str]:
+    return [one["message"] for one in reading["warnings"] if one["rule"] == rule]
+
+
+def test_the_cut_reads_back_as_the_words_it_kept(tmp_path: Path) -> None:
+    """The whole point: what does the assembly say, now that the takes are chosen?"""
+    reading = a_reading(tmp_path, delivered())
+
+    assert reading["text"] == "we start here and finish"
+
+
+def test_each_segment_reads_back_on_its_own(tmp_path: Path) -> None:
+    """Per shot, so a line that reads wrong can be traced to the segment that carries it."""
+    reading = a_reading(tmp_path, delivered())
+
+    assert [(one["id"], one["text"]) for one in reading["segments"]] == [
+        ("s001", "we start here"),
+        ("s002", "and finish"),
+    ]
+
+
+def test_every_word_lands_at_the_frame_the_build_will_put_it_at(tmp_path: Path) -> None:
+    """Source frames in, timeline frames out — the conversion nobody should do by hand.
+
+    ``we`` opens the good take, so it lands at 0 even though it is frame 48 of the camera;
+    ``and`` opens the second segment, so it lands at the seam, 44 frames in.
+    """
+    reading = a_reading(tmp_path, delivered())
+
+    assert [(one["word"], one["at"]["frames"]) for one in reading["words"]] == [
+        ("we", 0),
+        ("start", 12),
+        ("here", 28),
+        ("and", 44),
+        ("finish", 56),
+    ]
+
+
+def test_the_reading_echoes_the_cut_it_read(tmp_path: Path) -> None:
+    """The content hash is how a self-review is pinned to the exact cut state it reviewed."""
+    path = a_cut(tmp_path, delivered())
+
+    reading = virtual.virtual_transcript(path, {"cam_a": a_transcript(tmp_path)})
+
+    assert reading["cut_file"] == path
+    assert reading["content_hash"]
+    assert reading["timeline"] == {"name": "interview", "fps": FPS}
+    assert reading["total"]["frames"] == 74
+
+
+def test_a_word_the_cut_chops_in_half_is_reported(tmp_path: Path) -> None:
+    """``here`` runs to frame 92; a cut at 90 takes two thirds of it and leaves a fragment."""
+    doc = delivered()
+    doc["segments"][0]["out"] = 90
+
+    reading = a_reading(tmp_path, doc)
+
+    assert "W1" in rules(reading)
+    assert "'here'" in messages(reading, "W1")[0]
+
+
+def test_a_chopped_word_names_the_frame_that_would_have_spared_it(tmp_path: Path) -> None:
+    """A finding that only says "too early" costs a round trip to find out by how much."""
+    doc = delivered()
+    doc["segments"][0]["out"] = 90
+
+    reading = a_reading(tmp_path, doc)
+    hint = next(one["fix_hint"] for one in reading["warnings"] if one["rule"] == "W1")
+
+    assert "frame 92" in hint
+
+
+def test_a_chopped_word_is_not_counted_as_delivered(tmp_path: Path) -> None:
+    """A fragment is not a word the cut says, so it stays out of the read-back."""
+    doc = delivered()
+    doc["segments"][0]["out"] = 90
+
+    reading = a_reading(tmp_path, doc)
+
+    assert reading["segments"][0]["text"] == "we start"
+
+
+def test_the_same_line_surviving_twice_is_reported(tmp_path: Path) -> None:
+    """The false start left in front of the good take — the failure this pillar exists to catch."""
+    reading = a_reading(tmp_path, both_takes())
+
+    assert "W2" in rules(reading)
+    assert "'we start'" in messages(reading, "W2")[0]
+
+
+def test_one_word_repeating_across_a_seam_is_not_reported(tmp_path: Path) -> None:
+    """"and" ending one shot and opening the next is ordinary English, not a doubled take."""
+    words = (
+        Word("so", 0.0, 0.4, 0.9),
+        Word("and", 0.5, 1.0, 0.9),
+        Word("and", 2.0, 2.4, 0.9),
+        Word("then", 2.5, 3.0, 0.9),
+    )
+    doc = delivered()
+    doc["segments"] = [
+        {"id": "s001", "source": "cam_a", "in": 0, "out": 26},
+        {"id": "s002", "source": "cam_a", "in": 48, "out": 74},
+    ]
+    doc["overlays"] = []
+
+    reading = a_reading(tmp_path, doc, transcripts={"cam_a": a_transcript(tmp_path, words)})
+
+    assert reading["text"] == "so and and then"
+    assert "W2" not in rules(reading)
+
+
+def test_a_source_with_no_transcript_is_reported_not_guessed_at(tmp_path: Path) -> None:
+    """Silence in the read-back could mean "said nothing" or "nobody looked" — say which."""
+    reading = a_reading(tmp_path, delivered(), transcripts={})
+
+    assert rules(reading).count("W3") == 2
+    assert reading["text"] == ""
+
+
+def test_a_segment_with_no_transcript_still_holds_its_place(tmp_path: Path) -> None:
+    """Its words are unknown, but its frames are not: everything after it still lands right."""
+    reading = a_reading(tmp_path, delivered(), transcripts={})
+
+    assert [one["at"]["frames"] for one in reading["segments"]] == [0, 44]
+    assert reading["total"]["frames"] == 74
+
+
+def test_a_word_the_transcriber_was_unsure_of_is_flagged_where_it_is_delivered(
+    tmp_path: Path,
+) -> None:
+    """The uncertainty the cut report carries: it survived the edit, so it needs a listen."""
+    reading = a_reading(tmp_path, delivered())
+
+    assert messages(reading, "W4") == ["'finish' is delivered at confidence 0.3"]
+
+
+def test_an_unsure_word_left_out_of_the_cut_is_not_flagged(tmp_path: Path) -> None:
+    """Only delivered words are uncertainties; one that was cut is not the director's problem."""
+    doc = delivered()
+    doc["segments"] = [doc["segments"][0]]
+    doc["overlays"] = []
+
+    reading = a_reading(tmp_path, doc)
+
+    assert "W4" not in rules(reading)
+
+
+def test_the_confidence_floor_moves(tmp_path: Path) -> None:
+    """A noisy shoot flags everything at the default; the floor is the agent's to set."""
+    reading = a_reading(tmp_path, delivered(), below=0.2)
+
+    assert "W4" not in rules(reading)
+
+
+def test_a_cut_from_one_camera_back_to_itself_is_a_jump_cut(tmp_path: Path) -> None:
+    reading = a_reading(tmp_path, delivered())
+
+    assert [one["jump_cut"] for one in reading["seams"]] == [True]
+    assert reading["seams"][0]["at"]["frames"] == 44
+
+
+def test_a_cut_between_two_cameras_is_not(tmp_path: Path) -> None:
+    """Covering an ordinary A-to-B edit would be covering nothing."""
+    doc = delivered()
+    doc["segments"][1]["source"] = "broll_hands"
+    doc["segments"][1]["in"] = 0
+    doc["segments"][1]["out"] = 30
+
+    reading = a_reading(tmp_path, doc)
+
+    assert [one["jump_cut"] for one in reading["seams"]] == [False]
+    assert "W5" not in rules(reading)
+
+
+def test_an_overlay_riding_across_the_seam_covers_it(tmp_path: Path) -> None:
+    """b01 opens at 36 and closes at 52; the seam is at 44, so the jump is hidden."""
+    reading = a_reading(tmp_path, delivered())
+
+    assert reading["seams"][0]["covered_by"] == "b01"
+    assert "W5" not in rules(reading)
+
+
+def test_an_uncovered_jump_cut_is_reported(tmp_path: Path) -> None:
+    doc = delivered()
+    doc["overlays"] = []
+
+    reading = a_reading(tmp_path, doc)
+
+    assert "W5" in rules(reading)
+    assert reading["seams"][0]["covered_by"] is None
+
+
+def test_an_overlay_that_stops_short_of_the_seam_does_not_cover_it(tmp_path: Path) -> None:
+    """Anchored coverage is a span, not an intention — 36 to 44 ends exactly at the join."""
+    doc = delivered()
+    doc["overlays"][0]["out"] = 8
+
+    reading = a_reading(tmp_path, doc)
+
+    assert reading["seams"][0]["covered_by"] is None
+    assert "W5" in rules(reading)
+
+
+def test_the_counts_summarise_what_the_findings_say(tmp_path: Path) -> None:
+    """The line a cut report opens with, so nobody counts findings by hand."""
+    reading = a_reading(tmp_path, delivered())
+
+    assert reading["counts"] == {
+        "words": 5,
+        "unsure": 1,
+        "clipped": 0,
+        "jump_cuts": 1,
+        "uncovered": 0,
+    }
+
+
+def test_nothing_here_blocks_a_cut(tmp_path: Path) -> None:
+    """Every rule is a warning: this measures a cut, it never refuses one."""
+    doc = both_takes()
+    doc["segments"][1]["out"] = 90
+
+    reading = a_reading(tmp_path, doc)
+
+    assert set(rules(reading)) >= {"W1", "W2", "W5"}
+    assert all(rule.startswith("W") for rule in rules(reading))
+    assert "errors" not in reading
+
+
+def test_a_long_reading_goes_to_disk(tmp_path: Path) -> None:
+    """Past the inline cap the words are a file to grep, not a tool result to truncate."""
+    words = tuple(
+        Word(f"word{index}", index * 0.5, index * 0.5 + 0.4, 0.9)
+        for index in range(virtual.INLINE_WORDS + 50)
+    )
+    doc = delivered()
+    doc["segments"] = [{"id": "s001", "source": "cam_a", "in": 0, "out": 3100}]
+    doc["overlays"] = []
+    config = Config.from_env({"RESOLVE_MCP_CACHE": str(tmp_path / "cache")})
+
+    reading = a_reading(
+        tmp_path,
+        doc,
+        transcripts={"cam_a": a_transcript(tmp_path, words)},
+        config=config,
+    )
+
+    assert reading["truncated"] is True
+    assert len(reading["words"]) == virtual.INLINE_WORDS
+    assert Path(reading["spilled_to"]).is_file()
+
+
+def test_a_short_reading_stays_inline(tmp_path: Path) -> None:
+    reading = a_reading(tmp_path, delivered())
+
+    assert reading["truncated"] is False
+    assert reading["spilled_to"] is None
+
+
+def test_a_transcript_that_is_not_there_says_so(tmp_path: Path) -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        a_reading(tmp_path, delivered(), transcripts={"cam_a": str(tmp_path / "nope.json")})
+
+    assert "No transcript" in raised.value.cause
+    assert "transcribe_audio" in (raised.value.fix or "")
+
+
+def test_a_document_that_is_not_a_transcript_says_so(tmp_path: Path) -> None:
+    """A beats file and a transcript are both analysis JSON; only one has words in it."""
+    other = tmp_path / "beats.json"
+    other.write_text('{"kind": "beats", "beats": []}', encoding="utf-8")
+
+    with pytest.raises(InvalidRequestError) as raised:
+        a_reading(tmp_path, delivered(), transcripts={"cam_a": str(other)})
+
+    assert "no words" in raised.value.cause
+
+
+def test_a_cut_file_with_no_segments_is_sent_to_validate_cut(tmp_path: Path) -> None:
+    """This is a reading, not a second validator — one place owns what a cut file must be."""
+    doc = delivered()
+    doc["segments"] = []
+
+    with pytest.raises(InvalidRequestError) as raised:
+        a_reading(tmp_path, doc)
+
+    assert "validate_cut" in (raised.value.fix or "")
+
+
+def test_a_cut_file_that_is_not_json_is_sent_to_validate_cut(tmp_path: Path) -> None:
+    path = tmp_path / "broken.cut.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(InvalidRequestError) as raised:
+        virtual.virtual_transcript(str(path), {})
+
+    assert "validate_cut" in (raised.value.fix or "")
+
+
+def test_a_cut_file_with_no_fps_is_sent_to_validate_cut(tmp_path: Path) -> None:
+    """Without a frame rate a word in seconds has no frame to land on."""
+    doc = delivered()
+    doc["timeline"] = {"name": "interview"}
+
+    with pytest.raises(InvalidRequestError) as raised:
+        a_reading(tmp_path, doc)
+
+    assert "timeline.fps" in raised.value.cause
+
+
+def test_the_tool_returns_the_reading_in_an_envelope(attach: Attach, tmp_path: Path) -> None:
+    """Through the tool layer: the payload is the reading, and context rides along as always."""
+    attach(studio())
+
+    result = cut_tools.virtual_transcript(
+        a_cut(tmp_path, delivered()),
+        {"cam_a": a_transcript(tmp_path)},
+    )
+
+    assert result["ok"] is True
+    assert result["text"] == "we start here and finish"
+    assert "context" in result
+
+
+def test_the_tool_reports_a_missing_transcript_as_a_failed_envelope(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Never an exception across the tool boundary, never a traceback in the payload."""
+    attach(studio())
+
+    result = cut_tools.virtual_transcript(
+        a_cut(tmp_path, delivered()),
+        {"cam_a": str(tmp_path / "nope.json")},
+    )
+
+    assert result["ok"] is False
+    assert "transcribe_audio" in result["error"]["fix"]
+
+
+def test_the_good_take_is_the_one_the_fixture_delivers() -> None:
+    """Guards the fixture itself: the frames below are what every assertion above reads."""
+    assert GOOD_TAKE == (48, 92)
+    assert CLOSE == (120, 150)
+    assert len(SPOKEN) == 8

--- a/tests/test_virtual_transcript.py
+++ b/tests/test_virtual_transcript.py
@@ -101,8 +101,8 @@ def test_a_word_the_cut_chops_in_half_is_reported(tmp_path: Path) -> None:
 
     reading = a_reading(tmp_path, doc)
 
-    assert "W1" in rules(reading)
-    assert "'here'" in messages(reading, "W1")[0]
+    assert "W3" in rules(reading)
+    assert "'here'" in messages(reading, "W3")[0]
 
 
 def test_a_chopped_word_names_the_frame_that_would_have_spared_it(tmp_path: Path) -> None:
@@ -111,7 +111,7 @@ def test_a_chopped_word_names_the_frame_that_would_have_spared_it(tmp_path: Path
     doc["segments"][0]["out"] = 90
 
     reading = a_reading(tmp_path, doc)
-    hint = next(one["fix_hint"] for one in reading["warnings"] if one["rule"] == "W1")
+    hint = next(one["fix_hint"] for one in reading["warnings"] if one["rule"] == "W3")
 
     assert "frame 92" in hint
 
@@ -130,8 +130,8 @@ def test_the_same_line_surviving_twice_is_reported(tmp_path: Path) -> None:
     """The false start left in front of the good take — the failure this pillar exists to catch."""
     reading = a_reading(tmp_path, both_takes())
 
-    assert "W2" in rules(reading)
-    assert "'we start'" in messages(reading, "W2")[0]
+    assert "W4" in rules(reading)
+    assert "'we start'" in messages(reading, "W4")[0]
 
 
 def test_one_word_repeating_across_a_seam_is_not_reported(tmp_path: Path) -> None:
@@ -152,14 +152,14 @@ def test_one_word_repeating_across_a_seam_is_not_reported(tmp_path: Path) -> Non
     reading = a_reading(tmp_path, doc, transcripts={"cam_a": a_transcript(tmp_path, words)})
 
     assert reading["text"] == "so and and then"
-    assert "W2" not in rules(reading)
+    assert "W4" not in rules(reading)
 
 
 def test_a_source_with_no_transcript_is_reported_not_guessed_at(tmp_path: Path) -> None:
     """Silence in the read-back could mean "said nothing" or "nobody looked" — say which."""
     reading = a_reading(tmp_path, delivered(), transcripts={})
 
-    assert rules(reading).count("W3") == 2
+    assert rules(reading).count("W5") == 2
     assert reading["text"] == ""
 
 
@@ -177,7 +177,7 @@ def test_a_word_the_transcriber_was_unsure_of_is_flagged_where_it_is_delivered(
     """The uncertainty the cut report carries: it survived the edit, so it needs a listen."""
     reading = a_reading(tmp_path, delivered())
 
-    assert messages(reading, "W4") == ["'finish' is delivered at confidence 0.3"]
+    assert messages(reading, "W6") == ["'finish' is delivered at confidence 0.3"]
 
 
 def test_an_unsure_word_left_out_of_the_cut_is_not_flagged(tmp_path: Path) -> None:
@@ -188,14 +188,14 @@ def test_an_unsure_word_left_out_of_the_cut_is_not_flagged(tmp_path: Path) -> No
 
     reading = a_reading(tmp_path, doc)
 
-    assert "W4" not in rules(reading)
+    assert "W6" not in rules(reading)
 
 
 def test_the_confidence_floor_moves(tmp_path: Path) -> None:
     """A noisy shoot flags everything at the default; the floor is the agent's to set."""
     reading = a_reading(tmp_path, delivered(), below=0.2)
 
-    assert "W4" not in rules(reading)
+    assert "W6" not in rules(reading)
 
 
 def test_a_cut_from_one_camera_back_to_itself_is_a_jump_cut(tmp_path: Path) -> None:
@@ -215,7 +215,7 @@ def test_a_cut_between_two_cameras_is_not(tmp_path: Path) -> None:
     reading = a_reading(tmp_path, doc)
 
     assert [one["jump_cut"] for one in reading["seams"]] == [False]
-    assert "W5" not in rules(reading)
+    assert "W7" not in rules(reading)
 
 
 def test_an_overlay_riding_across_the_seam_covers_it(tmp_path: Path) -> None:
@@ -223,7 +223,7 @@ def test_an_overlay_riding_across_the_seam_covers_it(tmp_path: Path) -> None:
     reading = a_reading(tmp_path, delivered())
 
     assert reading["seams"][0]["covered_by"] == "b01"
-    assert "W5" not in rules(reading)
+    assert "W7" not in rules(reading)
 
 
 def test_an_uncovered_jump_cut_is_reported(tmp_path: Path) -> None:
@@ -232,7 +232,7 @@ def test_an_uncovered_jump_cut_is_reported(tmp_path: Path) -> None:
 
     reading = a_reading(tmp_path, doc)
 
-    assert "W5" in rules(reading)
+    assert "W7" in rules(reading)
     assert reading["seams"][0]["covered_by"] is None
 
 
@@ -244,7 +244,7 @@ def test_an_overlay_that_stops_short_of_the_seam_does_not_cover_it(tmp_path: Pat
     reading = a_reading(tmp_path, doc)
 
     assert reading["seams"][0]["covered_by"] is None
-    assert "W5" in rules(reading)
+    assert "W7" in rules(reading)
 
 
 def test_the_counts_summarise_what_the_findings_say(tmp_path: Path) -> None:
@@ -267,7 +267,7 @@ def test_nothing_here_blocks_a_cut(tmp_path: Path) -> None:
 
     reading = a_reading(tmp_path, doc)
 
-    assert set(rules(reading)) >= {"W1", "W2", "W5"}
+    assert set(rules(reading)) >= {"W3", "W4", "W7"}
     assert all(rule.startswith("W") for rule in rules(reading))
     assert "errors" not in reading
 


### PR DESCRIPTION
Closes #47.

## What this is

#47 is a pillar-validation ticket: the rough cut proven end to end. Most of its four ACs
are editorial judgements over real footage, which no seam can check. So this builds the
pieces the pillar needed and did not have, proves the mechanical half at the fake tier, and
routes the editorial half to the director — listed under `## Needs from you` on the ticket.

**`virtual_transcript`** — the P4 counterpart to `correlate_timeline`. Given a cut file and
the transcripts of its sources, it derives what the built timeline will actually say: the
words in cut order at the frames they land on, plus what a self-review needs — words cut in
half (W3), a run surviving on both sides of a seam because two takes were kept (W4), a
source with no transcript (W5), low-confidence words delivered (W6), and same-source seams
no overlay covers (W7). It touches no Resolve handle.

The failure it exists to catch: a cut file that keeps a false start in front of the good
take is structurally perfect — it validates, it builds, it plays — and only reading the
words back says the piece stammers. `test_the_self_review_catches_the_assembly_that_kept_both_takes`
is exactly that.

Every rule is a warning and there is no `errors` list, because nothing here is a judgement.
Following `analysis/transcript.py` ("Nothing is called a flub"), filler is not flagged at
all: whether an "um" carries thought or stalls is what the brief settles, not a detector.

**`docs/agents/rough-cut.md`** — the two documents the agent owns (the per-project brief and
the b-roll catalog), the assembly loop, the self-review and the cut report.

**Seam that verifies it** (per CLAUDE.md): the pure-function tier for the measurement — a
cut file and its transcripts are both documents, so no seam is involved — plus the one
primary seam for `tests/test_rough_cut_pillar.py`, which walks assemble → validate → build →
swap → read back → mark against the fake Resolve. Fake tier, mypy strict and ruff all clean.

## Review

`/code-review` against `origin/main`, two axes in parallel sub-agents.

### Standards — 5 documented breaches, 6 baseline smells

1. **Re-derived positions (hard).** `virtual.py` summed its own segment durations and
   resolved its own overlay anchors, while `cut/validate.py` says of those numbers "there is
   only this one" — E9 validates against them and the build places against them. A reading
   that derives its own layout can report a word at a frame no clip occupies, which is
   precisely the drift this tool exists to detect. **Fixed:** positions now come from
   `positions()`, `overlay_positions()` and `total_frames()`. The frame assertions did not
   move, which is the evidence the two derivations agreed today; now they cannot stop.
2. **Rule codes collided (hard).** W1/W2 already mean flash-frame and audio-span mismatch
   for the *same cut file*; a session holding a validate result and a reading of that file
   would have had two W2s that disagree. **Fixed:** renumbered W3–W7, with the reason
   recorded next to the table.
3. **`RULE_DESCRIPTIONS` exported, never consumed.** **Fixed:** deleted — the tool docstring
   is the catalog an MCP agent actually reads.
4. **`loaded: Any`** where `read_cut_file` returns `LoadedDocument`. **Fixed.**
5. **No CLAUDE.md entry** for the new agent doc, the only one of five without one. **Fixed.**

Smells: `roughcut.a_cut` duplicated `cutfile.a_cut` (**fixed** — delegates); the W3 fix hint
built its frame number via `.replace()` on the constant's wording, so rewording it would
have silently dropped the number (**fixed** — an explicit template); `_fps`/`_name` repeat a
small walk, `_result` takes nine parameters, `span` is a bare tuple where `correlate.py`
would use a `NamedTuple`, and one message chain (**not fixed** — judgement calls, and the
nine-parameter `_result` is the honest shape of "one reading, assembled once").

### Spec — reading judged faithful; 3 findings

1. **The guard was inert (c).** `rough-cut.md` claimed a guard that no module names these
   documents by path; the regex required a *directory* named `brief/` while the documented
   layout is `projects/<project>/brief.md`, so it would have passed forever proving nothing.
   **Fixed:** it now matches the documented layout, and `test_the_guard_catches_what_it_is_written_for`
   asserts it catches what it is written for and still ignores the `broll_pan` alias in the
   schema example.
2. **B-roll catalog location departed from a settled convention (a).** `style-layer.md`
   records the director's 2026-08-07 confirmation that sidecars stay in the repo, one file
   per project. `projects/<project>/broll.json` honours that principle but invents a
   directory without saying why. **Fixed in the doc:** the rationale is now stated — they
   are not under `styles/` because that layer is taste, and a brief is not taste — along
   with what it would cost to move them if the director prefers one agent-owned root.
   Flagged on the ticket as theirs to overrule.
3. **Cut report has no home in `src/` (a).** Delivered as prose plus markers via
   `set_markers`. **Not changed, deliberately:** which flags are worth the director's
   attention is the judgement the server is supposed to stay out of. Now said explicitly in
   the doc.

Also noted and now documented rather than changed: W4 compares adjacent seams only, so two
takes of a line with another shot between them read back clean — the doubling it catches is
the adjacent kind, which is where a false start actually lands. Tool-count drift (39
registered vs the spec's "32 + `run_python`") predates this diff.

Fix diff re-checked on its own; fake tier, mypy strict and ruff clean after it.

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
