### PR TITLE
fix: read a shot's source frames off its left offset (#120)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -169,7 +169,9 @@ see. Live tier: `test_live_smoke.py` (module-level
 
 - `docs/adr/` — 0001 interpreter must be a registered install; 0002
   analysis models are injected; 0003 stems fingerprinted (path is a
-  content hash).
+  content hash); 0004 editor-state getters answer only for the current
+  timeline; 0005 source frames are read off the left offset, not the
+  source start.
 - `docs/agents/` — issue-tracker conventions (wayfinder map ops), triage
   labels, domain-docs usage, the style layer (sidecar + profile formats,
   provenance tags, how a corpus pass is run), the rough-cut pillar

--- a/docs/adr/0005-source-frames-are-read-off-the-left-offset.md
+++ b/docs/adr/0005-source-frames-are-read-off-the-left-offset.md
@@ -87,6 +87,12 @@ real retime and is believed.
   21.0.3.7, so a retimed shot cannot be created through the scripting API at all; only a
   human retiming in the GUI produces one. The branch is held by a fake alone, and the fake's
   numbers are reasoned from the measured exclusivity rather than measured directly.
+- The exclusivity itself is not left to the fakes, but it had to be asserted in the right
+  place. The live take-selector test now checks `source.out` on the shot *before* the swap,
+  where both getters read true and a wrapper that adds one to the end reports a 48-frame
+  shot covering 49 source frames. On the swapped shot the two defects cancel — the start
+  getter loses the frame the `+ 1` adds back — so asserting there would have passed either
+  way and proved nothing.
 - The slip's arithmetic is unexplained. It is not a cumulative timecode drift — it does not
   grow over 69001 frames — and pinning the exact function was not needed to stop trusting the
   getter. If a future build changes the bound, `SOURCE_SLIP` is the one number to re-measure.

--- a/docs/adr/0005-source-frames-are-read-off-the-left-offset.md
+++ b/docs/adr/0005-source-frames-are-read-off-the-left-offset.md
@@ -1,0 +1,92 @@
+# ADR 0005 — A shot's source frames are read off its left offset, not its source start
+
+- **Status**: accepted
+- **Date**: 2026-08-07
+- **Context**: [#120](https://github.com/danielbaldwin47/resolve-mcp/issues/120), found during
+  the #119 Section B clean-baseline run against Resolve Studio 21.0.3.7
+
+## Context
+
+`swap_take` reported that it had put a shot on source frame 108 and the timeline read back
+107. The ticket opened on the theory that `AddTake` reads `endFrame` inclusive where
+`AppendToTimeline` reads it half-open — an off-by-one on the *write*.
+
+It is not. `AddTake` stores exactly the half-open range it is given, and Resolve plays it:
+a take sent `(108, 156)` reads back `GetTakeByIndex → {startFrame: 108, endFrame: 156}` and
+`GetLeftOffset → 108`. The write was never wrong. **`GetSourceStartFrame` misreports.**
+
+### The sweep
+
+One shot on a 23.976 timeline, the same range placed at consecutive source starts, each read
+back through both getters:
+
+| requested | 100 | 101 | 102 | 103 | 104 | 105 | 106 | 107 | 108 | 109 | 110 | 111 | 112 | 113 | 114 |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `GetLeftOffset` | 100 | 101 | 102 | 103 | 104 | 105 | 106 | 107 | 108 | 109 | 110 | 111 | 112 | 113 | 114 |
+| `GetSourceStartFrame` | 100 | 101 | 102 | **102** | **103** | 105 | 106 | **106** | **107** | **108** | 110 | 111 | **111** | **112** | 114 |
+
+Three things make the reading trustworthy:
+
+- **It is deterministic.** Re-running the sweep reproduced the sequence value for value.
+- **It is bounded.** Extending the sweep to source frames 0, 1, 2, 3, 47, 48, 72, 500, 1000,
+  5000, 20000, 40000, 60000 and 69001 — the far end of a 69952-frame clip — the slip is
+  always 0 or −1. It never accumulates and never runs the other way.
+- **Takes have nothing to do with it.** Plain shots appended at the same source starts, with
+  no take selector anywhere on the timeline, drift identically. Any shot whose source in
+  point lands on a bad frame is misreported, swapped or not.
+
+`GetLeftOffset` was exact in all 41 rows.
+
+The live test passed before only by coincidence: its shots start at source 0, 48 and 72,
+which are fixed points of the drift. The alternate at 108 is not.
+
+### The end getter is exclusive, and the wrapper added one to it
+
+Separately, `GetSourceEndFrame` returns **one past** the last frame — a shot cut from source
+0..47 reports 48, one cut from 100 over 48 frames reports 148. The wrapper read it as the
+last frame and added one, so `source.out` overshot by a frame wherever the getter was not
+also losing one. It carries the same ±1 slip, and it is not even stable across contexts: the
+same source range read 149 in one timeline and 150 in another.
+
+Note that the #84 sweep in [ADR 0004](0004-editor-state-getters-only-answer-for-the-current-timeline.md)
+lists source bounds among the getters "proven stable". That was true on the axis it measured
+— these getters do not drift with which timeline is current. Stable is not the same as
+accurate.
+
+## Decision
+
+`source_bounds` reads the start off **`GetLeftOffset`**, and falls back to
+`GetSourceStartFrame` only when the two disagree by more than the measured slip of one
+frame.
+
+The fallback is not hypothetical. A still is where the left offset stops being a source
+frame: media that is source frame 27 alone reports `GetSourceStartFrame → 27` against
+`GetLeftOffset → 86313`, which is the timeline's clock, not the media's. A disagreement that
+large means the two getters are no longer describing the same thing, and the absolute one —
+lossy as it is — is the only one still answering the question. The routes are never mixed:
+an in point counted from the media start against an out point in absolute source frames is a
+span that means nothing.
+
+The end comes from the **record duration**, which is exact, rather than from the lossy end
+getter. A retime is the one shot whose source span is not its record duration, so the getter
+is still read to notice one: a span differing from the duration by more than the slip is a
+real retime and is believed.
+
+## Consequences
+
+- `inspect_timeline` reports `source.in`, `source.out` and the `sync_offset` derived from
+  them correctly for any shot, not just ones that happen to start on a fixed point.
+  `correlate_timeline` reads through the same function and is fixed with it.
+- **The fakes were carrying the bug.** `FakeTimelineItem.GetSourceEndFrame` returned
+  `source_start + duration - 1` and its docstring called the value inclusive — the same
+  belief the wrapper held. Fake and wrapper agreed with each other and neither agreed with
+  Resolve, which is why the fake tier was green through all of it. It now returns the
+  exclusive end, and a test encodes the slip by setting `source_start` and `left_offset` a
+  frame apart.
+- **The retime branch has no seam.** `SetProperty("Speed", 50.0)` returns `False` on
+  21.0.3.7, so a retimed shot cannot be created through the scripting API at all; only a
+  human retiming in the GUI produces one. The branch is held by a fake alone, and the fake's
+  numbers are reasoned from the measured exclusivity rather than measured directly.
+- The slip's arithmetic is unexplained. It is not a cumulative timecode drift — it does not
+  grow over 69001 frames — and pinning the exact function was not needed to stop trusting the
+  getter. If a future build changes the bound, `SOURCE_SLIP` is the one number to re-measure.

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -734,6 +734,10 @@ def read_item(
     }
 
 
+SOURCE_SLIP: Final = 1
+"""How far ``GetSourceStartFrame`` may sit below the truth — measured on 21.0.3.7, #120."""
+
+
 def source_bounds(
     reader: Reader,
     item: TimelineItem,
@@ -741,27 +745,57 @@ def source_bounds(
 ) -> tuple[int | None, int | None]:
     """Where the shot starts and ends in its own media, both on the same clock.
 
-    ``GetSourceStartFrame``/``GetSourceEndFrame`` are the direct answer and exist only on
-    newer builds; the end is the last frame, hence the plus one. Reading it rather than
-    deriving it matters on a retime, where a shot covers more or fewer source frames than
-    it occupies on the timeline.
+    Two getters answer the start and they do not agree. ``GetLeftOffset`` is how far into
+    the media pool item the shot begins, and it is exact: #120 swept source frames 0 to
+    69001 on a 23.976 timeline and it was right every time. ``GetSourceStartFrame`` is the
+    same number in absolute source frames, and on that timeline it lands a frame low at
+    scattered positions — 108 reads 107, 112 reads 111, while 100 and 110 read true. The
+    slip never grows past the one frame and never runs the other way, but one frame was
+    enough: a take Resolve had really placed on source frame 108 read back as playing 107,
+    which is what made a swap look like it had moved the shot.
 
-    Failing those, ``GetLeftOffset`` is how far into the media pool item the shot begins —
-    the same number whenever the media itself starts at frame zero, which camera files do.
-    The two routes are never mixed: an in point counted from the media start against an
-    out point in absolute source frames would be a span that means nothing.
+    So the offset wins a disagreement it could have caused — one frame — and loses a
+    larger one, because past that the two are no longer describing the same thing. A still
+    is the case that separates them: its media is a single source frame, and it reports an
+    absolute start of 27 against a left offset of 86313, which is the timeline's clock
+    rather than the media's. There the absolute getter, lossy as it is, is the only one
+    answering the question, and the end it reports is read the way that route always read
+    it. The two routes are never mixed: an in point counted from the media start against
+    an out point in absolute source frames would be a span that means nothing.
+
+    The end of the offset route is the record duration, not ``GetSourceEndFrame``, which
+    is one past the last frame already (a shot on source 0..47 reports 48) and carries the
+    same slip. A retime is the one shot whose source span is not its record duration, so
+    the getter is still read to notice one: a span that differs by more than the slip is a
+    real retime and is believed, and anything closer is the duration.
     """
-    start = read_frames(reader.optional(item, "GetSourceStartFrame", None))
-    if start is not None:
-        last = read_frames(reader.optional(item, "GetSourceEndFrame", None))
-        if last is not None:
-            return start, last + 1
-        return start, (start + duration if duration is not None else None)
-
     offset = read_frames(reader.optional(item, "GetLeftOffset", None))
-    if offset is None:
+    start = read_frames(reader.optional(item, "GetSourceStartFrame", None))
+    if offset is not None and (start is None or abs(offset - start) <= SOURCE_SLIP):
+        return offset, _span_from(reader, item, start, duration, offset)
+    if start is None:
         return None, None
-    return offset, (offset + duration if duration is not None else None)
+    last = read_frames(reader.optional(item, "GetSourceEndFrame", None))
+    if last is not None:
+        return start, last + 1
+    return start, (start + duration if duration is not None else None)
+
+
+def _span_from(
+    reader: Reader,
+    item: TimelineItem,
+    start: int | None,
+    duration: int | None,
+    offset: int,
+) -> int | None:
+    """The exclusive end of a shot read off its left offset — see :func:`source_bounds`."""
+    last = read_frames(reader.optional(item, "GetSourceEndFrame", None))
+    span = None if start is None or last is None else last - start
+    if duration is None:
+        return None if span is None else offset + span
+    if span is None or abs(span - duration) <= SOURCE_SLIP:
+        return offset + duration
+    return offset + span
 
 
 def clip_name(reader: Reader, item: TimelineItem) -> str | None:

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -735,7 +735,12 @@ def read_item(
 
 
 SOURCE_SLIP: Final = 1
-"""How far ``GetSourceStartFrame`` may sit below the truth — measured on 21.0.3.7, #120."""
+"""How far a source-frame getter may sit below the truth — measured on 21.0.3.7, #120.
+
+The same one frame bounds both comparisons in :func:`source_bounds`, for reasons its
+docstring gives: it is how far ``GetSourceStartFrame`` strays from the left offset, and
+also how far a span built from two such getters strays from the duration it should equal.
+"""
 
 
 def source_bounds(
@@ -754,42 +759,49 @@ def source_bounds(
     enough: a take Resolve had really placed on source frame 108 read back as playing 107,
     which is what made a swap look like it had moved the shot.
 
-    So the offset wins a disagreement it could have caused — one frame — and loses a
-    larger one, because past that the two are no longer describing the same thing. A still
-    is the case that separates them: its media is a single source frame, and it reports an
-    absolute start of 27 against a left offset of 86313, which is the timeline's clock
-    rather than the media's. There the absolute getter, lossy as it is, is the only one
-    answering the question, and the end it reports is read the way that route always read
-    it. The two routes are never mixed: an in point counted from the media start against
-    an out point in absolute source frames would be a span that means nothing.
+    So the offset wins a disagreement it could have caused — one frame, in either
+    direction, since the offset is the exact one and stays right whichever way the other
+    landed — and loses a larger one, because past that the two are no longer describing
+    the same thing. A still is the case that separates them: its media is a single source
+    frame, and it reports an absolute start of 27 against a left offset of 86313, which is
+    the timeline's clock rather than the media's.
 
-    The end of the offset route is the record duration, not ``GetSourceEndFrame``, which
-    is one past the last frame already (a shot on source 0..47 reports 48) and carries the
-    same slip. A retime is the one shot whose source span is not its record duration, so
-    the getter is still read to notice one: a span that differs by more than the slip is a
-    real retime and is believed, and anything closer is the duration.
+    That still is also the only measured shot on the absolute route, and it is why the
+    route keeps its ``+ 1``: it reports its end as 27 as well, so the frame it plays is
+    counted by treating that as the last one. The offset route cannot read the end that
+    way — there ``GetSourceEndFrame`` is one *past* the last frame (a shot on source 0..47
+    reports 48) — which is the shape of build this is, two getters that do not share a
+    convention. The routes are never mixed either: an in point counted from the media
+    start against an out point in absolute source frames would be a span that means
+    nothing.
+
+    The end of the offset route is therefore the record duration, which is exact. A retime
+    is the one shot whose source span is not its duration, so the end getter is still read
+    to notice one. One frame of tolerance is the right width for that comparison and not a
+    borrowed number: the span is a difference of two getters that each slip by 0 or 1
+    frame, so an unretimed shot reads its true span ±1 and no wider — both extremes were
+    measured, source 2 reading a span of 47 and source 47 reading 49 against a duration of
+    48. Anything further out is a real retime and is believed.
     """
     offset = read_frames(reader.optional(item, "GetLeftOffset", None))
     start = read_frames(reader.optional(item, "GetSourceStartFrame", None))
+    last = read_frames(reader.optional(item, "GetSourceEndFrame", None))
     if offset is not None and (start is None or abs(offset - start) <= SOURCE_SLIP):
-        return offset, _span_from(reader, item, start, duration, offset)
+        return offset, _end_from_offset(offset, start, last, duration)
     if start is None:
         return None, None
-    last = read_frames(reader.optional(item, "GetSourceEndFrame", None))
     if last is not None:
         return start, last + 1
     return start, (start + duration if duration is not None else None)
 
 
-def _span_from(
-    reader: Reader,
-    item: TimelineItem,
-    start: int | None,
-    duration: int | None,
+def _end_from_offset(
     offset: int,
+    start: int | None,
+    last: int | None,
+    duration: int | None,
 ) -> int | None:
-    """The exclusive end of a shot read off its left offset — see :func:`source_bounds`."""
-    last = read_frames(reader.optional(item, "GetSourceEndFrame", None))
+    """Where a shot read off its left offset stops — see :func:`source_bounds`."""
     span = None if start is None or last is None else last - start
     if duration is None:
         return None if span is None else offset + span

--- a/tests/fakes/timeline_item.py
+++ b/tests/fakes/timeline_item.py
@@ -165,11 +165,18 @@ class FakeTimelineItem(AnswersNone):
         return self._source_start or 0
 
     def GetSourceEndFrame(self) -> int:  # noqa: N802
-        """The last source frame — inclusive, and not derivable from duration on a retime."""
+        """One past the last source frame, and not derivable from duration on a retime.
+
+        Exclusive because that is what 21.0.3.7 answers, not because it reads that way:
+        #120 measured a shot cut from source 0..47 reporting 48, and one cut from 100
+        reporting 148 over 48 frames. This fake used to subtract the one — the same belief
+        the wrapper held — so the two agreed with each other and neither agreed with
+        Resolve, which is exactly the shape of quirk this tier exists to carry.
+        """
         self._check()
         if self._source_end is not None:
             return self._source_end
-        return (self._source_start or 0) + self._duration - 1
+        return (self._source_start or 0) + self._duration
 
     def GetMediaPoolItem(self) -> FakeMediaPoolItem | None:  # noqa: N802
         self._check("GetMediaPoolItem")

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -496,6 +496,11 @@ def test_a_real_take_selector_swaps_the_angle_without_moving_the_shot(tmp_path: 
     before = _video_items(name)
     assert [item["takes"] for item in before] == [2, 2, 2]
     assert [item["source"]["in"]["frames"] for item in before][0] == source["start"]
+    # #120's second half, and it has to be measured on a shot whose getters both read true:
+    # Resolve's end getter is already one past the last frame, so a wrapper that adds one
+    # to it reports a 48-frame shot covering 49 source frames. On the *swapped* shot the
+    # start getter's own lost frame cancels that, which is why this is asserted here.
+    assert before[0]["source"]["out"]["frames"] == source["start"] + durations[0]
 
     swapped = swap_take(cut_file, "s000", 2, timeline=name)
 
@@ -504,6 +509,7 @@ def test_a_real_take_selector_swaps_the_angle_without_moving_the_shot(tmp_path: 
     assert swapped["sync"]["in"] == alternate_at
     after = _video_items(name)
     assert after[0]["source"]["in"]["frames"] == alternate_at
+    assert after[0]["source"]["out"]["frames"] == alternate_at + durations[0]
     assert [item["record"]["in"]["frames"] for item in after] == [
         item["record"]["in"]["frames"] for item in before
     ]

--- a/tests/test_timeline_tools.py
+++ b/tests/test_timeline_tools.py
@@ -248,15 +248,62 @@ def test_each_angle_carries_the_offset_that_maps_its_source_onto_the_timeline(
     assert offsets["Cam A"]["seconds"] == -16.683
 
 
-def test_the_source_start_is_read_before_the_left_offset_that_stands_in_for_it(
+def test_an_offset_that_is_not_source_frames_at_all_loses_to_the_absolute_start(
     attach: Attach,
 ) -> None:
+    """A still is where the left offset stops being a source frame and starts being noise.
+
+    #120 measured one: a still whose media is source frame 27 alone reported a left offset
+    of 86313 — the timeline's own clock, not the media's. Two getters that far apart are
+    not describing the same shot, so the absolute start is the only one still answering
+    the question, lossy or not.
+    """
     item = FakeTimelineItem("A.mp4", 120, 400, source_start=3000, left_offset=7)
     attach(studio(timeline=FakeTimeline("sync", video=[FakeTrack("Cam A", [item])])))
 
     result = inspect_timeline(detail="clips")
 
     assert result["tracks"][0]["items"][0]["source"]["in"]["frames"] == 3000
+
+
+def test_a_source_start_that_slipped_a_frame_loses_to_the_offset_that_did_not(
+    attach: Attach,
+) -> None:
+    """#120: ``GetSourceStartFrame`` lands a frame low, and reading it moved a whole shot.
+
+    Measured on 21.0.3.7 over a 23.976 timeline: across source frames 0 to 69001 the
+    absolute getter is either exact or one frame low, at scattered positions — 108 reads
+    107, 112 reads 111, while 100 and 110 read true. ``GetLeftOffset`` was exact at every
+    one of them. So a *one frame* disagreement is the lossy getter losing, and the offset
+    takes it; the numbers here are the ones the live box produced for a swapped take that
+    Resolve really had placed on source frame 108.
+    """
+    item = FakeTimelineItem("A.mp4", 0, 48, source_start=107, left_offset=108)
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", [item])])))
+
+    result = inspect_timeline(detail="clips")
+
+    source = result["tracks"][0]["items"][0]["source"]
+    assert source["in"]["frames"] == 108
+    assert source["out"]["frames"] == 156
+
+
+def test_an_exclusive_source_end_is_not_counted_as_a_frame_the_shot_plays(
+    attach: Attach,
+) -> None:
+    """The other half of #120: ``GetSourceEndFrame`` is already one past the last frame.
+
+    A 48-frame shot cut from source 100 reports 148 on 21.0.3.7, so adding one to reach a
+    half-open end reaches one frame past the media the shot actually covers.
+    """
+    item = FakeTimelineItem("A.mp4", 0, 48, source_start=100, left_offset=100, source_end=148)
+    attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", [item])])))
+
+    result = inspect_timeline(detail="clips")
+
+    source = result["tracks"][0]["items"][0]["source"]
+    assert source["in"]["frames"] == 100
+    assert source["out"]["frames"] == 148
 
 
 def test_an_angle_on_a_resolve_without_source_frames_still_reports_its_offset(
@@ -318,8 +365,12 @@ def test_a_source_span_is_never_half_one_clock_and_half_another(attach: Attach) 
 
 
 def test_a_retimed_shot_reports_the_source_frames_it_really_covers(attach: Attach) -> None:
-    """Half speed: 400 timeline frames over 200 source frames, so duration will not do."""
-    item = FakeTimelineItem("A.mp4", 0, 400, source_start=1000, source_end=1199)
+    """Half speed: 400 timeline frames over 200 source frames, so duration will not do.
+
+    The end is 1200 rather than 1199 because #120 measured the getter exclusive; the span
+    it describes — 200 source frames under 400 of record — is the same retime as before.
+    """
+    item = FakeTimelineItem("A.mp4", 0, 400, source_start=1000, source_end=1200)
     attach(studio(timeline=FakeTimeline("cut v1", video=[FakeTrack("Video 1", [item])])))
 
     result = inspect_timeline(detail="clips")


### PR DESCRIPTION
Closes #120.

## The ticket's theory was wrong, and the bug is bigger

#120 opened on the theory that `AddTake` reads `endFrame` inclusive where
`AppendToTimeline` reads it half-open — an off-by-one on the **write**. It isn't.
`AddTake` stores exactly the half-open range it is given and Resolve plays it: a take
sent `(108, 156)` reads back `GetTakeByIndex → {startFrame: 108, endFrame: 156}` and
`GetLeftOffset → 108`. The ticket left the door open for the alternative — "either
`AddTake`'s in/out convention **or the read-back mapping** is off by one" — and it is
the read-back.

`GetSourceStartFrame` misreports. Swept on a 23.976 timeline:

| requested | 100 | 101 | 102 | 103 | 104 | 105 | 106 | 107 | 108 | 109 | 110 | 111 | 112 |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| `GetLeftOffset` | 100 | 101 | 102 | 103 | 104 | 105 | 106 | 107 | 108 | 109 | 110 | 111 | 112 |
| `GetSourceStartFrame` | 100 | 101 | 102 | **102** | **103** | 105 | 106 | **106** | **107** | **108** | 110 | 111 | **111** |

Deterministic (the sweep reproduced value for value), bounded at one frame out to source
frame 69001, and — the decisive control — **identical for plain shots with no take
selector anywhere on the timeline**. So this was never about takes: any shot whose source
in point lands on a bad frame was misreported. The live test passed before only because
its shots start at 0, 48 and 72, which happen to be fixed points of the drift. The
alternate at 108 is not.

`source_bounds` now reads the start off `GetLeftOffset` (exact in all 41 measured rows),
falling back to `GetSourceStartFrame` only when the two disagree by more than that one
frame — which is what a still looks like, reporting an absolute start of 27 against a
left offset of 86313.

**A second off-by-one in the same function** came out of the measurements:
`GetSourceEndFrame` is already one past the last frame (a shot on source 0..47 reports
48) and the wrapper added one to it, so `source.out` overshot. The end now comes from the
record duration, with the getter read only to notice a retime.

The fakes were carrying the same bug — `FakeTimelineItem.GetSourceEndFrame` returned
`source_start + duration - 1` and its docstring called the value inclusive. Fake and
wrapper agreed with each other and neither agreed with Resolve, which is exactly why the
fake tier was green through all of it.

Measurements, the rejected hypothesis and the consequences are in
[ADR 0005](docs/adr/0005-source-frames-are-read-off-the-left-offset.md).

## Seams

- **Fake tier** — `test_a_source_start_that_slipped_a_frame_loses_to_the_offset_that_did_not`
  carries the live numbers (source start 107 against a left offset of 108) and fails
  `assert 107 == 108` without the fix, in 0.38s.
  `test_an_exclusive_source_end_is_not_counted_as_a_frame_the_shot_plays` covers the end.
- **Live smoke** — `test_a_real_take_selector_swaps_the_angle_without_moving_the_shot`, the
  ticket's own repro, plus a new `source.out` assertion on the shot *before* the swap.

## Live pass (recorded)

Windows 11, Resolve Studio 21.0.3.7, python.org 3.12.10, project `mcp-tests-zinc`.

- `uv run pytest -m live -k take_selector` → **1 passed** in 5.03s (ran, not skipped).
- Full live tier on this branch → **5 failed, 21 passed, 9 skipped**.
- Full live tier on clean `origin/main`, same box, same session → **8 failed, 18 passed,
  9 skipped**.

The branch's 5 failures are a strict subset of main's 8: `inspects_a_real_clip`,
`a_still_lands`, `render_queue`, `frame_grab`, `scene_scan` all fail identically on both
and are untouched by this diff. The take-selector failure is gone. Nothing new is red.

Six `resolve-mcp-probe120*` timelines created while measuring were deleted from
`mcp-tests-zinc`; the project's own timelines were not touched.

## Review

Two-axis `/code-review` against `origin/main`, on the branch before this PR existed.

**Standards — 4 findings, 0 hard violations, all judgement calls; 3 fixed, 1 answered.**

1. *Mysterious Name* — `_span_from` returned an absolute end, not a span, and its docstring
   had to correct its name. **Fixed**: renamed `_end_from_offset`, offset first, `reader`
   dropped so it is a pure function of four numbers.
2. *Primitive Obsession* — `SOURCE_SLIP` reused as a span tolerance without justification.
   **Fixed by justifying it, not by widening it**: the span is a difference of two getters
   that each slip 0 or 1, so an unretimed shot reads its span within one frame either way.
   Both extremes were measured — source 2 spanning 47, source 47 spanning 49, against a
   duration of 48 — so one frame is exactly the right width, and 2× would swallow small
   retimes.
3. *Duplicated Code* — `GetSourceEndFrame` read on both routes. **Fixed**: read once in
   `source_bounds` and passed in.
4. *Seam gap* — nothing live asserted `source.out`. **Fixed**, and the placement turned out
   to matter: see below.

**Spec — 7 findings; 2 fixed, 5 answered.**

1. *No live confirmation recorded* — **fixed**: the live pass is recorded above.
2. *The `+ 1` survives on the fallback route* — **answered, and the docstring now says why**.
   Exclusivity is a property of the getter, as the reviewer says, but this build does not
   apply one convention: the still that route exists for reports start and end alike as 27,
   so counting that as the last frame is what yields the single frame it plays. Changing it
   would report a zero-length span for the only shot ever measured on that route.
3. *`source.out` is scope creep* — **accepted as scope, kept**. It is the same function, the
   same getter family and the same measurement; leaving a known off-by-one in the function
   being fixed would ship a number already proven wrong.
4. *`abs()` admits an unmeasured direction* — **answered**: the offset is the exact getter,
   so preferring it is right whichever way the other one landed. Now stated in the docstring.
5. *Retime branch has no seam* — **accepted**: `SetProperty("Speed", 50.0)` returns `False`
   on 21.0.3.7, so a retimed shot cannot be created through the scripting API at all. Held
   by a fake alone; recorded as a known gap in ADR 0005.
6. *No fake models swap changing the source frames* — **declined**: the defect was never in
   the swap, so a fake seam there would guard a path that was already correct.
7. *Fix is scoped to media whose left offset tracks its source start* — **accepted**, and
   pre-existing; recorded in ADR 0005.

The `source.out` fix (Standards 4) is worth one more line, because the first placement of
the assertion was wrong and the review is what surfaced it. Asserted on the *swapped* shot
it passes either way: the start getter's lost frame cancels the wrapper's spare one and
the old code returns the right answer by accident. It is asserted on the shot before the
swap instead, where both getters read true — verified red-capable against the live
getters (`left=0, start=0, last=48, dur=48`; the old formula yields 49, the assertion
expects 48).

Fake tier 1247 passed, mypy strict clean, ruff clean.

Review: clean — 11 findings across both axes, 5 fixed, 6 answered in the record above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
