### PR TITLE
fix: bin="" addresses the pool root, so a root clip with a duplicated name is readable

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,12 @@ timelines. The server measures; Claude decides.
   (`tools/envelope.py`).
 - **spill** — oversized results written to disk for the agent to grep
   instead of truncating.
+- **bin path** — a media pool folder, slash-separated from the root. To a
+  tool addressing one clip by name: omitted is the whole pool, a name is
+  that bin and everything nested inside it, `""` is the root folder alone
+  — the value `list_media` reports for a root clip, so a listing reads
+  back verbatim (#122). `list_media` itself takes the same paths but says
+  how deep to walk with its own `recursive` flag.
 - **the seam** — `resolve/connection.py` singleton, substituted by
   `tests/fakes/` via `set_connection()`; the only place fakes attach.
 - **fake tier / live tier** — `pytest -m 'not live'` against fakes (the

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -167,10 +167,12 @@ class AmbiguousClipError(ResolveMcpError):
     code = "ambiguous_clip"
 
     def __init__(self, name: str, bins: list[str]) -> None:
-        listed = ", ".join(bin_path or "the root" for bin_path in bins)
+        # Every value printed has to be one the caller can pass back, the empty string for
+        # a clip at the pool root included (#122) — an unnamable option is not a fix.
+        listed = ", ".join(f'bin="{bin_path}"' for bin_path in bins)
         super().__init__(
             cause=f"{len(bins)} clips are named {name!r}, so the reference is ambiguous.",
-            fix=f"Pass bin= to say which one: {listed}.",
+            fix=f'Pass one of these to say which: {listed} — bin="" is the pool root itself.',
             detail={"requested": name, "bins": bins},
         )
 

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -166,13 +166,26 @@ class ClipNotFoundError(ResolveMcpError):
 class AmbiguousClipError(ResolveMcpError):
     code = "ambiguous_clip"
 
-    def __init__(self, name: str, bins: list[str]) -> None:
-        # Every value printed has to be one the caller can pass back, the empty string for
-        # a clip at the pool root included (#122) — an unnamable option is not a fix.
-        listed = ", ".join(f'bin="{bin_path}"' for bin_path in bins)
+    def __init__(self, name: str, bins: list[str], addressable: list[str]) -> None:
+        """``bins`` is the bin of every matching clip; ``addressable`` those that work.
+
+        Only an addressable bin is offered. A value that lands back on this same refusal is
+        not a fix (#122), and the empty string is offered like any other because it
+        addresses the pool root itself.
+        """
+        if addressable:
+            listed = ", ".join(f'bin="{path}"' for path in addressable)
+            root = ' (bin="" is the pool root itself)' if "" in addressable else ""
+            fix = f"Pass one of these to say which: {listed}{root}."
+        else:
+            fix = (
+                "No bin singles one out — they share a bin, or the one holding each also "
+                "holds another of the name. Rename one in the Resolve GUI, or work from "
+                "the file paths list_media reports."
+            )
         super().__init__(
             cause=f"{len(bins)} clips are named {name!r}, so the reference is ambiguous.",
-            fix=f'Pass one of these to say which: {listed} — bin="" is the pool root itself.',
+            fix=fix,
             detail={"requested": name, "bins": bins},
         )
 

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -239,14 +239,29 @@ def _clips_under(where: LocatedBin, recursive: bool) -> Iterator[LocatedClip]:
             yield LocatedClip(path, clip)
 
 
+def _searched_label(bin_path: str | None, where: LocatedBin) -> str:
+    if bin_path is None:
+        return "the media pool"
+    return f"the bin {where.path!r}" if where.path else "the media pool root"
+
+
 def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> LocatedClip:
-    """One clip by exact name, searched under ``bin_path`` (the whole pool by default)."""
-    searched = list(_clips_under(find_bin(pool, bin_path), recursive=True))
+    """One clip by exact name.
+
+    ``None`` searches the whole pool. A named bin searches that bin and everything nested
+    inside it. ``""`` — or the root's own name — is the root folder *alone*, not the pool:
+    naming the root recursively would be the whole-pool search again, which left a root
+    clip whose name is also used in a bin with no way to be addressed at all (#122). The
+    empty string is what :func:`summarise` reports for a root clip, so the ``bin`` value a
+    listing gives back always reads the clip it described.
+    """
+    where = find_bin(pool, bin_path)
+    the_root_itself = bin_path is not None and not where.path
+    searched = list(_clips_under(where, recursive=not the_root_itself))
     matches = [found for found in searched if str(found.clip.GetName() or "") == name]
     if not matches:
-        where = f"the bin {bin_path!r}" if bin_path else "the media pool"
         available = sorted({str(found.clip.GetName() or "") for found in searched})
-        raise ClipNotFoundError(name, where, available)
+        raise ClipNotFoundError(name, _searched_label(bin_path, where), available)
     if len(matches) > 1:
         raise AmbiguousClipError(name, [found.bin_path for found in matches])
     return matches[0]

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections import Counter
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -240,9 +241,27 @@ def _clips_under(where: LocatedBin, recursive: bool) -> Iterator[LocatedClip]:
 
 
 def _searched_label(bin_path: str | None, where: LocatedBin) -> str:
+    """What a clip_not_found says it looked in — the caller's own words for a named bin."""
     if bin_path is None:
         return "the media pool"
-    return f"the bin {where.path!r}" if where.path else "the media pool root"
+    return f"the bin {bin_path!r}" if where.path else "the media pool root"
+
+
+def _addressable(bins: list[str]) -> list[str]:
+    """Which bins holding a duplicated name would, passed on their own, reach one clip.
+
+    One entry per matching clip comes in, so a repeat means one bin holds two of the name —
+    passing it lands back on the same refusal. So does naming a bin whose subfolders hold
+    another copy, because a named bin is searched right through. The root is the exception:
+    ``""`` is the root folder alone, so a copy filed deeper never shadows it.
+    """
+    counted = Counter(bins)
+    return sorted(
+        path
+        for path, times in counted.items()
+        if times == 1
+        and not (path and any(other.startswith(f"{path}{BIN_SEPARATOR}") for other in bins))
+    )
 
 
 def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> LocatedClip:
@@ -251,8 +270,8 @@ def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> LocatedClip
     ``None`` searches the whole pool. A named bin searches that bin and everything nested
     inside it. ``""`` — or the root's own name — is the root folder *alone*, not the pool:
     naming the root recursively would be the whole-pool search again, which left a root
-    clip whose name is also used in a bin with no way to be addressed at all (#122). The
-    empty string is what :func:`summarise` reports for a root clip, so the ``bin`` value a
+    clip whose name a bin also used with no expressible address at all (#122). The empty
+    string is what :func:`summarise` reports for a root clip, so the ``bin`` value a
     listing gives back always reads the clip it described.
     """
     where = find_bin(pool, bin_path)
@@ -263,7 +282,8 @@ def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> LocatedClip
         available = sorted({str(found.clip.GetName() or "") for found in searched})
         raise ClipNotFoundError(name, _searched_label(bin_path, where), available)
     if len(matches) > 1:
-        raise AmbiguousClipError(name, [found.bin_path for found in matches])
+        found_in = [found.bin_path for found in matches]
+        raise AmbiguousClipError(name, found_in, _addressable(found_in))
     return matches[0]
 
 

--- a/src/resolve_mcp/resolve/titles.py
+++ b/src/resolve_mcp/resolve/titles.py
@@ -189,7 +189,12 @@ def _templates(
 
 
 def _under(bin_path: str | None, declared: str) -> bool:
-    """Whether a clip's bin is the declared one or nested inside it, as find_clip searches."""
+    """Whether a clip's bin is the declared one or nested inside it, as find_clip searches.
+
+    ``declared`` is compared as written, so the one spelling this does not share with
+    :func:`media.find_clip` is the root's own name: ``Master`` reads as a bin called
+    Master here, where find_clip reads it as the root.
+    """
     where = bin_path or ""
     return where == declared or where.startswith(f"{declared}{media.BIN_SEPARATOR}")
 

--- a/src/resolve_mcp/tools/media.py
+++ b/src/resolve_mcp/tools/media.py
@@ -54,7 +54,9 @@ def list_media(
 ) -> dict[str, Any]:
     """Summarise media pool clips: name, bin, path, type, frames, fps, resolution, offline.
 
-    Without a bin this walks the whole pool. offline_only shows the clips whose media has
+    Without a bin this walks the whole pool; bin="" is the pool root alone. Every clip's
+    reported bin reads that clip back verbatim — pass it to any tool that takes a bin.
+    offline_only shows the clips whose media has
     moved away — the ones relink_media exists for. Past limit clips the full listing is
     written to disk and spilled_to holds the path, so a large pool never blows the token
     budget: read or grep that file for the rest.
@@ -81,6 +83,10 @@ def inspect_clip(
     [in, out), the same convention the cut file uses. audio_mapping carries the linked-audio
     paths and sample offsets for externally synced audio; markers are the clip's own,
     numbered relative to the clip.
+
+    bin: omit it to search the whole pool, name a bin to search it and its subfolders, or
+    pass "" for the pool root alone — the form that names a root clip whose name is also
+    used inside a bin. list_media's reported bin is always the value to pass here.
     """
     connection = get_connection()
     return media.inspect_clip(connection, clip, bin_path=bin)

--- a/src/resolve_mcp/tools/media.py
+++ b/src/resolve_mcp/tools/media.py
@@ -54,8 +54,9 @@ def list_media(
 ) -> dict[str, Any]:
     """Summarise media pool clips: name, bin, path, type, frames, fps, resolution, offline.
 
-    Without a bin this walks the whole pool; bin="" is the pool root alone. Every clip's
-    reported bin reads that clip back verbatim — pass it to any tool that takes a bin.
+    Without a bin this walks the whole pool, recursive says whether a named one includes
+    its subfolders, and the bin reported against each clip reads that clip back verbatim —
+    pass it to any tool that takes a bin, "" included.
     offline_only shows the clips whose media has
     moved away — the ones relink_media exists for. Past limit clips the full listing is
     written to disk and spilled_to holds the path, so a large pool never blows the token

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -153,7 +153,7 @@ def test_inspects_a_real_clip_with_the_property_keys_the_wrappers_assume() -> No
         pytest.skip("No clips with media behind them in the media pool")
     first = decodable[0]
 
-    result = inspect_clip(first["name"], bin=first["bin"] or None)
+    result = inspect_clip(first["name"], bin=first["bin"])
 
     assert result["ok"] is True
     assert "File Path" in result["properties"]
@@ -386,7 +386,7 @@ def a_source_clip() -> dict[str, Any]:
     if not listing["ok"]:
         pytest.skip("No media pool")
     for entry in _decodable(listing["clips"]):
-        clip = inspect_clip(entry["name"], bin=entry["bin"] or None)
+        clip = inspect_clip(entry["name"], bin=entry["bin"])
         if not clip["ok"]:
             continue
         media = clip["bounds"]["media"]
@@ -395,7 +395,9 @@ def a_source_clip() -> dict[str, Any]:
             continue
         return {
             "name": entry["name"],
-            "bin": entry["bin"] or None,
+            # Verbatim, not `or None`: the bin a listing reports reads the same clip back,
+            # and "" is the pool root itself — the root copy of a duplicated name (#122).
+            "bin": entry["bin"],
             "fps": float(fps),
             # inspect_clip reports media bounds as in/out/duration — there is no "start".
             "start": media["in"]["frames"],
@@ -804,10 +806,10 @@ def test_a_real_frame_grab_lands_on_the_moment_resolve_numbers_it_at() -> None:
     footage = next(iter(_decodable(listing["clips"])), None)
     if footage is None:
         pytest.skip("No online clip with a frame rate in the media pool")
-    bounds = inspect_clip(footage["name"], bin=footage["bin"] or None)["bounds"]["media"]
+    bounds = inspect_clip(footage["name"], bin=footage["bin"])["bounds"]["media"]
     middle = bounds["in"]["frames"] + bounds["duration"]["frames"] // 2
 
-    result = grab_frames(footage["name"], [middle], bin=footage["bin"] or None)
+    result = grab_frames(footage["name"], [middle], bin=footage["bin"])
 
     assert result["ok"] is True, result.get("error")
     grabbed = result["frames"][0]
@@ -815,7 +817,7 @@ def test_a_real_frame_grab_lands_on_the_moment_resolve_numbers_it_at() -> None:
     assert grabbed["time"]["frames"] == middle
     assert max(grabbed["width"], grabbed["height"]) <= 1568
 
-    again = grab_frames(footage["name"], [middle], bin=footage["bin"] or None)
+    again = grab_frames(footage["name"], [middle], bin=footage["bin"])
     assert again["cached"] is True, "unchanged media must be a cache hit"
 
 
@@ -844,9 +846,9 @@ def test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock() -> None:
         chosen = matches[0]
     else:
         chosen = min(footage, key=lambda one: one["frames"])
-    bounds = inspect_clip(chosen["name"], bin=chosen["bin"] or None)["bounds"]["media"]
+    bounds = inspect_clip(chosen["name"], bin=chosen["bin"])["bounds"]["media"]
 
-    started = detect_scene_cuts(chosen["name"], bin=chosen["bin"] or None)
+    started = detect_scene_cuts(chosen["name"], bin=chosen["bin"])
     record = wait_for(started["job_id"], timeout=1800.0)
 
     assert started["ok"] is True, started.get("error")

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -584,6 +584,8 @@ def test_a_duplicated_name_still_refuses_without_a_bin(attach: Attach, tmp_path:
     assert result["error"]["detail"]["bins"] == ["", "Angles"]
     assert 'bin=""' in result["error"]["fix"]  # the root has to be expressible
     assert 'bin="Angles"' in result["error"]["fix"]
+    assert inspect_clip("C0012.mp4", bin="")["ok"] is True  # and every value offered works
+    assert inspect_clip("C0012.mp4", bin="Angles")["ok"] is True
 
 
 def test_every_bin_a_listing_reports_reads_the_same_clip_back(
@@ -622,6 +624,42 @@ def test_a_named_bin_still_reaches_a_clip_in_its_subfolder(
 
     assert result["ok"] is True
     assert result["clip"]["bin"] == "Angles/Cam A"
+
+
+def test_an_ambiguity_offers_only_the_bins_that_reach_one_clip(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A bin whose subfolder holds another copy is not an answer, so it is not offered."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(
+        studio(
+            pool=media_pool(bins={"Angles": [a_clip(same)], "Angles/Cam A": [a_clip(same)]})
+        )
+    )
+
+    result = inspect_clip("C0012.mp4", bin="Angles")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "ambiguous_clip"
+    assert result["error"]["fix"] == (
+        'Pass one of these to say which: bin="Angles/Cam A".'
+    )  # not bin="Angles": searching it reaches the nested copy too
+    assert inspect_clip("C0012.mp4", bin="Angles/Cam A")["ok"] is True
+
+
+def test_two_copies_in_one_bin_are_refused_with_advice_that_is_not_a_bin(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """When no bin can answer, the fix says so instead of naming a value that fails."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(studio(pool=media_pool(bins={"Angles": [a_clip(same), a_clip(same)]})))
+
+    result = inspect_clip("C0012.mp4", bin="Angles")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "ambiguous_clip"
+    assert "bin=" not in result["error"]["fix"]
+    assert "Rename one in the Resolve GUI" in result["error"]["fix"]
 
 
 def test_naming_the_root_master_reaches_the_root_clip_only(

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -553,6 +553,109 @@ def test_inspect_refuses_an_ambiguous_clip_name(attach: Attach, tmp_path: Path) 
     assert inspect_clip("C0012.mp4", bin="Broll")["ok"] is True
 
 
+def test_a_root_clip_is_reachable_when_its_name_is_also_used_in_a_bin(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """#122: bin="" is the root folder alone — the only way to name the root copy."""
+    same = a_file(tmp_path, "C0012.mp4")
+    root_copy = a_clip(same, Description="at the root")
+    binned_copy = a_clip(same, Description="filed away")
+    attach(studio(pool=media_pool(bins={"": [root_copy], "Angles/Cam A": [binned_copy]})))
+
+    at_root = inspect_clip("C0012.mp4", bin="")
+
+    assert at_root["ok"] is True
+    assert at_root["clip"]["bin"] == ""
+    assert at_root["properties"]["Description"] == "at the root"
+    binned = inspect_clip("C0012.mp4", bin="Angles/Cam A")
+    assert binned["clip"]["bin"] == "Angles/Cam A"
+    assert binned["properties"]["Description"] == "filed away"
+
+
+def test_a_duplicated_name_still_refuses_without_a_bin(attach: Attach, tmp_path: Path) -> None:
+    """Narrowing the root must not turn the whole-pool search into a first-match."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(studio(pool=media_pool(bins={"": [a_clip(same)], "Angles": [a_clip(same)]})))
+
+    result = inspect_clip("C0012.mp4")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "ambiguous_clip"
+    assert result["error"]["detail"]["bins"] == ["", "Angles"]
+    assert 'bin=""' in result["error"]["fix"]  # the root has to be expressible
+    assert 'bin="Angles"' in result["error"]["fix"]
+
+
+def test_every_bin_a_listing_reports_reads_the_same_clip_back(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The bin value list_media reports round-trips verbatim, root included."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(
+        studio(
+            pool=media_pool(
+                bins={
+                    "": [a_clip(same)],
+                    "Angles": [a_clip(a_file(tmp_path, "C0013.mp4"))],
+                    "Angles/Cam A": [a_clip(same)],
+                }
+            )
+        )
+    )
+
+    listed = list_media()["clips"]
+
+    assert len(listed) == 3
+    for entry in listed:
+        read_back = inspect_clip(entry["name"], bin=entry["bin"])
+        assert read_back["ok"] is True, entry
+        assert read_back["clip"]["bin"] == entry["bin"]
+
+
+def test_a_named_bin_still_reaches_a_clip_in_its_subfolder(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Only the root narrows: a named bin keeps searching what is nested inside it."""
+    attach(studio(pool=media_pool(bins={"Angles/Cam A": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
+
+    result = inspect_clip("C0012.mp4", bin="Angles")
+
+    assert result["ok"] is True
+    assert result["clip"]["bin"] == "Angles/Cam A"
+
+
+def test_naming_the_root_master_reaches_the_root_clip_only(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Master is the root's own name, so it narrows the same way the empty string does."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(
+        studio(
+            pool=media_pool(
+                bins={"": [a_clip(same, Description="at the root")], "Angles": [a_clip(same)]}
+            )
+        )
+    )
+
+    result = inspect_clip("C0012.mp4", bin="Master")
+
+    assert result["ok"] is True
+    assert result["clip"]["bin"] == ""
+    assert result["properties"]["Description"] == "at the root"
+
+
+def test_inspect_of_a_missing_root_clip_says_it_searched_the_root(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(pool=media_pool(bins={"Angles": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
+
+    result = inspect_clip("C0012.mp4", bin="")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "clip_not_found"
+    assert result["error"]["detail"]["searched"] == "the media pool root"
+
+
 # --- metadata --------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #122.

## What changed

`find_clip` resolved `bin=""` through `find_bin`, where `""` and `None` are both the root, and then searched recursively — so naming the root *was* the whole-pool search. A clip at the pool root whose name a bin also used had no expressible address: `None` and `""` both refused as `ambiguous_clip`, the bin path reached the other copy, and the refusal advised "the root", a value no caller could pass. 16% of `mcp-tests-zinc` was unreadable by name.

Now: `None` searches the whole pool; a named bin searches that bin and everything nested inside it (unchanged, as #122 decided); `""` — or the root's own name, `Master` — is the root folder **alone**. That makes `list_media`'s reported `bin` round-trip verbatim, which is the property the three live tests were patching around with `or None`; the `or None` is gone from all six call sites.

`AmbiguousClipError` now offers a bin only when passing it back would reach exactly one clip: not a bin holding two of the name, and not a bin whose subfolders hold another copy. `media._addressable` decides that, beside the `find_clip` search it describes; the error class renders what it is handed. When nothing qualifies, the fix says so rather than naming a value that fails.

Not changed: `list_media` keeps its own `recursive` flag — it is the tool that says how deep to walk, and `""` there still means "start at the root". `cut/validate.py:637` and `resolve/titles.py:_under` already matched `""` as the root exactly, so they now agree with `find_clip` rather than diverging from it.

**Seam:** fake tier — this is entirely a decision about name resolution, so it verifies at `tests/fakes/`, as #122 specified. Seven new tests in `tests/test_media_tools.py`. One live AC (below).

## Review record

`/code-review` against `origin/main` — Standards and Spec as parallel sub-agents, then a focused pass over the fix diff.

### Spec axis

1. **`tools/media.py` docstring was false** — it claimed `bin=""` is the pool root alone, but `list_media` was never changed and defaults to `recursive=True`, so `list_media(bin="")` still walks the whole pool. Fixed: the text now describes `recursive` and the round-trip, and says nothing untrue of the tool.
2. **The root note printed unconditionally** — `— bin="" is the pool root itself` appeared even when no candidate sat at the root, advertising a value that then raises `clip_not_found`. Fixed: the note appears only when `""` is among the offered bins.
3. **AC3 held only for the root** — clips named `X` in `Angles` and `Angles/Cam A` produced a fix naming `bin="Angles"`, which is recursive and lands back on the same refusal; two copies inside one bin had the same hole. Fixed at the error text (`_addressable`), not at resolution — see below.
4. **`clip_not_found` label drifted** — the named-bin case had started reporting the *resolved* path, so `bin="Master/Angles"` said `the bin 'Angles'`. Unasked; reverted to the caller's own string. The root case is the only new label.
5. **AC1 coverage stops at `inspect_clip`** — every other clip-by-name tool inherits the fix through `find_clip` (`audio/acquire.py:493`, `video/source.py:77`, `relink_media`, `_move_clips`), but no fake-tier test passes `bin=""` to one of them. Accepted as-is: `find_clip` is the single seam and is covered directly; a test per caller would assert the same line.

### Standards axis

6. **Live tier touched → the run must be recorded** (CLAUDE.md, Test seams §2). Recorded below.
7. **New vocabulary lived only in a docstring** — `bin` semantics are now a project-wide contract. Added a **bin path** entry to CONTEXT.md's Vocabulary, including the `list_media` distinction.
8. **`titles.py:_under`'s docstring claimed "as find_clip searches"**, which `Master` makes false. Fixed to name that one spelling as the difference.
9. **Primitive Obsession** — `bin_path: str | None` carries several meanings and callers re-derive them. Not taken: a selector type would touch every tool signature for a rule that now lives in two named helpers. Noted as the shape to reach for if a `recursive=` flag ever lands.
10. **`bin_paths()` excludes the root, so `BinNotFoundError` cannot offer `""`.** Not a defect: `find_bin` never raises for the root, so `bin_not_found` cannot be reached with it.

### Focused pass over the fix diff

11. **The reason given for the shallow-copy preference was false, and the preference itself narrowed AC5.** A first pass at finding 3 had a copy filed directly in the named bin win over one filed deeper, justified as "no bin value could separate them" — untrue in one direction, since `bin="Angles/Cam A"` does reach the deeper copy. It also meant `bin="Angles"` stopped refusing an ambiguity it used to refuse, which is what AC5 forbids, and #122 had already decided named bins stay recursive. **Reverted.** AC3 is met at the error text instead: a bin that cannot single a clip out is never offered. The residual is unchanged from before this PR and is #122's own parked question — nothing addresses the *shallow* copy of a name duplicated into its own subfolder; the honest shape for that is the separate `recursive=` flag the ticket describes, and it wants its own ticket.
12. CONTEXT.md's new entry said "every clip-addressing tool" and then named `list_media`, which differs — reworded.
13. Verified: `recursive=not the_root_itself` is correct for `None`, `""`, `Master`, a real bin named `Master`, `Master/Cam A`, and a plain bin; AC5's refusal is intact for `bin=None`; the fix text can never be empty or double-punctuated; `detail["bins"]` still carries one entry per matching clip.

## Checks

- Fake tier: `1255 passed` (`uv run pytest -m 'not live'`)
- mypy strict: `Success: no issues found in 156 source files`
- ruff: `All checks passed!`

## Live record

Live Windows 11 box, Resolve Studio 21.0.3.7, python.org 3.12.10 interpreter, project `mcp-tests-zinc`. `uv run pytest tests/test_live_smoke.py -m live -k "property_keys_the_wrappers_assume or real_frame_grab_lands or real_scene_scan_reports_cuts"` → **2 passed, 1 skipped**, re-run after every code change on this branch with the same result.

The three #122 tests, reading `entry["bin"]` verbatim:

- `test_inspects_a_real_clip_with_the_property_keys_the_wrappers_assume` — **passed** (was `assert False is True`)
- `test_a_real_frame_grab_lands_on_the_moment_resolve_numbers_it_at` — **passed** (was `KeyError: 'bounds'`)
- `test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock` — **ran past the defect, then skipped on its own gate**: `scan completed but 'maitland-boulevard_0001.png' has no cuts — the mapping went unexercised; set RESOLVE_MCP_SCENE_SCAN_CLIP to a pool clip with hard cuts`. The old failure was `KeyError: 'bounds'` on the refusal envelope from `inspect_clip`; that call now resolves and the scan runs. The remaining skip is the pre-existing "pick a clip with hard cuts" gate documented in the test, not a #122 residual.

Review: clean — 13 findings across three passes; the two false docstrings, the unconditional root note, the drifted not-found label, the stale `_under` docstring and the missing vocabulary entry are fixed, AC3 is met at the error text, the shallow-copy preference that narrowed AC5 is reverted, and three findings are accepted with reasons above.
