### PR TITLE
Read the camera model off the card when Resolve reports none (#94)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -91,10 +91,10 @@ contract), `fusion` (Text+ node, text, opacity fade spline), `interchange`
 (timeline export/import), `loader` (import DaVinciResolveScript +
 direct-attach), `markers` (read/write, review-loop transport), `media`
 (media pool: import, list, inspect, bins, relink), `render` (render
-queue), `scripting` (`run_python` with handles pre-bound), `session`
-(session/project wrappers), `sidecar` (camera model from the card's XML,
-for media Resolve reports no camera metadata for — #94),
-`takes` (take selectors + in-place swap),
+queue), `camera_sidecar` (camera model off the card's own XML, for media
+Resolve reports no camera metadata for — #94; not an **angle sidecar**),
+`scripting` (`run_python` with handles pre-bound), `session`
+(session/project wrappers), `takes` (take selectors + in-place swap),
 `timeline` (timeline read wrappers), `titles` (titles file against a
 project + dry run).
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -92,7 +92,9 @@ contract), `fusion` (Text+ node, text, opacity fade spline), `interchange`
 direct-attach), `markers` (read/write, review-loop transport), `media`
 (media pool: import, list, inspect, bins, relink), `render` (render
 queue), `scripting` (`run_python` with handles pre-bound), `session`
-(session/project wrappers), `takes` (take selectors + in-place swap),
+(session/project wrappers), `sidecar` (camera model from the card's XML,
+for media Resolve reports no camera metadata for — #94),
+`takes` (take selectors + in-place swap),
 `timeline` (timeline read wrappers), `titles` (titles file against a
 project + dry run).
 

--- a/src/resolve_mcp/resolve/camera_sidecar.py
+++ b/src/resolve_mcp/resolve/camera_sidecar.py
@@ -15,6 +15,11 @@ This module is that read and nothing more: it is consulted only after the clip p
 come back empty, and every failure — no sidecar, unreadable file, malformed XML, no
 ``Device`` element — returns ``None`` so the caller falls back exactly as it did before.
 A sidecar is untrusted input from a card, so nothing here raises.
+
+Named ``camera_sidecar`` rather than ``sidecar`` because this repo already spends that
+word on the angle sidecars of #13 — one JSON per project, and defined by contrast with
+exactly this kind of file (see ``docs/agents/style-layer.md``). Two different things
+called "the sidecar" in one codebase is one too many.
 """
 
 from __future__ import annotations
@@ -27,9 +32,12 @@ from ..logging_config import get_logger
 
 log = get_logger("media")
 
-# Sony numbers the sidecar per clip: C0012M01.XML. The index is not always 01 across
-# vendors and firmware, and Windows cards mix the case of the extension, so the suffix is
-# matched as a pattern rather than compared as a literal.
+# Sony numbers the sidecar per clip: C0012M01.XML. Nearly always index 01, so that name is
+# tried directly and the directory is only listed when it misses — a card's CLIP folder
+# holds thousands of entries on a drive that is often a network share, and an import walks
+# every clip in it. The index is not always 01 across vendors and firmware, and cards mix
+# the case of the extension, so the fallback matches the tail as a pattern.
+USUAL_TAIL = "M01.XML"
 SIDECAR_SUFFIX = re.compile(r"M\d{2}\.XML", re.IGNORECASE)
 
 # The sidecar is namespaced (urn:schemas-professionalDisc:nonRealTimeMeta:...) and the
@@ -53,11 +61,23 @@ def camera_model(file_path: str) -> str | None:
 
 
 def _beside(clip: Path) -> Path | None:
-    """The sidecar for ``clip``: the clip's own name plus the vendor's ``M01.XML`` tail.
+    """The sidecar for ``clip``: the clip's own name plus the vendor's ``M01.XML`` tail."""
+    usual = clip.with_name(f"{clip.stem}{USUAL_TAIL}")
+    try:
+        if usual.is_file():
+            return usual
+    except OSError:
+        log.debug("Could not reach %r looking for a camera sidecar", str(usual))
+        return None
+    return _hunted(clip)
 
-    The card directory is listed rather than probed for one guessed name, so a differing
-    index or extension case still matches — both vary in the wild and neither changes
-    which clip the sidecar belongs to.
+
+def _hunted(clip: Path) -> Path | None:
+    """The sidecar under a name this vendor spells differently, or ``None``.
+
+    Only reached when the usual name misses, because this is the expensive branch: it
+    lists the whole card directory. Sorted so that a card carrying more than one index
+    for a clip answers the same way every time rather than in directory order.
     """
     stem = clip.stem
     try:

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -57,6 +57,7 @@ from ..logging_config import get_logger
 from ..spill import spill
 from ..timing import dual_time
 from .connection import ResolveConnection
+from .sidecar import camera_model as sidecar_camera_model
 
 log = get_logger("media")
 
@@ -71,8 +72,10 @@ ASSETS_BIN = "04_Assets"
 # Camera fields in priority order, each consulted in the clip's properties then its
 # metadata. Live-verified on real FX6 XAVC (2026-08-07, Resolve Studio, #94): the model
 # lives in "Camera TC Type" ("ILME-FX6V") while "Camera Type" holds the manufacturer
-# ("Sony"), so the model key must win or every camera bins as its make. An unreadable
-# camera falls back to the bare footage bin rather than guessing.
+# ("Sony"), so the model key must win or every camera bins as its make. Media that reports
+# no camera key at all — A7-series MP4 on an M4ROOT card — gets a second look in the
+# sidecar beside the clip (see :mod:`.sidecar`); only a camera unreadable both ways falls
+# back to the bare footage bin rather than guessing.
 CAMERA_KEYS = ("Camera TC Type", "Camera Type")
 SEQUENCE_TOKEN = "%"
 # Resolve paths an imported image sequence by folding the index range into the name —
@@ -553,14 +556,25 @@ def _suggested_bin(item: str | dict[str, Any]) -> str:
     return FOOTAGE_BIN
 
 
-def _camera_model(clip: Clip, reported: dict[str, str]) -> str | None:
-    """The camera model the clip reports, sanitised for bin use, or ``None``.
+class CameraModel(NamedTuple):
+    """The model that will name the bin, and which reading produced it."""
+
+    name: str
+    source: str
+
+
+def _camera_model(clip: Clip, reported: dict[str, str]) -> CameraModel | None:
+    """The camera model for this clip, sanitised for bin use, or ``None``.
 
     Read after import — the model is embedded data Resolve surfaces, nothing the file
     path could carry. Key priority outranks dict priority: a model found anywhere beats a
     manufacturer found anywhere (see ``CAMERA_KEYS``), with the spec's clip properties
     consulted before metadata for each key. A slash in a model name would read as a bin
     separator, so it is folded to a dash.
+
+    What Resolve knows always wins. The sidecar is the last look rather than a preferred
+    one, so media Resolve reads properly keeps binning exactly as it did before this
+    existed, and the envelope says which reading answered.
     """
     metadata = clip.GetMetadata()
     dicts = [reported, metadata if isinstance(metadata, dict) else {}]
@@ -568,7 +582,10 @@ def _camera_model(clip: Clip, reported: dict[str, str]) -> str | None:
         for source in dicts:
             value = str(source.get(key) or "").strip()
             if value:
-                return value.replace(BIN_SEPARATOR, "-")
+                return CameraModel(value.replace(BIN_SEPARATOR, "-"), "camera_metadata")
+    recorded = sidecar_camera_model(reported.get(FILE_PATH, ""))
+    if recorded:
+        return CameraModel(recorded.replace(BIN_SEPARATOR, "-"), "camera_sidecar")
     return None
 
 
@@ -590,12 +607,12 @@ def _placed(pool: Pool, clip: Clip, reported: dict[str, str], target: LocatedBin
     model = _camera_model(clip, reported)
     if model is None:
         return Placement(target.path, "fallback")
-    leaf = ensure_bin(pool, f"{FOOTAGE_BIN}{BIN_SEPARATOR}{model}")
+    leaf = ensure_bin(pool, f"{FOOTAGE_BIN}{BIN_SEPARATOR}{model.name}")
     if not pool.MoveClips([clip], leaf.folder):
         name = str(clip.GetName() or "")
         log.warning("Camera bin move refused for %r; leaving it in %r", name, target.path)
         return Placement(target.path, "fallback")
-    return Placement(leaf.path, "camera_metadata")
+    return Placement(leaf.path, model.source)
 
 
 def _clip_summary(

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -56,8 +56,8 @@ from ..errors import (
 from ..logging_config import get_logger
 from ..spill import spill
 from ..timing import dual_time
+from .camera_sidecar import camera_model as recorded_camera_model
 from .connection import ResolveConnection
-from .sidecar import camera_model as sidecar_camera_model
 
 log = get_logger("media")
 
@@ -557,10 +557,18 @@ def _suggested_bin(item: str | dict[str, Any]) -> str:
 
 
 class CameraModel(NamedTuple):
-    """The model that will name the bin, and which reading produced it."""
+    """The model that will name the bin, and which reading produced it.
+
+    Built through :meth:`read`, so the one rule about the name — a slash in it would read
+    as a bin separator — is applied once however the model was found.
+    """
 
     name: str
     source: str
+
+    @classmethod
+    def read(cls, model: str, source: str) -> CameraModel:
+        return cls(model.replace(BIN_SEPARATOR, "-"), source)
 
 
 def _camera_model(clip: Clip, reported: dict[str, str]) -> CameraModel | None:
@@ -569,12 +577,11 @@ def _camera_model(clip: Clip, reported: dict[str, str]) -> CameraModel | None:
     Read after import — the model is embedded data Resolve surfaces, nothing the file
     path could carry. Key priority outranks dict priority: a model found anywhere beats a
     manufacturer found anywhere (see ``CAMERA_KEYS``), with the spec's clip properties
-    consulted before metadata for each key. A slash in a model name would read as a bin
-    separator, so it is folded to a dash.
+    consulted before metadata for each key.
 
-    What Resolve knows always wins. The sidecar is the last look rather than a preferred
-    one, so media Resolve reads properly keeps binning exactly as it did before this
-    existed, and the envelope says which reading answered.
+    What Resolve knows always wins. The card's own sidecar is the last look rather than a
+    preferred one, so media Resolve reads properly keeps binning exactly as it did before
+    this existed, and the envelope says which reading answered.
     """
     metadata = clip.GetMetadata()
     dicts = [reported, metadata if isinstance(metadata, dict) else {}]
@@ -582,10 +589,10 @@ def _camera_model(clip: Clip, reported: dict[str, str]) -> CameraModel | None:
         for source in dicts:
             value = str(source.get(key) or "").strip()
             if value:
-                return CameraModel(value.replace(BIN_SEPARATOR, "-"), "camera_metadata")
-    recorded = sidecar_camera_model(reported.get(FILE_PATH, ""))
+                return CameraModel.read(value, "camera_metadata")
+    recorded = recorded_camera_model(reported.get(FILE_PATH, ""))
     if recorded:
-        return CameraModel(recorded.replace(BIN_SEPARATOR, "-"), "camera_sidecar")
+        return CameraModel.read(recorded, "camera_sidecar")
     return None
 
 

--- a/src/resolve_mcp/resolve/sidecar.py
+++ b/src/resolve_mcp/resolve/sidecar.py
@@ -1,0 +1,92 @@
+"""The camera model for media Resolve reads no camera metadata from.
+
+Resolve fills its ``Camera *`` clip properties from the MXF wrapper on an XDROOT card, so
+FX6 footage names its own bin and mirrorless footage does not. Live-probed on 2026-08-07
+in one project (#94): an FX6 ``.MXF`` reports seven camera keys including ``Camera TC
+Type = ILME-FX6V``, while an A7 IV ``.MP4`` on an M4ROOT card reports *no* camera key at
+all — not an empty one, absent. The camera wrote the same facts to an XML sidecar beside
+the clip, which Resolve never reads:
+
+    20260617_D_A7IV_0001.MP4
+    20260617_D_A7IV_0001M01.XML   <Device manufacturer="Sony" modelName="ILCE-7M4"/>
+
+So the model is one file read away from a bin suggestion that would otherwise fall back.
+This module is that read and nothing more: it is consulted only after the clip properties
+come back empty, and every failure — no sidecar, unreadable file, malformed XML, no
+``Device`` element — returns ``None`` so the caller falls back exactly as it did before.
+A sidecar is untrusted input from a card, so nothing here raises.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from xml.etree import ElementTree
+
+from ..logging_config import get_logger
+
+log = get_logger("media")
+
+# Sony numbers the sidecar per clip: C0012M01.XML. The index is not always 01 across
+# vendors and firmware, and Windows cards mix the case of the extension, so the suffix is
+# matched as a pattern rather than compared as a literal.
+SIDECAR_SUFFIX = re.compile(r"M\d{2}\.XML", re.IGNORECASE)
+
+# The sidecar is namespaced (urn:schemas-professionalDisc:nonRealTimeMeta:...) and the
+# namespace has changed between camera generations, so elements are matched on local name.
+DEVICE_TAG = "Device"
+MODEL_ATTRIBUTE = "modelName"
+
+
+def camera_model(file_path: str) -> str | None:
+    """The camera model recorded beside ``file_path``, or ``None`` if there is not one.
+
+    ``None`` covers every way this can come up empty, because the caller's answer is the
+    same for all of them: suggest the bare footage bin.
+    """
+    if not file_path:
+        return None
+    sidecar = _beside(Path(file_path))
+    if sidecar is None:
+        return None
+    return _model_in(sidecar)
+
+
+def _beside(clip: Path) -> Path | None:
+    """The sidecar for ``clip``: the clip's own name plus the vendor's ``M01.XML`` tail.
+
+    The card directory is listed rather than probed for one guessed name, so a differing
+    index or extension case still matches — both vary in the wild and neither changes
+    which clip the sidecar belongs to.
+    """
+    stem = clip.stem
+    try:
+        entries = sorted(entry.name for entry in clip.parent.iterdir())
+    except OSError:
+        log.debug("Could not list %r looking for a camera sidecar", str(clip.parent))
+        return None
+    for name in entries:
+        if len(name) <= len(stem) or name[: len(stem)].lower() != stem.lower():
+            continue
+        if SIDECAR_SUFFIX.fullmatch(name[len(stem) :]):
+            return clip.parent / name
+    return None
+
+
+def _model_in(sidecar: Path) -> str | None:
+    """``Device/@modelName`` from a camera sidecar, without trusting the file."""
+    try:
+        root = ElementTree.parse(sidecar).getroot()
+    except (OSError, ElementTree.ParseError):
+        log.warning("Camera sidecar %r is not readable XML; ignoring it", str(sidecar))
+        return None
+    for element in root.iter():
+        tag = element.tag
+        if not isinstance(tag, str) or tag.rpartition("}")[2] != DEVICE_TAG:
+            continue
+        model = str(element.get(MODEL_ATTRIBUTE) or "").strip()
+        if model:
+            log.info("Camera model %r read from sidecar %r", model, sidecar.name)
+            return model
+    log.debug("Camera sidecar %r carries no %s model", str(sidecar), DEVICE_TAG)
+    return None

--- a/src/resolve_mcp/tools/media.py
+++ b/src/resolve_mcp/tools/media.py
@@ -28,10 +28,12 @@ def import_media(
     later timeline appends honour the exact durations you ask for.
 
     With no bin, each item gets a bin suggested by media type: video into
-    02_Footage/<Camera> (camera model read from clip metadata after import; plain
-    02_Footage when unreadable), audio into 03_Audio, stills and image sequences into
-    04_Assets — bins created on demand. Each imported clip reports the bin used and
-    bin_source (camera_metadata, fallback, media_type, or explicit). Suggestions are
+    02_Footage/<Camera> (camera model read from clip metadata after import, falling back
+    to the camera's XML sidecar for media Resolve reports no camera metadata for, such as
+    Sony mirrorless MP4; plain 02_Footage when neither is readable), audio into 03_Audio,
+    stills and image sequences into 04_Assets — bins created on demand. Each imported clip
+    reports the bin used and bin_source (camera_metadata, camera_sidecar, fallback,
+    media_type, or explicit). Suggestions are
     category-from-root; in a multi-gig project supply the <Gig>/ prefix yourself via bin=.
     In a project that already has its own bin structure, check that structure first and
     pass bin= to follow it rather than accepting a suggestion — a suggestion is never

--- a/src/resolve_mcp/tools/media.py
+++ b/src/resolve_mcp/tools/media.py
@@ -33,8 +33,8 @@ def import_media(
     Sony mirrorless MP4; plain 02_Footage when neither is readable), audio into 03_Audio,
     stills and image sequences into 04_Assets — bins created on demand. Each imported clip
     reports the bin used and bin_source (camera_metadata, camera_sidecar, fallback,
-    media_type, or explicit). Suggestions are
-    category-from-root; in a multi-gig project supply the <Gig>/ prefix yourself via bin=.
+    media_type, or explicit). Suggestions are category-from-root; in a multi-gig project
+    supply the <Gig>/ prefix yourself via bin=.
     In a project that already has its own bin structure, check that structure first and
     pass bin= to follow it rather than accepting a suggestion — a suggestion is never
     enforcement, and an explicit bin (any path at all) bypasses it entirely.

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from resolve_mcp.tools.media import (
     import_media,
     inspect_clip,
@@ -366,6 +368,159 @@ def test_a_refused_camera_move_falls_back_to_the_footage_bin(
 
     assert result["ok"] is True
     assert result["imported"][0]["bin"] == "02_Footage"
+    assert result["imported"][0]["bin_source"] == "fallback"
+
+
+# --- the camera sidecar (#94) ----------------------------------------------------------
+#
+# Resolve reads camera metadata off the MXF wrapper and not off an MP4 on an M4ROOT card,
+# so A7-series footage reports no camera key at all and used to bin as bare 02_Footage.
+# The model is in an XML sidecar beside the clip. These use the real shape: namespaced,
+# because the namespace differs between camera generations and a literal tag match would
+# pass here and fail on the card.
+
+SIDECAR_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<NonRealTimeMeta xmlns="urn:schemas-professionalDisc:nonRealTimeMeta:ver.2.20">
+  <Duration value="24"/>
+  <Device manufacturer="Sony" modelName="{model}" serialNo="4294967295"/>
+  <VideoFormat><VideoFrame formatFps="23.98p"/></VideoFormat>
+</NonRealTimeMeta>
+"""
+
+
+def a_sidecar(clip: Path, model: str, tail: str = "M01.XML") -> Path:
+    target = clip.with_name(f"{clip.stem}{tail}")
+    target.write_text(SIDECAR_XML.format(model=model), encoding="utf-8")
+    return target
+
+
+def test_a_camera_sidecar_names_the_bin_when_resolve_reports_no_camera(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The A7 IV case this ticket failed on live: no camera key anywhere, model on disk."""
+    video = a_file(tmp_path, "20260617_D_A7IV_0001.MP4")
+    a_sidecar(video, "ILCE-7M4")
+    clip = FakeMediaPoolItem("20260617_D_A7IV_0001.MP4", str(video))
+    pool = media_pool()
+    pool.import_result = [clip]
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["ok"] is True
+    assert result["bins"] == ["02_Footage/ILCE-7M4"]
+    assert result["imported"][0]["bin"] == "02_Footage/ILCE-7M4"
+    assert result["imported"][0]["bin_source"] == "camera_sidecar"
+    leaf = bin_named(pool, "02_Footage/ILCE-7M4")
+    assert [found.GetName() for found in leaf.GetClipList()] == ["20260617_D_A7IV_0001.MP4"]
+
+
+def test_what_resolve_reports_outranks_the_sidecar(attach: Attach, tmp_path: Path) -> None:
+    """The sidecar is the last look, not a preferred one: media Resolve reads is untouched."""
+    video = a_file(tmp_path, "A016C008_260618GD.MXF")
+    a_sidecar(video, "SOMETHING-ELSE")
+    clip = FakeMediaPoolItem(
+        "A016C008_260618GD.MXF", str(video), properties={"Camera TC Type": "ILME-FX6V"}
+    )
+    pool = media_pool()
+    pool.import_result = [clip]
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["imported"][0]["bin"] == "02_Footage/ILME-FX6V"
+    assert result["imported"][0]["bin_source"] == "camera_metadata"
+
+
+def test_a_sidecar_index_and_extension_case_still_match(attach: Attach, tmp_path: Path) -> None:
+    """Both vary on real cards and neither changes which clip the sidecar belongs to."""
+    video = a_file(tmp_path, "C0500.MP4")
+    a_sidecar(video, "ILCE-7M4", tail="M02.xml")
+    clip = FakeMediaPoolItem("C0500.MP4", str(video))
+    pool = media_pool()
+    pool.import_result = [clip]
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["imported"][0]["bin"] == "02_Footage/ILCE-7M4"
+    assert result["imported"][0]["bin_source"] == "camera_sidecar"
+
+
+def test_a_sidecar_for_a_different_clip_is_not_read(attach: Attach, tmp_path: Path) -> None:
+    """Cards hold every clip's sidecar in one directory; only this clip's may answer."""
+    video = a_file(tmp_path, "C0500.MP4")
+    a_sidecar(tmp_path / "C0501.MP4", "ILCE-7M4")
+    clip = FakeMediaPoolItem("C0500.MP4", str(video))
+    pool = media_pool()
+    pool.import_result = [clip]
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["imported"][0]["bin"] == "02_Footage"
+    assert result["imported"][0]["bin_source"] == "fallback"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param("<NonRealTimeMeta><Device modelName=", id="truncated"),
+        pytest.param("not xml at all", id="not-xml"),
+        pytest.param(
+            '<NonRealTimeMeta><Device manufacturer="Sony"/></NonRealTimeMeta>', id="no-model"
+        ),
+        pytest.param(
+            '<NonRealTimeMeta><Device modelName="  "/></NonRealTimeMeta>', id="blank-model"
+        ),
+        pytest.param("<NonRealTimeMeta><Duration value='24'/></NonRealTimeMeta>", id="no-device"),
+    ],
+)
+def test_an_unusable_sidecar_falls_back_rather_than_failing_the_import(
+    attach: Attach, tmp_path: Path, content: str
+) -> None:
+    """A sidecar is untrusted input off a card: it can cost a suggestion, never an import."""
+    video = a_file(tmp_path, "C0500.MP4")
+    video.with_name("C0500M01.XML").write_text(content, encoding="utf-8")
+    clip = FakeMediaPoolItem("C0500.MP4", str(video))
+    pool = media_pool()
+    pool.import_result = [clip]
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["ok"] is True
+    assert result["imported"][0]["bin"] == "02_Footage"
+    assert result["imported"][0]["bin_source"] == "fallback"
+
+
+def test_a_sidecar_model_with_a_slash_cannot_open_a_bin_level(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The sidecar is off a card, so its model gets the same folding a property's does."""
+    video = a_file(tmp_path, "C0500.MP4")
+    a_sidecar(video, "ILCE/7M4")
+    clip = FakeMediaPoolItem("C0500.MP4", str(video))
+    pool = media_pool()
+    pool.import_result = [clip]
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["imported"][0]["bin"] == "02_Footage/ILCE-7M4"
+
+
+def test_a_clip_with_no_path_reads_no_sidecar(attach: Attach, tmp_path: Path) -> None:
+    """Multicam and compound clips are pathless, not offline — and have nothing beside them."""
+    video = a_file(tmp_path, "C0500.MP4")
+    clip = FakeMediaPoolItem("C0500.MP4", "")
+    pool = media_pool()
+    pool.import_result = [clip]
+    attach(studio(pool=pool))
+
+    result = import_media(paths=[str(video)])
+
+    assert result["ok"] is True
     assert result["imported"][0]["bin_source"] == "fallback"
 
 


### PR DESCRIPTION
Closes the A7 IV half of #94's AC3, which failed live on 2026-08-07 and reopened the ticket.

## Why

Resolve fills its `Camera *` clip properties from the MXF wrapper on an XDROOT card. Probed
live in one project: an FX6 `.MXF` reports seven camera keys including `Camera TC Type =
ILME-FX6V`, while an A7 IV `.MP4` on an M4ROOT card reports **no camera key at all** — not an
empty one, absent. So every mirrorless clip fell back to bare `02_Footage`, and AC3 as written
("camera model resolves **from clip properties** on real FX6 and A7IV media") was not
satisfiable for A7 IV by any amount of tuning `CAMERA_KEYS`.

The camera had already written the model beside the clip:

```
20260617_D_A7IV_0001.MP4
20260617_D_A7IV_0001M01.XML    <Device manufacturer="Sony" modelName="ILCE-7M4"/>
```

Route 1 of the three offered on the ticket, per Daniel's call.

## What

`resolve/camera_sidecar.py` is that read and nothing more. It is consulted **only** after the
clip properties come back empty, so media Resolve reads properly bins exactly as it did
before. Every way it can fail — no sidecar, unreadable file, malformed XML, no `Device`
element, a sidecar belonging to a different clip — returns `None` and falls back, because a
file off a card is untrusted input that may cost a suggestion but must never cost an import.

`bin_source` gains `camera_sidecar` alongside `camera_metadata` and `fallback`, so the
envelope stays honest about which reading answered.

## Seam

**Fake tier** for every decision (8 new tests in `test_media_tools.py`): the sidecar is the
last look and never outranks Resolve; a foreign clip's sidecar in the same directory is not
read; index and extension case still match; a slash in the model cannot open a bin level; a
pathless clip reads nothing; and five parametrised unusable-sidecar cases each fall back
rather than failing the import. Fixtures use the real namespaced Sony shape — the namespace
differs between camera generations, so a literal tag match would pass here and fail on a card.

**Live smoke**, run this session on the live Windows 11 box (Resolve Studio 21.0.3.7, project
`mcp-tests-zinc`), and re-run after the review fixes:

```
20260617_D_A7IV_0004.MP4   -> 02_Footage/ILCE-7M4    bin_source camera_sidecar
A015C003_260617T0.MXF      -> 02_Footage/ILME-FX6V   bin_source camera_metadata
```

AC3 passes on both cameras, and the FX6 half is confirmed un-regressed.

Fake tier 1195 passed / 0 failed (34 live deselected), mypy strict clean over 153 files,
ruff clean.

## Review

`/code-review` on the branch before this PR existed — Standards and Spec as parallel
sub-agents. Four findings, all in the new code, all fixed in 802ce0b:

1. **Vocabulary clash (Standards).** The module was `sidecar`, but this repo already spends
   that word on the angle sidecars of #13, and `docs/agents/style-layer.md` defines those by
   contrast with exactly this kind of file — "not as a file sitting beside the Resolve project
   on the media drive." Renamed to `camera_sidecar`, which is what the envelope value already
   said. `CONTEXT.md` names the distinction rather than burying it.
2. **Directory listing per clip (both axes, independently).** `_beside` listed the whole card
   directory for every clip whose properties came back empty. A CLIP folder holds thousands of
   entries and often lives on a network share, so importing a card walked it once per clip —
   the Spec axis put it at O(clips x entries) against the ticket's stated cost of "one file
   read per clip." The usual `M01.XML` name is now tried directly; the listing survives only as
   the fallback for a vendor that spells the index differently, which is the case the tests
   cover.
3. **Duplicated slash-fold (Standards).** Applied at each of two returns; now in
   `CameraModel.read`, so however the model was found the rule runs once.
4. **Ragged prose (Standards).** Reflowed in `tools/media.py` and `CONTEXT.md`.

The Spec axis also flagged that AC3 had no live record on the branch — it does now, above —
and that the ticket's own AC3 wording still says "from clip properties" and should be amended
to name the sidecar. Left for the ticket rather than changed here; noted in the close comment.

Fix diff re-checked (focused pass over 802ce0b only, per the workflow): fake tier, mypy, ruff
and the live smoke were all re-run after the fixes and all pass.

Review: clean — 4 findings from the two-axis pass, all fixed in 802ce0b; fix diff re-checked and green at every seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
