### PR TITLE
Pin numpy below 2.5 so uv sync stops breaking PANNs inference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,17 @@ dev = [
     "ruff>=0.6",
 ]
 
+[tool.uv]
+# numba refuses numpy >= 2.5 outright ("Numba needs NumPy 2.4 or less"), and numba arrives
+# transitively on any box that injects the analysis models: panns_inference -> torchlibrosa ->
+# librosa -> numba. Without this, `uv sync` resolves numpy 2.5 and PANNs inference dies at import
+# while the whole fake tier stays green, because ADR 0002 injects the models rather than depending
+# on them. Constrained here rather than in [project.dependencies] so the cap governs this
+# environment without shipping in the published metadata: the server itself is fine on numpy 2.5.
+# numba 0.66.0 is the latest stable as of 2026-08; when 0.67 ships stable it likely lifts the
+# ceiling and this block can go.
+constraint-dependencies = ["numpy<2.5"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q --strict-markers -m 'not live'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dev = [
 # librosa -> numba. Without this, `uv sync` resolves numpy 2.5 and PANNs inference dies at import
 # while the whole fake tier stays green, because ADR 0002 injects the models rather than depending
 # on them. Constrained here rather than in [project.dependencies] so the cap governs this
-# environment without shipping in the published metadata: the server itself is fine on numpy 2.5.
+# environment without shipping in the published metadata: nothing the server itself imports has
+# this ceiling, only the injected analysis stack does.
 # numba 0.66.0 is the latest stable as of 2026-08; when 0.67 ships stable it likely lifts the
 # ceiling and this block can go.
 constraint-dependencies = ["numpy<2.5"]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = "==3.12.*"
 
+[manifest]
+constraints = [{ name = "numpy", specifier = "<2.5" }]
+
 [[package]]
 name = "aiofile"
 version = "3.12.3"
@@ -743,21 +746,21 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.5.1"
+version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
-    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
-    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
-    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
-    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
-    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this fixes

`uv.lock` pinned **numpy 2.5.1**. numba refuses numpy >= 2.5 with an explicit gate —
`ImportError: Numba needs NumPy 2.4 or less. Got NumPy 2.5.` — and numba arrives transitively on
any box that injects the analysis models:

```
panns_inference -> torchlibrosa -> librosa -> numba
```

So a plain `uv sync` reinstalled the broken numpy and PANNs inference died at import. This is the
mechanism behind the "`uv run` re-syncs numpy and breaks panns" note that has been living in a
human's head instead of in the repo. Measured on the live box, not reasoned about: upgraded to
2.5.1, ran real `SoundEventDetection` inference, got the ImportError; restored 2.4.6 and confirmed
framewise output of shape `(1, 501, 527)`.

`numba==0.66.0` is the latest stable — there is nothing newer to upgrade into. `0.67.0rc1` exists
and may lift the cap, but a release candidate is not something to stand on.

## Why `[tool.uv] constraint-dependencies` and not a cap on the core dependency

Capping `numpy>=2.0,<2.5` in `[project.dependencies]` would work, but that cap ships in the
published package metadata, so every consumer of `resolve-mcp` inherits it — including ones that
never inject an analysis model, for a reason that has nothing to do with the server.
`constraint-dependencies` binds resolution for *this* environment only. That also keeps ADR 0002's
line intact: an injected model does not become a dependency, it just constrains the box hosting it.

The comment in `pyproject.toml` names numba explicitly so that when 0.67 ships stable the ceiling
can be lifted deliberately rather than discovered by accident.

## A seam finding worth recording

`tests/test_applause_spans.py` **passes all 12 tests on numpy 2.5.1** while real inference is
completely broken. That is correct behaviour, not a bug — per ADR 0002 the model is injected, so
the fake tier never loads PANNs and structurally cannot see this. But it means the fake tier stays
green through exactly this failure every time, the same shape as the interpreter guard in
CLAUDE.md. Recorded here because the next person to hit it will otherwise trust the green tier.

## Verification

- `uv lock` diff is `numpy v2.5.1 -> v2.4.6` and nothing else; constraint recorded at `uv.lock:6`
- Fake tier: **1267 passed, 35 deselected**
- No live ACs — this changes no code path

## Review

Findings and resolutions:

1. **Comment claimed more than was measured.** It read "the server itself is fine on numpy 2.5",
   but what was actually verified is narrower — that numba is the only thing imposing the ceiling.
   The whole fake tier was never run on 2.5.1, only the 12 applause tests. Reworded to
   "nothing the server itself imports has this ceiling, only the injected analysis stack does."
   Fixed in 49b7f4e.

Also checked and clean: `constraint-dependencies` is not published metadata and does not
constrain downstream installers, so the scoping argument above holds; the lockfile carries no
collateral resolution changes; `[tool.uv]` placement does not disturb the surrounding tool
sections; the fake tier passes with the new lock.

Note on how this was reviewed: the session was instructed not to spawn sub-agents, so this is a
focused single-pass inline review by the authoring session rather than the two-axis
`/code-review`. Stating that plainly rather than implying a review that did not run. The diff is
one constraint line, its comment, and a mechanical lockfile version bump — CLAUDE.md's rule that
build config counts as executable is the reason it got a real pass at all.

Refs #37.

Review: clean — one finding, fixed in 49b7f4e; single-pass inline (no sub-agents, see note above)
