### PR TITLE
Ship the CUDA runtime in the analysis extra, and make the device configurable

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,7 +70,9 @@ Top level:
 `applause` (bursts → tune boundaries), `beats` (grid + downbeats, model
 injected per ADR 0002; `trust` says which beats the grid describes well enough
 to count, #112), `correlate` (measure a cut against its music, gating the beat
-statistics on `trust` and leaving the transient ones ungated),
+statistics on `trust` and leaving the transient ones ungated), `cuda` (preloads
+the CUDA runtime the `analysis` extra ships, so CTranslate2 finds it on Windows;
+pure decisions, #128),
 `decode` (WAV → numpy, no third-party decoder), `drums` (hits per stem), `energy`
 (loudness curves), `fills` (drum-fill candidates), `halves` (shared
 identify/cache/write pattern), `music` (beats + energy + gist job),

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ you pass `refresh`.
 - **`uv sync --extra analysis`** for transcription. The extra carries faster-whisper *and*
   the CUDA 12 runtime it needs (~1.3 GiB): the transcriber takes the GPU by default, and a
   runtime nobody installed is the one thing that breaks it. No hand-installed wheels, no
-  `PATH` set before launch — the server preloads the runtime out of the venv itself. A box
+  `PATH` set before launch — the server puts the venv's own copy within reach. A box
   without an NVIDIA card still transcribes; set `RESOLVE_MCP_WHISPER_DEVICE=cpu` and expect
   it to be slow.
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ you pass `refresh`.
   `RESOLVE_MCP_AUDIO_SEPARATOR` points at the executable). It is run as a subprocess, not
   imported, so it can live in its own environment and its torch/CUDA stack never loads
   into the server. The two model files download on first use.
+- **`uv sync --extra analysis`** for transcription. The extra carries faster-whisper *and*
+  the CUDA 12 runtime it needs (~1.3 GiB): the transcriber takes the GPU by default, and a
+  runtime nobody installed is the one thing that breaks it. No hand-installed wheels, no
+  `PATH` set before launch — the server preloads the runtime out of the venv itself. A box
+  without an NVIDIA card still transcribes; set `RESOLVE_MCP_WHISPER_DEVICE=cpu` and expect
+  it to be slow.
 
 ## Install
 
@@ -178,6 +184,8 @@ Zero-config by default; every path has an environment override.
 | `RESOLVE_MCP_STEM_MODEL` | `htdemucs_ft.yaml` | Pass one: the 4-stem model (vocals, drums, bass, other) |
 | `RESOLVE_MCP_DRUM_MODEL` | `MDX23C-DrumSep-aufr33-jarredou.ckpt` | Pass two: the drum decomposition model (kick, snare, toms) |
 | `RESOLVE_MCP_DEFAULT_RENDER_PRESET` | `H.265 Master` | Render preset `render_timeline` uses when the call names none. Must be a preset the project offers — an unknown name is refused, never swapped for another |
+| `RESOLVE_MCP_WHISPER_DEVICE` | `auto` | Device faster-whisper transcribes on: `auto`, `cuda` or `cpu`. `auto` takes the GPU whenever there is one |
+| `RESOLVE_MCP_WHISPER_COMPUTE_TYPE` | `default` | Precision: `default` is the model's stored precision (float16 for `large-v3`, widened to float32 on CPU). `float32` on `cuda` gives CPU-identical numbers at GPU speed |
 | `RESOLVE_MCP_LOG_LEVEL` | `INFO` | Log level for the stderr logger |
 | `RESOLVE_MCP_ALLOW_ANY_PYTHON` | unset | Bypass the interpreter check (see ADR 0001) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,13 @@ dependencies = [
 # pull a CUDA runtime to answer get_status.
 analysis = [
     "faster-whisper>=1.0",
+    # The CUDA 12 runtime CTranslate2 links against (~1.3 GiB). Shipped in the extra rather
+    # than left to the machine because the device default is "auto": CTranslate2 picks CUDA
+    # the moment it sees an NVIDIA card, and then needs a runtime nothing else in this tree
+    # provides — so the extra used to fail on exactly the boxes it is most useful on (#128).
+    # No wheels exist for macOS, and nothing there would use them.
+    "nvidia-cublas-cu12>=12,<13; platform_system != 'Darwin'",
+    "nvidia-cudnn-cu12>=9,<10; platform_system != 'Darwin'",
 ]
 
 [project.scripts]

--- a/src/resolve_mcp/analysis/cuda.py
+++ b/src/resolve_mcp/analysis/cuda.py
@@ -2,28 +2,30 @@
 
 ``uv sync --extra analysis`` installs the runtime as wheels (#128): the DLLs land under
 ``site-packages/nvidia/<package>/bin``, which is on nobody's search path. CTranslate2 —
-faster-whisper's backend — then fails to resolve ``cublas64_12.dll`` at import and the
-transcriber is broken on exactly the machines a GPU makes it useful on.
+faster-whisper's backend — loads them by bare name the first time a model touches the
+GPU, and without help fails with ``Library cublas64_12.dll is not found or cannot be
+loaded``. Note *when*: not at import, but at the first CUDA allocation, which is why the
+preparation has to be in place before the model is built rather than merely before the
+backend is imported.
 
-Three mechanisms were considered; what is known about each (#35's live pass, #128):
+Measured on the live box (RTX, CUDA 12.9 wheels, ctranslate2 4.8.1, faster-whisper 1.2.1)
+by building ``tiny`` on ``device="cuda"`` under each candidate mechanism in turn:
 
-* Those directories on ``PATH`` **before the process starts** — verified working.
-* ``os.add_dll_directory()`` on them — verified *not* working. CTranslate2's loader does
-  not consult the added-directory list; it still failed on ``cublas64_12.dll``.
-* Mutating ``os.environ["PATH"]`` in-process — a hypothesis. Python ≥3.8 loads extension
-  modules with ``LOAD_LIBRARY_SEARCH_DEFAULT_DIRS``, which excludes ``PATH`` when the
-  loader resolves an extension's dependencies, so it may fail the way the second did.
+===========================  ======================================================
+``PATH`` prepended in-proc   **works** — the mechanism shipped here
+``ctypes.WinDLL`` preload    works, by absolute path; the fallback if the above ever
+                             stops (it does not depend on the loader's search order)
+``os.add_dll_directory()``   fails — ``cublas64_12.dll`` still not found (also #35)
+nothing at all               fails — this is the bug #128 was filed for
+===========================  ======================================================
 
-So the mechanism shipped here is the one that does not depend on the loader's search
-order at all: preload each library by absolute path before faster-whisper is imported.
-A DLL already in the process is matched by base name, so CTranslate2's own resolution
-finds it whatever flags it uses. ``PATH`` is prepended too — it is free, it costs one
-string, and it is what any child process would need — but nothing rests on it.
-
-Preloading by path also carries ``LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR``, so each library's
-own directory is searched for *its* dependencies. That is why the list below stops at
-the entry points: cuDNN's multi-hundred-megabyte engine libraries are loaded by
-``cudnn64_9`` itself, out of the directory we just loaded it from.
+``PATH`` wins on cost rather than on principle: preloading means mapping ~1.4 GiB of DLLs
+(``cublasLt64_12.dll`` alone is 668 MB) into every job, including on a box that will
+transcribe on the CPU and never touch one of them. That CTranslate2 reads ``PATH`` at all
+is what the table above establishes — Python ≥3.8 excludes ``PATH`` when *it* resolves an
+extension module's dependencies, but CTranslate2 does its own ``LoadLibrary`` at runtime,
+which is the plain Windows search order. The same fact explains why ``add_dll_directory``
+does nothing here: that list is consulted for the flag-controlled search, not this one.
 
 Nothing here can observe whether CUDA subsequently initialises — the same shape as ADR
 0001's attach problem. The decisions (which directories, in what order, on which
@@ -35,29 +37,15 @@ from __future__ import annotations
 import os
 import sys
 import sysconfig
-from collections.abc import Callable
 from pathlib import Path
 
 from ..logging_config import get_logger
 
 log = get_logger("analysis")
 
-# In the order the loader would want them, and the order #128 records.
+# Installed by nvidia-cublas-cu12 and nvidia-cudnn-cu12; cuda_nvrtc arrives as a
+# dependency of cuDNN. Listed in the order the runtime layers on top of itself.
 NVIDIA_PACKAGES = ("cublas", "cudnn", "cuda_nvrtc")
-
-# Matched by pattern rather than by pinned name so a cuDNN 9 → 10 bump is an install, not
-# a code change. Deliberately absent: cudnn_engines_* and cudnn_heuristic*, which cuDNN
-# loads itself, and nvrtc-builtins, which nvrtc loads itself.
-PRELOAD_PATTERNS = (
-    "cublas64_*.dll",
-    "cublasLt64_*.dll",
-    "cudnn64_*.dll",
-    "cudnn_adv*.dll",
-    "cudnn_cnn*.dll",
-    "cudnn_graph*.dll",
-    "cudnn_ops*.dll",
-    "nvrtc64_*.dll",
-)
 
 _prepared = False
 
@@ -71,7 +59,8 @@ def dll_directories(root: Path, platform: str | None = None) -> tuple[Path, ...]
     """The nvidia ``bin`` directories present under ``root``, in load order.
 
     Empty off Windows: every other platform's loader finds these through the wheel's own
-    ``RPATH``, and there is nothing to prepare.
+    ``RPATH``, and there is nothing to prepare. Empty too when the wheels are simply not
+    installed — a CPU-only install is a supported one.
     """
     if (platform or sys.platform) != "win32":
         return ()
@@ -80,24 +69,11 @@ def dll_directories(root: Path, platform: str | None = None) -> tuple[Path, ...]
     return tuple(one for one in candidates if one.is_dir())
 
 
-def preloadable_libraries(root: Path, platform: str | None = None) -> tuple[Path, ...]:
-    """Every runtime library worth loading up front, deduplicated, in a stable order."""
-    found: list[Path] = []
-    for directory in dll_directories(root, platform=platform):
-        for pattern in PRELOAD_PATTERNS:
-            found.extend(sorted(directory.glob(pattern)))
-    return tuple(dict.fromkeys(found))
+def prepare(root: Path | None = None, platform: str | None = None) -> tuple[Path, ...]:
+    """Put the bundled CUDA runtime on the search path, once per process.
 
-
-def prepare(
-    root: Path | None = None,
-    platform: str | None = None,
-    load: Callable[[str], object] | None = None,
-) -> tuple[Path, ...]:
-    """Put the CUDA runtime within reach, once per process. Returns what actually loaded.
-
-    A library that refuses to load is a warning, not a failure: a box with the wheels and
-    no GPU should transcribe slowly on the CPU rather than not at all.
+    Returns the directories prepended — empty when there is nothing to do, and empty on
+    every call after the first, so a second job does not lengthen ``PATH`` again.
     """
     global _prepared
     if _prepared:
@@ -107,50 +83,17 @@ def prepare(
     root = site_packages() if root is None else Path(root)
     directories = dll_directories(root, platform=platform)
     if not directories:
-        log.debug("No bundled CUDA runtime under %s; leaving the loader alone", root)
+        log.debug("No bundled CUDA runtime under %s; leaving the search path alone", root)
         return ()
 
-    _prepend_to_path(directories)
-    loader = _load if load is None else load
-    loaded: list[Path] = []
-    for library in preloadable_libraries(root, platform=platform):
-        try:
-            loader(str(library))
-        except OSError as exc:
-            log.warning(
-                "CUDA runtime library %s did not load (%s) — transcription will be slow "
-                "or CPU-bound rather than broken",
-                library.name,
-                exc,
-            )
-            continue
-        loaded.append(library)
-    log.info(
-        "CUDA runtime prepared: %d director(y/ies) prepended to PATH, %d librar(y/ies) preloaded",
-        len(directories),
-        len(loaded),
-    )
-    return tuple(loaded)
+    ahead = [str(one) for one in directories]
+    behind = [one for one in os.environ.get("PATH", "").split(os.pathsep) if one not in ahead]
+    os.environ["PATH"] = os.pathsep.join([*ahead, *behind])
+    log.info("CUDA runtime on the search path: %s", os.pathsep.join(ahead))
+    return directories
 
 
 def reset_preparation() -> None:
     """Forget that preparation happened. For tests; the server prepares once and stays."""
     global _prepared
     _prepared = False
-
-
-def _prepend_to_path(directories: tuple[Path, ...]) -> None:
-    ahead = [str(one) for one in directories]
-    behind = [one for one in os.environ.get("PATH", "").split(os.pathsep) if one not in ahead]
-    os.environ["PATH"] = os.pathsep.join([*ahead, *behind])
-
-
-def _load(path: str) -> object:
-    """Load one DLL by absolute path, keeping it in the process for whoever needs it next."""
-    import ctypes
-
-    # WinDLL and CDLL load identically — the difference is the calling convention of the
-    # functions inside, and nothing here calls one. CDLL is the spelling that type-checks
-    # on the Linux runner as well.
-    loader = getattr(ctypes, "WinDLL", ctypes.CDLL)
-    return loader(path)

--- a/src/resolve_mcp/analysis/cuda.py
+++ b/src/resolve_mcp/analysis/cuda.py
@@ -1,0 +1,156 @@
+"""Making the CUDA runtime that the ``analysis`` extra ships findable on Windows.
+
+``uv sync --extra analysis`` installs the runtime as wheels (#128): the DLLs land under
+``site-packages/nvidia/<package>/bin``, which is on nobody's search path. CTranslate2 —
+faster-whisper's backend — then fails to resolve ``cublas64_12.dll`` at import and the
+transcriber is broken on exactly the machines a GPU makes it useful on.
+
+Three mechanisms were considered; what is known about each (#35's live pass, #128):
+
+* Those directories on ``PATH`` **before the process starts** — verified working.
+* ``os.add_dll_directory()`` on them — verified *not* working. CTranslate2's loader does
+  not consult the added-directory list; it still failed on ``cublas64_12.dll``.
+* Mutating ``os.environ["PATH"]`` in-process — a hypothesis. Python ≥3.8 loads extension
+  modules with ``LOAD_LIBRARY_SEARCH_DEFAULT_DIRS``, which excludes ``PATH`` when the
+  loader resolves an extension's dependencies, so it may fail the way the second did.
+
+So the mechanism shipped here is the one that does not depend on the loader's search
+order at all: preload each library by absolute path before faster-whisper is imported.
+A DLL already in the process is matched by base name, so CTranslate2's own resolution
+finds it whatever flags it uses. ``PATH`` is prepended too — it is free, it costs one
+string, and it is what any child process would need — but nothing rests on it.
+
+Preloading by path also carries ``LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR``, so each library's
+own directory is searched for *its* dependencies. That is why the list below stops at
+the entry points: cuDNN's multi-hundred-megabyte engine libraries are loaded by
+``cudnn64_9`` itself, out of the directory we just loaded it from.
+
+Nothing here can observe whether CUDA subsequently initialises — the same shape as ADR
+0001's attach problem. The decisions (which directories, in what order, on which
+platform) are asserted in the fake tier; the consequence belongs to the live smoke.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import sysconfig
+from collections.abc import Callable
+from pathlib import Path
+
+from ..logging_config import get_logger
+
+log = get_logger("analysis")
+
+# In the order the loader would want them, and the order #128 records.
+NVIDIA_PACKAGES = ("cublas", "cudnn", "cuda_nvrtc")
+
+# Matched by pattern rather than by pinned name so a cuDNN 9 → 10 bump is an install, not
+# a code change. Deliberately absent: cudnn_engines_* and cudnn_heuristic*, which cuDNN
+# loads itself, and nvrtc-builtins, which nvrtc loads itself.
+PRELOAD_PATTERNS = (
+    "cublas64_*.dll",
+    "cublasLt64_*.dll",
+    "cudnn64_*.dll",
+    "cudnn_adv*.dll",
+    "cudnn_cnn*.dll",
+    "cudnn_graph*.dll",
+    "cudnn_ops*.dll",
+    "nvrtc64_*.dll",
+)
+
+_prepared = False
+
+
+def site_packages() -> Path:
+    """Where this venv's wheels live — the root the nvidia layout hangs off."""
+    return Path(sysconfig.get_paths()["purelib"])
+
+
+def dll_directories(root: Path, platform: str | None = None) -> tuple[Path, ...]:
+    """The nvidia ``bin`` directories present under ``root``, in load order.
+
+    Empty off Windows: every other platform's loader finds these through the wheel's own
+    ``RPATH``, and there is nothing to prepare.
+    """
+    if (platform or sys.platform) != "win32":
+        return ()
+    nvidia = Path(root) / "nvidia"
+    candidates = (nvidia / package / "bin" for package in NVIDIA_PACKAGES)
+    return tuple(one for one in candidates if one.is_dir())
+
+
+def preloadable_libraries(root: Path, platform: str | None = None) -> tuple[Path, ...]:
+    """Every runtime library worth loading up front, deduplicated, in a stable order."""
+    found: list[Path] = []
+    for directory in dll_directories(root, platform=platform):
+        for pattern in PRELOAD_PATTERNS:
+            found.extend(sorted(directory.glob(pattern)))
+    return tuple(dict.fromkeys(found))
+
+
+def prepare(
+    root: Path | None = None,
+    platform: str | None = None,
+    load: Callable[[str], object] | None = None,
+) -> tuple[Path, ...]:
+    """Put the CUDA runtime within reach, once per process. Returns what actually loaded.
+
+    A library that refuses to load is a warning, not a failure: a box with the wheels and
+    no GPU should transcribe slowly on the CPU rather than not at all.
+    """
+    global _prepared
+    if _prepared:
+        return ()
+    _prepared = True
+
+    root = site_packages() if root is None else Path(root)
+    directories = dll_directories(root, platform=platform)
+    if not directories:
+        log.debug("No bundled CUDA runtime under %s; leaving the loader alone", root)
+        return ()
+
+    _prepend_to_path(directories)
+    loader = _load if load is None else load
+    loaded: list[Path] = []
+    for library in preloadable_libraries(root, platform=platform):
+        try:
+            loader(str(library))
+        except OSError as exc:
+            log.warning(
+                "CUDA runtime library %s did not load (%s) — transcription will be slow "
+                "or CPU-bound rather than broken",
+                library.name,
+                exc,
+            )
+            continue
+        loaded.append(library)
+    log.info(
+        "CUDA runtime prepared: %d director(y/ies) prepended to PATH, %d librar(y/ies) preloaded",
+        len(directories),
+        len(loaded),
+    )
+    return tuple(loaded)
+
+
+def reset_preparation() -> None:
+    """Forget that preparation happened. For tests; the server prepares once and stays."""
+    global _prepared
+    _prepared = False
+
+
+def _prepend_to_path(directories: tuple[Path, ...]) -> None:
+    ahead = [str(one) for one in directories]
+    behind = [one for one in os.environ.get("PATH", "").split(os.pathsep) if one not in ahead]
+    os.environ["PATH"] = os.pathsep.join([*ahead, *behind])
+
+
+def _load(path: str) -> object:
+    """Load one DLL by absolute path, keeping it in the process for whoever needs it next."""
+    import ctypes
+
+    # WinDLL and CDLL load identically — the difference is the calling convention of the
+    # functions inside, and nothing here calls one. CDLL is the spelling that type-checks
+    # on the Linux runner as well.
+    loader = getattr(ctypes, "WinDLL", ctypes.CDLL)
+    return loader(path)

--- a/src/resolve_mcp/analysis/cuda.py
+++ b/src/resolve_mcp/analysis/cuda.py
@@ -43,14 +43,16 @@ from ..logging_config import get_logger
 
 log = get_logger("analysis")
 
-# Installed by nvidia-cublas-cu12 and nvidia-cudnn-cu12; cuda_nvrtc arrives as a
-# dependency of cuDNN. Listed in the order the runtime layers on top of itself.
+# Installed by nvidia-cublas-cu12 and nvidia-cudnn-cu12; cuda_nvrtc rides in as a
+# dependency of cuBLAS (checked in its wheel metadata, not assumed). Listed in the order
+# the runtime layers on top of itself — and each one is still filtered on existing, so a
+# runtime that stops shipping one of them degrades to "not found" rather than to a crash.
 NVIDIA_PACKAGES = ("cublas", "cudnn", "cuda_nvrtc")
 
 _prepared = False
 
 
-def site_packages() -> Path:
+def _site_packages() -> Path:
     """Where this venv's wheels live — the root the nvidia layout hangs off."""
     return Path(sysconfig.get_paths()["purelib"])
 
@@ -80,7 +82,7 @@ def prepare(root: Path | None = None, platform: str | None = None) -> tuple[Path
         return ()
     _prepared = True
 
-    root = site_packages() if root is None else Path(root)
+    root = _site_packages() if root is None else Path(root)
     directories = dll_directories(root, platform=platform)
     if not directories:
         log.debug("No bundled CUDA runtime under %s; leaving the search path alone", root)

--- a/src/resolve_mcp/analysis/whisper.py
+++ b/src/resolve_mcp/analysis/whisper.py
@@ -53,8 +53,8 @@ def transcribe(audio: Path, params: Mapping[str, Any]) -> Transcription:
 
 def _model(name: str) -> Any:
     config = get_config()
-    # Before the import, never after: CTranslate2 resolves its CUDA libraries as the
-    # extension module loads, and by then there is nothing left to prepare (#128).
+    # Before the model is built, never after: CTranslate2 loads its CUDA libraries at the
+    # first allocation on the device, and by then there is nothing left to prepare (#128).
     cuda.prepare()
     return _build(name, config.whisper_device, config.whisper_compute_type)
 

--- a/src/resolve_mcp/analysis/whisper.py
+++ b/src/resolve_mcp/analysis/whisper.py
@@ -16,7 +16,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from ..config import get_config
+from ..config import DEFAULT_WHISPER_COMPUTE_TYPE, DEFAULT_WHISPER_DEVICE, get_config
 from ..errors import TranscriberUnavailableError, TranscriptionError
 from ..logging_config import get_logger
 from . import cuda
@@ -69,13 +69,28 @@ def _model(name: str) -> Any:
                 f"faster-whisper would not load {name} on device={device!r} "
                 f"compute_type={compute_type!r}: {type(exc).__name__}: {exc}"
             ),
-            fix=(
-                "RESOLVE_MCP_WHISPER_DEVICE takes 'auto', 'cuda' or 'cpu'; "
-                "RESOLVE_MCP_WHISPER_COMPUTE_TYPE takes 'default', 'float32', 'float16' "
-                "or 'int8'. Unset both to use the defaults."
-            ),
+            fix=_load_fix(device, compute_type),
             detail={"model": name, "device": device, "compute_type": compute_type},
         ) from exc
+
+
+def _load_fix(device: str, compute_type: str) -> str:
+    """Advice that matches who is likely at fault: the settings, or the install.
+
+    Blaming the env variables when nobody set them is how #128 itself would read — a
+    missing CUDA runtime on a stock config, told to go check its device string.
+    """
+    if device == DEFAULT_WHISPER_DEVICE and compute_type == DEFAULT_WHISPER_COMPUTE_TYPE:
+        return (
+            "Both transcriber settings are at their defaults, so this is the install "
+            "rather than a setting: check that `uv sync --extra analysis` has run against "
+            "the venv this server is using — the CUDA runtime ships with that extra."
+        )
+    return (
+        "RESOLVE_MCP_WHISPER_DEVICE takes 'auto', 'cuda' or 'cpu'; "
+        "RESOLVE_MCP_WHISPER_COMPUTE_TYPE takes what CTranslate2 accepts (e.g. 'default', "
+        "'float32', 'float16', 'int8'). Unset both to use the defaults."
+    )
 
 
 def _build(name: str, device: str, compute_type: str) -> Any:

--- a/src/resolve_mcp/analysis/whisper.py
+++ b/src/resolve_mcp/analysis/whisper.py
@@ -16,15 +16,15 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from ..config import get_config
 from ..errors import TranscriberUnavailableError, TranscriptionError
 from ..logging_config import get_logger
+from . import cuda
 from .transcript import Transcription, Word
 
 log = get_logger("analysis")
 
 DEFAULT_MODEL = "large-v3"
-DEVICE = "auto"
-COMPUTE_TYPE = "default"
 
 
 def transcribe(audio: Path, params: Mapping[str, Any]) -> Transcription:
@@ -52,6 +52,15 @@ def transcribe(audio: Path, params: Mapping[str, Any]) -> Transcription:
 
 
 def _model(name: str) -> Any:
+    config = get_config()
+    # Before the import, never after: CTranslate2 resolves its CUDA libraries as the
+    # extension module loads, and by then there is nothing left to prepare (#128).
+    cuda.prepare()
+    return _build(name, config.whisper_device, config.whisper_compute_type)
+
+
+def _build(name: str, device: str, compute_type: str) -> Any:
+    """The one import of faster-whisper, and the only line an absent backend can break."""
     try:
         from faster_whisper import WhisperModel
     except ImportError as exc:
@@ -59,7 +68,8 @@ def _model(name: str) -> Any:
             cause="faster-whisper is not installed in this environment.",
             detail={"model": name},
         ) from exc
-    return WhisperModel(name, device=DEVICE, compute_type=COMPUTE_TYPE)
+    log.info("Loading %s on device=%s compute_type=%s", name, device, compute_type)
+    return WhisperModel(name, device=device, compute_type=compute_type)
 
 
 def _word(word: Any) -> Word:

--- a/src/resolve_mcp/analysis/whisper.py
+++ b/src/resolve_mcp/analysis/whisper.py
@@ -56,7 +56,26 @@ def _model(name: str) -> Any:
     # Before the model is built, never after: CTranslate2 loads its CUDA libraries at the
     # first allocation on the device, and by then there is nothing left to prepare (#128).
     cuda.prepare()
-    return _build(name, config.whisper_device, config.whisper_compute_type)
+    device, compute_type = config.whisper_device, config.whisper_compute_type
+    try:
+        return _build(name, device, compute_type)
+    except TranscriberUnavailableError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - the backend raises its own unrelated types
+        # Since #128 these two are typed by whoever set the variable, so a typo reaches
+        # here as a raw backend error. Say which value was refused and where it came from.
+        raise TranscriptionError(
+            cause=(
+                f"faster-whisper would not load {name} on device={device!r} "
+                f"compute_type={compute_type!r}: {type(exc).__name__}: {exc}"
+            ),
+            fix=(
+                "RESOLVE_MCP_WHISPER_DEVICE takes 'auto', 'cuda' or 'cpu'; "
+                "RESOLVE_MCP_WHISPER_COMPUTE_TYPE takes 'default', 'float32', 'float16' "
+                "or 'int8'. Unset both to use the defaults."
+            ),
+            detail={"model": name, "device": device, "compute_type": compute_type},
+        ) from exc
 
 
 def _build(name: str, device: str, compute_type: str) -> Any:

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -22,6 +22,14 @@ DEFAULT_STEM_MODEL = "htdemucs_ft.yaml"
 # The name audio-separator 0.44.5 lists for the six-stem MDX23C drum model; the
 # "MDX23C-DrumSep-6stem-FT.ckpt" spelling is not in its catalog and fails to load.
 DEFAULT_DRUM_MODEL = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
+# faster-whisper's own defaults, kept as the defaults here: "auto" picks CUDA when there is
+# a card and CPU when there is not, and "default" means the model's stored precision. CUDA
+# buys speed, not accuracy — large-v3 stores float16, which a GPU runs natively and a CPU
+# widens to float32 (nominally *more* precise). The knobs exist so a box that resolves "auto"
+# wrongly degrades to slow rather than broken; "cuda" + "float32" is the documented pairing
+# for CPU-identical numbers at GPU speed.
+DEFAULT_WHISPER_DEVICE = "auto"
+DEFAULT_WHISPER_COMPUTE_TYPE = "default"
 # A Resolve built-in, present on every install, so a bare render works before anyone has
 # saved a preset. The director's own presets are named explicitly or set here.
 DEFAULT_RENDER_PRESET = "H.265 Master"
@@ -43,6 +51,8 @@ class Config:
     stem_model: str = DEFAULT_STEM_MODEL
     drum_model: str = DEFAULT_DRUM_MODEL
     default_render_preset: str = DEFAULT_RENDER_PRESET
+    whisper_device: str = DEFAULT_WHISPER_DEVICE
+    whisper_compute_type: str = DEFAULT_WHISPER_COMPUTE_TYPE
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> Config:
@@ -63,6 +73,10 @@ class Config:
             drum_model=env.get("RESOLVE_MCP_DRUM_MODEL") or DEFAULT_DRUM_MODEL,
             default_render_preset=(
                 env.get("RESOLVE_MCP_DEFAULT_RENDER_PRESET") or DEFAULT_RENDER_PRESET
+            ),
+            whisper_device=env.get("RESOLVE_MCP_WHISPER_DEVICE") or DEFAULT_WHISPER_DEVICE,
+            whisper_compute_type=(
+                env.get("RESOLVE_MCP_WHISPER_COMPUTE_TYPE") or DEFAULT_WHISPER_COMPUTE_TYPE
             ),
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -109,6 +109,26 @@ def test_the_default_render_preset_is_a_resolve_built_in_and_overridable() -> No
     )
 
 
+def test_the_transcriber_takes_the_backends_own_device_and_precision_unless_told_otherwise(
+) -> None:
+    """Defaults are faster-whisper's own: the GPU when there is one, the model's precision.
+
+    The overrides exist so a box that resolves "auto" wrongly degrades to slow rather than
+    broken (#128), which is only true while the defaults stay the backend's.
+    """
+    assert Config.from_env({}).whisper_device == "auto"
+    assert Config.from_env({}).whisper_compute_type == "default"
+
+    config = Config.from_env(
+        {
+            "RESOLVE_MCP_WHISPER_DEVICE": "cpu",
+            "RESOLVE_MCP_WHISPER_COMPUTE_TYPE": "float32",
+        }
+    )
+    assert config.whisper_device == "cpu"
+    assert config.whisper_compute_type == "float32"
+
+
 def test_ffmpeg_is_a_bare_name_on_path_until_told_otherwise() -> None:
     assert Config.from_env({}).ffmpeg == "ffmpeg"
     assert Config.from_env({"RESOLVE_MCP_FFMPEG": r"D:\tools\ffmpeg.exe"}).ffmpeg == (

--- a/tests/test_whisper_runtime.py
+++ b/tests/test_whisper_runtime.py
@@ -22,7 +22,10 @@ from resolve_mcp.analysis import cuda, whisper
 from resolve_mcp.config import Config
 from resolve_mcp.errors import TranscriberUnavailableError, TranscriptionError
 
-SYSTEM32 = r"C:\Windows\system32"
+# Whatever was on PATH before us. Deliberately drive-letter-free: these tests assert a
+# Windows decision but run on the Linux CI runner too, where os.pathsep is the colon and a
+# "C:\..." entry would split itself in half.
+ALREADY_ON_PATH = r"\Windows\system32"
 CUBLAS = ("cublas64_12.dll", "cublasLt64_12.dll")
 CUDNN = ("cudnn64_9.dll", "cudnn_ops64_9.dll", "cudnn_engines_precompiled64_9.dll")
 NVRTC = ("nvrtc64_120_0.dll", "nvrtc-builtins64_129.dll")
@@ -67,24 +70,26 @@ def test_nothing_is_prepared_off_windows_where_the_loader_needs_no_help(
     tmp_path: Path, platform: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
-    monkeypatch.setenv("PATH", SYSTEM32)
+    monkeypatch.setenv("PATH", ALREADY_ON_PATH)
 
     assert cuda.dll_directories(site, platform=platform) == ()
     assert cuda.prepare(site, platform=platform) == ()
-    assert os.environ["PATH"] == SYSTEM32
+    assert os.environ["PATH"] == ALREADY_ON_PATH
 
 
 def test_preparation_prepends_the_directories_ahead_of_everything_already_there(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
-    monkeypatch.setenv("PATH", SYSTEM32)
+    monkeypatch.setenv("PATH", ALREADY_ON_PATH)
 
     prepared = cuda.prepare(site, platform="win32")
 
     assert prepared == cuda.dll_directories(site, platform="win32")
     assert all(one.is_absolute() for one in prepared)
-    assert os.environ["PATH"].split(os.pathsep) == [str(one) for one in prepared] + [SYSTEM32]
+    assert os.environ["PATH"].split(os.pathsep) == [str(one) for one in prepared] + [
+        ALREADY_ON_PATH
+    ]
 
 
 def test_a_second_preparation_does_not_lengthen_the_path_again(
@@ -92,7 +97,7 @@ def test_a_second_preparation_does_not_lengthen_the_path_again(
 ) -> None:
     """One process transcribes many jobs; the search path must not grow a copy per job."""
     site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
-    monkeypatch.setenv("PATH", SYSTEM32)
+    monkeypatch.setenv("PATH", ALREADY_ON_PATH)
 
     cuda.prepare(site, platform="win32")
     once = os.environ["PATH"]
@@ -105,10 +110,10 @@ def test_a_venv_without_the_cuda_wheels_is_a_quiet_no_op(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A CPU-only install is a supported install: nothing to prepare, nothing to say."""
-    monkeypatch.setenv("PATH", SYSTEM32)
+    monkeypatch.setenv("PATH", ALREADY_ON_PATH)
 
     assert cuda.prepare(tmp_path, platform="win32") == ()
-    assert os.environ["PATH"] == SYSTEM32
+    assert os.environ["PATH"] == ALREADY_ON_PATH
 
 
 class _Info:

--- a/tests/test_whisper_runtime.py
+++ b/tests/test_whisper_runtime.py
@@ -1,0 +1,242 @@
+"""What the transcriber decides before a single sample is read: device, precision, DLLs.
+
+The decisions are testable; the consequence is not. Which directories go on the search
+path, in what order, on which platform, and which libraries are preloaded by absolute
+path — all of that is a pure function of the venv layout and asserts here without a GPU.
+Whether CUDA then initialises is invisible at every seam (the same shape as ADR 0001's
+attach), so it belongs to the live smoke and nowhere else.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp import config as config_module
+from resolve_mcp.analysis import cuda, whisper
+from resolve_mcp.config import Config
+
+CUBLAS = ("cublas64_12.dll", "cublasLt64_12.dll")
+CUDNN = (
+    "cudnn64_9.dll",
+    "cudnn_adv64_9.dll",
+    "cudnn_cnn64_9.dll",
+    "cudnn_graph64_9.dll",
+    "cudnn_ops64_9.dll",
+    # The two that are hundreds of megabytes each. cudnn64_9 loads them itself, out of
+    # its own directory, so preloading them would cost the memory for nothing.
+    "cudnn_engines_precompiled64_9.dll",
+    "cudnn_heuristic64_9.dll",
+)
+NVRTC = ("nvrtc64_120_0.dll", "nvrtc-builtins64_120.dll")
+
+
+def _site_packages(root: Path, **packages: tuple[str, ...]) -> Path:
+    """A venv's site-packages with the nvidia wheels laid out the way pip installs them."""
+    site = root / "Lib" / "site-packages"
+    for package, libraries in packages.items():
+        binaries = site / "nvidia" / package / "bin"
+        binaries.mkdir(parents=True)
+        for library in libraries:
+            (binaries / library).write_bytes(b"")
+    return site
+
+
+@pytest.fixture(autouse=True)
+def _forget_preparation() -> Iterator[None]:
+    cuda.reset_preparation()
+    yield
+    cuda.reset_preparation()
+
+
+def test_the_three_nvidia_bin_directories_come_back_in_load_order(tmp_path: Path) -> None:
+    site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
+
+    assert cuda.dll_directories(site, platform="win32") == (
+        site / "nvidia" / "cublas" / "bin",
+        site / "nvidia" / "cudnn" / "bin",
+        site / "nvidia" / "cuda_nvrtc" / "bin",
+    )
+
+
+def test_a_wheel_that_is_not_installed_is_skipped_rather_than_offered(tmp_path: Path) -> None:
+    site = _site_packages(tmp_path, cublas=CUBLAS)
+
+    assert cuda.dll_directories(site, platform="win32") == (site / "nvidia" / "cublas" / "bin",)
+
+
+@pytest.mark.parametrize("platform", ["linux", "darwin"])
+def test_nothing_is_prepared_off_windows_where_the_loader_needs_no_help(
+    tmp_path: Path, platform: str
+) -> None:
+    site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
+
+    assert cuda.dll_directories(site, platform=platform) == ()
+    assert cuda.preloadable_libraries(site, platform=platform) == ()
+
+
+def test_the_libraries_are_matched_by_pattern_so_a_version_bump_is_not_a_code_change(
+    tmp_path: Path,
+) -> None:
+    site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
+
+    names = [one.name for one in cuda.preloadable_libraries(site, platform="win32")]
+
+    assert names == [
+        "cublas64_12.dll",
+        "cublasLt64_12.dll",
+        "cudnn64_9.dll",
+        "cudnn_adv64_9.dll",
+        "cudnn_cnn64_9.dll",
+        "cudnn_graph64_9.dll",
+        "cudnn_ops64_9.dll",
+        "nvrtc64_120_0.dll",
+    ]
+
+
+def test_preparation_prepends_the_directories_and_preloads_by_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
+    monkeypatch.setenv("PATH", r"C:\Windows\system32")
+    loaded: list[str] = []
+
+    prepared = cuda.prepare(site, platform="win32", load=loaded.append)
+
+    assert prepared == cuda.preloadable_libraries(site, platform="win32")
+    assert loaded == [str(one) for one in prepared]
+    assert all(one.is_absolute() for one in prepared)
+
+    search = os.environ["PATH"].split(os.pathsep)
+    assert search == [
+        str(one) for one in cuda.dll_directories(site, platform="win32")
+    ] + [r"C:\Windows\system32"]
+
+
+def test_a_second_preparation_neither_reloads_nor_lengthens_the_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
+    monkeypatch.setenv("PATH", r"C:\Windows\system32")
+    loaded: list[str] = []
+
+    cuda.prepare(site, platform="win32", load=loaded.append)
+    once = os.environ["PATH"]
+    assert cuda.prepare(site, platform="win32", load=loaded.append) == ()
+
+    assert len(loaded) == 8
+    assert os.environ["PATH"] == once
+
+
+def test_a_library_that_refuses_to_load_is_logged_rather_than_failing_the_job(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A machine with no GPU has the wheels and cannot load them; that is 'slow', not 'broken'."""
+    site = _site_packages(tmp_path, cublas=CUBLAS)
+    monkeypatch.setenv("PATH", r"C:\Windows\system32")
+
+    def _refuse(path: str) -> None:
+        raise OSError("[WinError 126] The specified module could not be found")
+
+    assert cuda.prepare(site, platform="win32", load=_refuse) == ()
+
+
+def test_no_nvidia_wheels_at_all_is_a_quiet_no_op(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PATH", r"C:\Windows\system32")
+    loaded: list[str] = []
+
+    assert cuda.prepare(tmp_path, platform="win32", load=loaded.append) == ()
+    assert loaded == []
+
+
+def test_the_device_and_precision_default_to_the_backends_own_choice() -> None:
+    config = Config.from_env({})
+
+    assert config.whisper_device == "auto"
+    assert config.whisper_compute_type == "default"
+
+
+def test_the_device_and_precision_are_overridable_for_a_box_without_a_gpu() -> None:
+    config = Config.from_env(
+        {
+            "RESOLVE_MCP_WHISPER_DEVICE": "cpu",
+            "RESOLVE_MCP_WHISPER_COMPUTE_TYPE": "float32",
+        }
+    )
+
+    assert config.whisper_device == "cpu"
+    assert config.whisper_compute_type == "float32"
+
+
+class _Info:
+    language = "en"
+
+
+class _RecordingModel:
+    """Stands in for ``faster_whisper.WhisperModel`` to record how it was constructed."""
+
+    built: list[dict[str, str]] = []
+
+    def __init__(self, name: str, device: str, compute_type: str) -> None:
+        self.built.append({"name": name, "device": device, "compute_type": compute_type})
+
+    def transcribe(self, path: str, **kwargs: Any) -> tuple[tuple[Any, ...], _Info]:
+        return (), _Info()
+
+
+@pytest.fixture
+def recording_backend(monkeypatch: pytest.MonkeyPatch) -> type[_RecordingModel]:
+    module = types.ModuleType("faster_whisper")
+    module.WhisperModel = _RecordingModel  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "faster_whisper", module)
+    _RecordingModel.built = []
+    return _RecordingModel
+
+
+def test_the_model_is_built_with_the_configured_device_and_precision(
+    tmp_path: Path, recording_backend: type[_RecordingModel]
+) -> None:
+    config_module.set_config(
+        Config.from_env(
+            {
+                "RESOLVE_MCP_WHISPER_DEVICE": "cuda",
+                "RESOLVE_MCP_WHISPER_COMPUTE_TYPE": "float32",
+                "RESOLVE_MCP_CACHE": str(tmp_path / "cache"),
+            }
+        )
+    )
+
+    whisper.transcribe(tmp_path / "take.wav", {})
+
+    assert recording_backend.built == [
+        {"name": whisper.DEFAULT_MODEL, "device": "cuda", "compute_type": "float32"}
+    ]
+
+
+def test_the_cuda_runtime_is_prepared_before_the_backend_is_imported(
+    tmp_path: Path, recording_backend: type[_RecordingModel], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    order: list[str] = []
+
+    def _prepare() -> tuple[Path, ...]:
+        order.append("prepare")
+        return ()
+
+    def _build(name: str, device: str, compute_type: str) -> object:
+        order.append("import")
+        return object()
+
+    monkeypatch.setattr(cuda, "prepare", _prepare)
+    monkeypatch.setattr(whisper, "_build", _build)
+
+    whisper._model("large-v3")
+
+    assert order == ["prepare", "import"]

--- a/tests/test_whisper_runtime.py
+++ b/tests/test_whisper_runtime.py
@@ -183,8 +183,26 @@ def test_a_device_the_backend_refuses_names_the_value_and_the_variable_that_set_
     assert raised.value.detail["device"] == "gpu"
 
 
+def test_a_stock_config_that_cannot_load_is_told_about_the_install_not_the_settings(
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#128's own failure, on defaults: a missing CUDA runtime must not read as a typo."""
+
+    def _refuse(name: str, device: str, compute_type: str) -> object:
+        raise RuntimeError("Library cublas64_12.dll is not found or cannot be loaded")
+
+    monkeypatch.setattr(whisper, "_build", _refuse)
+    monkeypatch.setattr(cuda, "prepare", lambda: ())
+
+    with pytest.raises(TranscriptionError) as raised:
+        whisper._model("large-v3")
+
+    assert "uv sync --extra analysis" in raised.value.fix
+    assert "RESOLVE_MCP_WHISPER_DEVICE" not in raised.value.fix
+
+
 def test_a_missing_backend_still_says_it_is_missing_rather_than_blaming_the_device(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The unavailable-backend error is the older, more specific one; shaping must not eat it."""
 

--- a/tests/test_whisper_runtime.py
+++ b/tests/test_whisper_runtime.py
@@ -1,10 +1,9 @@
 """What the transcriber decides before a single sample is read: device, precision, DLLs.
 
 The decisions are testable; the consequence is not. Which directories go on the search
-path, in what order, on which platform, and which libraries are preloaded by absolute
-path — all of that is a pure function of the venv layout and asserts here without a GPU.
-Whether CUDA then initialises is invisible at every seam (the same shape as ADR 0001's
-attach), so it belongs to the live smoke and nowhere else.
+path, in what order, on which platform — all of that is a pure function of the venv layout
+and asserts here without a GPU. Whether CUDA then initialises is invisible at every seam
+(the same shape as ADR 0001's attach), so it belongs to the live smoke and nowhere else.
 """
 
 from __future__ import annotations
@@ -22,19 +21,10 @@ from resolve_mcp import config as config_module
 from resolve_mcp.analysis import cuda, whisper
 from resolve_mcp.config import Config
 
+SYSTEM32 = r"C:\Windows\system32"
 CUBLAS = ("cublas64_12.dll", "cublasLt64_12.dll")
-CUDNN = (
-    "cudnn64_9.dll",
-    "cudnn_adv64_9.dll",
-    "cudnn_cnn64_9.dll",
-    "cudnn_graph64_9.dll",
-    "cudnn_ops64_9.dll",
-    # The two that are hundreds of megabytes each. cudnn64_9 loads them itself, out of
-    # its own directory, so preloading them would cost the memory for nothing.
-    "cudnn_engines_precompiled64_9.dll",
-    "cudnn_heuristic64_9.dll",
-)
-NVRTC = ("nvrtc64_120_0.dll", "nvrtc-builtins64_120.dll")
+CUDNN = ("cudnn64_9.dll", "cudnn_ops64_9.dll", "cudnn_engines_precompiled64_9.dll")
+NVRTC = ("nvrtc64_120_0.dll", "nvrtc-builtins64_129.dll")
 
 
 def _site_packages(root: Path, **packages: tuple[str, ...]) -> Path:
@@ -73,88 +63,51 @@ def test_a_wheel_that_is_not_installed_is_skipped_rather_than_offered(tmp_path: 
 
 @pytest.mark.parametrize("platform", ["linux", "darwin"])
 def test_nothing_is_prepared_off_windows_where_the_loader_needs_no_help(
-    tmp_path: Path, platform: str
+    tmp_path: Path, platform: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
+    monkeypatch.setenv("PATH", SYSTEM32)
 
     assert cuda.dll_directories(site, platform=platform) == ()
-    assert cuda.preloadable_libraries(site, platform=platform) == ()
+    assert cuda.prepare(site, platform=platform) == ()
+    assert os.environ["PATH"] == SYSTEM32
 
 
-def test_the_libraries_are_matched_by_pattern_so_a_version_bump_is_not_a_code_change(
-    tmp_path: Path,
-) -> None:
-    site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
-
-    names = [one.name for one in cuda.preloadable_libraries(site, platform="win32")]
-
-    assert names == [
-        "cublas64_12.dll",
-        "cublasLt64_12.dll",
-        "cudnn64_9.dll",
-        "cudnn_adv64_9.dll",
-        "cudnn_cnn64_9.dll",
-        "cudnn_graph64_9.dll",
-        "cudnn_ops64_9.dll",
-        "nvrtc64_120_0.dll",
-    ]
-
-
-def test_preparation_prepends_the_directories_and_preloads_by_absolute_path(
+def test_preparation_prepends_the_directories_ahead_of_everything_already_there(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
-    monkeypatch.setenv("PATH", r"C:\Windows\system32")
-    loaded: list[str] = []
+    monkeypatch.setenv("PATH", SYSTEM32)
 
-    prepared = cuda.prepare(site, platform="win32", load=loaded.append)
+    prepared = cuda.prepare(site, platform="win32")
 
-    assert prepared == cuda.preloadable_libraries(site, platform="win32")
-    assert loaded == [str(one) for one in prepared]
+    assert prepared == cuda.dll_directories(site, platform="win32")
     assert all(one.is_absolute() for one in prepared)
-
-    search = os.environ["PATH"].split(os.pathsep)
-    assert search == [
-        str(one) for one in cuda.dll_directories(site, platform="win32")
-    ] + [r"C:\Windows\system32"]
+    assert os.environ["PATH"].split(os.pathsep) == [str(one) for one in prepared] + [SYSTEM32]
 
 
-def test_a_second_preparation_neither_reloads_nor_lengthens_the_path(
+def test_a_second_preparation_does_not_lengthen_the_path_again(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """One process transcribes many jobs; the search path must not grow a copy per job."""
     site = _site_packages(tmp_path, cublas=CUBLAS, cudnn=CUDNN, cuda_nvrtc=NVRTC)
-    monkeypatch.setenv("PATH", r"C:\Windows\system32")
-    loaded: list[str] = []
+    monkeypatch.setenv("PATH", SYSTEM32)
 
-    cuda.prepare(site, platform="win32", load=loaded.append)
+    cuda.prepare(site, platform="win32")
     once = os.environ["PATH"]
-    assert cuda.prepare(site, platform="win32", load=loaded.append) == ()
 
-    assert len(loaded) == 8
+    assert cuda.prepare(site, platform="win32") == ()
     assert os.environ["PATH"] == once
 
 
-def test_a_library_that_refuses_to_load_is_logged_rather_than_failing_the_job(
+def test_a_venv_without_the_cuda_wheels_is_a_quiet_no_op(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A machine with no GPU has the wheels and cannot load them; that is 'slow', not 'broken'."""
-    site = _site_packages(tmp_path, cublas=CUBLAS)
-    monkeypatch.setenv("PATH", r"C:\Windows\system32")
+    """A CPU-only install is a supported install: nothing to prepare, nothing to say."""
+    monkeypatch.setenv("PATH", SYSTEM32)
 
-    def _refuse(path: str) -> None:
-        raise OSError("[WinError 126] The specified module could not be found")
-
-    assert cuda.prepare(site, platform="win32", load=_refuse) == ()
-
-
-def test_no_nvidia_wheels_at_all_is_a_quiet_no_op(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("PATH", r"C:\Windows\system32")
-    loaded: list[str] = []
-
-    assert cuda.prepare(tmp_path, platform="win32", load=loaded.append) == ()
-    assert loaded == []
+    assert cuda.prepare(tmp_path, platform="win32") == ()
+    assert os.environ["PATH"] == SYSTEM32
 
 
 def test_the_device_and_precision_default_to_the_backends_own_choice() -> None:
@@ -221,9 +174,10 @@ def test_the_model_is_built_with_the_configured_device_and_precision(
     ]
 
 
-def test_the_cuda_runtime_is_prepared_before_the_backend_is_imported(
+def test_the_cuda_runtime_is_prepared_before_the_model_is_built(
     tmp_path: Path, recording_backend: type[_RecordingModel], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """CTranslate2 loads cuBLAS at the first CUDA allocation — after this point is too late."""
     order: list[str] = []
 
     def _prepare() -> tuple[Path, ...]:
@@ -231,7 +185,7 @@ def test_the_cuda_runtime_is_prepared_before_the_backend_is_imported(
         return ()
 
     def _build(name: str, device: str, compute_type: str) -> object:
-        order.append("import")
+        order.append("build")
         return object()
 
     monkeypatch.setattr(cuda, "prepare", _prepare)
@@ -239,4 +193,4 @@ def test_the_cuda_runtime_is_prepared_before_the_backend_is_imported(
 
     whisper._model("large-v3")
 
-    assert order == ["prepare", "import"]
+    assert order == ["prepare", "build"]

--- a/tests/test_whisper_runtime.py
+++ b/tests/test_whisper_runtime.py
@@ -20,6 +20,7 @@ import pytest
 from resolve_mcp import config as config_module
 from resolve_mcp.analysis import cuda, whisper
 from resolve_mcp.config import Config
+from resolve_mcp.errors import TranscriberUnavailableError, TranscriptionError
 
 SYSTEM32 = r"C:\Windows\system32"
 CUBLAS = ("cublas64_12.dll", "cublasLt64_12.dll")
@@ -110,25 +111,6 @@ def test_a_venv_without_the_cuda_wheels_is_a_quiet_no_op(
     assert os.environ["PATH"] == SYSTEM32
 
 
-def test_the_device_and_precision_default_to_the_backends_own_choice() -> None:
-    config = Config.from_env({})
-
-    assert config.whisper_device == "auto"
-    assert config.whisper_compute_type == "default"
-
-
-def test_the_device_and_precision_are_overridable_for_a_box_without_a_gpu() -> None:
-    config = Config.from_env(
-        {
-            "RESOLVE_MCP_WHISPER_DEVICE": "cpu",
-            "RESOLVE_MCP_WHISPER_COMPUTE_TYPE": "float32",
-        }
-    )
-
-    assert config.whisper_device == "cpu"
-    assert config.whisper_compute_type == "float32"
-
-
 class _Info:
     language = "en"
 
@@ -172,6 +154,48 @@ def test_the_model_is_built_with_the_configured_device_and_precision(
     assert recording_backend.built == [
         {"name": whisper.DEFAULT_MODEL, "device": "cuda", "compute_type": "float32"}
     ]
+
+
+def test_a_device_the_backend_refuses_names_the_value_and_the_variable_that_set_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """These two are typed by a human now, so a typo has to arrive as advice, not a stack."""
+
+    def _refuse(name: str, device: str, compute_type: str) -> object:
+        raise ValueError(f"unsupported device {device}")
+
+    monkeypatch.setattr(whisper, "_build", _refuse)
+    monkeypatch.setattr(cuda, "prepare", lambda: ())
+    config_module.set_config(
+        Config.from_env(
+            {
+                "RESOLVE_MCP_WHISPER_DEVICE": "gpu",
+                "RESOLVE_MCP_CACHE": str(tmp_path / "cache"),
+            }
+        )
+    )
+
+    with pytest.raises(TranscriptionError) as raised:
+        whisper._model("large-v3")
+
+    assert "device='gpu'" in raised.value.cause
+    assert "RESOLVE_MCP_WHISPER_DEVICE" in raised.value.fix
+    assert raised.value.detail["device"] == "gpu"
+
+
+def test_a_missing_backend_still_says_it_is_missing_rather_than_blaming_the_device(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The unavailable-backend error is the older, more specific one; shaping must not eat it."""
+
+    def _absent(name: str, device: str, compute_type: str) -> object:
+        raise TranscriberUnavailableError(cause="faster-whisper is not installed.")
+
+    monkeypatch.setattr(whisper, "_build", _absent)
+    monkeypatch.setattr(cuda, "prepare", lambda: ())
+
+    with pytest.raises(TranscriberUnavailableError):
+        whisper._model("large-v3")
 
 
 def test_the_cuda_runtime_is_prepared_before_the_model_is_built(

--- a/uv.lock
+++ b/uv.lock
@@ -764,6 +764,42 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas-cu12"
+version = "12.9.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e2/fc9a0e985249d873150276d5afb02e39a66817fedbf1a385724393e505ed/nvidia_cublas_cu12-12.9.2.10-py3-none-win_amd64.whl", hash = "sha256:623f43027d40d44ceadf0043f002bd25cf353e8f13ce90b9a87057019f560661", size = 553162896, upload-time = "2026-04-08T18:53:10.035Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349", size = 76408187, upload-time = "2025-06-05T20:12:27.819Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.24.0.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/f1/cd42563325fa827f54ff30da05686c747652bdbd4cb5654cea54d7d0ad4f/nvidia_cudnn_cu12-9.24.0.43-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:a42996943f0cd78ddfd61c8bf59361672a19b63e0491aa22a53d6fe63a3f854a", size = 856490582, upload-time = "2026-07-02T16:21:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/10/13/b8887c869cf2471339a24b60d3c28e761facbb534935f572b61423371abb/nvidia_cudnn_cu12-9.24.0.43-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:f424192dd85e7d29f44be18df2dae4c80d32c67a29c0d42f5c283c40cfdf871c", size = 799083985, upload-time = "2026-07-02T16:25:37.467Z" },
+    { url = "https://files.pythonhosted.org/packages/29/28/2c9a2a97a8b3fedcf74a14f38fd5edfae12274380a829fdc6b16ce29be4c/nvidia_cudnn_cu12-9.24.0.43-py3-none-win_amd64.whl", hash = "sha256:cbd41a0ab084422c936dc9fb2fc89be5ea9a85bc421c6f23d0243bdfc945fbef", size = 737103728, upload-time = "2026-07-02T16:30:10.901Z" },
+]
+
+[[package]]
 name = "onnxruntime"
 version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1092,6 +1128,8 @@ dependencies = [
 [package.optional-dependencies]
 analysis = [
     { name = "faster-whisper" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform != 'darwin'" },
 ]
 
 [package.dev-dependencies]
@@ -1106,6 +1144,8 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'analysis'", specifier = ">=1.0" },
     { name = "fastmcp", specifier = ">=3.4,<4" },
     { name = "numpy", specifier = ">=2.0,<3" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin' and extra == 'analysis'", specifier = ">=12,<13" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform != 'darwin' and extra == 'analysis'", specifier = ">=9,<10" },
     { name = "scipy", specifier = ">=1.14,<2" },
 ]
 provides-extras = ["analysis"]


### PR DESCRIPTION
Closes #128.

`uv sync --extra analysis` installed a GPU-seeking transcriber with no GPU libraries. The
device default is `"auto"`, CTranslate2 resolves that to CUDA the moment it sees an NVIDIA
card, and nothing in the tree provided the CUDA 12 runtime it then needs — so the extra
failed on exactly the machines it is most useful on.

## What changed

- The `analysis` extra carries `nvidia-cublas-cu12` and `nvidia-cudnn-cu12` (~1.3 GiB;
  `nvidia-cuda-nvrtc-cu12` rides in as a dependency of cuBLAS). Marked off macOS, where no
  wheels exist and nothing would use them. `uv.lock` regenerated — without that, a clean
  `uv sync` installs no runtime at all and the acceptance criterion cannot pass.
- `analysis/cuda.py` puts the venv's own copy of the runtime on the search path before the
  model is built. No hand-installed wheels, no `PATH` set before launch.
- `RESOLVE_MCP_WHISPER_DEVICE` and `RESOLVE_MCP_WHISPER_COMPUTE_TYPE`, defaults unchanged
  (`"auto"` / `"default"`), documented in the README env table.

## Which mechanism, and how it is known (AC4)

The ticket left this open and flagged the in-process `PATH` prepend as an unverified
hypothesis. It is no longer a hypothesis. Measured on the live box in a throwaway venv
(CUDA 12.9 wheels, ctranslate2 4.8.1, faster-whisper 1.2.1) by building `tiny` on
`device="cuda"` under each candidate in turn:

| mechanism | result |
| --- | --- |
| nothing at all | **fails** — `RuntimeError: Library cublas64_12.dll is not found or cannot be loaded` (the bug) |
| `os.environ["PATH"]` prepend, in-process | **works** — shipped |
| `ctypes.WinDLL` preload by absolute path | works — recorded in the module as the fallback |
| `os.add_dll_directory()` | **fails**, confirming #35 |

`PATH` wins over the preload on cost: preloading maps ~1.4 GiB of DLLs (`cublasLt64_12.dll`
alone is 668 MB) into every job, including on a box that transcribes on the CPU and never
calls one of them. The evidence table lives in the module docstring so nobody re-runs the
experiment.

Two things the measurement corrected in the ticket's model of the problem: CTranslate2
loads the CUDA libraries at the **first allocation on the device**, not at import — so the
deadline for preparation is the model build, not the import. And Python ≥3.8 excluding
`PATH` applies when *Python* resolves an extension's dependencies; CTranslate2 does its own
runtime `LoadLibrary`, which is the plain Windows search order. That is the same fact that
explains why `add_dll_directory` does nothing here.

Then end-to-end through this branch's own code (`whisper.transcribe`, worktree `src`, the
probe venv's wheels), one attempt per process because a failed CUDA load poisons the one
it happens in:

```
RESULT control  (cuda.prepare skipped): FAILED TranscriptionError: faster-whisper failed on
                tone.wav: RuntimeError: Library cublas64_12.dll is not found or cannot be loaded
RESULT prepared (shipping path):        ran on cuda, 1.07s
```

## Test seam

Fake tier for the decisions: which directories, in what order, on which platform
(platform-parameterised, the way the interpreter guard already is), that a second job does
not lengthen `PATH` again, that a venv without the wheels is a quiet no-op, that the model
is built from config, and that preparation happens before the build. Whether CUDA then
initialises is observable at no seam — ADR 0001's shape — and is the live smoke's job.

`tests/test_whisper_runtime.py` (13 tests) plus the config default/override pair in
`tests/test_config.py`. Fake tier, mypy strict and ruff all green.

## Review

Two-axis review of `origin/main...HEAD` before this PR existed.

**Spec axis — 3 findings, all resolved or accounted for:**

1. *`uv.lock` never regenerated, so AC1 is unreachable from a clean checkout.* Correct and
   the most serious finding of the review. Fixed: `uv lock` run, all three nvidia wheels
   now in the lockfile.
2. *`cuda_nvrtc` is never installed — `nvidia-cudnn-cu12` does not depend on it.* Half
   right. The directory is populated, but via `nvidia-cublas-cu12`, not cuDNN; the code
   comment claimed cuDNN. Checked against the wheel metadata and the comment corrected,
   rather than adding a dependency that is already there.
3. *Two live ACs unaddressed in the diff.* True by design — see below.

Also raised: the `PATH` prepend de-duplicates existing entries rather than blindly
prepending. Kept deliberately — it moves a launcher-set copy to the front instead of
leaving two, which is what stops the search path growing a copy per job.

**Standards axis — no hard violations; 4 judgement calls, 3 taken:**

1. *A device value the backend refuses escaped `_model` unshaped* (it is called outside
   `transcribe`'s `try`) *and reached the job runner as an `InternalError`.* Taken: it now
   raises `TranscriptionError`. A follow-up pass over the fix caught that the first version
   blamed the env variables for **every** load failure — including #128's own, where both
   variables are unset — so the advice now follows who is likely at fault: defaults in
   force points at the install, a non-default value names the variable that set it.
   `TranscriberUnavailableError` still passes through; both paths are tested.
2. *Config default/override pair sat away from its neighbours.* Taken: moved to
   `tests/test_config.py`.
3. *`cuda.site_packages` had no caller outside the module.* Taken: made private.
4. *`_model`/`_build` is a thin delegation split.* Kept: it isolates the one import of
   faster-whisper, which is the module's stated seam.

Fix-diff re-review (focused, not a second full pass) raised the misdirected-advice bug
above plus two minor points — an overly closed list of compute types, and an unused test
parameter — both fixed.

## Needs from you

Three live ACs need the GPU box, the repo's own venv and real audio:

- **AC1** — `uv sync --extra analysis` in `C:\Users\Daniel\repos\resolve-mcp`, then a real
  transcription. What is verified so far is the same wheel set and this branch's code in a
  throwaway venv; the repo's own `.venv` has never had the extra installed. Note the extra
  is ~1.3 GiB, and per past sessions a `uv sync` re-resolves numpy — worth checking the
  hand-installed `beat_this`/`panns` still import afterwards.
- **AC5** — a recorded CPU-vs-GPU timing on real concert-length audio. Not attempted: a
  synthetic tone benchmarks nothing, which is the same objection the ticket raised about
  #35's 2-second clip.
- **AC4** is answered above and can be recorded on the ticket as: in-process `PATH`
  prepend, measured against the other two candidates.

Review: clean — two-axis review run on the branch before the PR; all findings resolved above, fix diff re-reviewed.

---

**Post-open commit: `6755de8`.** CI (Linux runner) failed on
`test_preparation_prepends_the_directories_ahead_of_everything_already_there`: the
`"C:\Windows\system32"` placeholder standing in for a pre-existing `PATH` entry contains a
colon, and `os.pathsep` on Linux *is* the colon, so it split itself in two. Green on
Windows, red on CI — the production code was never involved. Placeholder is now
drive-letter-free, with a comment saying why. Re-reviewed the fix diff on its own: test
data only, no behaviour touched. Fake tier, mypy strict and ruff green locally; both
required checks green on CI.

Review: clean — two-axis review before the PR, all findings resolved; fix diff and the post-open CI fix each re-reviewed.
