### PR TITLE
Run the gated corpus pass (#112 AC4/AC5) and record what the gate could and could not say

### DIFF
--- a/styles/concert.md
+++ b/styles/concert.md
@@ -20,7 +20,9 @@ that the grid is a live band's grid, so it moves.
 - **Rubato is not measurable and not evidence.** Where the beat confidence
   drops — free intros, out-of-time codas — cut placement there says nothing
   about taste and is gated out of the evidence rather than averaged in.
-  `[stated principle]` (#13, analysis workflow)
+  `[stated principle]` (#13, analysis workflow) — and the pass that applies it
+  shows the principle is not a rounding error: the gate refuses every cut on
+  three of the six corpus timelines and a third of them on a fourth.
 - **Cuts land close to a transient without landing on one.** The median cut sits
   a few frames from the nearest transient and almost never on it: 33 ms on the
   anchor (2 of 360 cuts on a transient), 41 ms on Monkfish, 34 ms on Freefall,
@@ -36,33 +38,37 @@ that the grid is a live band's grid, so it moves.
   "always cut just before the hit", not the presence of one: the placement is
   about distance, not side.
   `[measured — 3 projects, n=1043 cuts, concert]`
-- Beat-grid position patterns, in frames and in beat-fraction, conditioned on
-  context. *Open, and blocked rather than merely unmeasured. Every timeline so
-  far skews hard to the first beat of the bar — anchor 171:111:44:30, Scullers
-  203:55:38:27, Mercies 25:6:2:3 — which would be a real finding if the grids
-  were trustworthy, and they are not: the anchor's reports `meter: 1` at 214 bpm
-  over a jazz set, Mercies puts a cut in a bar 6, and Scullers puts cuts in bars
-  5, 6 and 7. There is no such position in 4/4, so the grid is demonstrably
-  wrong where those cuts are — and it is the same grid the other 96% were
-  scored against.
+- **Cuts skew to the first beat of the bar — where the grid can be trusted at
+  all.** 49.0% of gated cuts land on beat 1 and 71.6% on beats 1–2, against a
+  uniform 25%: 223 / 103 / 63 / 66 over beats 1–4. The skew is not the gate's
+  doing and not an artefact of the broken grids — ungated, over the same three
+  timelines, beat 1 held 53.1%, so refusing a third of the beats moved it four
+  points. Read it as a tendency and not a rule: half of a bar's cuts are
+  somewhere other than beat 1.
+  `[measured — 3 projects, n=455 cuts, concert]` (`corpus.md`, the gated pass)
 
-  **The gate is built (#112); the pass that would settle this has not run.**
-  `correlate_timeline` now refuses a beat whose bar position its own meter
-  cannot hold, or whose interval does not match the tempo around it, and
-  refuses whole any grid whose meter comes out as 1 — filtering such a grid
-  against its own meter would keep exactly its position-1 beats and leave a
-  histogram that is 100% beat one *by construction*, which is a gate
-  manufacturing the very skew it was built to test. Cuts are marked
-  `in_grid: false` and counted, never silently dropped.
+  **Three of the six corpus timelines can say nothing here at all**, including
+  the anchor. Their grids report `meter: 1` and the gate refuses them whole
+  rather than filter them, since keeping only a meter-1 grid's position-1 beats
+  would leave a histogram reading 100% beat one *by construction*. The
+  histograms those three used to show — anchor 171:111:44:30, Mercies 25:6:2:3
+  — were never evidence, and the positions 5, 6 and 7 that Scullers and Mercies
+  reported are gone from every surviving row. This claim therefore rests on
+  Freefall, Monkfish Main and Concert Full Cut: one timeline from each of the
+  three projects, which is the thinnest a three-project claim can be.
 
-  What that changes here: the instrument can now say when it cannot be
-  trusted, so this item is **open but no longer blocked**. What it does not
-  change: still no beat-position claim, because a claim needs numbers out of
-  `correlate_timeline` over the six corpus timelines, and that pass needs each
-  project open in Resolve. A provisional offline check suggests three of the
-  six grids will produce no bar histogram at all under the gate. If that
-  holds, half the histograms quoted above were never evidence — but it is a
-  prediction until the tool has been run.*
+  One confound the gate cannot address, and it is the reason this reads
+  `[measured]` rather than settled: `beat_this` places downbeats from the same
+  mix the cuts were made to, and a downbeat detector keys on strong onsets —
+  roughly where cuts land. Part of the skew could be the detector agreeing with
+  the director about where the strong moments are. Separating the two needs a
+  grid from an independent source (a click track, a hand-tapped grid), which
+  this corpus does not have.
+
+- Beat-grid position patterns **conditioned on context** — by tune section, by
+  energy, in beat-fraction rather than whole positions. *Open. The unconditioned
+  histogram above is what the gated pass could support; conditioning it splits
+  455 cuts across three timelines into samples too small to defend.*
 
 ## 2. Energy — the master concept
 

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -43,7 +43,7 @@ that the grid is a live band's grid, so it moves.
   uniform 25%: 223 / 103 / 63 / 66 over beats 1–4. The skew is not the gate's
   doing and not an artefact of the broken grids — ungated, over the same three
   timelines, beat 1 held 53.1%, so refusing a third of the beats moved it four
-  points. Read it as a tendency and not a rule: half of a bar's cuts are
+  points. Read it as a tendency and not a rule: half the cuts still land
   somewhere other than beat 1.
   `[measured — 3 projects, n=455 cuts, concert]` (`corpus.md`, the gated pass)
 

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -318,7 +318,10 @@ the transient numbers are computed over every cut and are untouched.
 
 **The pass has now run.** Each of the three projects was opened in Resolve in
 turn and each timeline re-measured through `correlate_timeline` with
-`refresh=True`, on the live Windows 11 box against Resolve Studio 21.0.3.7.
+`refresh=True`, on the live Windows 11 box against Resolve Studio 21.0.3.7 on
+CPython 3.12.10 — and the attach held throughout, so that interpreter is not a
+uv-managed standalone (ADR 0001, where the failure is a process-killing access
+violation rather than an error).
 Every parameter — beats file, audio, `angles`, `track`, `audio_at` — was copied
 verbatim out of the matching pre-gate `.correlate.json` header, so the gate is
 the only thing that differs between an entry's row above and its row here. No
@@ -427,7 +430,9 @@ against the nearest **surviving** beat, however far away that is. It is one cut
 in 455 and it does not touch the histogram, but a mean is not safe from it.
 The clean fix would be to refuse a cut whose nearest trusted beat is further
 than some multiple of the local beat interval; that is a change to the gate, not
-to this corpus, and there is one instance of it to justify the work.
+to this corpus, and one instance across 455 cuts is thin justification for
+making it. Recorded here so the next mean that looks wrong has an explanation
+waiting.
 
 ### Two bookkeeping consequences of re-running
 
@@ -460,8 +465,8 @@ Monkfish Main and its master, `uv run pytest -m live -k correlate -s` — **1
 passed in 30.79 s**, on the same box and Resolve build. It ran without an
 `angles` sidecar and into pytest's own temporary cache, and still reported
 `measured: 202`, `median_abs: 0.084`, `max_abs: 0.39` — identical to the
-labelled run in the table above. That is the third independent demonstration in
-this corpus that labels add names and move no number.
+labelled run in the table above. That is one more independent demonstration
+that labels add names and move no number.
 
 ## What the labels settled: operation, not framing
 

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -101,6 +101,12 @@ One row per timeline, appended in order, never rewritten: a rerun that
 disagrees with an earlier row gets its own row and a note, because the
 disagreement is itself evidence.
 
+The per-entry cautions below that treat rubato gating as pending were written
+before the gate existed; **the gated pass has since run** and answers them, in
+"The gated pass (#112 AC4)" further down. Every bar-position histogram in the
+entries below is ungated and half of them are now known to have come from a
+grid the gate refuses whole — read them with that section beside them.
+
 `alignment` is `correlate_timeline`'s reading of where the times were measured
 from. **`timeline_start` rows are excluded from every timing claim** — those
 times count from the timeline's own first frame rather than from the mix, and a
@@ -299,10 +305,10 @@ Two notes:
 - The transient median (41 ms) is the highest in the corpus and still inside
   two frames. Six timelines now span 17–41 ms.
 
-## Rubato gating exists; the corpus pass that uses it is still to run (#112)
+## The gated pass (#112 AC4), measured 2026-08-07
 
-`correlate_timeline` now gates the beat statistics. A beat is refused on either
-of two independent grounds — a bar position its own meter cannot hold, or an
+`correlate_timeline` gates the beat statistics. A beat is refused on either of
+two independent grounds — a bar position its own meter cannot hold, or an
 interval that does not match the tempo around it — and a grid whose meter comes
 out as 1 is refused whole rather than filtered, since keeping only its
 position-1 beats would leave a histogram reading 100% beat one *by
@@ -310,21 +316,152 @@ construction*. Cuts landing on a refused beat stay in the records marked
 `in_grid: false` and are counted out of the bar and beat-offset statistics only;
 the transient numbers are computed over every cut and are untouched.
 
-**No gated histogram is recorded here yet, deliberately.** A number in this file
-is evidence, and evidence comes from the tool: step 4 of the analysis workflow
-in `docs/agents/style-layer.md` is explicit that `correlate_timeline` is the one
-tested measurement path and that statistics are never recomputed ad hoc. The six
-gated rows therefore need a live re-run through the tool, which needs each
-project open in Resolve. Until that pass runs, the ungated bar histograms
-recorded in the entries above stand as they are — already marked, in entries 1,
-2 and 4, as saying nothing.
+**The pass has now run.** Each of the three projects was opened in Resolve in
+turn and each timeline re-measured through `correlate_timeline` with
+`refresh=True`, on the live Windows 11 box against Resolve Studio 21.0.3.7.
+Every parameter — beats file, audio, `angles`, `track`, `audio_at` — was copied
+verbatim out of the matching pre-gate `.correlate.json` header, so the gate is
+the only thing that differs between an entry's row above and its row here. No
+number below was computed anywhere but in the tool.
 
-A provisional offline pass over the cut records and grids in the analysis cache
-was run to size the job, and is recorded on the ticket rather than here. Its one
-result worth acting on: three of the six grids look likely to report `meter: 1`
-and so to produce no bar histogram at all under the gate, which would mean half
-the corpus never described a bar position in the first place. Treat that as a
-prediction about what the live pass will show, not as a measurement.
+| # | Timeline | Meter | Cuts in span | Gated out | Measured | Bar position, gated | Beat offset: median / mean / max |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Zinc - Set 2 Main | **1** | 360 | 360 | **0** | — refused whole | — |
+| 2 | Freefall Timeline | 4 | 43 | 8 | 35 | 1:15, 2:14, 3:2, 4:4 | 69 ms / 249 ms / 6.08 s |
+| 2 | Sunshine Timeline | **1** | 49 | 49 | **0** | — refused whole | — |
+| 2 | Mercies Timeline | **1** | 37 | 37 | **0** | — refused whole | — |
+| 3 | Concert Full Cut | 4 | 326 | 108 | 218 | 1:128, 2:40, 3:27, 4:23 | 81 ms / 102 ms / 324 ms |
+| 5 | Monkfish Main | 4 | 228 | 26 | 202 | 1:80, 2:49, 3:34, 4:39 | 84 ms / 94 ms / 390 ms |
+
+"Cuts in span" is `count − openings`: an opening has no outgoing angle and no
+offset to measure. The transient columns in the entries above are unchanged by
+this pass, as designed — the gate never touches them.
+
+**Half the corpus never described a bar position in the first place.** The
+offline prediction held exactly: three of the six grids report `meter: 1` and
+are refused whole. Every beat in all three is refused on bar position — 11,130
+on the anchor, 2,348 on Sunshine, 1,261 on Mercies — and their bar histograms
+were therefore never evidence, whatever the entries above appeared to say. The
+anchor is the expensive case: 366 shots, the strongest exemplar in the corpus,
+and it contributes nothing to any beat claim. It still contributes its 360
+transient measurements, which is the half that was always the trustworthy one.
+
+**On the three that survive, the gate removed a tail rather than a centre.**
+
+| Timeline | Beat-offset mean, ungated → gated | Max, ungated → gated | Median, ungated → gated |
+| --- | --- | --- | --- |
+| Freefall | 228 ms → 249 ms | 6.08 s → 6.08 s | 63 ms → 69 ms |
+| Concert Full Cut | 846 ms → **102 ms** | 22.69 s → **0.324 s** | 97 ms → 81 ms |
+| Monkfish Main | 457 ms → **94 ms** | 13.92 s → **0.390 s** | 95 ms → 84 ms |
+
+Ungated, every mean ran three to nine times its own median — the signature of a
+grid that fits in places and wanders elsewhere, and the reason entry 1's row
+carries that caution. Gated, Scullers' and Monkfish's means sit just above their
+medians (102 against 81 ms, 94 against 84 ms) and their worst cut is under
+0.4 s from a beat, where ungated it was 23 s and 14 s. The medians barely moved,
+which is the useful part: the gate is not shifting where cuts sit, it is
+deleting the passages where the grid could not say.
+
+**The bar histograms are now strictly 1–4.** Positions 5, 6 and 7 — the ones
+that cannot exist in 4/4 and that made the ungated histograms unusable — are
+gone from every surviving row, refused rather than argued away.
+
+Summing the three surviving rows (three timelines, one from each of the three
+projects, 455 cuts):
+
+| Beat of the bar | 1 | 2 | 3 | 4 |
+| --- | --- | --- | --- | --- |
+| Cuts | 223 | 103 | 63 | 66 |
+| Share | **49.0%** | 22.6% | 13.8% | 14.5% |
+
+Against a uniform 25%, that is a real skew to the first beat, and 71.6% of cuts
+fall on beats 1–2. **Gating did not manufacture it and did not remove it**: over
+the same three timelines the ungated share on beat 1 was 53.1%, so refusing a
+third of the beats moved it four points. That is the shape of a finding rather
+than of an artefact — an artefact of a broken grid should have collapsed when
+the broken grids were refused.
+
+One confound stays attached, and the gate cannot address it: `beat_this` places
+downbeats from the audio, and a downbeat detector keys on strong onsets, which
+is also roughly where cuts land. Some part of a beat-1 skew could be the
+detector agreeing with the director about where the strong moments are rather
+than the director cutting to bar lines. Nothing measurable here separates the
+two; it would take a grid from a source independent of the mix — a click track,
+or a hand-tapped grid.
+
+### `UNSTEADY_FRACTION = 0.15` stands — it is a shoulder, not a cliff
+
+The one constant in the gate with no fake-tier ground truth. It was checked the
+way #35's silence defaults were: run the same tool over the same timelines with
+only the constant changed, and see whether any conclusion depends on it. 0.15
+was run last of the four so the artifacts left on disk are the shipped value's.
+
+| Timeline | | 0.10 | 0.15 | 0.20 | 0.30 |
+| --- | --- | --- | --- | --- | --- |
+| Freefall | measured | 34 | 35 | 38 | 38 |
+| | median | 66 ms | 69 ms | 61 ms | 61 ms |
+| | beat-1 share | 41.2% | 42.9% | 42.1% | 42.1% |
+| Concert Full Cut | measured | 207 | 218 | 225 | 231 |
+| | median | 82 ms | 81 ms | 80 ms | 82 ms |
+| | beat-1 share | 58.0% | 58.7% | 60.0% | 59.7% |
+| Monkfish Main | measured | 199 | 202 | 204 | 205 |
+| | median | 86 ms | 84 ms | 86 ms | 87 ms |
+| | beat-1 share | 39.7% | 39.6% | 39.2% | 39.0% |
+
+Over a **threefold** range of the constant, the surviving cut count moves by
+about a tenth, no median moves by more than 8 ms, and no beat-1 share moves by
+more than two points. Nothing in this corpus is sensitive to it, so 0.15 is
+confirmed by the pass rather than merely left alone — and the honest reading is
+that the number is not load-bearing, not that it is precisely right. The three
+`meter: 1` refusals are untouched at every value: that refusal comes from the
+meter rule, and no setting of this constant rescues them.
+
+### What the gate does not fix: a cut beside a refused stretch
+
+Freefall keeps a cut 6.08 s from its nearest beat at every setting, and it is
+the reason Freefall's mean still sits 3.6× its median while the other two came
+into line. The record shows why: the cut at t=676.802 is 34 ms from a transient
+and marked `in_grid: true` with `in_bar: 1`. The gate refuses *beats*, not cuts
+— so where it refuses a run of beats, a cut sitting in that hole is still scored
+against the nearest **surviving** beat, however far away that is. It is one cut
+in 455 and it does not touch the histogram, but a mean is not safe from it.
+The clean fix would be to refuse a cut whose nearest trusted beat is further
+than some multiple of the local beat interval; that is a change to the gate, not
+to this corpus, and there is one instance of it to justify the work.
+
+### Two bookkeeping consequences of re-running
+
+- **The anchor's clock moved one frame, and the gate did not do it.** Zinc's
+  alignment now reads `zero_frame: 83824` where the pre-gate row read 83825 —
+  that is **PR #121**'s fix to #120, `GetSourceStartFrame` being lossy by a frame
+  at 23.976, reaching a second reader. The `audio_clip` zero is derived from it.
+  Nothing in the entry-1 row above changes materially — median transient offset
+  is still 33 ms and the mean still 46 ms — but the early/late split moved from
+  195/163 to 174/183, which is what shifting every measurement by 41.7 ms does
+  to a distribution whose median is 33 ms. It reinforces entry 1's own note that
+  the direction split carries no habit: a one-frame clock correction reverses it.
+  Monkfish is also `audio_clip` and did **not** move, because its audio starts
+  exactly on the timeline's first frame and had no fraction to lose.
+- **Five of the six result files were overwritten in place.** The cache key
+  covers the inputs and the parameters, not the version of the code, so a
+  re-run with identical parameters lands on the same filename. The `Result`
+  paths in the Measured table above now hold *gated* content; the ungated
+  numbers survive in this document and nowhere else. Zinc is the exception —
+  its key changed with the one-frame clock, so its gated result is
+  `…/analysis/Zinc---Set-2-Main-1cc8ebd14cb3.correlate.json` and its ungated
+  `dcb16e19eca1` file is still on disk.
+
+### #40's live AC, discharged the same sitting
+
+`test_correlate_measures_a_real_hand_edited_timeline` had never been recorded
+against a real cut. Rather than decide whether this corpus pass supersedes it,
+it was run: `RESOLVE_MCP_CORRELATE_BEATS` / `_TIMELINE` / `_AUDIO` pointed at
+Monkfish Main and its master, `uv run pytest -m live -k correlate -s` — **1
+passed in 30.79 s**, on the same box and Resolve build. It ran without an
+`angles` sidecar and into pytest's own temporary cache, and still reported
+`measured: 202`, `median_abs: 0.084`, `max_abs: 0.39` — identical to the
+labelled run in the table above. That is the third independent demonstration in
+this corpus that labels add names and move no number.
 
 ## What the labels settled: operation, not framing
 


### PR DESCRIPTION
Discharges **#112 AC4 and AC5**, carried on **#119 section C**, plus the two
loose items in that section: `UNSTEADY_FRACTION` and #40's live AC.

## What ran

Each of the three corpus projects opened in Resolve in turn; all six corpus
timelines re-measured through `correlate_timeline` with `refresh=True`. Every
parameter — beats file, audio, `angles`, `track`, `audio_at` — copied verbatim
out of the matching pre-gate `.correlate.json` header, so the gate is the only
difference between an entry's recorded row and its new one. Live Windows 11 box,
Resolve Studio 21.0.3.7, CPython 3.12.10, attach held throughout.

**Test seam:** this is the live tier and nothing else — a gate that decides
which beats are trustworthy can only be judged against real grids over real
music, and the fake tier has no ground truth for it (which is exactly why
`UNSTEADY_FRACTION` was the one constant #119 asked to confirm). No production
code changed, so the fake tier is unaffected; the diff is two markdown files.

## What it found

- **Half the corpus never described a bar position.** Zinc (the anchor),
  Sunshine and Mercies report `meter: 1` and are refused whole — exactly what
  the offline check predicted. Their published bar histograms were never
  evidence.
- **The three that survive give the corpus its first gated histogram**: 49.0%
  of 455 cuts on beat 1, 71.6% on beats 1–2, strictly positions 1–4. The skew
  survives gating (53.1% ungated over the same three), so it is not an artefact
  of the broken grids. `concert.md` §1 gets a `[measured]` claim with the
  downbeat-detector confound attached.
- **The gate removes a tail, not a centre.** Scullers' beat-offset mean 846 ms →
  102 ms and its max 22.7 s → 0.32 s, while its median moved 97 → 81 ms.
- **`UNSTEADY_FRACTION = 0.15` confirmed as a shoulder.** Swept through the tool
  at 0.10/0.15/0.20/0.30: surviving cut count moves ~a tenth, no median more
  than 8 ms, no beat-1 share more than two points. 0.15 run last so the
  artifacts on disk are the shipped value's.
- **#40's live AC run rather than waived** — `uv run pytest -m live -k correlate
  -s` against Monkfish Main: **1 passed in 30.79 s**, reproducing the labelled
  run's numbers without a sidecar.
- Two side effects recorded honestly: the anchor's `zero_frame` moved one frame
  (PR #121's #120 fix reaching a second reader, not the gate), and re-running
  overwrote five result files in place because the cache key covers inputs and
  parameters but not code.

## Review

Pure prose — two markdown files, no executable change — so one lightweight
inline pass per CLAUDE.md, over the branch diff before this PR existed.

Findings, all mine and all fixed in `08f2bb3`:

1. **Arithmetic overstated.** "every mean ran five to nine times its own median"
   was false for Freefall (3.6×) and Monkfish (4.8×) → "three to nine". "means
   sit within a quarter of their medians" was 26% for Scullers → replaced with
   the actual pairs. "worst cut is under four frames from a beat" was ~9 frames
   → "under 0.4 s". (Fixed before the first commit.)
2. **Unchecked count.** "the third independent demonstration that labels move no
   number" — I had not verified it was the third → "one more".
3. **Live record incomplete.** CLAUDE.md wants hardware, interpreter and outcome;
   the interpreter was missing → named, with the note that a held attach is
   itself the evidence it is not a uv-managed standalone (ADR 0001).
4. **Two ambiguous referents** ("half of a bar's cuts", "one instance to justify
   the work") reworded.

Verified: every number in the diff traces to a tool result, not to a side
calculation; the summed histogram is the only arithmetic and its three inputs
are in the table above it.

Review: clean — prose only, single-pass
