### PR TITLE
Live smoke: assert Audio Ch reads the way E7 reads it (#62's last AC)

### DIFF
--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -39,6 +39,7 @@ from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.naming import timestamped_name
 from resolve_mcp.resolve.connection import get_connection
 from resolve_mcp.resolve.media import (
+    AUDIO_CHANNELS,
     apply_still_workaround,
     ensure_bin,
     find_clip,
@@ -158,6 +159,32 @@ def test_inspects_a_real_clip_with_the_property_keys_the_wrappers_assume() -> No
     assert result["ok"] is True
     assert "File Path" in result["properties"]
     assert result["bounds"]["media"]["duration"] is not None
+
+
+def test_the_audio_ch_key_is_spelled_the_way_e7_reads_it() -> None:
+    """#62 item 5: E7 fails open when this key is unreadable, so if Resolve ever renamed
+    it, `validate_cut` would silently pass every clip as having audio.
+
+    Swept across the pool rather than pinned to one clip: an image sequence may not
+    enumerate audio keys, and that absence is not the rename this test guards against.
+    """
+    listing = list_media()
+    if not listing["ok"]:
+        pytest.skip("No media pool")
+    decodable = _decodable(listing["clips"])
+    if not decodable:
+        pytest.skip("No clips with media behind them in the media pool")
+
+    seen: set[str] = set()
+    for clip in decodable:
+        result = inspect_clip(clip["name"], bin=clip["bin"])
+        if not result["ok"]:
+            continue
+        seen.update(result["properties"])
+        if AUDIO_CHANNELS in seen:
+            break
+
+    assert AUDIO_CHANNELS in seen
 
 
 def test_lists_the_real_timelines() -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -41,6 +41,7 @@ from resolve_mcp.resolve.connection import get_connection
 from resolve_mcp.resolve.media import (
     AUDIO_CHANNELS,
     apply_still_workaround,
+    audio_channels,
     ensure_bin,
     find_clip,
     import_into,
@@ -161,12 +162,14 @@ def test_inspects_a_real_clip_with_the_property_keys_the_wrappers_assume() -> No
     assert result["bounds"]["media"]["duration"] is not None
 
 
-def test_the_audio_ch_key_is_spelled_the_way_e7_reads_it() -> None:
-    """#62 item 5: E7 fails open when this key is unreadable, so if Resolve ever renamed
-    it, `validate_cut` would silently pass every clip as having audio.
+def test_the_audio_ch_key_reads_the_way_e7_reads_it() -> None:
+    """#62 item 5: E7 fails open whenever ``audio_channels`` reads ``None``.
 
-    Swept across the pool rather than pinned to one clip: an image sequence may not
-    enumerate audio keys, and that absence is not the rename this test guards against.
+    That happens on a renamed key *and* on a kept key whose value stopped parsing —
+    either way `validate_cut` would silently pass every clip as having audio, so the
+    assertion is E7's own read, not key presence. Swept across the pool rather than
+    pinned to one clip, and skipped when no clip carries audio keys at all: an
+    image-sequence-only pool has nothing E7 could misread.
     """
     listing = list_media()
     if not listing["ok"]:
@@ -175,16 +178,22 @@ def test_the_audio_ch_key_is_spelled_the_way_e7_reads_it() -> None:
     if not decodable:
         pytest.skip("No clips with media behind them in the media pool")
 
-    seen: set[str] = set()
+    seen_keys: set[str] = set()
     for clip in decodable:
         result = inspect_clip(clip["name"], bin=clip["bin"])
         if not result["ok"]:
             continue
-        seen.update(result["properties"])
-        if AUDIO_CHANNELS in seen:
-            break
+        properties = result["properties"]
+        seen_keys.update(properties)
+        if audio_channels(properties) is not None:
+            return
 
-    assert AUDIO_CHANNELS in seen
+    audio_ish = sorted(key for key in seen_keys if "audio" in key.lower())
+    if not audio_ish:
+        pytest.skip("No clip in the pool enumerates audio keys at all")
+    raise AssertionError(
+        f"No clip gave a readable {AUDIO_CHANNELS!r} count; audio keys seen: {audio_ish}"
+    )
 
 
 def test_lists_the_real_timelines() -> None:


### PR DESCRIPTION
Closes the last open AC on #62: "anything that turns out to be checkable read-only gets a live smoke test so it never needs a human again", applied to item 5 — the `Audio Ch` property key that `validate_cut` rule E7 reads for its has-audio check and fails open on.

**Seam:** live smoke only, by definition (#62's own seam line) — the key's existence in the real API has no fake-tier seam; the fakes spell it the way the wrappers assume, which is exactly the assumption under test.

**Live run (recorded on #62 as well):** live Windows 11 box, Resolve Studio up, Python 3.12.10 (python.org, MSC v.1943 AMD64) — `uv run pytest -m live -k audio_ch`: **1 passed** (18.3s, real attach — not skipped). Fake tier 1281 passed; mypy strict clean (159 files); ruff clean.

## Review record

Two-axis `/code-review` on the branch (Standards + Spec sub-agents), diff pinned to `origin/main`:

- **Standards:** no hard violations (import from defining module; live-tier conventions matched). Judgement calls: duplicated setup preamble (left — matches the file's existing habit at four call sites; a shared helper is a candidate refactor, not this PR), `seen` naming (fixed → `seen_keys`), docstring summary shape (fixed), assertion-strength gap (fixed, below).
- **Spec:** (1) test asserted key *presence*, but E7 fails open on `audio_channels()` reading `None` — a kept key with an unparseable value would pass the test while E7 passed everything → **fixed**: assertion is now E7's own read. (2) A rename failure reported nothing about the real key name, though the ticket asked "if not, what the real name is" → **fixed**: failure message lists the audio-ish keys seen. (3) A stills-only pool would fail as a false rename alarm → **fixed**: skips when no clip enumerates audio keys. No scope creep.
- Fix diff re-checked (focused pass): all findings addressed; gates re-run green, live smoke re-run passed.

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
