### PR TITLE
Read audio-only clip bounds from Duration; label the MCP Monkfish reference sources

### DIFF
--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -78,13 +78,15 @@ class ClipFacts:
 
     Gathered once from Resolve and then handed to pure functions, so the rules never
     hold a Resolve handle. Bounds are half-open — ``end_exclusive`` is Resolve's last
-    frame plus one — matching the cut file's own convention.
+    frame plus one — matching the cut file's own convention. A bound is ``None`` when
+    Resolve reported nothing and nothing could derive it: that means "cannot verify",
+    never "0-0", so the range rules fail open on it (#46).
     """
 
     name: str
     bin_path: str | None
-    start: int
-    end_exclusive: int
+    start: int | None
+    end_exclusive: int | None
     fps: float | None
     has_audio: bool = False
     is_still: bool = False
@@ -680,7 +682,14 @@ def _bounds_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[
 
 
 def _outside_media(item: dict[str, Any], clip: ClipFacts) -> bool:
-    """Whether a half-open range asks for frames the clip's media does not have."""
+    """Whether a half-open range asks for frames the clip's media does not have.
+
+    Unknown bounds cannot convict: when Resolve never reported the clip's extent the
+    check fails open — the same stance E7's has-audio leg takes on an unreported
+    channel count, because "Resolve did not say" is not evidence of an overrun.
+    """
+    if clip.start is None or clip.end_exclusive is None:
+        return False
     return bool(item["in"] < clip.start or item["out"] > clip.end_exclusive)
 
 

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -165,8 +165,11 @@ def _facts(bin_path: str, clip: Clip, timeline_fps: float) -> ClipFacts:
     return ClipFacts(
         name=name,
         bin_path=bin_path,
-        start=start if start is not None else 0,
-        end_exclusive=out if out is not None else 0,
+        # Bounds nothing could derive stay None — "cannot verify", so the range legs of
+        # E5/E7 skip the clip rather than fail every range against fictitious 0-0 media
+        # (the same fail-open stance has_audio takes below).
+        start=start,
+        end_exclusive=out,
         fps=media.frame_rate(reported),
         # An unreported channel count must not fail a cut that is fine: E7 blocks the
         # build, and "Resolve did not say" is not evidence of silence.

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -107,8 +107,9 @@ def preflight(
         log.info("Cut file %s is not schema-valid; the media pool was not read", loaded.path)
         return Preflight(loaded, findings, [])
 
+    timeline_fps = float(loaded.doc["timeline"]["fps"])
     sources = [
-        Source(_facts(found.bin_path, found.clip), found)
+        Source(_facts(found.bin_path, found.clip, timeline_fps), found)
         for found in _located(connection, loaded.doc)
     ]
     facts = [source.facts for source in sources]
@@ -149,10 +150,12 @@ def _located(connection: ResolveConnection, doc: dict[str, Any]) -> list[media.L
     return located
 
 
-def _facts(bin_path: str, clip: Clip) -> ClipFacts:
+def _facts(bin_path: str, clip: Clip, timeline_fps: float) -> ClipFacts:
     name = str(clip.GetName() or "")
     reported = media.properties(clip)
-    start, out = media.frame_bounds(reported)
+    # The timeline's rate is what the Duration fallback counts at: an audio-only clip
+    # reports no Start/End/Frames and no rate of its own (#46), only a Duration timecode.
+    start, out = media.frame_bounds(reported, fps=timeline_fps)
     channels = media.audio_channels(reported)
     if channels is None:
         # E7's has-audio leg reads an undocumented property key. If Resolve renames it

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -366,27 +366,39 @@ def frame_bounds(
     missing. The rule lives here so bounds mean the same thing to a listing and to a cut.
 
     Audio-only clips report ``Start``, ``End`` and ``Frames`` as empty strings (#46,
-    live-verified): only ``Duration`` carries the length, as timecode. When nothing else
-    is readable that timecode is the bounds — ``[0, duration)``, counted at the clip's
-    own rate or, since audio reports no rate either, at the caller's ``fps`` (the
-    timeline's, for a cut). With no rate at all the bounds stay unknown.
+    live-verified): only ``Duration`` carries the length, as timecode. So whenever the
+    out point is unreadable and ``Duration`` parses, the duration stands in — bounds are
+    ``[start, start + duration)`` with an unreported start read as 0 — counted at the
+    clip's own rate or, since audio reports no rate either, at the caller's ``fps`` (the
+    timeline's, for a cut). With no rate at all, or no parseable ``Duration``, the
+    unknowns stay ``None`` — unknown, never invented.
     """
     start = _number(reported, START)
     end = _number(reported, END)
     frames = _number(reported, FRAMES)
     out = end + 1 if end is not None else (start + frames if start is not None and frames else None)
-    if start is None and out is None:
+    if out is None:
         rate = frame_rate(reported) or fps
         duration = frames_from_timecode(reported.get(DURATION, ""), rate) if rate else None
-        if duration:
-            log.info(
-                "Start/End/Frames unreported; bounds 0-%d read from %s %r at %s fps",
-                duration,
+        if duration is not None:
+            begin = start if start is not None else 0
+            log.debug(
+                "End/Frames unreported; bounds %d-%d read from %s %r at %s fps",
+                begin,
+                begin + duration,
                 DURATION,
                 reported.get(DURATION),
                 rate,
             )
-            return 0, duration
+            return begin, begin + duration
+        # The case a live session most needs to see: nothing reported and nothing to
+        # derive from, so every bounds-based check downstream silently fails open.
+        log.debug(
+            "End/Frames unreported and %s %r cannot stand in (rate %s); bounds unknown",
+            DURATION,
+            reported.get(DURATION),
+            rate,
+        )
     return start, out
 
 
@@ -830,7 +842,8 @@ def _bounds(clip: Clip, reported: dict[str, str]) -> dict[str, Any]:
     the out point is that frame plus one and ``duration = out - in`` everywhere.
     """
     fps = frame_rate(reported)
-    start, out = frame_bounds(reported)
+    # The same rate feeds the Duration fallback, so a listing and a cut read one bounds.
+    start, out = frame_bounds(reported, fps=fps)
     duration = (
         out - start if out is not None and start is not None else _number(reported, FRAMES)
     )

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -56,7 +56,7 @@ from ..errors import (
 )
 from ..logging_config import get_logger
 from ..spill import spill
-from ..timing import dual_time
+from ..timing import dual_time, frames_from_timecode
 from .camera_sidecar import camera_model as recorded_camera_model
 from .connection import ResolveConnection
 
@@ -84,6 +84,7 @@ SEQUENCE_TOKEN = "%"
 SEQUENCE_RANGE = re.compile(r"\[(\d+)-\d+\]")
 
 FILE_PATH = "File Path"
+DURATION = "Duration"
 FRAMES = "Frames"
 FPS = "FPS"
 START = "Start"
@@ -355,17 +356,37 @@ def frame_rate(reported: dict[str, str]) -> float | None:
         return None
 
 
-def frame_bounds(reported: dict[str, str]) -> tuple[int | None, int | None]:
+def frame_bounds(
+    reported: dict[str, str], fps: float | None = None
+) -> tuple[int | None, int | None]:
     """Media bounds as half-open ``[start, out)``.
 
     Resolve reports ``End`` as the last frame; every range in this server is half-open, so
     the out point is that frame plus one. Frame count is the fallback when ``End`` is
     missing. The rule lives here so bounds mean the same thing to a listing and to a cut.
+
+    Audio-only clips report ``Start``, ``End`` and ``Frames`` as empty strings (#46,
+    live-verified): only ``Duration`` carries the length, as timecode. When nothing else
+    is readable that timecode is the bounds — ``[0, duration)``, counted at the clip's
+    own rate or, since audio reports no rate either, at the caller's ``fps`` (the
+    timeline's, for a cut). With no rate at all the bounds stay unknown.
     """
     start = _number(reported, START)
     end = _number(reported, END)
     frames = _number(reported, FRAMES)
     out = end + 1 if end is not None else (start + frames if start is not None and frames else None)
+    if start is None and out is None:
+        rate = frame_rate(reported) or fps
+        duration = frames_from_timecode(reported.get(DURATION, ""), rate) if rate else None
+        if duration:
+            log.info(
+                "Start/End/Frames unreported; bounds 0-%d read from %s %r at %s fps",
+                duration,
+                DURATION,
+                reported.get(DURATION),
+                rate,
+            )
+            return 0, duration
     return start, out
 
 

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -842,7 +842,10 @@ def _bounds(clip: Clip, reported: dict[str, str]) -> dict[str, Any]:
     the out point is that frame plus one and ``duration = out - in`` everywhere.
     """
     fps = frame_rate(reported)
-    # The same rate feeds the Duration fallback, so a listing and a cut read one bounds.
+    # The same rate feeds the Duration fallback, so a listing and a cut read one bounds —
+    # except when the clip itself reports no rate (audio-only media): a listing has no
+    # timeline to borrow a rate from, so its bounds stay unknown while a cut, which does,
+    # can still derive them.
     start, out = frame_bounds(reported, fps=fps)
     duration = (
         out - start if out is not None and start is not None else _number(reported, FRAMES)

--- a/src/resolve_mcp/timing.py
+++ b/src/resolve_mcp/timing.py
@@ -23,6 +23,9 @@ import re
 from typing import Any, Literal
 
 from .errors import InvalidRequestError
+from .logging_config import get_logger
+
+log = get_logger(__name__)
 
 SECONDS_PRECISION = 3
 SNAPS = ("floor", "ceil")
@@ -40,13 +43,18 @@ _BOUNDARY_TOLERANCE = 9
 """Decimal places kept before snapping — enough to kill float noise, not a real fraction."""
 
 
+def _nominal_rate(fps: float) -> int:
+    """The whole rate a non-drop count runs at: 59.94 counts at 60, and never below 1."""
+    return max(round(fps), 1)
+
+
 def timecode(frames: int, fps: float) -> str:
     """``HH:MM:SS:FF`` at the nearest whole frame rate, non-drop.
 
     A negative count is signed rather than wrapped: not every number here is a position on
     a timeline — a sync offset is a distance, and it routinely points backwards.
     """
-    rate = max(round(fps), 1)
+    rate = _nominal_rate(fps)
     if frames < 0:
         return f"-{timecode(-int(frames), fps)}"
     whole_seconds, frame = divmod(int(frames), rate)
@@ -55,23 +63,36 @@ def timecode(frames: int, fps: float) -> str:
     return f"{hours:02d}:{minutes:02d}:{seconds:02d}:{frame:02d}"
 
 
-_TIMECODE = re.compile(r"(\d+):(\d\d):(\d\d):(\d\d)")
+_TIMECODE = re.compile(r"(-?)(\d+):(\d\d):(\d\d):(\d\d)")
+_DROP_FRAME = re.compile(r"-?\d+:\d\d:\d\d;\d\d")
 
 
 def frames_from_timecode(value: str, fps: float) -> int | None:
     """``HH:MM:SS:FF`` back to frames — the mirror of :func:`timecode`, and just as
-    non-drop: the frame count runs at the nearest whole rate.
+    non-drop: the frame count runs at the nearest whole rate, and a leading sign reads
+    back as a negative count, exactly as :func:`timecode` writes one.
 
     This reads strings Resolve reported rather than times a caller typed, so anything
     that is not a timecode — blank being the usual way Resolve says "no value" — is
-    ``None`` rather than an error.
+    ``None`` rather than an error. That includes two things that look like timecode but
+    are not one :func:`timecode` could have written: the drop-frame form Resolve writes
+    as ``HH:MM:SS;FF`` (drop-frame arithmetic is not v1, so it is refused rather than
+    miscounted) and a frame field at or past the whole rate.
     """
-    matched = _TIMECODE.fullmatch(value.strip())
+    text = value.strip()
+    if _DROP_FRAME.fullmatch(text):
+        log.debug("drop-frame timecode not supported: %r", text)
+        return None
+    matched = _TIMECODE.fullmatch(text)
     if matched is None:
         return None
-    rate = max(round(fps), 1)
-    hours, minutes, seconds, frame = (int(part) for part in matched.groups())
-    return ((hours * 60 + minutes) * 60 + seconds) * rate + frame
+    rate = _nominal_rate(fps)
+    sign, *fields = matched.groups()
+    hours, minutes, seconds, frame = (int(part) for part in fields)
+    if frame >= rate:
+        return None
+    total = ((hours * 60 + minutes) * 60 + seconds) * rate + frame
+    return -total if sign else total
 
 
 def frames_from_seconds(seconds: float, fps: float, snap: Snap) -> int:

--- a/src/resolve_mcp/timing.py
+++ b/src/resolve_mcp/timing.py
@@ -19,6 +19,7 @@ takes share a boundary frame without either owning it twice.
 from __future__ import annotations
 
 import math
+import re
 from typing import Any, Literal
 
 from .errors import InvalidRequestError
@@ -52,6 +53,25 @@ def timecode(frames: int, fps: float) -> str:
     minutes, seconds = divmod(whole_seconds, 60)
     hours, minutes = divmod(minutes, 60)
     return f"{hours:02d}:{minutes:02d}:{seconds:02d}:{frame:02d}"
+
+
+_TIMECODE = re.compile(r"(\d+):(\d\d):(\d\d):(\d\d)")
+
+
+def frames_from_timecode(value: str, fps: float) -> int | None:
+    """``HH:MM:SS:FF`` back to frames — the mirror of :func:`timecode`, and just as
+    non-drop: the frame count runs at the nearest whole rate.
+
+    This reads strings Resolve reported rather than times a caller typed, so anything
+    that is not a timecode — blank being the usual way Resolve says "no value" — is
+    ``None`` rather than an error.
+    """
+    matched = _TIMECODE.fullmatch(value.strip())
+    if matched is None:
+        return None
+    rate = max(round(fps), 1)
+    hours, minutes, seconds, frame = (int(part) for part in matched.groups())
+    return ((hours * 60 + minutes) * 60 + seconds) * rate + frame
 
 
 def frames_from_seconds(seconds: float, fps: float, snap: Snap) -> int:

--- a/src/resolve_mcp/video/source.py
+++ b/src/resolve_mcp/video/source.py
@@ -84,12 +84,15 @@ def locate(
             detail={"clip": clip, "file_path": path},
         )
 
-    start, out = media.frame_bounds(reported)
+    fps = media.frame_rate(reported)
+    # The clip's own rate is the only one this seam has; it feeds the Duration fallback
+    # so a grab sees the same bounds a listing and a cut do.
+    start, out = media.frame_bounds(reported, fps=fps)
     return Source(
         name=clip,
         path=path,
         bin_path=located.bin_path,
-        fps=media.frame_rate(reported),
+        fps=fps,
         start=start or 0,
         out=out,
     )

--- a/styles/angles/2026-06_Zinc_and_Monkfish.json
+++ b/styles/angles/2026-06_Zinc_and_Monkfish.json
@@ -1,8 +1,8 @@
 {
   "project": "2026-06_Zinc_and_Monkfish",
   "context": "concert",
-  "labelled": "2026-08-06 (Zinc), 2026-08-07 (Monkfish)",
-  "method": "Zinc: frame grabs off the multicam's source clips, read by the agent, then confirmed. Monkfish: stated by the director, nothing looked at.",
+  "labelled": "2026-08-06 (Zinc), 2026-08-07 (Monkfish), 2026-08-08 (MCP Monkfish Main reference sources)",
+  "method": "Zinc: frame grabs off the multicam's source clips, read by the agent, then confirmed. Monkfish: stated by the director, nothing looked at. MCP Monkfish Main sources: frame grabs off the source clips themselves, read by the agent (2026-08-08), corroborating the director's statements about the night.",
   "confirmed_by_director": "2026-08-07",
   "note": "Two nights in one project: Zinc - Set 2 (corpus entry 1) and Monkfish Main (entry 5), each with its own multicam and its own angle numbers. Both nights happen to put the operated camera on Video 1 and the drums on Video 2, but Video 1 is a wide at Zinc and a moving camera at Monkfish - the angle number does not carry the framing, which is why both nights are labelled separately rather than once.",
   "angles": {
@@ -40,6 +40,35 @@
       "stated_by_director": "angle 1 is the moving camera; and separately, that the moving camera generally follows the soloist but also roams the band for interesting movement",
       "inferred": [],
       "inference_basis": "Both axes are now stated rather than inferred. The subject is soloist-PRIMARY by design: the director's account is that this camera goes to whoever is soloing and also moves around the band for visual interest. Enough for role-level claims; not enough to attribute any single shot, since no frames from this night have been looked at."
+    },
+    "20260618_D_A7IV_0001.MP4": {
+      "role": "drums-tight",
+      "subject": "drums",
+      "character": "tight",
+      "note": "Source clip behind the 'Drummer Camera - Fixed' track (V1) of the MCP Monkfish Main reference timeline; one continuous A7IV recording. Locked off level with the kit: drummer foreground right, bass beyond him - the same framing family as the Zinc A7IV. Keyed by clip name because the reference timeline is plain tracks, not a multicam, and correlate_timeline groups on the clip.",
+      "camera": "A7IV",
+      "confidence": "high",
+      "evidence": [
+        "frames/20260618_D_A7IV_0001.MP4-cbb8e8d2387c.jpg",
+        "frames/20260618_D_A7IV_0001.MP4-b19594b6f176.jpg",
+        "frames/20260618_D_A7IV_0001.MP4-f0a8712c5267.jpg",
+        "frames/20260618_D_A7IV_0001.MP4-d41b43a298a0.jpg"
+      ]
+    },
+    "A016C004_260618HC.MXF": {
+      "role": "soloist-moving",
+      "subject": "soloist",
+      "character": "moving",
+      "note": "Source clip behind the 'Moving Camera' track (V2) of the MCP Monkfish Main reference timeline, FX6, covering the selected tune only (ends 164 frames before the tune does). Grabs at four spread moments: tight on tenor twice, on the bass player during the quiet passage (his solo), sax-with-drummer late - the soloist-primary roaming the director described, now seen.",
+      "camera": "FX6",
+      "confidence": "high",
+      "subject_is_primary_not_exclusive": true,
+      "evidence": [
+        "frames/A016C004_260618HC.MXF-7aae3643a5be.jpg",
+        "frames/A016C004_260618HC.MXF-d0df8cb4bb33.jpg",
+        "frames/A016C004_260618HC.MXF-0cc4e35652c5.jpg",
+        "frames/A016C004_260618HC.MXF-2e4b851ec542.jpg"
+      ]
     },
     "Monkfish Multicam - Video 2": {
       "role": "drums-tight",

--- a/styles/angles/2026-06_Zinc_and_Monkfish.json
+++ b/styles/angles/2026-06_Zinc_and_Monkfish.json
@@ -2,9 +2,9 @@
   "project": "2026-06_Zinc_and_Monkfish",
   "context": "concert",
   "labelled": "2026-08-06 (Zinc), 2026-08-07 (Monkfish), 2026-08-08 (MCP Monkfish Main reference sources)",
-  "method": "Zinc: frame grabs off the multicam's source clips, read by the agent, then confirmed. Monkfish: stated by the director, nothing looked at. MCP Monkfish Main sources: frame grabs off the source clips themselves, read by the agent (2026-08-08), corroborating the director's statements about the night.",
+  "method": "Zinc: frame grabs off the multicam's source clips, read by the agent, then confirmed. Monkfish: stated by the director, nothing looked at. MCP Monkfish Main sources: frame grabs off the source clips themselves, read by the agent (2026-08-08), corroborating the director's statements about the night. The 2026-08-07 confirmation below covers the two multicam nights only; the 2026-08-08 clip-name entries rest on frame evidence, unconfirmed and, per the style-layer rule for frame-derived labels, not requiring it.",
   "confirmed_by_director": "2026-08-07",
-  "note": "Two nights in one project: Zinc - Set 2 (corpus entry 1) and Monkfish Main (entry 5), each with its own multicam and its own angle numbers. Both nights happen to put the operated camera on Video 1 and the drums on Video 2, but Video 1 is a wide at Zinc and a moving camera at Monkfish - the angle number does not carry the framing, which is why both nights are labelled separately rather than once.",
+  "note": "Two nights in one project: Zinc - Set 2 (corpus entry 1) and Monkfish Main (entry 5), each with its own multicam and its own angle numbers. Both nights happen to put the operated camera on Video 1 and the drums on Video 2, but Video 1 is a wide at Zinc and a moving camera at Monkfish - the angle number does not carry the framing, which is why both nights are labelled separately rather than once. A third keying scheme sits alongside the per-night multicam angle numbers: the MCP Monkfish Main reference timeline is plain tracks, not a multicam, so its two entries are keyed by source clip name, which is what correlate_timeline groups on there.",
   "angles": {
     "Zinc - Set 2 Multicam - Video 1": {
       "role": "ensemble-wide",

--- a/tests/test_cut_tools.py
+++ b/tests/test_cut_tools.py
@@ -207,10 +207,12 @@ AUDIO_ONLY_MASTER = {
     "End": "",
     "Duration": "01:26:38:09",
     "Sample Rate": "48000",
+    "Audio Ch": "2",
 }
 """What an audio-only pool clip really reports (#46, live-verified): Start/End/Frames are
 empty strings and only Duration carries the length — 01:26:38:09 is 124761 frames at the
-timeline's nominal 24."""
+timeline's nominal 24. The channel count is present so these tests exercise E7's bounds
+leg, not its has-audio fail-open."""
 
 
 def test_an_audio_clip_reporting_only_a_duration_still_bounds_the_audio_block(
@@ -242,6 +244,25 @@ def test_e7_still_catches_an_overrun_against_duration_read_bounds(
 
     assert [error["rule"] for error in result["errors"]] == ["E7"]
     assert "124761" in result["errors"][0]["message"]
+
+
+def test_bounds_nothing_could_derive_fail_open_rather_than_read_as_empty_media(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """An unparseable Duration leaves the bounds unknown, and unknown means "cannot
+    verify", never "media runs 0-0" (the E7 resurrection this guards against): the
+    bounds leg skips the clip, the same fail-open stance as the has-audio leg."""
+    master = {**AUDIO_ONLY_MASTER, "Duration": "01:26:38"}  # not a timecode
+    attach(studio(pool=a_pool(angle={"FPS": "23.976"}, master=master)))
+    doc = valid_doc()
+    doc["timeline"]["fps"] = 23.976
+    doc["audio"] = {"source": "master_mix", "in": 36439, "out": 47531}
+    doc["segments"] = [{"id": "s001", "source": "gtr_close", "in": 2000, "out": 13092}]
+
+    result = validate_cut(a_cut(tmp_path, doc))
+
+    assert result["errors"] == []
+    assert result["valid"] is True
 
 
 def test_a_short_segment_warns_without_blocking(attach: Attach, tmp_path: Path) -> None:

--- a/tests/test_cut_tools.py
+++ b/tests/test_cut_tools.py
@@ -200,6 +200,50 @@ def test_a_channel_count_resolve_will_not_report_fails_open(
     assert result["errors"] == []
 
 
+AUDIO_ONLY_MASTER = {
+    "FPS": "",
+    "Frames": "",
+    "Start": "",
+    "End": "",
+    "Duration": "01:26:38:09",
+    "Sample Rate": "48000",
+}
+"""What an audio-only pool clip really reports (#46, live-verified): Start/End/Frames are
+empty strings and only Duration carries the length — 01:26:38:09 is 124761 frames at the
+timeline's nominal 24."""
+
+
+def test_an_audio_clip_reporting_only_a_duration_still_bounds_the_audio_block(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The bug that motivated the fallback: bounds read as 0-0 failed every valid range."""
+    attach(studio(pool=a_pool(angle={"FPS": "23.976"}, master=AUDIO_ONLY_MASTER)))
+    doc = valid_doc()
+    doc["timeline"]["fps"] = 23.976
+    doc["audio"] = {"source": "master_mix", "in": 36439, "out": 47531}
+    doc["segments"] = [{"id": "s001", "source": "gtr_close", "in": 2000, "out": 13092}]
+
+    result = validate_cut(a_cut(tmp_path, doc))
+
+    assert result["errors"] == []
+    assert result["warnings"] == []
+    assert result["valid"] is True
+
+
+def test_e7_still_catches_an_overrun_against_duration_read_bounds(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(pool=a_pool(angle={"FPS": "23.976"}, master=AUDIO_ONLY_MASTER)))
+    doc = valid_doc()
+    doc["timeline"]["fps"] = 23.976
+    doc["audio"] = {"source": "master_mix", "in": 0, "out": 124762}  # one past the media
+
+    result = validate_cut(a_cut(tmp_path, doc))
+
+    assert [error["rule"] for error in result["errors"]] == ["E7"]
+    assert "124761" in result["errors"][0]["message"]
+
+
 def test_a_short_segment_warns_without_blocking(attach: Attach, tmp_path: Path) -> None:
     attach(studio(pool=a_pool()))
     doc = valid_doc()

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -1109,3 +1109,18 @@ def test_frame_bounds_with_no_rate_at_all_stays_unknown() -> None:
     reported = {"FPS": "", "Frames": "", "Start": "", "End": "", "Duration": "01:26:38:09"}
 
     assert frame_bounds(reported) == (None, None)
+
+
+def test_the_duration_fallback_applies_whenever_the_out_point_is_unreadable() -> None:
+    """A reported Start does not disqualify the fallback: only End/Frames being blank
+    leaves the out point unknown, and Duration stands in from wherever start is."""
+    reported = {"FPS": "", "Frames": "", "Start": "0", "End": "", "Duration": "01:26:38:09"}
+
+    assert frame_bounds(reported, fps=23.976) == (0, 124761)
+
+
+def test_a_zero_frame_duration_is_empty_media_not_unknown_media() -> None:
+    """[0, 0) is a statement about the media; only an unparseable length is unknown."""
+    reported = {"FPS": "", "Frames": "", "Start": "", "End": "", "Duration": "00:00:00:00"}
+
+    assert frame_bounds(reported, fps=24.0) == (0, 0)

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from resolve_mcp.resolve.media import frame_bounds
 from resolve_mcp.tools.media import (
     import_media,
     inspect_clip,
@@ -1081,3 +1082,30 @@ def test_a_media_pool_resolve_will_not_hand_over_is_reported(attach: Attach) -> 
     assert result["ok"] is False
     assert result["error"]["code"] == "media_pool_unavailable"
     assert result["error"]["fix"]
+
+
+# --- frame bounds -----------------------------------------------------------------------
+
+
+def test_frame_bounds_falls_back_to_duration_for_an_audio_only_clip() -> None:
+    """Audio-only clips report Start/End/Frames as empty strings (#46, live-verified);
+    Duration is the only length they carry, counted at the caller's rate because audio
+    reports no rate of its own either."""
+    reported = {
+        "Type": "Audio",
+        "FPS": "",
+        "Frames": "",
+        "Start": "",
+        "End": "",
+        "Duration": "01:26:38:09",
+        "Sample Rate": "48000",
+        "Audio Ch": "1",
+    }
+
+    assert frame_bounds(reported, fps=23.976) == (0, 124761)
+
+
+def test_frame_bounds_with_no_rate_at_all_stays_unknown() -> None:
+    reported = {"FPS": "", "Frames": "", "Start": "", "End": "", "Duration": "01:26:38:09"}
+
+    assert frame_bounds(reported) == (None, None)

--- a/tests/test_scene_cuts.py
+++ b/tests/test_scene_cuts.py
@@ -171,8 +171,12 @@ def test_a_clip_resolve_reports_no_end_for_still_catalogs_the_shots_it_can(
     attach: Attach,
     fixture_video: Path,
 ) -> None:
-    """The tail runs to an out point nothing knows; every shot before it is still real."""
-    attach(_studio_holding(fixture_video, {"End": "", "Frames": ""}))
+    """The tail runs to an out point nothing knows; every shot before it is still real.
+
+    Duration is blanked with End/Frames: a reported Duration now stands in for a missing
+    out point (#46), and this test is about the case where nothing at all reports one.
+    """
+    attach(_studio_holding(fixture_video, {"End": "", "Frames": "", "Duration": ""}))
 
     record = wait_for(
         detect_scene_cuts(get_connection(), "broll_pan.mp4", runner=_finding([], [1.0, 4.0]))[

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -12,6 +12,7 @@ from resolve_mcp.timing import (
     dual_time,
     duration_frames,
     frames_from_seconds,
+    frames_from_timecode,
     ranges_overlap,
     timecode,
     to_frames,
@@ -32,6 +33,28 @@ def test_timecode_counts_frames_at_the_nearest_whole_rate(
     frames: int, fps: float, expected: str
 ) -> None:
     assert timecode(frames, fps) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "fps", "expected"),
+    [
+        ("00:00:00:00", 24.0, 0),
+        ("00:00:01:00", 24.0, 24),
+        ("00:00:01:30", 59.94, 90),
+        # The Duration an audio-only pool clip reports (#46, live-verified): 23.976
+        # counts at the nominal 24, exactly as timecode() writes it.
+        ("01:26:38:09", 23.976, 124761),
+    ],
+)
+def test_frames_from_timecode_mirrors_timecode(value: str, fps: float, expected: int) -> None:
+    assert frames_from_timecode(value, fps) == expected
+    assert timecode(expected, fps) == value
+
+
+@pytest.mark.parametrize("value", ["", "300", "audio", "01:26:38", "2.5s"])
+def test_a_string_that_is_not_a_timecode_reads_as_none(value: str) -> None:
+    """Resolve says "no value" with an empty string — an absence, not an error."""
+    assert frames_from_timecode(value, 24.0) is None
 
 
 def test_a_backwards_distance_is_signed_not_wrapped() -> None:

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -44,6 +44,9 @@ def test_timecode_counts_frames_at_the_nearest_whole_rate(
         # The Duration an audio-only pool clip reports (#46, live-verified): 23.976
         # counts at the nominal 24, exactly as timecode() writes it.
         ("01:26:38:09", 23.976, 124761),
+        # A signed distance reads back signed: timecode() writes negatives, so its
+        # mirror parses them.
+        ("-00:00:16:40", 59.94, -1000),
     ],
 )
 def test_frames_from_timecode_mirrors_timecode(value: str, fps: float, expected: int) -> None:
@@ -55,6 +58,19 @@ def test_frames_from_timecode_mirrors_timecode(value: str, fps: float, expected:
 def test_a_string_that_is_not_a_timecode_reads_as_none(value: str) -> None:
     """Resolve says "no value" with an empty string — an absence, not an error."""
     assert frames_from_timecode(value, 24.0) is None
+
+
+def test_drop_frame_timecode_is_refused_not_miscounted() -> None:
+    """Resolve writes drop-frame as HH:MM:SS;FF. Non-drop arithmetic over it would be
+    silently wrong, so the semicolon form reads as None until drop-frame is a feature."""
+    assert frames_from_timecode("00:01:00;02", 29.97) is None
+
+
+def test_a_frame_field_at_or_past_the_whole_rate_reads_as_none() -> None:
+    """timecode() never writes ff >= rate, so a mirror that accepted 00:00:00:99 at 24
+    fps would be reading something that is not a timecode of this rate."""
+    assert frames_from_timecode("00:00:00:99", 24.0) is None
+    assert frames_from_timecode("00:00:00:24", 24.0) is None
 
 
 def test_a_backwards_distance_is_signed_not_wrapped() -> None:


### PR DESCRIPTION
Work from the #46 pillar run that belongs in the repo: the angle-sidecar labels the run required, and the E7 bug the run surfaced.

## What's here

- **`styles/angles/2026-06_Zinc_and_Monkfish.json`** — labels for the two MCP Monkfish Main reference sources, keyed by clip name (the reference timeline is plain tracks, not a multicam), with frame-grab evidence, and scope notes keeping the 2026-08-07 director confirmation honest (it covers the two multicam nights only; the new entries rest on frame evidence, which needs no confirmation).
- **E7 false positive on audio blocks** — audio-only media-pool clips report `Start`/`End`/`Frames` as empty strings, so `frame_bounds` collapsed them to `0–0` and `validate_cut` raised E7 against every cut file with a WAV audio source (and `build_timeline` pre-flight would have refused too). Fix: `frames_from_timecode` in `timing.py` (non-drop, nominal-rate counting, the mirror of `timecode()`), a `Duration` fallback in `frame_bounds` applied at every call site, and unknown bounds now failing open ("cannot verify") instead of reading as empty media.

## Seam

Fake tier: the fakes now carry the real quirk (empty-string frame properties on audio clips), covering the fallback arithmetic, the widened gate, zero-frame Duration, drop-frame refusal, signed round-trip, and the E7 fail-open/overrun discriminator pair. Live: `validate_cut` on the run's `tune02.cut.json` went from E7-red to clean on the live box, and `build_timeline`/`correlate_timeline` ran against the built result (record on #46).

## Review record

Two-axis full review (Standards + Spec as parallel sub-agents) on the branch before this PR:

- **Standards (7 findings)**: `frame_bounds` fps fallback diverged between the cut path and listings (its own docstring rule); duplicated nominal-rate rule; false "mirror" docstring claim; sidecar confirmation scope + stale keying note; log-altitude and fps-dig judgement calls (one deliberately skipped as out of scope).
- **Spec (9 findings)**: worst — cut.py flattened unknown bounds back to `0–0`, resurrecting the E7 bug for every unparseable-Duration path; fallback gate narrower than the quirk; zero-frame Duration treated as absent; success-only logging; drop-frame silently misrouted; cut-tier fake missing `Audio Ch` so the E7 test passed via the wrong branch; negative-timecode mirror gap; sidecar over-claim.

All accepted findings fixed in 2628ad7 (fake tier 1300 passed, mypy strict clean, ruff clean; the fixed E7 test verified to fail without the fallback). Focused pass on the fix diff found one residual: a comment claiming listing/cut bounds unity that the audio-only case can't deliver (a listing has no timeline fps to borrow) — stated honestly in 5e551fa.

Review: clean — two-axis full review, all findings fixed (2628ad7) and the fix diff re-checked (5e551fa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
