### PR TITLE
Name and document the owner of songs.json (#132)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,9 @@ timelines. The server measures; Claude decides.
   `cut/schema.py`); validated then materialised, never edited in place.
 - **titles file** — agent-authored JSON of Text+ title events, applied to
   one owned track.
+- **songs file** — `projects/<project>/songs.json`, song key → title +
+  personnel; agent-authored, never read by server code — the facts behind
+  the titles file (`docs/agents/rough-cut.md`, #132).
 - **job** — background compute (analysis, stems, scenes) with one JSON
   record on disk; disk is the only source of truth.
 - **envelope** — the shared tool-result shape every MCP tool returns
@@ -186,5 +189,7 @@ see. Live tier: `test_live_smoke.py` (module-level
   labels, domain-docs usage, the style layer (sidecar + profile formats,
   provenance tags, how a corpus pass is run), the rough-cut pillar
   (`rough-cut.md`: the brief and b-roll catalog the agent owns, the
-  assembly loop, the `virtual_transcript` self-review and the cut report).
+  assembly loop, the `virtual_transcript` self-review and the cut report;
+  also home of the `projects/<project>/` convention and the songs file's
+  ownership, #132).
 - Wayfinder: map = issue #1, scope = #2, spec = #22, build tickets #23–#47.

--- a/docs/agents/rough-cut.md
+++ b/docs/agents/rough-cut.md
@@ -14,11 +14,12 @@ timeline is as an `overlays[]` entry in the cut file you author, and the only wa
 reaches anything is by changing what you decide. `tests/test_rough_cut_pillar.py` guards
 that — no module under `src/` names a brief or a catalog by path.
 
-They live per project, in the repo:
+They live per project, in the repo, in the agent-owned per-project root:
 
 ```
 projects/<project>/brief.md      # what the director wants this to be
 projects/<project>/broll.json    # what you have to cover with
+projects/<project>/songs.json    # concert pillar: song key → title + personnel (below)
 ```
 
 In the repo, one file per project, keyed to the project — the same reading the angle
@@ -27,6 +28,40 @@ control rather than sitting beside the footage on a media drive
 (`docs/agents/style-layer.md`). They are not under `styles/` because that layer is taste:
 a profile says how you cut, and neither a brief nor a shot list does. If the director would
 rather have one agent-owned root than two, moving them is a rename and a regex.
+
+### songs.json — the concert pillar's file, homed here
+
+`songs.json` is not a rough-cut document — it is the song data behind concert titling
+(#14 §2) — but this directory is the agent-owned per-project root, and this doc owns
+that convention, so its ownership is recorded here (#132, 2026-08-08).
+
+Yours in exactly the same sense as the two above. You author it from whatever loose
+input exists — chat, a setlist photo, a text file — and the director eyeballs it once.
+The server never reads or writes it: no tool takes a songs path, `apply_titles` reads
+only `titles.json`, and the server never formats prose — every string that reaches a
+title is one you passed. `songs.json` is where the facts live; `titles.json` is where
+you turn them into events. The path guard in `tests/test_rough_cut_pillar.py` bars
+`src/` from anything under `projects/`, so the location carries the same protection as
+the two documents above without a test change.
+
+One object per song key, the key being the name of the blue marker that starts the song:
+
+```jsonc
+{
+  "sunset": {
+    "title": "Sunset Over Water",
+    "personnel": [
+      { "name": "Dana Reeve", "instrument": "keys" }   // optional, ordered as rendered
+    ]
+  }
+}
+```
+
+Because no tool reads the file, #14 §2's validation is your authoring check, not a
+server rule: before `apply_titles`, confirm every blue marker's key exists here, and
+treat a key with no marker as a note to yourself. Tool-side, the only echo of this is
+W2 — a blue marker whose song has no title events — and that is deliberately a warning,
+because titling a set song-by-song is normal (#42).
 
 ### The brief
 

--- a/docs/agents/rough-cut.md
+++ b/docs/agents/rough-cut.md
@@ -60,7 +60,7 @@ One object per song key, the key being the name of the blue marker that starts t
 Because no tool reads the file, #14 §2's validation is your authoring check, not a
 server rule: before `apply_titles`, confirm every blue marker's key exists here, and
 treat a key with no marker as a note to yourself. Tool-side, the only echo of this is
-W2 — a blue marker whose song has no title events — and that is deliberately a warning,
+W2 — a blue marker with no song entry in the titles file — and that is deliberately a warning,
 because titling a set song-by-song is normal (#42).
 
 ### The brief


### PR DESCRIPTION
Closes #132 (spawned by #119 Section G, gap (c) of the #42 decisions).

## The decision

`songs.json` gets the same owner and home as every other agent per-project document:

- **Owner: the agent.** Claude authors it from whatever loose input exists (chat, setlist photo, text file); the director eyeballs it once (#14 §2). The server never reads or writes it — no tool takes a songs path, `apply_titles` reads only `titles.json`, and every string that reaches a title is one the agent passed.
- **Location: `projects/<project>/songs.json`**, beside `brief.md` and `broll.json` — the PR #118 precedent, and consistent with `cut/schema.py`'s existing "beside `songs.json`/`titles.json`/sidecars" line. The path guard in `tests/test_rough_cut_pillar.py` bars `src/` from anything under `projects/`, so the location is guarded with no test change.
- **#14 §2's hard validation becomes the agent's authoring check** (every blue marker's key exists in the file; an unused key is a note to yourself). Its only tool-side echo stays W2, deliberately a warning per the #42 decision.
- **Shape unchanged from #14 §2** (`{title, personnel: [{name, instrument}]}`, personnel optional, ordered as rendered) — so per the ticket's condition, no amendment lands on #42.

Documented in `docs/agents/rough-cut.md` because that doc owns the `projects/<project>/` convention (the section is explicitly flagged as the concert pillar's file, homed there for the convention, not the pillar). `CONTEXT.md` gains the **songs file** vocabulary entry and a pointer on the docs line.

## Seam

Prose-only, as the ticket's seam line anticipated: no server code reads the file, no test changes.

## Review record

Single-pass inline review (prose-only diff):

- **Finding:** the W2 gloss read "a blue marker whose song has no title events", which is W1's territory; W2 fires when the marker's key has no entry in the titles file at all (`titles/validate.py`). **Resolved** in f40c2c4.
- Verified against sources: shape vs #14 §2, W2 semantics vs `titles/validate.py`, guard regex (`\bprojects[/\\]`) vs `test_rough_cut_pillar.py`, "no tool reads it" vs a repo-wide grep for `songs.json` (docstring mentions only).

Review: clean — prose only, single-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
