### PR TITLE
Name the separator's encoding instead of inheriting the console's

### DIFF
--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -178,12 +178,20 @@ def _run(argv: Sequence[str], on_line: Lines) -> int:
 
     Universal newlines makes the progress bar's carriage returns line breaks, which is the
     only reason a tqdm bar can be followed line by line at all.
+
+    The encoding is named rather than inherited. Left to the console, the decode is whatever
+    codepage the launching process happened to have — cp1252 for a detached process or a
+    service, where the first byte outside that page raises out of the read loop and takes a
+    twenty-minute job with it (#139). ``replace`` for the same reason: what arrives here is a
+    progress bar, and no character in one is worth failing a separation over.
     """
     with subprocess.Popen(
         argv,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         bufsize=1,
     ) as process:
         if process.stdout is not None:

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -10,6 +10,7 @@ real WAVs under the real naming convention rather than empty files.
 
 from __future__ import annotations
 
+import locale
 import shutil
 import sys
 from collections.abc import Sequence
@@ -454,25 +455,35 @@ def test_a_separator_that_writes_nothing_at_all_is_a_failure_not_an_empty_result
 # The runner parameter is what every test above substitutes, so the one thing it cannot cover
 # is the decode ``_run`` itself performs. These two spawn a real child — this interpreter, so
 # no binary has to exist — and hand it bytes the separator genuinely emits.
+#
+# Both run with the console codepage of the machine that reported #139, whatever the machine
+# running the test has: ``subprocess`` reads the encoding a text-mode pipe inherits from
+# ``locale.getencoding``, so pinning that is what makes a Windows-console bug go red on a
+# UTF-8 CI runner rather than passing there for the wrong reason.
 
 
+@pytest.fixture
+def cp1252_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A launching process whose codepage is cp1252 — a service, or a detached process."""
+    monkeypatch.setattr(locale, "getencoding", lambda: "cp1252")
+
+
+@pytest.mark.usefixtures("cp1252_console")
 def test_a_byte_the_consoles_codepage_cannot_decode_does_not_kill_the_run() -> None:
     """#139: a progress line held one 0x8f and a twenty-minute job died at 1%.
 
-    ``0x8f`` is undefined in cp1252 and illegal in UTF-8 and ASCII alike, so this goes red
-    under any console the runner happens to have — a strict decode raises whatever the
-    platform's codec is called, and the exception surfaces out of the read loop, not the
-    child, so nothing downstream can catch it.
+    The strict decode raised out of the read loop rather than out of the child, so nothing
+    downstream could catch it — the job simply died at "separating four stems (1%)".
     """
     seen: list[str] = []
 
     returncode = separator._run(_emitting(b"separating four stems (1%): \x8f"), seen.append)
 
     assert returncode == 0
-    assert len(seen) == 1
-    assert "separating four stems (1%)" in seen[0]
+    assert seen == ["separating four stems (1%): �\n"]
 
 
+@pytest.mark.usefixtures("cp1252_console")
 def test_the_output_is_read_as_utf_8_whatever_the_console_is() -> None:
     """The bar audio-separator draws is UTF-8; decoded as cp1252 it comes back as mojibake."""
     seen: list[str] = []

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -11,6 +11,7 @@ real WAVs under the real naming convention rather than empty files.
 from __future__ import annotations
 
 import shutil
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -448,7 +449,46 @@ def test_a_separator_that_writes_nothing_at_all_is_a_failure_not_an_empty_result
     assert "drums" in raised.value.cause
 
 
+# --- reading the real process's output ------------------------------------------------------
+#
+# The runner parameter is what every test above substitutes, so the one thing it cannot cover
+# is the decode ``_run`` itself performs. These two spawn a real child — this interpreter, so
+# no binary has to exist — and hand it bytes the separator genuinely emits.
+
+
+def test_a_byte_the_consoles_codepage_cannot_decode_does_not_kill_the_run() -> None:
+    """#139: a progress line held one 0x8f and a twenty-minute job died at 1%.
+
+    ``0x8f`` is undefined in cp1252 and illegal in UTF-8 and ASCII alike, so this goes red
+    under any console the runner happens to have — a strict decode raises whatever the
+    platform's codec is called, and the exception surfaces out of the read loop, not the
+    child, so nothing downstream can catch it.
+    """
+    seen: list[str] = []
+
+    returncode = separator._run(_emitting(b"separating four stems (1%): \x8f"), seen.append)
+
+    assert returncode == 0
+    assert len(seen) == 1
+    assert "separating four stems (1%)" in seen[0]
+
+
+def test_the_output_is_read_as_utf_8_whatever_the_console_is() -> None:
+    """The bar audio-separator draws is UTF-8; decoded as cp1252 it comes back as mojibake."""
+    seen: list[str] = []
+
+    separator._run(_emitting("100%|██████| 4/4 café".encode()), seen.append)
+
+    assert seen == ["100%|██████| 4/4 café\n"]
+
+
 # --- helpers -------------------------------------------------------------------------------
+
+
+def _emitting(payload: bytes) -> list[str]:
+    """Argv for a child that writes exactly these bytes to stdout and exits cleanly."""
+    source = f"import sys; sys.stdout.buffer.write({payload!r} + b'\\n')"
+    return [sys.executable, "-c", source]
 
 
 def _flag(argv: Sequence[str], name: str) -> str:


### PR DESCRIPTION
Closes #139.

`separator._run` opened the audio-separator child with `text=True` and no `encoding`, so the decode used whatever codepage the launching process happened to have. From a UTF-8 session shell that is fine; from a detached process or a service it is cp1252, and the first byte outside that page raised `UnicodeDecodeError` out of the read loop — killing a twenty-minute separation at 1% with nothing downstream able to catch it.

The fix is the two arguments the issue names: `encoding="utf-8", errors="replace"`. `stderr` is already folded into `stdout`, and that `Popen` is the only subprocess in the module, so the one call site covers "wherever the separator subprocess's output is read".

## Seam

Fake tier, at `_run` itself. Every existing test in `tests/test_stem_separation.py` substitutes the `runner` parameter, which is exactly why the decode was never observed — the seam that makes the module testable is the seam that hid this bug. The two new tests spawn `sys.executable` as the child, so no separator or GPU has to exist, and run under a `cp1252_console` fixture pinning `locale.getencoding`, so the reported environment is what CI exercises.

Verified by checking out the pre-fix `separator.py` under the new tests and watching both fail with the reported error verbatim (`'charmap' codec can't decode byte 0x8f`), then restoring it and watching them pass. Full fake tier 1302 passed, mypy strict clean, ruff clean.

The confirmed hypothesis, for the next reader: `text=True` with `encoding=None` resolves the codec through `subprocess._text_encoding()` → `locale.getencoding()`. Patching `locale.getpreferredencoding` does **not** reach it — that dead end cost the first pass its CI coverage, see below.

## Review findings and resolutions

Two-axis review (`/code-review`) against `origin/main`, Standards and Spec as parallel sub-agents.

**Spec — the tests were only half pinned (fixed, commit `e3d136b`).** The first pass concluded the encoding could not be forced and let the tests inherit the runner's own. On this Windows box that is cp1252, so both went red and the fix looked verified. On the `ubuntu-latest` runner CI actually gates on, only the `0x8f` test would have stayed red — `0x8f` is illegal in UTF-8 too — while the mojibake test would have passed with or without the fix. Deleting `encoding="utf-8"` would have left the fake tier green on CI. The axis correctly identified `locale.getencoding` as the reachable hook; re-probed, confirmed, and both tests now run under the forced codepage. This is the finding that mattered.

**Standards — `src/resolve_mcp/ffmpeg.py:41` carries the same latent defect (not fixed here, deliberately).** `subprocess.run(argv, capture_output=True, text=True, check=False)` decodes ffmpeg's stderr under the launching process's codepage, and that stderr is what the error messages quote. #139 scopes itself to "the separator subprocess's output" and names `audio/separator.py`; the Spec axis independently agreed it should be filed separately rather than widen this PR. Flagged on the issue for a follow-up ticket.

**Standards — everything else clear.** Reaching for the private `_run` from a test has precedent (`store._sharing` in `test_job_store.py`, `whisper._model` in `test_whisper_runtime.py`), and spawning a real child in the default tier has precedent too (`test_read_guard.py` spawns `sys.executable`). Two low-priority notes: `_emitting` reads as an action but returns argv — judged within the file's existing participle idiom for helpers (`_copying`, `_recording`) and left; the two tests asserted on the same shape differently — tightened to the exact-list form in `e3d136b`.

No module added, moved or deleted, so `CONTEXT.md` needs no update.

## Needs from you

- **Nothing blocking.** No live-tier AC: the bug is in how the parent decodes a pipe, and the fake tier now reproduces the exact reported failure with the codepage pinned, so a live run would add no signal this PR does not already have.
- **A decision:** whether `ffmpeg.py:41` should get its own ticket. It is the same one-line defect on a different binary, and it bites in the same environment (a detached process, a service) — but on a filename or metadata string rather than a progress bar, so the blast radius is a render or an extract rather than a separation. I did not file it, to leave the wayfinder map yours to place.

Review: clean — the Spec axis's CI-coverage finding is fixed in e3d136b and re-verified red-then-green against the pre-fix source; the ffmpeg sibling defect is recorded above as out of scope by the issue's own wording.
