### PR TITLE
Audio export takes the Audio Only preset first, keeps the pair as fallback

### DIFF
--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -63,7 +63,8 @@ SCOPES = (TIMELINE_SCOPE, CLIP_SCOPE)
 
 RENDER_FORMAT = "wav"
 RENDER_CODEC = "lpcm"
-#: Stock Resolve preset, and the only route to a WAV on a build that refuses the pair above.
+#: Stock Resolve preset, and the only route to a WAV on a build that refuses the pair above —
+#: so it is tried first and the pair is what is left for builds that take it (#131).
 AUDIO_ONLY_PRESET = "Audio Only"
 
 EXPORT_FLOOR = 0.1
@@ -150,7 +151,7 @@ def export_timeline_mix(
                 project,
                 settings,
                 (RENDER_FORMAT, RENDER_CODEC),
-                fallback_preset=AUDIO_ONLY_PRESET,
+                preset=AUDIO_ONLY_PRESET,
             )
             render.render(
                 project,

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -206,7 +206,7 @@ def _select_output(
     refusal: str | None = None
     detail: dict[str, Any] = {}
     if preset is not None:
-        refusal, detail = _load_the_preset(project, preset, format_and_codec)
+        refusal, detail = _preset_refusal(project, preset, format_and_codec)
         if refusal is None:
             return
     if format_and_codec is None:
@@ -248,12 +248,15 @@ def _select_output(
     )
 
 
-def _load_the_preset(
+def _preset_refusal(
     project: Project,
     preset: str,
     format_and_codec: tuple[str, str] | None,
 ) -> tuple[str | None, dict[str, Any]]:
     """Load ``preset``; answer why it is no route to the asked-for format, ``None`` if it is.
+
+    Loading is how the question is asked — a preset that will not load, and one that loads
+    and selects something else, are both "no route", and only the attempt tells them apart.
 
     The detail returned alongside carries what presets do exist, which is the one fact that
     identifies a renamed or localised install.

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -75,6 +75,15 @@ RESTORE_THE_PRESET_FIX = (
 """What to tell a caller that never chose the preset name: the worker hardcodes it, so the
 install is what is wrong, not the request."""
 
+PRESET_UNUSABLE_FIX = (
+    "Restore the stock {preset!r} preset in this Resolve, or open the Deliver page and see "
+    "what it selects — nothing else names the output this render needs."
+)
+
+UNKNOWN_FORMAT = "unknown"
+"""What 21.0.3.7 answers for the current format after ``Audio Only`` loads — and it renders a
+WAV regardless (live). A reading of it says the build will not say, not that it disagrees."""
+
 STATUS = "JobStatus"
 PERCENT = "CompletionPercentage"
 
@@ -155,15 +164,22 @@ def submit(
     settings are applied after the preset either way, so the caller's target directory and
     name still win.
 
-    What the preset route deliberately does *not* do is confirm the preset selected the
-    format that was asked for. On the build this exists for, ``GetCurrentRenderFormatAndCodec``
-    answers ``{"format": "unknown"}`` after ``Audio Only`` loads and still renders a WAV —
-    so a check against the requested format would reject the one route that works. The
-    file the job writes is what settles it, and ``render`` already refuses a job that
-    produced nothing.
+    Going first costs the preset something the fallback ordering never had to pay: a preset
+    carries a *whole* render config, so on a build that would have taken the pair, loading it
+    replaces settings the caller never asked to change. That is the price of the swap and it
+    is accepted — ``Audio Only`` is the shape this render wants anyway, the caller's settings
+    are re-applied over it, and the alternative is the guaranteed-failing call on the build
+    that is actually supported.
+
+    What is *not* accepted is a preset quietly rendering something else. Only a reading that
+    succeeded may say so: ``GetCurrentRenderFormatAndCodec`` answers ``{"format": "unknown"}``
+    after ``Audio Only`` loads on 21.0.3.7 and renders a WAV regardless (live), so an
+    unreadable format leaves the preset in charge — a check that treated it as disagreement
+    would reject the one route that works. A readable format that differs demotes the preset
+    to the pair, because a customised preset otherwise beats an explicit request silently and
+    the job lands a file under a name that says it is something it is not.
     """
-    if preset is not None or format_and_codec is not None:
-        _select_output(project, format_and_codec, preset)
+    _select_output(project, format_and_codec, preset)
     if not project.SetRenderSettings(settings):
         raise RenderQueueError(
             cause="Resolve refused the render settings.",
@@ -181,56 +197,91 @@ def _select_output(
     format_and_codec: tuple[str, str] | None,
     preset: str | None,
 ) -> None:
-    """Put the project on the asked-for output: by preset if this build takes one, else pair."""
-    unusable: ResolveMcpError | None = None
-    if preset is not None:
-        # load_preset, not LoadRenderPreset: a bare False means both "no such preset" and
-        # "will not load", and the two want different answers from the caller.
-        try:
-            load_preset(project, preset)
-        except ResolveMcpError as exc:
-            unusable = exc
-        else:
-            return
-        if format_and_codec is None:
-            # Nothing else names the output, and queuing anyway would render whatever the
-            # project was last set to — a file the caller never asked for.
-            raise RenderQueueError(
-                cause=f"The {preset!r} render preset is unusable: {unusable.cause}",
-                fix=RESTORE_THE_PRESET_FIX.format(preset=preset),
-                detail={**unusable.detail, "preset": preset},
-            ) from unusable
+    """Put the project on the asked-for output: by preset where this build takes one, else pair.
 
+    This is where ``submit``'s ordering lives, and its docstring is where the reasons are.
+    Nothing is selected when the caller named neither — the deliver route loaded its own
+    preset before calling and would have this overwrite it.
+    """
+    refusal: str | None = None
+    detail: dict[str, Any] = {}
+    if preset is not None:
+        refusal, detail = _load_the_preset(project, preset, format_and_codec)
+        if refusal is None:
+            return
     if format_and_codec is None:
-        return
+        if refusal is None:
+            return
+        # Nothing else names the output, and queuing anyway would render whatever the
+        # project was last set to — a file the caller never asked for.
+        raise RenderQueueError(
+            cause=f"Resolve would not render through the {preset!r} preset: {refusal}",
+            fix=PRESET_UNUSABLE_FIX.format(preset=preset),
+            detail={**detail, "preset": preset},
+        )
     format_, codec = format_and_codec
     if project.SetCurrentRenderFormatAndCodec(format_, codec):
-        if unusable is not None:
+        if refusal is not None:
             log.info(
-                "The %r preset is unusable (%s) — asking Resolve for %s/%s directly",
+                "Not rendering through the %r preset (%s) — asking Resolve for %s/%s directly",
                 preset,
-                unusable.cause,
+                refusal,
                 format_,
                 codec,
             )
         return
-    if unusable is None:
+    if refusal is None:
         raise RenderQueueError(
             cause=f"Resolve would not render {format_}/{codec}.",
             detail={"format": format_, "codec": codec, "preset": None},
         )
     raise RenderQueueError(
         cause=(
-            f"The {preset!r} render preset is unusable: {unusable.cause} "
-            f"Resolve would not render {format_}/{codec} directly either."
+            f"Resolve would not render {format_}/{codec}, and the {preset!r} preset is no "
+            f"route to it either: {refusal}"
         ),
-        # Not unusable.fix: that one tells the caller to re-spell the preset, and the caller
-        # never chose this name — the worker hardcodes it. What is wrong is the install.
+        # Not the underlying error's fix: that one tells the caller to re-spell the preset,
+        # and the caller never chose this name — the worker hardcodes it. What is actually
+        # wrong is the install.
         fix=RESTORE_THE_PRESET_FIX.format(preset=preset),
-        # unusable.detail carries what presets do exist, which is the one fact that
-        # identifies a renamed or localised install.
-        detail={**unusable.detail, "format": format_, "codec": codec, "preset": preset},
-    ) from unusable
+        detail={**detail, "format": format_, "codec": codec, "preset": preset},
+    )
+
+
+def _load_the_preset(
+    project: Project,
+    preset: str,
+    format_and_codec: tuple[str, str] | None,
+) -> tuple[str | None, dict[str, Any]]:
+    """Load ``preset``; answer why it is no route to the asked-for format, ``None`` if it is.
+
+    The detail returned alongside carries what presets do exist, which is the one fact that
+    identifies a renamed or localised install.
+    """
+    # load_preset, not LoadRenderPreset: a bare False means both "no such preset" and
+    # "will not load", and the two want different answers from the caller.
+    try:
+        load_preset(project, preset)
+    except ResolveMcpError as exc:
+        return exc.cause, exc.detail
+    if format_and_codec is None:
+        return None, {}
+    selected = current_format(project).get("format", "")
+    # Only a reading that *succeeded* may demote the preset. The build this ordering exists
+    # for answers "unknown" here after ``Audio Only`` loads and then renders a WAV anyway
+    # (live, 21.0.3.7), so treating an unreadable format as disagreement would reject the one
+    # route that works. A readable format that differs is another matter: a preset customised
+    # to render something else would otherwise silently beat an explicit request, and the job
+    # would land a file under a name that says it is something it is not.
+    if selected.casefold() in ("", UNKNOWN_FORMAT):
+        return None, {}
+    wanted = format_and_codec[0]
+    if selected.casefold() == wanted.casefold():
+        return None, {}
+    return (
+        f"it renders {selected}, not {wanted}",
+        {"selected": selected},
+    )
 
 
 def render(

--- a/src/resolve_mcp/resolve/render.py
+++ b/src/resolve_mcp/resolve/render.py
@@ -68,6 +68,13 @@ The order is what was observed twice live: in #88's wedge and #92's, no dialog w
 only a restart cleared it. Naming the dialog alone sends the reader to a GUI with nothing to
 show them."""
 
+RESTORE_THE_PRESET_FIX = (
+    "Restore the stock {preset!r} preset in this Resolve — it is the only route to this "
+    "format on builds that refuse the format/codec pair directly."
+)
+"""What to tell a caller that never chose the preset name: the worker hardcodes it, so the
+install is what is wrong, not the request."""
+
 STATUS = "JobStatus"
 PERCENT = "CompletionPercentage"
 
@@ -128,69 +135,35 @@ def submit(
     project: Project,
     settings: dict[str, Any],
     format_and_codec: tuple[str, str] | None = None,
-    fallback_preset: str | None = None,
+    preset: str | None = None,
 ) -> str:
     """Push one job onto the queue and return its id.
 
-    ``SetRenderSettings`` and the format/codec pair are project-level state; they are set
-    immediately before the job is added so that the job captures them. The pair travels as
-    one because Resolve takes it as one, and it is optional because a loaded preset has
-    already set both — setting them again would overwrite the rest of what the preset chose.
+    ``SetRenderSettings``, the format/codec pair and a loaded preset are all project-level
+    state; they are set immediately before the job is added so that the job captures them.
+    The pair travels as one because Resolve takes it as one, and both selectors are optional
+    because a caller that has already loaded a preset itself (the deliver route) has both
+    set — setting them again would overwrite the rest of what that preset chose.
 
-    ``fallback_preset`` is the way past a build that refuses the pair outright: Resolve
-    21.0.3 lists Wave among its render formats, returns an empty codec map for it, and
-    refuses every ("wav", …) pair, so audio can only be reached through the stock preset
-    that already selects it (#32, live). The settings are applied after the preset either
-    way, so the caller's target directory and name still win.
+    Given both, ``preset`` is the route tried first and the pair is what is left when the
+    preset is unusable. That order is the way round it is because of the build this runs on:
+    Resolve 21.0.3 lists Wave among its render formats, returns an empty codec map for it,
+    and refuses every ("wav", …) pair, so audio is reachable only through the stock preset
+    that already selects it (#32, live) — asking for the pair first spent one guaranteed
+    failure on every export there (#131). The pair stays as the fallback for the builds
+    where it works, including an install whose stock preset was renamed or deleted. The
+    settings are applied after the preset either way, so the caller's target directory and
+    name still win.
 
-    What the fallback deliberately does *not* do is confirm the preset selected the format
-    that was asked for. On the build this exists for, ``GetCurrentRenderFormatAndCodec``
+    What the preset route deliberately does *not* do is confirm the preset selected the
+    format that was asked for. On the build this exists for, ``GetCurrentRenderFormatAndCodec``
     answers ``{"format": "unknown"}`` after ``Audio Only`` loads and still renders a WAV —
     so a check against the requested format would reject the one route that works. The
     file the job writes is what settles it, and ``render`` already refuses a job that
     produced nothing.
     """
-    if format_and_codec is not None:
-        format_, codec = format_and_codec
-        if not project.SetCurrentRenderFormatAndCodec(format_, codec):
-            if fallback_preset is None:
-                raise RenderQueueError(
-                    cause=f"Resolve would not render {format_}/{codec}.",
-                    detail={"format": format_, "codec": codec, "preset": None},
-                )
-            # load_preset, not LoadRenderPreset: a bare False means both "no such preset"
-            # and "will not load", and the two want different answers from the caller.
-            try:
-                load_preset(project, fallback_preset)
-            except ResolveMcpError as exc:
-                raise RenderQueueError(
-                    cause=(
-                        f"Resolve would not render {format_}/{codec}, and the "
-                        f"{fallback_preset!r} preset it falls back on is unusable: {exc.cause}"
-                    ),
-                    # Not exc.fix: that one tells the caller to re-spell the preset, and
-                    # the caller never chose this name — the worker hardcodes it. What is
-                    # actually wrong is the install.
-                    fix=(
-                        f"Restore the stock {fallback_preset!r} preset in this Resolve — "
-                        "it is the only route to this format on builds that refuse the "
-                        "format/codec pair directly."
-                    ),
-                    # exc.detail carries what presets do exist, which is the one fact that
-                    # identifies a renamed or localised install.
-                    detail={
-                        **exc.detail,
-                        "format": format_,
-                        "codec": codec,
-                        "preset": fallback_preset,
-                    },
-                ) from exc
-            log.info(
-                "Resolve refused %s/%s — rendering through the %r preset instead",
-                format_,
-                codec,
-                fallback_preset,
-            )
+    if preset is not None or format_and_codec is not None:
+        _select_output(project, format_and_codec, preset)
     if not project.SetRenderSettings(settings):
         raise RenderQueueError(
             cause="Resolve refused the render settings.",
@@ -201,6 +174,63 @@ def submit(
         raise RenderQueueError(cause="Resolve would not add the job to the render queue.")
     log.info("Queued render job %s", job_id)
     return str(job_id)
+
+
+def _select_output(
+    project: Project,
+    format_and_codec: tuple[str, str] | None,
+    preset: str | None,
+) -> None:
+    """Put the project on the asked-for output: by preset if this build takes one, else pair."""
+    unusable: ResolveMcpError | None = None
+    if preset is not None:
+        # load_preset, not LoadRenderPreset: a bare False means both "no such preset" and
+        # "will not load", and the two want different answers from the caller.
+        try:
+            load_preset(project, preset)
+        except ResolveMcpError as exc:
+            unusable = exc
+        else:
+            return
+        if format_and_codec is None:
+            # Nothing else names the output, and queuing anyway would render whatever the
+            # project was last set to — a file the caller never asked for.
+            raise RenderQueueError(
+                cause=f"The {preset!r} render preset is unusable: {unusable.cause}",
+                fix=RESTORE_THE_PRESET_FIX.format(preset=preset),
+                detail={**unusable.detail, "preset": preset},
+            ) from unusable
+
+    if format_and_codec is None:
+        return
+    format_, codec = format_and_codec
+    if project.SetCurrentRenderFormatAndCodec(format_, codec):
+        if unusable is not None:
+            log.info(
+                "The %r preset is unusable (%s) — asking Resolve for %s/%s directly",
+                preset,
+                unusable.cause,
+                format_,
+                codec,
+            )
+        return
+    if unusable is None:
+        raise RenderQueueError(
+            cause=f"Resolve would not render {format_}/{codec}.",
+            detail={"format": format_, "codec": codec, "preset": None},
+        )
+    raise RenderQueueError(
+        cause=(
+            f"The {preset!r} render preset is unusable: {unusable.cause} "
+            f"Resolve would not render {format_}/{codec} directly either."
+        ),
+        # Not unusable.fix: that one tells the caller to re-spell the preset, and the caller
+        # never chose this name — the worker hardcodes it. What is wrong is the install.
+        fix=RESTORE_THE_PRESET_FIX.format(preset=preset),
+        # unusable.detail carries what presets do exist, which is the one fact that
+        # identifies a renamed or localised install.
+        detail={**unusable.detail, "format": format_, "codec": codec, "preset": preset},
+    ) from unusable
 
 
 def render(

--- a/tests/fakes/project.py
+++ b/tests/fakes/project.py
@@ -52,13 +52,18 @@ class FakeProject:
         # which is why the deliver route never sets a format of its own.
         # "H.265 Master" is here because Resolve ships it on every install: it is the
         # config's default preset, so a fake without it would make every bare render fail
-        # for a reason no real machine has.
+        # for a reason no real machine has. "Audio Only" is stock for the same reason, and
+        # it is the route the audio export takes first (#131), so a fake without it would
+        # exercise the fallback on every audio test and the primary route on none.
         self.render_presets: dict[str, tuple[str, str]] = {
+            "Audio Only": ("wav", "lpcm"),
             "H.264 Master": ("mp4", "H.264"),
             "H.265 Master": ("mp4", "H.265"),
             "ProRes 422 HQ": ("mov", "ProRes422HQ"),
         }
         self.loaded_presets: list[str] = []
+        #: Every pair asked for, refused ones included — the record that says which route ran.
+        self.format_calls: list[tuple[str, str]] = []
         self.accepts_preset = True
         self.accepts_format = True
         self.accepts_settings = True
@@ -75,6 +80,7 @@ class FakeProject:
         return True
 
     def SetCurrentRenderFormatAndCodec(self, format_: str, codec: str) -> bool:  # noqa: N802
+        self.format_calls.append((format_, codec))
         if not self.accepts_format:
             return False
         self.render_format = (format_, codec)

--- a/tests/test_audio_acquisition.py
+++ b/tests/test_audio_acquisition.py
@@ -165,17 +165,16 @@ def test_the_export_renders_one_file_for_the_whole_timeline(attach: Attach) -> N
     assert _project(resolve).render_mode == 1
 
 
-def test_the_mix_still_exports_on_a_build_that_refuses_the_wav_pair(attach: Attach) -> None:
-    """Resolve 21.0.3 refuses every ("wav", …) pair, and the mix has to come out anyway.
+def test_the_mix_exports_through_the_audio_only_preset(attach: Attach) -> None:
+    """Studio 21.0.3.7 refuses every ("wav", …) pair, so the preset is the route (#32, live).
 
-    The stock ``Audio Only`` preset is the only route to a WAV on that build (#32, live),
-    so the worker names it as the fallback. Without this test the worker could stop passing
-    it and every other test here would stay green.
+    It goes first, not second (#131): on the supported build the pair is one guaranteed
+    failure before the preset succeeds. Without this test the worker could stop naming the
+    preset and every other test here would stay green.
     """
     resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
     project = _project(resolve)
     project.accepts_format = False
-    project.render_presets["Audio Only"] = ("wav", "lpcm")
     attach(resolve)
 
     record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
@@ -184,16 +183,36 @@ def test_the_mix_still_exports_on_a_build_that_refuses_the_wav_pair(attach: Atta
     assert record.result is not None
     assert Path(record.result["path"]).exists()
     assert project.loaded_presets == ["Audio Only"]
+    assert project.format_calls == []
     # The preset chose the format; the caller still chose where it lands.
     assert project.render_settings["TargetDir"] == str(get_config().audio_dir)
     assert project.render_settings["ExportVideo"] is False
 
 
-def test_a_build_with_no_wav_route_at_all_fails_the_job_naming_both(attach: Attach) -> None:
-    """The pair refused and no usable fallback: the reply has to name the preset too,
-    or the machine that cannot render audio looks identical to one missing a codec."""
+def test_a_build_missing_the_preset_still_exports_through_the_pair(attach: Attach) -> None:
+    """The pair stays as the fallback for builds where it works — an install whose stock
+    preset was renamed or deleted still has to get the mix out."""
     resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
-    _project(resolve).accepts_format = False  # and no "Audio Only" among the presets
+    project = _project(resolve)
+    del project.render_presets["Audio Only"]
+    attach(resolve)
+
+    record = wait_for(acquire_timeline_audio(get_connection())["job_id"])
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert Path(record.result["path"]).exists()
+    assert project.loaded_presets == []
+    assert project.format_calls == [("wav", "lpcm")]
+
+
+def test_a_build_with_no_wav_route_at_all_fails_the_job_naming_both(attach: Attach) -> None:
+    """Neither route usable: the reply has to name the preset too, or the machine that
+    cannot render audio looks identical to one missing a codec."""
+    resolve = studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94")))
+    project = _project(resolve)
+    project.accepts_format = False
+    del project.render_presets["Audio Only"]
     attach(resolve)
 
     record = wait_for(acquire_timeline_audio(get_connection())["job_id"])

--- a/tests/test_render_queue.py
+++ b/tests/test_render_queue.py
@@ -220,60 +220,100 @@ def test_every_way_the_queue_can_refuse_a_job_says_which(
     assert expected in raised.value.cause
 
 
-def test_a_build_that_refuses_the_pair_renders_through_the_fallback_preset(
+def test_a_named_preset_is_the_route_taken_and_the_pair_is_never_asked_for(
     tmp_path: Path,
 ) -> None:
-    """Resolve 21.0.3 refuses every ("wav", …) pair, so the preset is the only way in (#32).
+    """Studio 21.0.3.7 refuses every ("wav", …) pair, so the preset goes first (#131).
 
+    Asking for the pair first cost one guaranteed-failing call on every export there; the
+    call record is what holds the order, since either route leaves the same format behind.
     The settings are applied after the preset, so the caller's target directory survives it.
     """
     project = FakeProject("sunset-set")
     project.accepts_format = False
-    project.render_presets["Audio Only"] = ("wav", "lpcm")
 
     job_id = render.submit(
         project,
         {"TargetDir": str(tmp_path)},
         ("wav", "lpcm"),
-        fallback_preset="Audio Only",
+        preset="Audio Only",
     )
 
     assert job_id
     assert project.loaded_presets == ["Audio Only"]
+    assert project.format_calls == []
     assert project.render_settings["TargetDir"] == str(tmp_path)
 
 
-def test_the_fallback_preset_is_left_alone_when_the_pair_is_taken(tmp_path: Path) -> None:
-    """A preset carries a whole render config — loading one a build did not need would
-    overwrite settings the caller never asked to change."""
+def test_a_build_without_the_preset_still_renders_through_the_pair(tmp_path: Path) -> None:
+    """The pair is kept as the fallback for builds where it works — an install missing
+    the stock preset (renamed, localised, deleted) is one of them."""
     project = FakeProject("sunset-set")
-    project.render_presets["Audio Only"] = ("wav", "lpcm")
+    del project.render_presets["Audio Only"]
 
-    render.submit(
+    job_id = render.submit(
         project,
         {"TargetDir": str(tmp_path)},
         ("wav", "lpcm"),
-        fallback_preset="Audio Only",
+        preset="Audio Only",
     )
 
+    assert job_id
+    assert project.loaded_presets == []
+    assert project.format_calls == [("wav", "lpcm")]
+    assert project.render_format == ("wav", "lpcm")
+
+
+def test_a_preset_that_will_not_load_falls_back_to_the_pair(tmp_path: Path) -> None:
+    """A preset Resolve lists and then refuses is the other build the pair is kept for."""
+    project = FakeProject("sunset-set")
+    project.accepts_preset = False
+
+    job_id = render.submit(
+        project,
+        {"TargetDir": str(tmp_path)},
+        ("wav", "lpcm"),
+        preset="Audio Only",
+    )
+
+    assert job_id
     assert project.loaded_presets == []
     assert project.render_format == ("wav", "lpcm")
 
 
-def test_a_refused_pair_with_no_preset_to_fall_back_on_says_both(tmp_path: Path) -> None:
+def test_a_preset_with_no_pair_behind_it_fails_rather_than_queueing_the_wrong_format(
+    tmp_path: Path,
+) -> None:
+    """Nothing queues on a format nobody selected: the job would render whatever the
+    project was last set to and land a file the caller never asked for."""
+    project = FakeProject("sunset-set")
+    del project.render_presets["Audio Only"]
+
+    with pytest.raises(RenderQueueError) as raised:
+        render.submit(project, {"TargetDir": str(tmp_path)}, preset="Audio Only")
+
+    assert "Audio Only" in raised.value.cause
+    assert project.render_jobs == []
+
+
+def test_neither_route_to_the_format_working_says_both(tmp_path: Path) -> None:
     project = FakeProject("sunset-set")
     project.accepts_format = False
+    del project.render_presets["Audio Only"]
 
     with pytest.raises(RenderQueueError) as raised:
         render.submit(
             project,
             {"TargetDir": str(tmp_path)},
             ("wav", "lpcm"),
-            fallback_preset="Audio Only",
+            preset="Audio Only",
         )
 
     assert "would not render" in raised.value.cause
+    assert "Audio Only" in raised.value.cause
     assert raised.value.detail["preset"] == "Audio Only"
+    # What presets do exist is the one fact that identifies a renamed or localised install.
+    assert "H.265 Master" in raised.value.detail["available"]
 
 
 def test_a_queue_that_will_not_start_takes_its_job_back_off(tmp_path: Path) -> None:

--- a/tests/test_render_queue.py
+++ b/tests/test_render_queue.py
@@ -278,7 +278,50 @@ def test_a_preset_that_will_not_load_falls_back_to_the_pair(tmp_path: Path) -> N
 
     assert job_id
     assert project.loaded_presets == []
+    assert project.format_calls == [("wav", "lpcm")]
     assert project.render_format == ("wav", "lpcm")
+
+
+def test_a_preset_that_renders_something_else_does_not_beat_the_pair(tmp_path: Path) -> None:
+    """A customised stock preset would otherwise silently win over an explicit request, and
+    the job would land a file under a name saying it is something it is not."""
+    project = FakeProject("sunset-set")
+    project.render_presets["Audio Only"] = ("mp4", "AAC")
+
+    job_id = render.submit(
+        project,
+        {"TargetDir": str(tmp_path)},
+        ("wav", "lpcm"),
+        preset="Audio Only",
+    )
+
+    assert job_id
+    assert project.loaded_presets == ["Audio Only"]
+    assert project.render_format == ("wav", "lpcm")
+
+
+def test_a_preset_the_build_will_not_report_a_format_for_keeps_the_render(
+    tmp_path: Path,
+) -> None:
+    """21.0.3.7 answers "unknown" after ``Audio Only`` loads and renders a WAV anyway (live).
+
+    Only a reading that succeeded may demote the preset: treating an unreadable format as
+    disagreement would reject the one route that works on the supported build.
+    """
+    project = FakeProject("sunset-set")
+    project.render_presets["Audio Only"] = ("unknown", "")
+    project.accepts_format = False
+
+    job_id = render.submit(
+        project,
+        {"TargetDir": str(tmp_path)},
+        ("wav", "lpcm"),
+        preset="Audio Only",
+    )
+
+    assert job_id
+    assert project.loaded_presets == ["Audio Only"]
+    assert project.format_calls == []
 
 
 def test_a_preset_with_no_pair_behind_it_fails_rather_than_queueing_the_wrong_format(

--- a/tests/test_render_tools.py
+++ b/tests/test_render_tools.py
@@ -24,7 +24,7 @@ from .fakes import FakeProject, FakeResolve, FakeTimeline, studio
 
 PRESET = "H.264 Master"
 DEFAULT_PRESET = "H.265 Master"
-PRESETS_ON_THIS_PROJECT = ["H.264 Master", "H.265 Master", "ProRes 422 HQ"]
+PRESETS_ON_THIS_PROJECT = ["Audio Only", "H.264 Master", "H.265 Master", "ProRes 422 HQ"]
 
 
 # --- presets -------------------------------------------------------------------------------
@@ -37,7 +37,7 @@ def test_the_preset_list_names_what_the_deliver_page_offers(attach: Attach) -> N
 
     assert reply["ok"] is True
     assert reply["presets"] == PRESETS_ON_THIS_PROJECT
-    assert reply["count"] == 3
+    assert reply["count"] == 4
 
 
 def test_the_preset_list_reports_the_format_currently_loaded(attach: Attach) -> None:
@@ -377,7 +377,7 @@ def test_a_default_preset_this_project_lacks_refuses_rather_than_falling_back(
     assert reply["ok"] is False
     assert reply["error"]["code"] == "render_preset_not_found"
     assert reply["error"]["detail"]["requested"] == DEFAULT_PRESET
-    assert reply["error"]["detail"]["available"] == ["H.264 Master", "ProRes 422 HQ"]
+    assert reply["error"]["detail"]["available"] == ["Audio Only", "H.264 Master", "ProRes 422 HQ"]
     assert _project(resolve).render_jobs == []
 
 

--- a/tests/test_render_tools.py
+++ b/tests/test_render_tools.py
@@ -37,7 +37,7 @@ def test_the_preset_list_names_what_the_deliver_page_offers(attach: Attach) -> N
 
     assert reply["ok"] is True
     assert reply["presets"] == PRESETS_ON_THIS_PROJECT
-    assert reply["count"] == 4
+    assert reply["count"] == len(PRESETS_ON_THIS_PROJECT)
 
 
 def test_the_preset_list_reports_the_format_currently_loaded(attach: Attach) -> None:
@@ -377,7 +377,9 @@ def test_a_default_preset_this_project_lacks_refuses_rather_than_falling_back(
     assert reply["ok"] is False
     assert reply["error"]["code"] == "render_preset_not_found"
     assert reply["error"]["detail"]["requested"] == DEFAULT_PRESET
-    assert reply["error"]["detail"]["available"] == ["Audio Only", "H.264 Master", "ProRes 422 HQ"]
+    assert reply["error"]["detail"]["available"] == [
+        one for one in PRESETS_ON_THIS_PROJECT if one != DEFAULT_PRESET
+    ]
     assert _project(resolve).render_jobs == []
 
 


### PR DESCRIPTION
Closes #131.

`LoadRenderPreset("Audio Only")` is now the primary route for audio export and the
`("wav", "lpcm")` pair is the fallback. On Studio 21.0.3.7 the pair is refused outright, so
every export used to spend one guaranteed-failing call before the preset succeeded.

**Seam: fake tier**, as the ticket names — the ordering is a decision. Either route leaves the
same format behind on the fake, so the order is unobservable by itself; `FakeProject` now
records every pair asked for (`format_calls`, refused ones included) and that record is what
the tests assert on. `"Audio Only"` joins the fake's stock presets: it ships on every install
(the live box lists 39 presets including it), so a fake without it exercised the fallback on
every audio test and the primary route on none.

**Behaviour, stated plainly:** the ticket calls this "no behaviour change on either kind of
build". That holds for the supported build. On a build that *would* have taken the pair it is
not quite true, and the review made it explicit: a preset carries a whole render config, so
loading it replaces settings the caller never asked to change, where the pair moved only
format and codec. That is inherent to preset-first and is accepted — `Audio Only` is the shape
this render wants, and the caller's own settings are re-applied over it.

## Review

**Standards axis** — no hard violations. Findings, all judgement calls, all addressed:

- *Speculative Generality / split precondition*: the both-`None` case was stated in `submit`
  and again in `_select_output`. `submit` now calls the helper unconditionally; the helper
  owns the precondition.
- *Duplicated Code*: the two "preset unusable" raises shared cause, fix and detail shaping.
  They now differ only where they should — the preset-only path gets `PRESET_UNUSABLE_FIX`,
  since `RESTORE_THE_PRESET_FIX` described a pair refusal that never happened there.
- *Mysterious Name*: `unusable: ResolveMcpError | None` read as a flag at every use. The
  helper now returns a refusal reason string, and a later fix-diff pass renamed it
  `_preset_refusal` — it judges what the preset selected, not just loading it.
- *Knowledge split*: `_select_output` now points at `submit`'s docstring, where the reasons
  for the ordering live.
- *Shotgun Surgery (mild)*: the render-tools preset literals derive from
  `PRESETS_ON_THIS_PROJECT` instead of respelling it in three places.
- Missing assertion: the will-not-load test now pins `format_calls` like its siblings.

**Spec axis** — one finding worth code, one worth prose:

- *Implementation risk (fixed)*: with the preset primary, a customised `Audio Only` would
  silently beat an explicit `("wav", "lpcm")` request on a build that honours the pair, and
  the job would land a file under a name saying it is something it is not. Now only a reading
  that *succeeded* may demote the preset — probed live on 21.0.3.7, where
  `GetCurrentRenderFormatAndCodec` answers `{"format": "unknown", "codec": ""}` after
  `Audio Only` loads and renders a WAV regardless, so an unreadable format leaves the preset
  in charge and only a readable, different one falls through to the pair. Two fake-tier tests
  cover both halves.
- *"No behaviour change" overstated (documented)*: the preset-config clobber above. Stated in
  the docstring and in this body rather than fixed, because it is the swap itself.
- *Scope*: `submit(preset=…)` with no pair raises rather than queueing a job on whatever
  format the project was last set to. No caller uses it — `acquire.py` passes both,
  `deliver.py` passes neither — but the code had to do something, and silently queueing was
  the wrong something. Tested.

## Checks

- Fake tier: `1305 passed, 36 deselected`.
- mypy strict: `Success: no issues found in 159 source files`. ruff: `All checks passed!`.
- **Live smoke (run, not skipped)**: Windows 11, Resolve Studio 21.0.3.7, python.org 3.11
  interpreter, project `2026-06_Zinc_and_Monkfish`, timeline `MCP Monkfish Tune 02 v5`.
  A forced export (`refresh=True`, so the cache could not stand in for a render) logged
  `Loaded render preset Audio Only` with **no pair attempt before it**, and wrote 447.7s of
  24-bit/48kHz audio (128,926,384 bytes). Re-run after the review fixes: same, 51s.
  `tests/test_live_smoke.py -k "render_queue_exports_the_real_timeline_mix or preset"`:
  `3 passed` before and after the fixes.

Review: clean — findings above are all resolved or explicitly accepted in the docstring.
