### PR TITLE
Derive drum-fill eventfulness per tune instead of decreeing that toms are fills

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,8 @@ timelines. The server measures; Claude decides.
 - **fake tier / live tier** — `pytest -m 'not live'` against fakes (the
   default) vs `-m live` against a running Resolve Studio. See CLAUDE.md.
 - **stem** — separated audio (mix → vocals/drums/bass/other; drums →
-  kick/snare/toms), path is a content hash (ADR 0003).
+  kick/snare/toms/ride/crash), path is a content hash (ADR 0003). The drum
+  model writes `hh` too; it is not collected (#125).
 - **style layer** — `styles/` at the repo root: layered Markdown style
   profiles (`base.md` + `concert.md`), the corpus record (`corpus.md`) and
   per-project angle sidecars (`angles/*.json`). Agent-authored,

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ scene-cut detection, the render/deliver tools, and the `run_python` escape hatch
 | `edit_title` | Fixes one placed title in place — its words or its exposed params, neighbours untouched |
 | `grab_frames` | Grabs chosen moments on a clip as JPEGs (≤1568px) the agent reads off disk |
 | `detect_scene_cuts` | Job: catalogs where a clip changes shot, gist inline and the full list on disk |
-| `separate_stems` | Two-pass GPU stem separation: mix → 4 stems, drums → kick/snare/toms |
+| `separate_stems` | Two-pass GPU stem separation: mix → 4 stems, drums → kick/snare/toms/ride/crash |
 | `list_render_presets` | The project's render presets, spelled the way `render_timeline` needs |
 | `render_timeline` | Renders a timeline or a range of one as a background job |
 | `get_job` | Polls one background job: progress, result, or a structured failure |
@@ -182,7 +182,7 @@ Zero-config by default; every path has an environment override.
 | `RESOLVE_MCP_FFMPEG` | `ffmpeg` (found on PATH) | ffmpeg executable used for per-clip audio extraction, frame grabs and scene-cut detection |
 | `RESOLVE_MCP_AUDIO_SEPARATOR` | `audio-separator` (found on PATH) | python-audio-separator CLI used for stem separation |
 | `RESOLVE_MCP_STEM_MODEL` | `htdemucs_ft.yaml` | Pass one: the 4-stem model (vocals, drums, bass, other) |
-| `RESOLVE_MCP_DRUM_MODEL` | `MDX23C-DrumSep-aufr33-jarredou.ckpt` | Pass two: the drum decomposition model (kick, snare, toms) |
+| `RESOLVE_MCP_DRUM_MODEL` | `MDX23C-DrumSep-aufr33-jarredou.ckpt` | Pass two: the drum decomposition model (kick, snare, toms, ride, crash) |
 | `RESOLVE_MCP_DEFAULT_RENDER_PRESET` | `H.265 Master` | Render preset `render_timeline` uses when the call names none. Must be a preset the project offers — an unknown name is refused, never swapped for another |
 | `RESOLVE_MCP_WHISPER_DEVICE` | `auto` | Device faster-whisper transcribes on: `auto`, `cuda` or `cpu`. `auto` takes the GPU whenever there is one |
 | `RESOLVE_MCP_WHISPER_COMPUTE_TYPE` | `default` | Precision: `default` is the model's stored precision (float16 for `large-v3`, widened to float32 on CPU). `float32` on `cuda` gives CPU-identical numbers at GPU speed |

--- a/src/resolve_mcp/analysis/beats.py
+++ b/src/resolve_mcp/analysis/beats.py
@@ -13,7 +13,7 @@ import bisect
 import importlib
 import statistics
 from collections import Counter
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -191,7 +191,7 @@ def gist(grid: BeatGrid, records: Sequence[dict[str, Any]]) -> dict[str, Any]:
         "tempo_bpm": round(statistics.median(tempos), 2) if tempos else None,
         "tempo_min_bpm": round(tempos[0], 2) if tempos else None,
         "tempo_max_bpm": round(tempos[-1], 2) if tempos else None,
-        "meter": _meter(records),
+        "meter": meter(records),
         "first_seconds": round(grid.beats[0], 3) if grid.beats else None,
         "last_seconds": round(grid.beats[-1], 3) if grid.beats else None,
     }
@@ -211,8 +211,8 @@ def trust(records: Sequence[dict[str, Any]]) -> GridTrust:
     positions and only the timing gives it away. beat_this exposes no per-beat confidence of
     its own (it returns two lists of times), so steadiness is derived from the intervals.
     """
-    meter = _meter(records)
-    describes_bars = meter is not None and meter >= MINIMUM_METER
+    bar_length = meter(records)
+    describes_bars = bar_length is not None and bar_length >= MINIMUM_METER
     steady = _steady_flags([float(record["t"]) for record in records])
     reasons: Counter[str] = Counter()
     trusted: list[bool] = []
@@ -220,23 +220,24 @@ def trust(records: Sequence[dict[str, Any]]) -> GridTrust:
         in_bar = record.get("in_bar")
         placed = (
             describes_bars
-            and meter is not None
+            and bar_length is not None
             and isinstance(in_bar, int)
-            and 1 <= in_bar <= meter
+            and 1 <= in_bar <= bar_length
         )
         if not placed:
             reasons["bar_position"] += 1
         if not holds_time:
             reasons["tempo"] += 1
         trusted.append(placed and holds_time)
-    return GridTrust(tuple(trusted), meter, dict(reasons))
+    return GridTrust(tuple(trusted), bar_length, dict(reasons))
 
 
-def _meter(records: Sequence[dict[str, Any]]) -> int | None:
+def meter(records: Sequence[Mapping[str, Any]]) -> int | None:
     """The meter the grid behaves as if it is in: the commonest bar length it produced.
 
-    One definition, shared by the gist that reports it and the gate that judges bar positions
-    against it, so a grid can never be described as one meter and gated against another.
+    One definition, shared by the gist that reports it, the gate that judges bar positions
+    against it, and the fill detector sizing a window in bars (#125), so a grid can never be
+    described as one meter and measured against another.
     """
     lengths = list(Counter(record["bar"] for record in records).values())
     return statistics.mode(lengths) if lengths else None

--- a/src/resolve_mcp/analysis/fills.py
+++ b/src/resolve_mcp/analysis/fills.py
@@ -9,11 +9,14 @@ the rule layer over two readings that already exist — drum-stem hits (#36 sepa
   the time. So everything is measured against the median beat of this performance: busy
   means busy *for this drummer, tonight*.
 
-* **Toms are the tell.** Kick and snare keep time; toms are mostly reserved for fills, so
-  tom activity on its own is enough to nominate a beat, and tom share is a quarter of the
-  confidence. Cymbals would be the other tell, and there is no cymbal stem — the
-  decomposition is kick, snare and toms (#36) — so a fill's crash resolution is inferred
-  from a hit landing on the following downbeat rather than heard.
+* **No instrument is eventful by decree.** A beat is nominated two ways: it is busier than
+  the median beat of the performance, or it carries hits some stem does not usually play
+  *around here*, measured against that stem's own median over a window of bars. Which
+  instruments announce something is a fact about the tune, not about the kit — the toms are
+  reserved for fills in rock and are ordinary comping in jazz, and a rule that knew that in
+  advance found the real fills in a jazz tune and then discarded them (#125). Tom *share*
+  is still a quarter of the confidence, because once a beat is nominated the toms are
+  evidence about what kind of event it is.
 
 * **The grid decides the edges.** A candidate starts at a beat and ends at the beat it
   resolves into, because that resolution point is what a cut is placed against. Nothing
@@ -54,18 +57,51 @@ FILLS = "fills"
 PLACES = 3
 
 TOM_STEM = "toms"
+CYMBAL_STEM = "cymbals"
+CYMBAL_SOURCES = ("ride", "crash")
+"""Ride and crash are tallied as one stem, because in this idiom they are one gesture.
+
+The ride *becomes* crashy at a phrase end. Counted apart, that reads as a ride dropping out
+and a crash appearing — two half-signals that partly cancel — putting a hole in exactly the
+moment the cymbals were carried in to catch (#125).
+"""
+COUNTED = tuple(
+    dict.fromkeys(CYMBAL_STEM if one in CYMBAL_SOURCES else one for one in DRUM_STEMS)
+)
+"""The stems as this file counts them: the separated ones, with the cymbals merged into one."""
 BUSY_MULTIPLE = 1.6
 """How much busier than the median beat a beat must be before it is part of a fill."""
 STRONG_MULTIPLE = 3.0
 """The ratio at which the density factor is already as convinced as it gets."""
 MINIMUM_HITS = 3
-"""Hits in a beat below which "busier than usual" is noise, not a fill."""
-TOM_HITS = 2
-"""Toms in one beat are a fill on their own, however quiet the beat reads."""
+"""Hits below which "busier than usual" is noise, not a fill.
+
+Read two ways, one per gate: hits in the beat for the density gate, and hits *beyond the
+local baseline* for the departure gate. One number rather than two, because it is answering
+one question — how small a difference this file is willing to call a difference.
+"""
 MAXIMUM_BEATS = 8
 """Two bars in four. Longer is a solo, and this file does not answer that question."""
 MAXIMUM_GAP_BEATS = 1
 """One beat the detector found nothing in does not end a fill that carries on after it."""
+BASELINE_BARS = 16
+"""Bars of context a stem's local baseline is taken over.
+
+Deliberately not anchored to the phrase (#125). The only phrase length here is
+``PHRASE_BARS``, a constant, so keying the window to it would hard-code phrase length one
+level up — the very mistake that ticket exists to undo. The window does not need to know
+phrase length; it needs to be wide enough to hold several phrases, and a median over sixteen
+bars behaves the same whether they run four, eight or twelve.
+"""
+EXCLUDED_BEATS = MAXIMUM_BEATS
+"""How far either side of a beat is left out of its own baseline.
+
+The longest run this file will call a fill, so a fill can never be a large part of the window
+it is judged against. Without this a fill inflates the very median meant to reveal it, which
+is this ticket's failure arriving by another door.
+"""
+DEFAULT_METER = 4
+"""Beats to the bar when the grid does not say — reached only on a grid with no bars at all."""
 TOM_SHARE = 0.5
 """The tom share of a run at which the tom factor is fully convinced."""
 RESOLUTION_BEATS = 0.25
@@ -155,10 +191,10 @@ def candidates(
         times=sorted(hit.seconds for hit in hits),
         baseline=baseline,
     )
+    local = _local_baselines(tallies, _bar_length(beats))
     busy = [
-        (density >= baseline * BUSY_MULTIPLE and sum(tally.values()) >= MINIMUM_HITS)
-        or tally[TOM_STEM] >= TOM_HITS
-        for tally, density in zip(tallies, densities, strict=True)
+        _dense(tally, density, baseline) or _departs(tally, usual)
+        for tally, density, usual in zip(tallies, densities, local, strict=True)
     ]
 
     kept: list[Candidate] = []
@@ -189,8 +225,75 @@ def _tally(hits: Sequence[drums.Hit], edges: Sequence[float]) -> list[Counter[st
     for hit in hits:
         index = bisect.bisect_right(edges, hit.seconds) - 1
         if 0 <= index < len(tallies):
-            tallies[index][hit.stem] += 1
+            tallies[index][_counted_as(hit.stem)] += 1
     return tallies
+
+
+def _counted_as(stem: str) -> str:
+    """The name a stem is tallied under. The cymbals arrive separated and are counted as one.
+
+    Here rather than in the weighting, so that everything downstream — both gates, the run
+    builder, the scorer — sees one cymbal signal instead of separating them and then undoing
+    the separation.
+    """
+    return CYMBAL_STEM if stem in CYMBAL_SOURCES else stem
+
+
+def _bar_length(beats: Sequence[Mapping[str, Any]]) -> int:
+    """Beats to the bar, from the grid's own account of itself."""
+    found = beats_module.meter(beats)
+    return found if found is not None and found > 0 else DEFAULT_METER
+
+
+def _dense(tally: Counter[str], density: float, baseline: float) -> bool:
+    """Gate one: busier than the median beat of the performance, and busy in absolute terms."""
+    return density >= baseline * BUSY_MULTIPLE and sum(tally.values()) >= MINIMUM_HITS
+
+
+def _departs(tally: Counter[str], usual: Mapping[str, float]) -> bool:
+    """Gate two: hits beyond what the stems carrying them usually play around here.
+
+    Only the excess counts, and only upwards. A timekeeper contributes nothing however loud
+    it is, because it is already in its own baseline — which is what makes a stem safe to
+    carry whether it turns out to be a fill instrument in this performance or the pulse. A
+    stem that *stops* is left out on purpose: an absence is not activity, and nominating on
+    it would make every rest the start of a fill.
+    """
+    excess = sum(max(0.0, count - usual.get(stem, 0.0)) for stem, count in tally.items())
+    return excess >= MINIMUM_HITS
+
+
+def _local_baselines(
+    tallies: Sequence[Counter[str]],
+    bar_length: int,
+) -> list[dict[str, float]]:
+    """Per beat, per stem: what that stem is usually doing around there.
+
+    Local rather than whole-tune, because a single baseline over the performance would catch
+    a drummer who comps on the toms all night and miss one who switches into a tom groove
+    halfway — the average lands between the two and describes neither (#125).
+    """
+    stems = sorted({stem for tally in tallies for stem in tally})
+    half = max(1, BASELINE_BARS * bar_length // 2)
+    return [
+        {stem: _usual(tallies, stem, index, half) for stem in stems}
+        for index in range(len(tallies))
+    ]
+
+
+def _usual(
+    tallies: Sequence[Counter[str]],
+    stem: str,
+    index: int,
+    half: int,
+) -> float:
+    """The median count for one stem around one beat, that beat's own neighbourhood left out."""
+    sample = [
+        tallies[other][stem]
+        for other in range(max(0, index - half), min(len(tallies), index + half + 1))
+        if abs(other - index) > EXCLUDED_BEATS
+    ]
+    return statistics.median(sample) if sample else 0.0
 
 
 def _runs(busy: Sequence[bool]) -> list[tuple[int, int]]:
@@ -228,9 +331,12 @@ def _weighed(reading: Reading, first: int, last: int) -> Candidate:
 
     into = reading.grid[last + 1] if last + 1 < len(reading.grid) else None
     tolerance = RESOLUTION_BEATS * (end - start) / length
+    # Tom share is of the kit without the cymbals, so that carrying two more stems does not
+    # quietly lower the score of every tom fill the detector already reads correctly (#125).
+    kit = total - counts[CYMBAL_STEM]
     factors = {
         "density": _clamp((density / reading.baseline - 1.0) / (STRONG_MULTIPLE - 1.0)),
-        "toms": _clamp(counts[TOM_STEM] / total / TOM_SHARE) if total else 0.0,
+        "toms": _clamp(counts[TOM_STEM] / kit / TOM_SHARE) if kit else 0.0,
         "resolution": 1.0 if _hit_near(reading.times, end, tolerance) else 0.0,
         "phrase": _phrase(into),
     }
@@ -282,7 +388,7 @@ def rows(detection: Detection) -> tuple[dict[str, Any], ...]:
             "beats": one.beats,
             "resolves_into_bar": one.resolves_into_bar,
             "hits": one.hits,
-            **{stem: one.counts.get(stem, 0) for stem in DRUM_STEMS},
+            **{stem: one.counts.get(stem, 0) for stem in COUNTED},
             "density": one.density,
             "density_ratio": one.density_ratio,
             "confidence": one.confidence,

--- a/src/resolve_mcp/analysis/fills.py
+++ b/src/resolve_mcp/analysis/fills.py
@@ -65,7 +65,7 @@ The ride *becomes* crashy at a phrase end. Counted apart, that reads as a ride d
 and a crash appearing — two half-signals that partly cancel — putting a hole in exactly the
 moment the cymbals were carried in to catch (#125).
 """
-COUNTED = tuple(
+COUNTED_STEMS = tuple(
     dict.fromkeys(CYMBAL_STEM if one in CYMBAL_SOURCES else one for one in DRUM_STEMS)
 )
 """The stems as this file counts them: the separated ones, with the cymbals merged into one."""
@@ -101,13 +101,26 @@ it is judged against. Without this a fill inflates the very median meant to reve
 is this ticket's failure arriving by another door.
 """
 DEFAULT_METER = 4
-"""Beats to the bar when the grid does not say — reached only on a grid with no bars at all."""
+"""Beats to the bar when the grid cannot say.
+
+The guard on a type rather than a state the detector reaches: ``beats.meter`` is typed
+``int | None`` and answers ``None`` only for an empty record sequence, which ``candidates``
+has already turned away by the time the window is sized.
+"""
 TOM_SHARE = 0.5
 """The tom share of a run at which the tom factor is fully convinced."""
 RESOLUTION_BEATS = 0.25
 """How near the resolution point a hit must land to count as landing on it."""
 PHRASE_BARS = 4
-"""Bars to the phrase. A fill into bar 5 of 8 is doing more work than one into bar 4."""
+"""Bars to the phrase. A fill into bar 5 is doing more work than one into bar 4.
+
+Four rather than eight, settled rather than inherited (#125 asked for the disagreement
+between this constant and its old docstring to be resolved deliberately). Phrases in this
+material run four, eight or twelve bars, and every eight- and twelve-bar boundary is also a
+four-bar one — so four is the divisor that marks all of them, at the cost of also marking
+the bar line halfway through a longer phrase. That cost is affordable because this is a
+quarter of the confidence and not a gate.
+"""
 PHRASE_AT_BAR_LINE = 0.6
 PHRASE_MID_BAR = 0.15
 WEIGHTS = {"density": 0.35, "toms": 0.25, "resolution": 0.15, "phrase": 0.25}
@@ -287,12 +300,16 @@ def _usual(
     index: int,
     half: int,
 ) -> float:
-    """The median count for one stem around one beat, that beat's own neighbourhood left out."""
-    sample = [
-        tallies[other][stem]
-        for other in range(max(0, index - half), min(len(tallies), index + half + 1))
-        if abs(other - index) > EXCLUDED_BEATS
-    ]
+    """The median count for one stem around one beat, that beat's own neighbourhood left out.
+
+    A grid shorter than the exclusion zone has no context left after the zone is taken out,
+    and a baseline of zero there would read every beat as a departure. So the zone is given
+    up before the baseline is: on a clip that short, the rest of the clip is the context.
+    """
+    window = range(max(0, index - half), min(len(tallies), index + half + 1))
+    sample = [tallies[other][stem] for other in window if abs(other - index) > EXCLUDED_BEATS]
+    if not sample:
+        sample = [tallies[other][stem] for other in window if other != index]
     return statistics.median(sample) if sample else 0.0
 
 
@@ -388,7 +405,7 @@ def rows(detection: Detection) -> tuple[dict[str, Any], ...]:
             "beats": one.beats,
             "resolves_into_bar": one.resolves_into_bar,
             "hits": one.hits,
-            **{stem: one.counts.get(stem, 0) for stem in COUNTED},
+            **{stem: one.counts.get(stem, 0) for stem in COUNTED_STEMS},
             "density": one.density,
             "density_ratio": one.density_ratio,
             "confidence": one.confidence,

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -1,7 +1,7 @@
 """Two passes, because fill detection needs near-clean drums.
 
 Pass one splits the mix into four stems; pass two takes the drum stem alone and decomposes
-it into kick, snare and toms. Running the drum model on the full mix is what the second
+it into the pieces of the kit. Running the drum model on the full mix is what the second
 pass exists to avoid — it has bass and vocals bleeding into every hit, and a fill detector
 reading that is reading the band, not the drummer.
 
@@ -51,7 +51,15 @@ log = get_logger("audio")
 KIND = "separate_stems"
 
 FOUR_STEMS = ("vocals", "drums", "bass", "other")
-DRUM_STEMS = ("kick", "snare", "toms")
+DRUM_STEMS = ("kick", "snare", "toms", "ride", "crash")
+"""What the second pass is kept for. The drum model writes ``hh`` too and it is left behind.
+
+Fills in the material this was built against are frequently cymbal-led (#125), and the model
+already computes the cymbals — collecting three of its six outputs was throwing away the
+evidence that tells a fill from ordinary comping. ``hh`` stays out for now: it is the stem most
+likely to be pure timekeeping, and it is the strongest test of the detector's local baseline
+rather than the first one to run.
+"""
 DRUM_SOURCE = "drums"
 """Which of the four stems the second pass decomposes."""
 
@@ -173,7 +181,7 @@ def two_pass(
     reuse: bool = True,
     config: Config | None = None,
 ) -> JobOutput:
-    """The worker: four stems, then the drum stem decomposed into kick, snare and toms."""
+    """The worker: four stems, then the drum stem decomposed into the pieces of the kit."""
     config = config or get_config()
     key = stem_key(audio, params)
     directory = config.stems_dir / f"{slug(Path(str(audio['path'])).stem, 'stems')}-{key[:12]}"

--- a/tests/test_drum_fills.py
+++ b/tests/test_drum_fills.py
@@ -189,6 +189,21 @@ def test_constant_tom_comping_alone_makes_no_run_to_discard() -> None:
     assert found.dropped == 0
 
 
+def test_a_clip_too_short_for_the_exclusion_zone_still_has_a_baseline() -> None:
+    """Twelve beats leaves nothing outside the excluded neighbourhood of a middle beat.
+
+    A baseline of zero there would read steady comping as a departure on every beat, so the
+    exclusion is what gets given up on a clip this short, not the baseline.
+    """
+    rows = _grid(bars=3)
+
+    found = fills.candidates(_comping(rows) + _timekeeper(rows, "toms", count=3), rows)
+
+    assert found.candidates == ()
+    assert found.considered == 0
+    assert found.dropped == 0
+
+
 def test_a_sustained_dense_passage_is_still_discarded() -> None:
     """A run past ``MAXIMUM_BEATS`` is a solo or a groove, and dropping it whole stays right."""
     rows = _grid(bars=16)

--- a/tests/test_drum_fills.py
+++ b/tests/test_drum_fills.py
@@ -95,6 +95,15 @@ def _step(rows: Sequence[Mapping[str, Any]]) -> float:
     return float(rows[1]["t"]) - float(rows[0]["t"])
 
 
+def _timekeeper(
+    rows: Sequence[Mapping[str, Any]],
+    stem: str,
+    count: int = 2,
+) -> list[Hit]:
+    """A stem played the same way on every beat — the thing a fill has to stand out from."""
+    return [hit for beat in range(1, len(rows) + 1) for hit in _burst(rows, beat, count, stem)]
+
+
 # --- the rule layer -----------------------------------------------------------------
 
 
@@ -151,6 +160,93 @@ def test_a_run_that_outlasts_a_fill_is_dropped_and_counted() -> None:
 
     assert found.candidates == ()
     assert found.dropped == 1
+
+
+def test_a_fill_is_found_under_constant_tom_comping() -> None:
+    """#125: toms on nearly every beat used to nominate the whole tune, which was then dropped.
+
+    The regression test for the ticket. A drummer comping on the low toms all night is playing
+    a timekeeper, not filling; the burst on beat 40 is the fill, and it is the only thing here
+    that departs from what the kit is otherwise doing.
+    """
+    rows = _grid(bars=16)
+    hits = _comping(rows) + _timekeeper(rows, "toms", count=2) + _burst(rows, 40, count=6)
+
+    found = fills.candidates(hits, rows)
+
+    assert [one.beat for one in found.candidates] == [40]
+    assert found.dropped == 0
+
+
+def test_constant_tom_comping_alone_makes_no_run_to_discard() -> None:
+    """The other half of #125: with nothing departing, nothing is nominated in the first place."""
+    rows = _grid(bars=16)
+
+    found = fills.candidates(_comping(rows) + _timekeeper(rows, "toms", count=2), rows)
+
+    assert found.candidates == ()
+    assert found.considered == 0
+    assert found.dropped == 0
+
+
+def test_a_sustained_dense_passage_is_still_discarded() -> None:
+    """A run past ``MAXIMUM_BEATS`` is a solo or a groove, and dropping it whole stays right."""
+    rows = _grid(bars=16)
+    sustained = [
+        hit
+        for beat in range(20, 20 + fills.MAXIMUM_BEATS + 4)
+        for hit in _burst(rows, beat, count=6)
+    ]
+
+    found = fills.candidates(_comping(rows) + _timekeeper(rows, "toms", count=2) + sustained, rows)
+
+    assert found.candidates == ()
+    assert found.dropped == 1
+
+
+def test_a_fill_under_a_loud_timekeeper_survives_the_density_gate() -> None:
+    """A cymbal riding six to the beat inflates both halves of the ratio until it says nothing.
+
+    The local gate is what finds this one: the ride is baseline here and the toms are not.
+    """
+    rows = _grid(bars=16)
+    hits = _comping(rows) + _timekeeper(rows, "ride", count=6) + _burst(rows, 40, count=3)
+
+    found = fills.candidates(hits, rows)
+
+    assert [one.beat for one in found.candidates] == [40]
+    assert found.candidates[0].density_ratio < fills.BUSY_MULTIPLE
+
+
+def test_ride_and_crash_are_counted_as_one_cymbal_signal() -> None:
+    """A ride turning crashy at a phrase end is one gesture, so it is tallied as one stem."""
+    rows = _grid()
+    hits = (
+        _comping(rows)
+        + _burst(rows, 15, count=3, stem="ride")
+        + _burst(rows, 16, count=3, stem="crash")
+    )
+
+    found = fills.candidates(hits, rows)
+    record = fills.rows(found)[0]
+
+    assert found.candidates[0].counts["cymbals"] == 6
+    assert record["cymbals"] == 6
+    assert "ride" not in record
+    assert "crash" not in record
+
+
+def test_the_tom_share_is_not_diluted_by_the_cymbals() -> None:
+    """Carrying the cymbals must not quietly lower the confidence of every tom fill."""
+    rows = _grid()
+    played = _comping(rows) + _timekeeper(rows, "snare", count=3)
+    fill = _burst(rows, 15, count=3) + _burst(rows, 16, count=3)
+
+    without = fills.candidates(played + fill, rows)
+    carried = fills.candidates(played + fill + _timekeeper(rows, "ride", count=2), rows)
+
+    assert without.candidates[0].factors["toms"] < 1.0
+    assert carried.candidates[0].factors["toms"] == without.candidates[0].factors["toms"]
 
 
 def test_one_quiet_beat_inside_a_fill_does_not_split_it() -> None:
@@ -291,7 +387,7 @@ def test_the_job_writes_one_record_per_candidate_and_returns_the_gist(
     assert document[fills.FILLS][0]["confidence"] == pytest.approx(
         result["strongest"]["confidence"]
     )
-    assert result["stems"] == list(DRUM_STEMS)
+    assert result["stems"] == sorted(DRUM_STEMS)
 
 
 def test_the_document_holds_one_candidate_per_line(
@@ -312,14 +408,14 @@ def test_the_directory_a_separation_reports_is_accepted(
     """The job hands back the parent of both passes, so the parent is what this takes."""
     result = _ran(separation, master, _grid())
 
-    assert result["stems"] == list(DRUM_STEMS)
+    assert result["stems"] == sorted(DRUM_STEMS)
     assert result["count"] == 1
 
 
 def test_the_drum_pass_on_its_own_is_accepted_too(master: Path, separation: Path) -> None:
     result = _ran(separation / DRUM_PASS, master, _grid())
 
-    assert result["stems"] == list(DRUM_STEMS)
+    assert result["stems"] == sorted(DRUM_STEMS)
 
 
 def test_the_four_stem_pass_is_not_mistaken_for_the_drum_stems(
@@ -344,7 +440,7 @@ def test_a_drum_pass_holding_nothing_labelled_falls_back_to_the_directory(
 
     result = _ran(directory, master, _grid())
 
-    assert result["stems"] == list(DRUM_STEMS)
+    assert result["stems"] == sorted(DRUM_STEMS)
 
 
 def test_a_kit_missing_a_stem_is_read_rather_than_refused(

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -105,6 +105,26 @@ def test_the_drum_stem_is_what_the_second_pass_decomposes(
     assert all(Path(one).exists() for one in record.result["drums"].values())
 
 
+def test_the_cymbals_are_carried_out_of_the_drum_pass(
+    attach: Attach,
+    separating: FakeSeparator,
+) -> None:
+    """#125: fills here are often cymbal-led, so the pass keeps the ride and crash it writes.
+
+    ``hh`` stays out: the drum model produces it either way, and a hat playing four to the beat
+    is a timekeeper the detector gains nothing from counting.
+    """
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
+
+    record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    assert {"ride", "crash"} <= set(DRUM_STEMS)
+    assert "hh" not in DRUM_STEMS
+    assert separation_params()["drum_stems"] == list(DRUM_STEMS)
+    assert record.result is not None
+    assert {"ride", "crash"} <= set(record.result["drums"])
+
+
 def test_each_pass_runs_its_own_model(attach: Attach, separating: FakeSeparator) -> None:
     attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
     config = get_config()


### PR DESCRIPTION
Closes #125.

The fills detector found the real fills in a jazz tune and then discarded them. `tally["toms"] >= TOM_HITS` was an unconditional trigger, so the toms comping through the whole tune nominated 145 of 206 beats, `_runs` merged them into runs of 25/38/44 beats, and `MAXIMUM_BEATS` dropped each whole run. The fills were inside those runs.

## What changed

**1. The absolute tom trigger is gone**, `TOM_HITS` with it. No instrument is eventful by decree.

**2. Eventfulness is derived per tune, from a local per-stem baseline.** A beat is now nominated two ways:

- **gate one, unchanged** — busier than the median beat of the performance (`BUSY_MULTIPLE`), and busy in absolute terms (`MINIMUM_HITS`);
- **gate two, new** — carrying at least `MINIMUM_HITS` more hits than the stems carrying them usually play *around here*: each stem's own median count over `BASELINE_BARS` (16) of context.

Only upward excess counts, so a timekeeper contributes nothing however loud it is — it is already inside its own baseline. That is what makes any stem safe to carry, whatever it turns out to be doing in this performance.

**3. The window excludes the span it judges.** `EXCLUDED_BEATS` (= `MAXIMUM_BEATS`) either side is left out, so a fill can never be a large part of the window it is compared against — the ticket's failure arriving by another door.

The window is sized in **bars of context, not phrases**, per the ticket's "read before building": the only phrase length here is a constant, so keying the window to it would hard-code phrase length one level up. `beats._meter` became `beats.meter` to supply the bar length — its own docstring already argued for one shared definition.

**4. `DRUM_STEMS` gains `ride` and `crash`**, merged into one `cymbals` count at tally time (not in `WEIGHTS`, which stays four entries). A ride turning crashy at a phrase end is one gesture; counted apart it reads as a ride dropping out plus a crash appearing, two half-signals that partly cancel exactly where the cymbals were wanted. `hh` stays out — it is the strongest test of the mechanism, not the first one to run.

Tom share is now taken over the kit **without** the cymbals, so carrying two more stems does not quietly lower the confidence of every tom fill the detector already reads correctly.

## Which seam verifies it

**Fake tier**, except one AC no seam can cover.

| AC | Test |
| --- | --- |
| AC1 — burst found under constant tom comping | `test_a_fill_is_found_under_constant_tom_comping` |
| AC2a — near-constant toms produce no over-long run | `test_constant_tom_comping_alone_makes_no_run_to_discard` |
| AC2b — a genuinely sustained dense passage is still discarded | `test_a_sustained_dense_passage_is_still_discarded` |
| AC3 — `DRUM_STEMS` flows through separation and the envelope | `test_the_cymbals_are_carried_out_of_the_drum_pass`, plus every existing test that derives from `DRUM_STEMS` |
| AC4 — ear-check on Scullers tune 5 | **yours** (see below) |

AC1 and AC2a both fail on `main`. Also added: the local gate finding a fill the density ratio cannot (`test_a_fill_under_a_loud_timekeeper_survives_the_density_gate`), the cymbal merge, and the tom share not diluting.

**The AC no fake can cover** — that the real DrumSep checkpoint actually labels outputs `ride` and `crash` — is `test_the_real_separator_produces_the_stems_the_two_passes_expect`. **Run, not skipped:** live Windows 11 box, repo `.venv` via `uv run`, real `audio-separator` and both real models, **1 passed in 80s**. `set(output.result["drums"]) >= set(DRUM_STEMS)` now includes the cymbals, so that pass is the check.

Fake tier 1308 passed, mypy strict clean, ruff clean.

## Review record

Two-axis review (Standards and Spec, parallel sub-agents) against `origin/main`.

### Findings fixed

1. **Correctness — short grids nominated everything.** On a grid shorter than `2 * EXCLUDED_BEATS + 1` (17 beats), a middle beat had no sample left once its own neighbourhood was excluded; the empty-sample fallback of `0.0` made steady comping read as a departure on every beat. A twelve-beat clip nominated six of its beats. Fixed: the exclusion zone is what gets given up on a clip that short, not the baseline. Test: `test_a_clip_too_short_for_the_exclusion_zone_still_has_a_baseline`.
2. **`DEFAULT_METER`'s docstring claimed a reachable state.** It is unreachable from `candidates`, which turns away grids under two beats. Reworded as what it is: the guard on `beats.meter` being typed `int | None`.
3. **`PHRASE_BARS` disagreed with its own docstring** about phrase length. The ticket asked for this to be resolved deliberately rather than inherited, so it now records why four: every eight- and twelve-bar boundary is also a four-bar one, and this is a quarter of the confidence, not a gate.
4. **`COUNTED` read as a bare adjective** beside `DRUM_STEMS` → `COUNTED_STEMS`.

### Findings answered, not changed

5. **`MINIMUM_HITS` carries two meanings** (hits in the beat for gate one, hits above baseline for gate two). Kept as one constant, documented: it answers one question — how small a difference this file is willing to call a difference. Two knobs where one will do is the tuning surface this ticket exists to shrink.
6. **Standards axis flagged the six-stem fake as circular.** Checked: `SIX_DRUM_STEMS` predates this PR, so the six model outputs were already the repo's belief, not this PR's assertion — and the live run above now proves it directly.
7. **Performance.** `_local_baselines` is O(beats x stems x window): about 58k `statistics.median` calls on a two-hour set, seconds inside a job whose GPU separation already costs minutes.

### Deviations from the ticket — please read

The ticket's change 2 claimed three wins for the local baseline. **One is delivered as described, two are not**, and I would rather say so than let them be discovered later.

- **Delivered: constant toms are discounted.** This is the ticket's bug, and AC1 pins it.
- **Not delivered: "a ride that *stops* reads too".** `_departs` counts upward excess only. Nominating on absence would make every rest the start of a fill, which is a new bug traded for the old one. The phrase-end signal is *partly* recovered by the merge: a crash landing at a phrase end is an upward departure in the merged cymbal count, which is precisely what counting ride and crash apart would have cancelled. Only a cymbal going fully silent is missed. Reading absence properly wants corroboration at scoring time, and `WEIGHTS` is frozen at four entries by the ticket — so this needs a decision, not a quiet implementation.
- **Not delivered: "toms *appearing* after an absence read loud".** Simulated on the real algorithm: at 2–4 toms/beat the straddling window's median sits at about half the new count and the excess never reaches `MINIMUM_HITS`; at 6+/beat the switch nominates nine consecutive beats, which `MAXIMUM_BEATS` then discards whole. A groove change is sustained by definition, so it collides with AC2's decision that a sustained busy passage is correctly dropped. I think marking groove changes wants its own output shape rather than being a fill candidate — worth a ticket, not a patch here.

**Scope note:** the Spec axis flagged the tom-share denominator as unasked-for, and it is. Keeping it, because the asymmetry is principled: tom *share* gains no information from a larger denominator (pure dilution), while the density *level* legitimately rises when more of the kit is heard. Pinned by `test_the_tom_share_is_not_diluted_by_the_cymbals`.

**ADR conflict, flagged not overridden:** `docs/adr/0003` still says "its **three** drum stems". The ADR's argument gets stronger at five, not weaker, but amending a decision record is not this PR's call.

## Needs from you

- **AC4 is yours.** Re-run detection on Scullers tune 5 and compare against what you heard: ~5.1 s and ~46 s should appear, the ~2.5 s candidate should not, and something should land in 30–40 s. A direction check, not a score. Note that `refresh=True` is needed to recompute — the analysis cache key does not include the code version.
- **Two decisions, if you want them:** whether a cymbal going silent should be readable (needs `WEIGHTS` to grow, which this ticket froze), and whether groove changes deserve their own detector rather than being fill candidates. Both are follow-up tickets if you say so.

Review: clean
