### PR TITLE
A tune has a pulse: drop the pulse-less calls from the applause tagger's tune set

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,7 +67,8 @@ Top level:
 | `timing.py` | frames authoritative; seconds/timecode/fps derived |
 
 `analysis/` — compute jobs that read audio and write findings to disk:
-`applause` (bursts → tune boundaries), `beats` (grid + downbeats, model
+`applause` (bursts → tune boundaries, then a beat-density floor drops the calls
+with no pulse under them, #133), `beats` (grid + downbeats, model
 injected per ADR 0002; `trust` says which beats the grid describes well enough
 to count, #112), `correlate` (measure a cut against its music, gating the beat
 statistics on `trust` and leaving the transient ones ungated), `cuda` (preloads
@@ -77,7 +78,8 @@ pure decisions, #128),
 (loudness curves), `fills` (drum-fill candidates), `halves` (shared
 identify/cache/write pattern), `music` (beats + energy + gist job),
 `records` (sliceable record files), `silence` (RMS spans), `solos` (front
-of band changes), `structure` (tunes + solo changes job), `transcribe`
+of band changes), `structure` (tunes + solo changes job; both halves read the
+shared beats half), `transcribe`
 (job), `transcript` (document + Word/Transcription/Transcriber vocabulary),
 `virtual` (a cut file read back as the words it will contain — the P4
 self-review, warnings only, touches no Resolve handle), `whisper`

--- a/src/resolve_mcp/analysis/applause.py
+++ b/src/resolve_mcp/analysis/applause.py
@@ -17,12 +17,23 @@ is ordinary arithmetic that a test can pin exactly. Three rules do that work:
 * **A gap between bursts is not always a tune.** Announcing the band takes twenty seconds
   and is bounded by applause at both ends, so anything under ``minimum_seconds`` of music
   is banter and is left out of the boundaries rather than reported as a very short tune.
+
+The length rule is not enough on its own, which the first live pass showed: three of the
+thirteen calls on a real concert had no musical pulse under them and one of those was two
+minutes of talking (#119 section D, #133). Length cannot separate those from a tune, so a
+fourth rule reads the beat grid the music analysis already wrote:
+
+* **A tune has a pulse.** Beats per second over the call, against ``minimum_density``.
+  Talking and long announcements come back near zero; the sparsest real tune on the
+  measured concert was 1.36. That is the whole check — the grid is somebody else's
+  measurement (#37) and this module only divides by it.
 """
 
 from __future__ import annotations
 
 import importlib
 import statistics
+from bisect import bisect_left
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -52,6 +63,20 @@ DEFAULT_GAP_SECONDS = 1.5
 DEFAULT_TUNE_SECONDS = 60.0
 """Under a minute between two bursts of applause is an announcement, not a tune."""
 
+DEFAULT_DENSITY_PER_SECOND = 0.5
+"""Beats per second a call needs before it counts as music.
+
+Measured, not guessed (#133; the sweep is recorded on the ticket). On the concert master
+the tagger called thirteen tunes, and the beat grid puts the ten real ones between 1.36 and
+2.70 beats per second while the three the ear rejected sit at 0.07, 0.00 and 0.00. The floor
+goes in the gap, nearer the false side than the middle: 0.5 is a third of the sparsest real
+tune and seven times the densest false one, so neither shoulder is close. It is also below
+any tempo a band plays — 0.5 beats per second is 30 bpm — which is the reason the number is
+defensible beyond this one concert.
+
+Set it to 0.0 to turn the check off and get the unfiltered set back, which is also what
+avoids needing a beat grid at all (see ``structure``)."""
+
 
 class Curve(NamedTuple):
     """How likely the room is clapping, frame by frame. ``seconds`` is each frame's start."""
@@ -73,16 +98,30 @@ class Span(NamedTuple):
 
 
 class Tune(NamedTuple):
-    """Music between two bursts of applause — or between a burst and the end of the file."""
+    """Music between two bursts of applause — or between a burst and the end of the file.
+
+    ``beats`` and ``beats_per_second`` are ``None`` until ``counted`` reads a grid over the
+    call. None is not zero: no grid was read, so nothing is known about the pulse, and a
+    call in that state is never dropped for want of one.
+    """
 
     start: float
     end: float
     applause_before: float | None
     applause_after: float | None
+    beats: int | None = None
+    beats_per_second: float | None = None
 
     @property
     def seconds(self) -> float:
         return round(self.end - self.start, 3)
+
+
+class Called(NamedTuple):
+    """The tune set after the density check: what has a pulse under it, and what does not."""
+
+    kept: tuple[Tune, ...]
+    dropped: tuple[Tune, ...]
 
 
 Tagger = Callable[[Path], Curve]
@@ -257,6 +296,44 @@ def tunes(
     return tuple(one for one in found if one.seconds >= minimum_seconds)
 
 
+def counted(found: Sequence[Tune], beats: Sequence[float]) -> tuple[Tune, ...]:
+    """The same tunes with the grid's beats counted inside each one, and the density that is.
+
+    The spans are half-open: a beat landing exactly on a boundary belongs to the call that
+    starts there, so consecutive tunes never count the same downbeat twice. ``beats`` is
+    expected sorted, which is what ``beats.detect`` guarantees.
+    """
+    ordered = sorted(beats)
+    return tuple(one._replace(**_density(one, ordered)) for one in found)
+
+
+def _density(one: Tune, ordered: Sequence[float]) -> dict[str, Any]:
+    inside = bisect_left(ordered, one.end) - bisect_left(ordered, one.start)
+    seconds = one.seconds
+    return {
+        "beats": inside,
+        "beats_per_second": round(inside / seconds, 3) if seconds > 0 else 0.0,
+    }
+
+
+def dense(
+    found: Sequence[Tune],
+    minimum_density: float = DEFAULT_DENSITY_PER_SECOND,
+) -> Called:
+    """Split the calls into the ones with a pulse under them and the ones without.
+
+    A call whose density was never measured is kept: there is no grid, so there is no
+    evidence to drop it on, and inventing one by treating "unknown" as "zero" would delete
+    tunes on any path that skipped the beat model.
+    """
+    kept: list[Tune] = []
+    dropped: list[Tune] = []
+    for one in found:
+        pulseless = one.beats_per_second is not None and one.beats_per_second < minimum_density
+        (dropped if pulseless else kept).append(one)
+    return Called(tuple(kept), tuple(dropped))
+
+
 def numbered(found: Sequence[Tune]) -> tuple[dict[str, Any], ...]:
     """One record per tune, numbered from one — the rows a songs.json author reads."""
     return tuple(
@@ -267,16 +344,29 @@ def numbered(found: Sequence[Tune]) -> tuple[dict[str, Any], ...]:
             "seconds": one.seconds,
             "applause_before": one.applause_before,
             "applause_after": one.applause_after,
+            "beats": one.beats,
+            "beats_per_second": one.beats_per_second,
         }
         for index, one in enumerate(found, start=1)
     )
 
 
-def gist(curve: Curve, applause: Sequence[Span], found: Sequence[Tune]) -> dict[str, Any]:
+def gist(
+    curve: Curve,
+    applause: Sequence[Span],
+    found: Sequence[Tune],
+    dropped: Sequence[Tune] = (),
+) -> dict[str, Any]:
     """How many tunes, how much clapping, and which tune is the long one — no lists.
 
     The boundaries themselves are on disk. A set is a dozen records; what belongs in a tool
     result is the shape of the set, and "the file has 12 tunes, the longest starts at 41:12".
+
+    The density check reports the same way, and deliberately does not list what it dropped:
+    what a caller needs inline is whether the floor was anywhere near a decision, so it gets
+    the two shoulders — the densest call that was dropped and the sparsest that was kept.
+    A wide gap between them says the filter did not have to choose; a narrow one says the
+    threshold wants looking at, and the dropped calls themselves are named in the log.
     """
     longest = max(found, key=lambda one: one.seconds, default=None)
     shortest = min(found, key=lambda one: one.seconds, default=None)
@@ -290,8 +380,19 @@ def gist(curve: Curve, applause: Sequence[Span], found: Sequence[Tune]) -> dict[
         ),
         "longest": _summary(longest),
         "shortest": _summary(shortest),
+        "dropped": len(dropped),
+        "dropped_seconds": round(sum(one.seconds for one in dropped), 3),
+        "densest_dropped": _summary(max(dropped, key=_pulse, default=None)),
+        "sparsest_kept": _summary(min(found, key=_pulse, default=None)),
     }
 
 
+def _pulse(one: Tune) -> float:
+    """A call's density for ordering, with "never measured" sorting above every measured one."""
+    return float("inf") if one.beats_per_second is None else one.beats_per_second
+
+
 def _summary(one: Tune | None) -> dict[str, Any] | None:
-    return None if one is None else {"t": one.start, "seconds": one.seconds}
+    if one is None:
+        return None
+    return {"t": one.start, "seconds": one.seconds, "beats_per_second": one.beats_per_second}

--- a/src/resolve_mcp/analysis/applause.py
+++ b/src/resolve_mcp/analysis/applause.py
@@ -66,13 +66,13 @@ DEFAULT_TUNE_SECONDS = 60.0
 DEFAULT_DENSITY_PER_SECOND = 0.5
 """Beats per second a call needs before it counts as music.
 
-Measured, not guessed (#133; the sweep is recorded on the ticket). On the concert master
-the tagger called thirteen tunes, and the beat grid puts the ten real ones between 1.36 and
-2.70 beats per second while the three the ear rejected sit at 0.07, 0.00 and 0.00. The floor
-goes in the gap, nearer the false side than the middle: 0.5 is a third of the sparsest real
-tune and seven times the densest false one, so neither shoulder is close. It is also below
-any tempo a band plays — 0.5 beats per second is 30 bpm — which is the reason the number is
-defensible beyond this one concert.
+Measured, not guessed — the sweep and the live run are recorded on #133. On the concert
+master the tagger called thirteen tunes, and the beat grid puts the ten real ones between
+1.36 and 2.70 beats per second while the three the ear rejected sit at 0.07, 0.00 and 0.00.
+Every floor from 0.1 to 1.25 calls that concert the same way, so 0.5 is not on a cliff but
+in the middle of a plateau an order of magnitude wide. It is also below any tempo a band
+plays — 0.5 beats per second is 30 bpm — which is the reason the number should hold on
+material this concert cannot speak for.
 
 Set it to 0.0 to turn the check off and get the unfiltered set back, which is also what
 avoids needing a beat grid at all (see ``structure``)."""
@@ -117,7 +117,7 @@ class Tune(NamedTuple):
         return round(self.end - self.start, 3)
 
 
-class Called(NamedTuple):
+class Calls(NamedTuple):
     """The tune set after the density check: what has a pulse under it, and what does not."""
 
     kept: tuple[Tune, ...]
@@ -300,26 +300,28 @@ def counted(found: Sequence[Tune], beats: Sequence[float]) -> tuple[Tune, ...]:
     """The same tunes with the grid's beats counted inside each one, and the density that is.
 
     The spans are half-open: a beat landing exactly on a boundary belongs to the call that
-    starts there, so consecutive tunes never count the same downbeat twice. ``beats`` is
-    expected sorted, which is what ``beats.detect`` guarantees.
+    starts there, so consecutive tunes never count the same downbeat twice. The grid is
+    sorted here rather than assumed sorted — the bisect below needs it, and this module does
+    not own the measurement it is dividing by.
     """
     ordered = sorted(beats)
-    return tuple(one._replace(**_density(one, ordered)) for one in found)
+    return tuple(_over(one, ordered) for one in found)
 
 
-def _density(one: Tune, ordered: Sequence[float]) -> dict[str, Any]:
+def _over(one: Tune, ordered: Sequence[float]) -> Tune:
+    """One call with the beats between its boundaries counted, and the density they make."""
     inside = bisect_left(ordered, one.end) - bisect_left(ordered, one.start)
     seconds = one.seconds
-    return {
-        "beats": inside,
-        "beats_per_second": round(inside / seconds, 3) if seconds > 0 else 0.0,
-    }
+    return one._replace(
+        beats=inside,
+        beats_per_second=round(inside / seconds, 3) if seconds > 0 else 0.0,
+    )
 
 
-def dense(
+def sifted(
     found: Sequence[Tune],
     minimum_density: float = DEFAULT_DENSITY_PER_SECOND,
-) -> Called:
+) -> Calls:
     """Split the calls into the ones with a pulse under them and the ones without.
 
     A call whose density was never measured is kept: there is no grid, so there is no
@@ -331,7 +333,7 @@ def dense(
     for one in found:
         pulseless = one.beats_per_second is not None and one.beats_per_second < minimum_density
         (dropped if pulseless else kept).append(one)
-    return Called(tuple(kept), tuple(dropped))
+    return Calls(tuple(kept), tuple(dropped))
 
 
 def numbered(found: Sequence[Tune]) -> tuple[dict[str, Any], ...]:
@@ -351,27 +353,47 @@ def numbered(found: Sequence[Tune]) -> tuple[dict[str, Any], ...]:
     )
 
 
-def gist(
-    curve: Curve,
-    applause: Sequence[Span],
-    found: Sequence[Tune],
-    dropped: Sequence[Tune] = (),
-) -> dict[str, Any]:
+def dropped_calls(dropped: Sequence[Tune], minimum_density: float) -> tuple[dict[str, Any], ...]:
+    """What the density check took out, with the measurement that took it out.
+
+    On disk beside the tune set rather than in the gist, for the reason every boundary is:
+    a tool result is stats. But it has to be somewhere a caller can read, because a filter
+    whose rejects cannot be inspected is one nobody can check (#38) — this is the record
+    that says the eighth call was two minutes of talking rather than a lost tune.
+
+    It rides in the file's header, which puts it on one line, and that is affordable because
+    it is bounded by the applause: there is at most one call per burst, so a whole concert
+    is tens of these and never the thousands a beat grid or an energy curve would be.
+    """
+    return tuple(
+        {
+            "t": one.start,
+            "end": one.end,
+            "seconds": one.seconds,
+            "beats": one.beats,
+            "beats_per_second": one.beats_per_second,
+            "reason": f"no pulse: under the beat-density floor of {minimum_density} per second",
+        }
+        for one in dropped
+    )
+
+
+def gist(curve: Curve, applause: Sequence[Span], calls: Calls) -> dict[str, Any]:
     """How many tunes, how much clapping, and which tune is the long one — no lists.
 
     The boundaries themselves are on disk. A set is a dozen records; what belongs in a tool
     result is the shape of the set, and "the file has 12 tunes, the longest starts at 41:12".
 
-    The density check reports the same way, and deliberately does not list what it dropped:
-    what a caller needs inline is whether the floor was anywhere near a decision, so it gets
-    the two shoulders — the densest call that was dropped and the sparsest that was kept.
-    A wide gap between them says the filter did not have to choose; a narrow one says the
-    threshold wants looking at, and the dropped calls themselves are named in the log.
+    The density check reports the same way, and deliberately does not list what it dropped —
+    that goes on disk with the boundaries, in ``dropped_calls``. What a caller needs inline
+    is whether the floor was anywhere near a decision, so it gets the two shoulders: the
+    densest call that was dropped and the sparsest that was kept. A wide gap between them
+    says the filter did not have to choose; a narrow one says the threshold wants looking at.
     """
-    longest = max(found, key=lambda one: one.seconds, default=None)
-    shortest = min(found, key=lambda one: one.seconds, default=None)
+    longest = max(calls.kept, key=lambda one: one.seconds, default=None)
+    shortest = min(calls.kept, key=lambda one: one.seconds, default=None)
     return {
-        "count": len(found),
+        "count": len(calls.kept),
         "applause_count": len(applause),
         "applause_seconds": round(sum(one.seconds for one in applause), 3),
         "peak_probability": round(max(curve.probability), 4) if curve.probability else None,
@@ -380,10 +402,10 @@ def gist(
         ),
         "longest": _summary(longest),
         "shortest": _summary(shortest),
-        "dropped": len(dropped),
-        "dropped_seconds": round(sum(one.seconds for one in dropped), 3),
-        "densest_dropped": _summary(max(dropped, key=_pulse, default=None)),
-        "sparsest_kept": _summary(min(found, key=_pulse, default=None)),
+        "dropped": len(calls.dropped),
+        "dropped_seconds": round(sum(one.seconds for one in calls.dropped), 3),
+        "densest_dropped": _summary(max(calls.dropped, key=_pulse, default=None)),
+        "sparsest_kept": _summary(min(calls.kept, key=_pulse, default=None)),
     }
 
 

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -101,12 +101,22 @@ def written(
     described: Mapping[str, Any],
     gist: Mapping[str, Any],
     rows: Sequence[Mapping[str, Any]],
+    aside: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """One file per half: a header of gist stats, then one record per line."""
+    """One file per half: a header of gist stats, then one record per line.
+
+    ``aside`` is written into the header but kept out of what comes back, which is the way
+    a half records something too long for a tool result and too short for its own file —
+    the calls the tune half rejected, say (#133). The gist rides home in the job record and
+    stays stats; the aside stays on disk with the records it is about. It goes in under the
+    gist rather than over it, so a name a half picks for an aside can never quietly replace
+    a stat and leave the header saying something the returned dict does not.
+    """
     header = {
         "kind": kind,
         "audio": described["path"],
         "duration_seconds": described["duration_seconds"],
+        **(aside or {}),
         **gist,
     }
     records.write(target, header, kind, list(rows))

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -6,7 +6,10 @@ Two halves, because they answer the two questions a concert's shape is made of (
 * **Tune boundaries** come off the master mix. Applause is the only reliable segmentation a
   jazz set offers — there is no verse and no chorus to find — so the mix is tagged for it
   and the music between the bursts is the tune. This is what a ``songs.json`` author reads
-  before placing a single marker (#22, story 33).
+  before placing a single marker (#22, story 33). Applause alone over-calls, though: on the
+  first live concert three of thirteen calls were talking bounded by clapping, so a call
+  also has to have a pulse under it, and this half reads the beat grid too (#133). Set
+  ``density_per_second`` to zero and it does not.
 
 * **Solo changes** come off the stems, because "who is out front" is not a question the mix
   can answer. They are also snapped to downbeats, which means this job needs a beat grid —
@@ -45,7 +48,19 @@ KIND = "analyze_structure"
 TUNES = "tunes"
 SOLOS = "solos"
 
-APPLAUSE_SHAPE = ("threshold", "burst_seconds", "gap_seconds", "tune_seconds")
+APPLAUSE_SHAPE = (
+    "threshold",
+    "burst_seconds",
+    "gap_seconds",
+    "tune_seconds",
+    "density_per_second",
+)
+"""Every setting that changes what the tune half says — and so what it is keyed on.
+
+``density_per_second`` is in here even though it only filters what the tagger already
+produced, which means moving it re-tags the room. That is the same bargain
+``tune_seconds`` has always made, and the alternative is worse: two floors sharing one
+cache entry would serve whichever set happened to be computed first."""
 SOLO_SHAPE = (
     "window_seconds",
     "hop_seconds",
@@ -66,6 +81,7 @@ def analyze_structure(
     burst_seconds: float = applause_module.DEFAULT_MINIMUM_SECONDS,
     gap_seconds: float = applause_module.DEFAULT_GAP_SECONDS,
     tune_seconds: float = applause_module.DEFAULT_TUNE_SECONDS,
+    density_per_second: float = applause_module.DEFAULT_DENSITY_PER_SECOND,
     window_seconds: float = solos_module.DEFAULT_WINDOW_SECONDS,
     hop_seconds: float = solos_module.DEFAULT_HOP_SECONDS,
     solo_seconds: float = solos_module.DEFAULT_MINIMUM_SECONDS,
@@ -81,7 +97,7 @@ def analyze_structure(
     config = config or get_config()
     source = halves.readable(audio)
     _asked_for_something(tunes, solos)
-    _sane_numbers(threshold, window_seconds, hop_seconds)
+    _sane_numbers(threshold, window_seconds, hop_seconds, density_per_second)
     found = _stems(stems, solos)
 
     settings: dict[str, Any] = {
@@ -91,6 +107,7 @@ def analyze_structure(
         "burst_seconds": float(burst_seconds),
         "gap_seconds": float(gap_seconds),
         "tune_seconds": float(tune_seconds),
+        "density_per_second": float(density_per_second),
         "window_seconds": float(window_seconds),
         "hop_seconds": float(hop_seconds),
         "solo_seconds": float(solo_seconds),
@@ -135,19 +152,35 @@ def _asked_for_something(tunes: bool, solos: bool) -> None:
         )
 
 
-def _sane_numbers(threshold: float, window_seconds: float, hop_seconds: float) -> None:
-    if not 0.0 < threshold <= 1.0 or window_seconds <= 0 or hop_seconds <= 0:
+def _sane_numbers(
+    threshold: float,
+    window_seconds: float,
+    hop_seconds: float,
+    density_per_second: float,
+) -> None:
+    if (
+        not 0.0 < threshold <= 1.0
+        or window_seconds <= 0
+        or hop_seconds <= 0
+        or density_per_second < 0
+    ):
         raise InvalidRequestError(
-            cause="The applause threshold must be a probability, and the windows positive.",
+            cause=(
+                "The applause threshold must be a probability, the windows positive, and the "
+                "beat-density floor zero or more."
+            ),
             fix=(
                 f"Defaults are threshold={applause_module.DEFAULT_THRESHOLD}, "
                 f"window_seconds={solos_module.DEFAULT_WINDOW_SECONDS}, "
-                f"hop_seconds={solos_module.DEFAULT_HOP_SECONDS}."
+                f"hop_seconds={solos_module.DEFAULT_HOP_SECONDS}, "
+                f"density_per_second={applause_module.DEFAULT_DENSITY_PER_SECOND} "
+                "(0 turns the density check off)."
             ),
             detail={
                 "threshold": threshold,
                 "window_seconds": window_seconds,
                 "hop_seconds": hop_seconds,
+                "density_per_second": density_per_second,
             },
         )
 
@@ -239,7 +272,17 @@ def analyze(
         result[TUNES] = halves.cached(
             f"{KIND}:{TUNES}",
             cache.cache_key(f"{KIND}:{TUNES}", [identity], shape),
-            lambda path: _tunes(source, path, described, shape, tagger),
+            lambda path: _tunes(
+                source,
+                path,
+                described,
+                shape,
+                tagger,
+                identity,
+                detector,
+                refresh,
+                config,
+            ),
             source,
             refresh,
             config,
@@ -286,6 +329,10 @@ def _tunes(
     described: Mapping[str, Any],
     shape: Mapping[str, Any],
     tagger: applause_module.Tagger | None,
+    identity: Mapping[str, Any],
+    detector: beats_module.Detector | None,
+    refresh: bool,
+    config: Config,
 ) -> dict[str, Any]:
     curve = applause_module.tag(source, tagger)
     spans = applause_module.spans(
@@ -299,9 +346,56 @@ def _tunes(
         float(described["duration_seconds"]),
         float(shape["tune_seconds"]),
     )
-    gist = {**applause_module.gist(curve, spans, found), **shape}
-    log.info("Found %d tunes and %d bursts of applause in %s", len(found), len(spans), source.name)
-    return halves.written(target, TUNES, described, gist, applause_module.numbered(found))
+    called = _with_a_pulse(
+        found,
+        float(shape["density_per_second"]),
+        source,
+        described,
+        identity,
+        detector,
+        refresh,
+        config,
+    )
+    gist = {**applause_module.gist(curve, spans, called.kept, called.dropped), **shape}
+    log.info(
+        "Found %d tunes and %d bursts of applause in %s",
+        len(called.kept),
+        len(spans),
+        source.name,
+    )
+    for one in called.dropped:
+        log.info(
+            "Dropped the call at %.2fs (%.1fs, %s beats/s) from %s: no pulse under it",
+            one.start,
+            one.seconds,
+            one.beats_per_second,
+            source.name,
+        )
+    return halves.written(target, TUNES, described, gist, applause_module.numbered(called.kept))
+
+
+def _with_a_pulse(
+    found: Sequence[applause_module.Tune],
+    minimum_density: float,
+    source: Path,
+    described: Mapping[str, Any],
+    identity: Mapping[str, Any],
+    detector: beats_module.Detector | None,
+    refresh: bool,
+    config: Config,
+) -> applause_module.Called:
+    """The calls the beat grid says are music, and the ones it says are talking (#133).
+
+    The grid is the one ``analyze_music`` writes, for the same reason ``_downbeats`` reads
+    it: one detection per piece of audio, whichever job asks first. A floor of zero is the
+    way out — the check is off, no grid is read, and this half needs nothing but the tagger,
+    which is what a caller with panns installed and no beat model has to pass.
+    """
+    if minimum_density <= 0:
+        return applause_module.Called(tuple(found), ())
+    rows = music.numbered_beats(source, dict(described), dict(identity), detector, refresh, config)
+    grid = tuple(float(row["t"]) for row in rows)
+    return applause_module.dense(applause_module.counted(found, grid), minimum_density)
 
 
 def _solos(

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -33,13 +33,13 @@ from typing import Any
 from ..audio import separator
 from ..audio import stems as stems_module
 from ..config import Config, get_config
-from ..errors import InvalidRequestError
+from ..errors import AnalysisDependencyError, InvalidRequestError
 from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, start_job
 from ..logging_config import get_logger
 from . import applause as applause_module
 from . import beats as beats_module
-from . import halves, music, records
+from . import halves, music
 from . import solos as solos_module
 
 log = get_logger("analysis")
@@ -346,32 +346,31 @@ def _tunes(
         float(described["duration_seconds"]),
         float(shape["tune_seconds"]),
     )
-    called = _with_a_pulse(
-        found,
-        float(shape["density_per_second"]),
-        source,
-        described,
-        identity,
-        detector,
-        refresh,
-        config,
-    )
-    gist = {**applause_module.gist(curve, spans, called.kept, called.dropped), **shape}
+    floor = float(shape["density_per_second"])
+    calls = _with_a_pulse(found, floor, source, described, identity, detector, refresh, config)
+    gist = {**applause_module.gist(curve, spans, calls), **shape}
     log.info(
         "Found %d tunes and %d bursts of applause in %s",
-        len(called.kept),
+        len(calls.kept),
         len(spans),
         source.name,
     )
-    for one in called.dropped:
+    for one in calls.dropped:
         log.info(
-            "Dropped the call at %.2fs (%.1fs, %s beats/s) from %s: no pulse under it",
+            "Dropped the call at %.2fs (%.1fs, %.2f beats/s) from %s: no pulse under it",
             one.start,
             one.seconds,
-            one.beats_per_second,
+            one.beats_per_second or 0.0,
             source.name,
         )
-    return halves.written(target, TUNES, described, gist, applause_module.numbered(called.kept))
+    return halves.written(
+        target,
+        TUNES,
+        described,
+        gist,
+        applause_module.numbered(calls.kept),
+        {"dropped_calls": list(applause_module.dropped_calls(calls.dropped, floor))},
+    )
 
 
 def _with_a_pulse(
@@ -383,19 +382,65 @@ def _with_a_pulse(
     detector: beats_module.Detector | None,
     refresh: bool,
     config: Config,
-) -> applause_module.Called:
+) -> applause_module.Calls:
     """The calls the beat grid says are music, and the ones it says are talking (#133).
 
     The grid is the one ``analyze_music`` writes, for the same reason ``_downbeats`` reads
     it: one detection per piece of audio, whichever job asks first. A floor of zero is the
-    way out — the check is off, no grid is read, and this half needs nothing but the tagger,
-    which is what a caller with panns installed and no beat model has to pass.
+    way out — the check is off, no grid is read, and this half needs nothing but the tagger.
+
+    That way out is why this half asks ``_grid`` for the escape hatch to name.
     """
     if minimum_density <= 0:
-        return applause_module.Called(tuple(found), ())
-    rows = music.numbered_beats(source, dict(described), dict(identity), detector, refresh, config)
+        return applause_module.Calls(tuple(found), ())
+    rows = _grid(
+        source,
+        described,
+        identity,
+        detector,
+        refresh,
+        config,
+        "run the job with density_per_second=0 to keep every call the applause tagger makes",
+    )
     grid = tuple(float(row["t"]) for row in rows)
-    return applause_module.dense(applause_module.counted(found, grid), minimum_density)
+    return applause_module.sifted(applause_module.counted(found, grid), minimum_density)
+
+
+def _grid(
+    source: Path,
+    described: Mapping[str, Any],
+    identity: Mapping[str, Any],
+    detector: beats_module.Detector | None,
+    refresh: bool,
+    config: Config,
+    without: str,
+) -> list[dict[str, Any]]:
+    """The beat grid both halves read, with a missing beat model shaped for the half asking.
+
+    ``beats`` tells a caller who has no model to pass ``beats=false``, which is advice for
+    ``analyze_music`` and no help in this job at all. Each half here has its own way to run
+    without a grid — a density floor of zero, or solos off — and ``without`` is the half
+    naming its own. The relabelling is gated on the model actually being the thing that is
+    missing, so some other dependency failing inside the beats half still says what it is.
+    """
+    try:
+        return music.numbered_beats(
+            source, dict(described), dict(identity), detector, refresh, config
+        )
+    except AnalysisDependencyError as exc:
+        if exc.detail.get("module") != beats_module.MODULE:
+            raise
+        raise AnalysisDependencyError(
+            cause=(
+                "This job reads the beat grid, and beat_this is not installed, so there is "
+                "no grid to read."
+            ),
+            fix=(
+                f"Install it on the machine running the server ({beats_module.INSTALL}), or "
+                f"{without}."
+            ),
+            detail={"module": beats_module.MODULE},
+        ) from exc
 
 
 def _solos(
@@ -462,8 +507,16 @@ def _downbeats(
     Deliberately the *same* cache entry ``analyze_music`` writes, not a private copy: the
     grid for a piece of audio is the grid, and a second detection over an hour of concert
     to learn what is already on disk is the cost that keying halves separately exists to
-    avoid.
+    avoid. Both halves of this job reach it through the one accessor, so neither can drift
+    into keying its own copy.
     """
-    half = music.beats_of(source, dict(described), dict(identity), detector, refresh, config)
-    rows: Sequence[Mapping[str, Any]] = records.read(Path(half["path"]))[music.BEATS]
+    rows = _grid(
+        source,
+        described,
+        identity,
+        detector,
+        refresh,
+        config,
+        "run the job with solos=false for tune boundaries only",
+    )
     return tuple(float(row["t"]) for row in rows if row["downbeat"])

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -70,6 +70,7 @@ def analyze_structure(
     stems: str | None = None,
     threshold: float = applause.DEFAULT_THRESHOLD,
     tune_seconds: float = applause.DEFAULT_TUNE_SECONDS,
+    density_per_second: float = applause.DEFAULT_DENSITY_PER_SECOND,
     solo_seconds: float = solos.DEFAULT_MINIMUM_SECONDS,
     snap_seconds: float = solos.DEFAULT_SNAP_SECONDS,
     refresh: bool = False,
@@ -78,9 +79,19 @@ def analyze_structure(
 
     A jazz set has no verses to segment, so the boundaries come from the room: applause is
     tagged on the master mix, and the music between two bursts is a tune. The tunes file
-    holds one record per tune — its number, start, end, length, and the seconds of applause
-    on either side of it — which is what a songs.json author reads before placing markers.
-    Inline you get how many tunes, how much clapping, and where the longest one starts.
+    holds one record per tune — its number, start, end, length, the seconds of applause on
+    either side of it, and the beats per second measured under it — which is what a
+    songs.json author reads before placing markers. Inline you get how many tunes, how much
+    clapping, and where the longest one starts.
+
+    Applause on its own over-calls: announcing the band at length, or talking between two
+    rounds of clapping, looks exactly like a tune. So a call also has to have a musical
+    pulse under it, measured against the beat grid, and this tool reads that grid the way
+    the solo half does — analyze_music's if it exists, or it detects one and leaves it
+    behind. Inline you get how many calls that dropped, and the two shoulders it decided
+    on. density_per_second is the floor in beats per second; set it to 0 to keep every
+    call the tagger made, which is also the way to run this tool with no beat model
+    installed.
 
     solos=true adds the second half and needs stems: pass the directory a separate_stems
     job returned. It measures which stem is out front over its own quiet baseline, and
@@ -107,6 +118,7 @@ def analyze_structure(
             stems=stems,
             threshold=threshold,
             tune_seconds=tune_seconds,
+            density_per_second=density_per_second,
             solo_seconds=solo_seconds,
             snap_seconds=snap_seconds,
             refresh=refresh,

--- a/tests/test_applause_spans.py
+++ b/tests/test_applause_spans.py
@@ -122,6 +122,86 @@ def test_a_concert_with_no_applause_at_all_is_one_tune() -> None:
     assert found[0].applause_before is None and found[0].applause_after is None
 
 
+# --- which calls have a pulse under them --------------------------------------------------
+
+
+def _called(*bounds: tuple[float, float]) -> tuple[applause.Tune, ...]:
+    """Tunes at the given boundaries, as ``tunes`` would hand them over — no density yet."""
+    return tuple(applause.Tune(start, end, None, None) for start, end in bounds)
+
+
+def _beats(start: float, end: float, per_second: float) -> tuple[float, ...]:
+    """A steady grid over ``[start, end)`` at the given density."""
+    step = 1.0 / per_second
+    return tuple(round(start + index * step, 6) for index in range(int((end - start) * per_second)))
+
+
+def test_the_density_of_a_call_is_the_beats_inside_it_over_its_length() -> None:
+    found = applause.counted(_called((0.0, 10.0)), _beats(0.0, 10.0, 2.0))
+
+    assert found[0].beats == 20
+    assert found[0].beats_per_second == 2.0
+
+
+def test_a_beat_on_the_closing_boundary_belongs_to_the_next_call() -> None:
+    """The spans are half-open, so a downbeat landing on the boundary is counted once."""
+    found = applause.counted(_called((0.0, 4.0), (4.0, 8.0)), (0.0, 2.0, 4.0, 6.0))
+
+    assert [one.beats for one in found] == [2, 2]
+
+
+def test_counting_leaves_the_boundaries_and_the_applause_alone() -> None:
+    found = applause.counted((applause.Tune(3.0, 9.0, 2.0, 1.5),), (4.0, 5.0, 6.0))
+
+    assert (found[0].start, found[0].end) == (3.0, 9.0)
+    assert (found[0].applause_before, found[0].applause_after) == (2.0, 1.5)
+
+
+def test_a_call_with_no_beats_under_it_has_a_density_of_zero() -> None:
+    """Zero, not unmeasured: the grid was read and it found nothing, which is the finding."""
+    found = applause.counted(_called((0.0, 100.0)), ())
+
+    assert found[0].beats == 0
+    assert found[0].beats_per_second == 0.0
+
+
+def test_a_call_with_no_pulse_is_dropped_and_the_playing_one_is_kept() -> None:
+    """Announcements and talking are bounded by applause and read as tunes until now."""
+    counted = applause.counted(
+        _called((0.0, 100.0), (110.0, 210.0)),
+        _beats(0.0, 100.0, 1.8),
+    )
+
+    called = applause.dense(counted, minimum_density=0.5)
+
+    assert [(one.start, one.end) for one in called.kept] == [(0.0, 100.0)]
+    assert [(one.start, one.end) for one in called.dropped] == [(110.0, 210.0)]
+
+
+def test_a_call_sitting_exactly_on_the_floor_is_kept() -> None:
+    counted = applause.counted(_called((0.0, 100.0)), _beats(0.0, 100.0, 0.5))
+
+    assert len(applause.dense(counted, minimum_density=0.5).kept) == 1
+
+
+def test_a_floor_of_zero_keeps_every_call() -> None:
+    """The escape hatch: nothing is dropped, so a caller can see the unfiltered set."""
+    counted = applause.counted(_called((0.0, 100.0), (110.0, 210.0)), ())
+
+    called = applause.dense(counted, minimum_density=0.0)
+
+    assert len(called.kept) == 2
+    assert called.dropped == ()
+
+
+def test_an_unmeasured_call_is_never_dropped() -> None:
+    """No grid was read, so there is no evidence to drop it on."""
+    called = applause.dense(_called((0.0, 100.0)), minimum_density=0.5)
+
+    assert len(called.kept) == 1
+    assert called.dropped == ()
+
+
 # --- what is written and what comes back ------------------------------------------------
 
 
@@ -130,9 +210,33 @@ def test_every_tune_is_one_record_with_its_own_number() -> None:
     rows = applause.numbered(applause.tunes(_spans(curve), 64.0, minimum_seconds=10.0))
 
     assert [row["tune"] for row in rows] == [1, 2]
-    assert set(rows[0]) == {"tune", "t", "end", "seconds", "applause_before", "applause_after"}
+    assert set(rows[0]) == {
+        "tune",
+        "t",
+        "end",
+        "seconds",
+        "applause_before",
+        "applause_after",
+        "beats",
+        "beats_per_second",
+    }
     assert rows[0]["t"] == 0.0
     assert rows[1]["applause_before"] == 4.0
+
+
+def test_a_record_carries_the_density_it_was_kept_on() -> None:
+    """What the filter measured, on the row, so a songs.json author can see the evidence."""
+    rows = applause.numbered(applause.counted(_called((0.0, 10.0)), _beats(0.0, 10.0, 2.0)))
+
+    assert rows[0]["beats"] == 20
+    assert rows[0]["beats_per_second"] == 2.0
+
+
+def test_a_record_written_without_a_grid_says_so_rather_than_claiming_zero() -> None:
+    rows = applause.numbered(_called((0.0, 10.0)))
+
+    assert rows[0]["beats"] is None
+    assert rows[0]["beats_per_second"] is None
 
 
 def test_the_gist_counts_the_tunes_and_the_applause_without_listing_them() -> None:
@@ -150,3 +254,35 @@ def test_the_gist_counts_the_tunes_and_the_applause_without_listing_them() -> No
     assert summary["shortest"]["seconds"] == 20.0
     assert summary["peak_probability"] == 0.9
     assert not any(isinstance(value, list) for value in summary.values())
+
+
+def test_the_gist_says_how_many_calls_had_no_pulse_and_how_close_the_floor_came() -> None:
+    """Not the dropped calls themselves — the two shoulders, which is what says the floor held."""
+    curve = _concert((0.0, 30.0), (0.9, 4.0), (0.0, 30.0))
+    spans = _spans(curve)
+    counted = applause.counted(
+        applause.tunes(spans, 64.0, minimum_seconds=10.0),
+        _beats(0.0, 30.0, 1.8),
+    )
+    called = applause.dense(counted, minimum_density=0.5)
+
+    summary = applause.gist(curve, spans, called.kept, called.dropped)
+
+    assert summary["count"] == 1
+    assert summary["dropped"] == 1
+    assert summary["dropped_seconds"] == 30.0
+    assert summary["densest_dropped"]["beats_per_second"] == 0.0
+    assert summary["sparsest_kept"]["beats_per_second"] == 1.8
+    assert not any(isinstance(value, list) for value in summary.values())
+
+
+def test_the_gist_of_a_set_that_lost_nothing_has_no_dropped_shoulder() -> None:
+    curve = _concert((0.0, 30.0), (0.9, 4.0), (0.0, 20.0))
+    spans = _spans(curve)
+    tunes = applause.tunes(spans, 54.0, minimum_seconds=10.0)
+
+    summary = applause.gist(curve, spans, tunes)
+
+    assert summary["dropped"] == 0
+    assert summary["dropped_seconds"] == 0.0
+    assert summary["densest_dropped"] is None

--- a/tests/test_applause_spans.py
+++ b/tests/test_applause_spans.py
@@ -172,7 +172,7 @@ def test_a_call_with_no_pulse_is_dropped_and_the_playing_one_is_kept() -> None:
         _beats(0.0, 100.0, 1.8),
     )
 
-    called = applause.dense(counted, minimum_density=0.5)
+    called = applause.sifted(counted, minimum_density=0.5)
 
     assert [(one.start, one.end) for one in called.kept] == [(0.0, 100.0)]
     assert [(one.start, one.end) for one in called.dropped] == [(110.0, 210.0)]
@@ -181,14 +181,14 @@ def test_a_call_with_no_pulse_is_dropped_and_the_playing_one_is_kept() -> None:
 def test_a_call_sitting_exactly_on_the_floor_is_kept() -> None:
     counted = applause.counted(_called((0.0, 100.0)), _beats(0.0, 100.0, 0.5))
 
-    assert len(applause.dense(counted, minimum_density=0.5).kept) == 1
+    assert len(applause.sifted(counted, minimum_density=0.5).kept) == 1
 
 
 def test_a_floor_of_zero_keeps_every_call() -> None:
     """The escape hatch: nothing is dropped, so a caller can see the unfiltered set."""
     counted = applause.counted(_called((0.0, 100.0), (110.0, 210.0)), ())
 
-    called = applause.dense(counted, minimum_density=0.0)
+    called = applause.sifted(counted, minimum_density=0.0)
 
     assert len(called.kept) == 2
     assert called.dropped == ()
@@ -196,7 +196,7 @@ def test_a_floor_of_zero_keeps_every_call() -> None:
 
 def test_an_unmeasured_call_is_never_dropped() -> None:
     """No grid was read, so there is no evidence to drop it on."""
-    called = applause.dense(_called((0.0, 100.0)), minimum_density=0.5)
+    called = applause.sifted(_called((0.0, 100.0)), minimum_density=0.5)
 
     assert len(called.kept) == 1
     assert called.dropped == ()
@@ -245,7 +245,7 @@ def test_the_gist_counts_the_tunes_and_the_applause_without_listing_them() -> No
     found = _spans(curve)
     tunes = applause.tunes(found, 54.0, minimum_seconds=10.0)
 
-    summary = applause.gist(curve, found, tunes)
+    summary = applause.gist(curve, found, applause.Calls(tunes, ()))
 
     assert summary["count"] == 2
     assert summary["applause_count"] == 1
@@ -264,9 +264,9 @@ def test_the_gist_says_how_many_calls_had_no_pulse_and_how_close_the_floor_came(
         applause.tunes(spans, 64.0, minimum_seconds=10.0),
         _beats(0.0, 30.0, 1.8),
     )
-    called = applause.dense(counted, minimum_density=0.5)
+    calls = applause.sifted(counted, minimum_density=0.5)
 
-    summary = applause.gist(curve, spans, called.kept, called.dropped)
+    summary = applause.gist(curve, spans, calls)
 
     assert summary["count"] == 1
     assert summary["dropped"] == 1
@@ -281,8 +281,21 @@ def test_the_gist_of_a_set_that_lost_nothing_has_no_dropped_shoulder() -> None:
     spans = _spans(curve)
     tunes = applause.tunes(spans, 54.0, minimum_seconds=10.0)
 
-    summary = applause.gist(curve, spans, tunes)
+    summary = applause.gist(curve, spans, applause.Calls(tunes, ()))
 
     assert summary["dropped"] == 0
     assert summary["dropped_seconds"] == 0.0
     assert summary["densest_dropped"] is None
+
+
+def test_a_dropped_call_is_recorded_with_the_measurement_that_dropped_it() -> None:
+    """A filter whose rejects cannot be inspected is one nobody can check (#38)."""
+    counted = applause.counted(_called((0.0, 100.0), (110.0, 210.0)), _beats(0.0, 100.0, 1.8))
+    calls = applause.sifted(counted, minimum_density=0.5)
+
+    rows = applause.dropped_calls(calls.dropped, 0.5)
+
+    assert [(row["t"], row["end"]) for row in rows] == [(110.0, 210.0)]
+    assert rows[0]["beats"] == 0
+    assert rows[0]["beats_per_second"] == 0.0
+    assert "0.5" in rows[0]["reason"]

--- a/tests/test_music_structure.py
+++ b/tests/test_music_structure.py
@@ -101,6 +101,18 @@ def _detector_that_must_not_run() -> beats_module.Detector:
     return detect
 
 
+def _pulse_in_the_first_tune_only() -> beats_module.Detector:
+    """A grid that stops when the first tune does — the second call has no pulse under it.
+
+    Which is the shape the live pass found (#133): the tagger hears clapping on both sides
+    of two minutes of talking and calls it a tune, and only the beat grid disagrees.
+    """
+    beats = tuple(
+        round(DOWNBEAT_OFFSET + index * 0.5, 6) for index in range(int(TUNE_SECONDS / 0.5))
+    )
+    return _detector(BeatGrid(beats=beats, downbeats=beats[::4]))
+
+
 def _stems(tmp_path: Path, seconds: float = 24.0) -> Path:
     """Three stems of a two-solo set: the vocal has the first half, the horns the second.
 
@@ -148,6 +160,7 @@ def _started(**kwargs: Any) -> dict[str, Any]:
         "burst_seconds": 1.0,
         "gap_seconds": 1.0,
         "tune_seconds": 2.0,
+        "detector": _detector(),
     }
     settings.update(kwargs)
     return structure.analyze_structure(**settings)
@@ -207,6 +220,48 @@ def test_the_tunes_file_is_readable_in_slices(concert: Path) -> None:
     rows = [line for line in lines if line.lstrip().startswith('{"tune":')]
 
     assert len(rows) == result["tunes"]["count"] == 2
+
+
+def test_a_call_with_no_pulse_under_it_never_reaches_the_tunes_file(concert: Path) -> None:
+    """Clapping on both sides of talking is not a tune, and the beat grid is what says so."""
+    result = _result(
+        _started(audio=concert, tagger=_heard(), detector=_pulse_in_the_first_tune_only())
+    )
+
+    written = json.loads(Path(result["tunes"]["path"]).read_text(encoding="utf-8"))
+
+    assert [(one["t"], one["end"]) for one in written["tunes"]] == [(0.0, 4.0)]
+    assert result["tunes"]["count"] == 1
+    assert result["tunes"]["dropped"] == 1
+
+
+def test_a_kept_tune_carries_the_density_it_was_kept_on(concert: Path) -> None:
+    result = _result(
+        _started(audio=concert, tagger=_heard(), detector=_pulse_in_the_first_tune_only())
+    )
+
+    written = json.loads(Path(result["tunes"]["path"]).read_text(encoding="utf-8"))
+
+    assert written["tunes"][0]["beats"] == 8
+    assert written["tunes"][0]["beats_per_second"] == 2.0
+
+
+def test_a_floor_of_zero_keeps_every_call_and_never_reads_a_grid(concert: Path) -> None:
+    """The escape hatch is also the way to run this half with no beat model installed."""
+    result = _result(
+        _started(
+            audio=concert,
+            tagger=_heard(),
+            detector=_detector_that_must_not_run(),
+            density_per_second=0.0,
+        )
+    )
+
+    written = json.loads(Path(result["tunes"]["path"]).read_text(encoding="utf-8"))
+
+    assert [(one["t"], one["end"]) for one in written["tunes"]] == [(0.0, 4.0), (6.0, 10.0)]
+    assert result["tunes"]["dropped"] == 0
+    assert written["tunes"][1]["beats_per_second"] is None
 
 
 def test_solo_changes_land_on_disk_snapped_to_a_downbeat(solo_audio: Path, stems: Path) -> None:
@@ -332,6 +387,52 @@ def test_music_analysis_reuses_the_beat_grid_this_job_wrote(
     assert beats["beats"]["count"] > 0
 
 
+def test_the_tune_half_reuses_the_beat_grid_music_analysis_already_wrote(concert: Path) -> None:
+    """The density check pays for no second detection either — same entry, same rule."""
+    _result(music.analyze_music(concert, energy=False, detector=_pulse_in_the_first_tune_only()))
+
+    result = _result(
+        _started(audio=concert, tagger=_heard(), detector=_detector_that_must_not_run())
+    )
+
+    assert result["tunes"]["count"] == 1
+
+
+def test_music_analysis_reuses_the_beat_grid_the_tune_half_wrote(concert: Path) -> None:
+    _result(_started(audio=concert, tagger=_heard()))
+
+    beats = _result(
+        music.analyze_music(concert, energy=False, detector=_detector_that_must_not_run())
+    )
+
+    assert beats["beats"]["count"] > 0
+
+
+def test_moving_the_density_floor_gets_its_own_answer(concert: Path) -> None:
+    """Two floors are two results, so they are keyed apart rather than sharing an entry."""
+    loose = _result(
+        _started(
+            audio=concert,
+            tagger=_heard(),
+            detector=_pulse_in_the_first_tune_only(),
+            density_per_second=0.0,
+        )
+    )
+
+    strict = _result(
+        _started(
+            audio=concert,
+            tagger=_heard(),
+            detector=_pulse_in_the_first_tune_only(),
+            density_per_second=0.5,
+        )
+    )
+
+    assert loose["tunes"]["count"] == 2
+    assert strict["tunes"]["count"] == 1
+    assert loose["tunes"]["path"] != strict["tunes"]["path"]
+
+
 def test_a_finer_solo_window_does_not_re_tag_the_room(concert: Path, stems: Path) -> None:
     """The halves are keyed apart, so changing one does not pay for the other again."""
     _result(_solos(concert, stems, tunes=True, tagger=_heard()))
@@ -381,6 +482,13 @@ def test_an_impossible_threshold_is_refused(concert: Path) -> None:
         _started(audio=concert, threshold=1.5)
 
 
+def test_a_negative_density_floor_is_refused(concert: Path) -> None:
+    with pytest.raises(Exception, match="density"):
+        _started(audio=concert, density_per_second=-1.0)
+
+    assert store.load_all() == []
+
+
 def test_a_missing_tagger_names_the_install(concert: Path, monkeypatch: Any) -> None:
     real = importlib.import_module
 
@@ -418,6 +526,16 @@ def test_the_tool_returns_a_job_and_never_the_boundaries(concert: Path) -> None:
     assert envelope["ok"] is True
     assert envelope["job"]["kind"] == structure.KIND
     assert "tunes" not in envelope
+
+
+def test_the_tool_hands_the_density_floor_to_the_job(concert: Path) -> None:
+    """Refused rather than started, which is the cheap proof the value reached the starter."""
+    envelope = analysis_tools.analyze_structure(str(concert), density_per_second=-1.0)
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["code"] == "invalid_request"
+    assert "density_per_second" in envelope["error"]["fix"]
+    assert store.load_all() == []
 
 
 def test_the_tool_is_registered() -> None:

--- a/tests/test_music_structure.py
+++ b/tests/test_music_structure.py
@@ -235,6 +235,29 @@ def test_a_call_with_no_pulse_under_it_never_reaches_the_tunes_file(concert: Pat
     assert result["tunes"]["dropped"] == 1
 
 
+def test_the_dropped_call_is_on_disk_with_the_reason_it_was_dropped(concert: Path) -> None:
+    """Out of the tune set but not out of the record — the filter has to be auditable."""
+    result = _result(
+        _started(audio=concert, tagger=_heard(), detector=_pulse_in_the_first_tune_only())
+    )
+
+    written = json.loads(Path(result["tunes"]["path"]).read_text(encoding="utf-8"))
+
+    assert [(one["t"], one["end"]) for one in written["dropped_calls"]] == [(6.0, 10.0)]
+    assert written["dropped_calls"][0]["beats_per_second"] == 0.0
+    assert "no pulse" in written["dropped_calls"][0]["reason"]
+
+
+def test_the_dropped_calls_stay_out_of_what_comes_back_inline(concert: Path) -> None:
+    """The gist is stats; the rejects are boundaries, so they live on disk with the rest."""
+    result = _result(
+        _started(audio=concert, tagger=_heard(), detector=_pulse_in_the_first_tune_only())
+    )
+
+    assert "dropped_calls" not in result["tunes"]
+    assert not any(isinstance(value, list) for value in result["tunes"].values())
+
+
 def test_a_kept_tune_carries_the_density_it_was_kept_on(concert: Path) -> None:
     result = _result(
         _started(audio=concert, tagger=_heard(), detector=_pulse_in_the_first_tune_only())
@@ -504,6 +527,28 @@ def test_a_missing_tagger_names_the_install(concert: Path, monkeypatch: Any) -> 
     assert record.error is not None
     assert record.error["code"] == "analysis_dependency_missing"
     assert "panns" in record.error["fix"]
+
+
+def test_a_missing_beat_model_names_the_way_to_run_without_one(
+    concert: Path,
+    monkeypatch: Any,
+) -> None:
+    """beats' own advice is beats=false, which is no help to a caller asking for tunes."""
+    real = importlib.import_module
+
+    def missing(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == beats_module.MODULE:
+            raise ImportError(name)
+        return real(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", missing)
+
+    record = _finished(_started(audio=concert, tagger=_heard(), detector=None))
+
+    assert record.error is not None
+    assert record.error["code"] == "analysis_dependency_missing"
+    assert "density_per_second=0" in record.error["fix"]
+    assert "beat_this" in record.error["fix"]
 
 
 def test_a_tagger_that_falls_over_is_an_analysis_failure(concert: Path) -> None:


### PR DESCRIPTION
Closes #133.

Applause alone over-calls. The live pass on the concert master called 13 tunes and the ear
check found 3 with no musical pulse under them — one of them two minutes of talking bounded
by clapping on both sides. ~23% of calls were false, and length cannot separate them from a
tune because an announcement can run for minutes. So a call now has to have a beat under it
as well.

`applause.counted` divides the #37 beat grid over each call, `applause.sifted` splits the set
on a floor, and the tunes half of the structure job reads the same shared beats half the solo
half already reads — one detection per piece of audio, whichever job asks first.

**The floor is 0.5 beats per second, measured rather than guessed.** The full sweep and both
live runs are recorded on #133. The short version: every floor from 0.10 to 1.25 calls the
concert identically, so 0.5 is in the middle of a plateau an order of magnitude wide rather
than on a shoulder — and it is below any tempo a band plays (30 bpm), which is the argument
that should travel past this one concert.

**The filter is auditable.** Kept rows carry the beats and the density they were kept on; the
rejects go in the tunes file's header as `dropped_calls` with the reason on each; the gist
carries the count and the two shoulders the floor decided on, so a narrow gap is visible
inline. Every dropped call is also named in the log.

`density_per_second=0` turns the check off and returns the unfiltered set — which is also how
to run this half with no beat model installed, since a floor of zero reads no grid at all.

## Test seam

**Fake tier**, per CLAUDE.md — the arithmetic and every decision around the two injected
models. `tests/test_applause_spans.py` pins the density arithmetic on hand-built grids of
known density: the half-open boundary, the zero-beat call, a call sitting exactly on the
floor, the unmeasured call that is never dropped, and the reject rows.
`tests/test_music_structure.py` pins the job decisions: the pulse-less call never reaches the
file, the rejects land on disk while the gist stays scalar, the grid is shared with
`analyze_music` in both directions, two floors key apart, a negative floor is refused before a
job starts, and a missing beat model names `density_per_second=0` rather than beats' own
`beats=false`.

**Live smoke:** run and recorded on #133 (both runs, on the Scullers master, this box).

## Two judgement calls worth flagging

- **`density_per_second` is in `APPLAUSE_SHAPE`**, so moving the floor re-tags the room
  (~103 s on the master) even though it only filters what the tagger already produced. That is
  the same bargain `tune_seconds` already makes, and the alternative — filtering outside the
  cached half — would leave the *artifact* unfiltered, which is the thing a songs.json author
  reads. Correctness over the re-tag.
- **`tunes=true` now needs the beat model** by default where it previously needed only
  `panns_inference`. Flagged on the ticket; the escape hatch is named in the error.

## Review

Two-axis review (`/code-review`, Standards and Spec as parallel sub-agents) against
`origin/main`, on the branch before this PR existed.

**Standards — no hard violations**, six judgement calls, all fixed in b7d4a8a:

1. *Data Clump* — `gist` took `(found, dropped=())` when `Calls` is that pair → takes `Calls`
   whole; the speculative `= ()` default is gone.
2. *Duplicated Code* — `_downbeats` read the grid via `beats_of` + `records.read` while the new
   code used `numbered_beats` → both halves now go through one `_grid` accessor.
3. *Mysterious Name* — `Called` → `Calls` (house types are nouns), `dense` → `sifted` (the old
   name read like a predicate returning a bool).
4. *Primitive Obsession* — `_density` returned `dict[str, Any]` only to be `**`-splatted into
   `Tune._replace`, the one place mypy stopped checking those two field names → `_over` returns
   a `Tune`.
5. Docstring claimed the grid is trusted sorted, then sorted it anyway → says what it does.
6. Drop log formatted a float with `%s` → `%.2f`.

**Spec — three real gaps**, all closed:

1. *"record the constant's ground truth the way #35 recorded its silence knobs"* — the ticket
   had zero comments, and a docstring already claimed the sweep was recorded there. Now
   genuinely recorded on #133 in #35's Material / Defaults / Result / sweep / evidence /
   Verdict shape, and the docstring cites the measured plateau.
2. *"one live sanity pass against the concert master, recorded on this ticket"* — had not run.
   Run twice (the default floor, then the final code at 0.6), recorded on #133.
3. #38's *"the density and the reason recorded per tune so the caller can see what was dropped
   and why"* — only kept rows were written. The rejects now land on disk via a new `aside`
   parameter on `halves.written` that reaches the record-file header but not the returned gist,
   so the two tests pinning "no lists in the gist" keep holding.

A focused pass over the fix diff (not a second full review) raised four MINORs, all fixed in
the same commit: the `except AnalysisDependencyError` was too broad and is now gated on the
beat model actually being what is missing; `aside` merged over `gist` and now merges under it,
so an aside can never replace a stat; the one-line header field is bounded by the applause
(one call per burst, tens per concert) and says so; and the solos half was still handing back
beats' `beats=false` advice, which the shared `_grid` helper now shapes per half.

CI: fake tier 1326 tests green, mypy strict clean over 159 files, ruff clean.

Review: clean — two-axis review on the branch; ten findings, all fixed before this PR was opened.
