### PR TITLE
Measure the visible edit, not the V1 skeleton

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,8 +69,10 @@ Top level:
 `analysis/` — compute jobs that read audio and write findings to disk:
 `applause` (bursts → tune boundaries), `beats` (grid + downbeats, model
 injected per ADR 0002; `trust` says which beats the grid describes well enough
-to count, #112), `correlate` (measure a cut against its music, gating the beat
-statistics on `trust` and leaving the transient ones ungated), `cuda` (preloads
+to count, #112), `correlate` (measure a cut against its music — by default the *visible* edit,
+every frame resolved to the topmost enabled video item with uncovered stretches
+as black shots, #142; `track=` measures one video track alone. Gates the beat
+statistics on `trust` and leaves the transient ones ungated), `cuda` (preloads
 the CUDA runtime the `analysis` extra ships, so CTranslate2 finds it on Windows;
 pure decisions, #128),
 `decode` (WAV → numpy, no third-party decoder), `drums` (hits per stem), `energy`

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -46,18 +46,20 @@ from ..naming import keyed_name
 from ..resolve.connection import ResolveConnection
 from ..resolve.session import frame_rate
 from ..resolve.timeline import (
-    FIRST_TRACK,
     Reader,
     angle_of,
     clip_name,
+    current_name,
     find_timeline,
     fingerprint,
+    item_enabled,
     items_in_track,
     name_of,
     open_project,
     read_frames,
     source_bounds,
     start_frame,
+    track_enabled,
 )
 from ..timing import SECONDS_PRECISION, dual_time, to_frames
 from . import decode, energy, records
@@ -73,6 +75,18 @@ INLINE_CUTS = 12
 UNLABELLED = "unlabelled"
 """Where shots from a clip the angle sidecar does not name are counted."""
 
+BLACK = "black"
+"""Where the stretches nothing covers are counted — a known absence, not a missing label."""
+
+READING = 2
+"""The shape of the reading this writes; bumped whenever the records or the header change.
+
+The cache is keyed on what was measured, not on the code that measured it, so a call whose
+inputs have not changed is otherwise answered out of a file the *previous* shape wrote — for
+#142 that is a report with no track on its records and no ``visible`` on its header, handed
+back as though it were this measurement rather than the one before it.
+"""
+
 GIVEN = "given"
 """The alignment mode where the caller named the frame rather than the server reading it."""
 
@@ -83,11 +97,16 @@ Onsets = Callable[[Path], tuple[float, ...]]
 class Shot(NamedTuple):
     """One shot as the measurement needs it: what it is and where it sits."""
 
-    clip: str
+    clip: str | None
+    """The angle on screen, or ``None`` for black — the stretch no enabled item covers."""
+
     record_in: int
     duration: int
     media: bool = True
     """Whether Resolve gave it a media pool item — false for transitions and generators."""
+
+    track: int | None = None
+    """The video track the frame is taken from; ``None`` along with ``clip`` for black."""
 
     @property
     def record_out(self) -> int:
@@ -138,7 +157,7 @@ def correlate_timeline(
     tunes: str | None = None,
     solos: str | None = None,
     angles: Mapping[str, Any] | None = None,
-    track: int = FIRST_TRACK,
+    track: int | None = None,
     audio_at: Any | None = None,
     refresh: bool = False,
     onsets: Onsets | None = None,
@@ -149,6 +168,12 @@ def correlate_timeline(
     Every input is read and checked here, before the job exists: a path that is not there
     and a file that is not what it claims are wrong *calls*, and a wrong call should come
     back from the tool rather than from a poll two seconds later.
+
+    ``track`` chooses what is measured. Left out, it is the *visible* edit: every frame
+    resolved to the topmost enabled video item, so an overlay on V2 is a shot and the frames
+    it covers belong to it rather than to whatever sits underneath. Named, it is that video
+    track alone, laid out as the editor left it. Both are real questions, but only the first
+    describes the film anybody watches (#142).
 
     ``angles`` is a mapping the caller passes, not a file this reads: the angle sidecar is
     the agent's document (#45 — no server path reads or writes it), so the labels arrive
@@ -162,11 +187,12 @@ def correlate_timeline(
     config = config or get_config()
     roles = _roles(angles)
     music = _music(beats, audio, tunes, solos, roles)
-    shots, clock, print_, name = _read_cut(connection, timeline, track, music.audio, audio_at)
+    cut = _read_cut(connection, timeline, track, music.audio, audio_at)
+    shots, clock, name = cut.shots, cut.clock, cut.name
 
     params: dict[str, Any] = {
         "timeline": name,
-        "track": int(track),
+        "track": None if track is None else int(track),
         "audio_at": clock.zero_frame if clock.mode == GIVEN else None,
         "beats": _named(beats),
         "audio": _named(audio),
@@ -174,11 +200,13 @@ def correlate_timeline(
         "solos": _named(solos),
         "angles": dict(sorted(roles.items())) if roles is not None else None,
     }
-    watched = [print_, *_fingerprints(beats, audio, tunes, solos)]
+    watched = [{"reading": READING}, cut.fingerprint, *_fingerprints(beats, audio, tunes, solos)]
     key = cache.cache_key(KIND, watched, params)
 
     def work(progress: Progress) -> JobOutput:
-        return correlate(shots, clock, name, music, key, params, progress, onsets, config)
+        return correlate(
+            shots, clock, name, music, key, params, cut.visible, progress, onsets, config
+        )
 
     return start_job(KIND, params, work, cache_key=key, refresh=refresh, config=config)
 
@@ -190,6 +218,7 @@ def correlate(
     music: Music,
     key: str,
     params: dict[str, Any],
+    visible: dict[str, Any],
     progress: Progress,
     onsets: Onsets | None = None,
     config: Config | None = None,
@@ -203,7 +232,9 @@ def correlate(
     progress(0.7, "measuring the cut against the music")
     grid = trust(music.beats)
     rows = measure(shots, clock, music, transients, grid)
-    summary = _summary(rows, clock, transients, [float(one["t"]) for one in music.beats], grid)
+    summary = _summary(
+        rows, clock, visible, transients, [float(one["t"]) for one in music.beats], grid
+    )
 
     target = config.analysis_dir / keyed_name(name, key, ".correlate.json", "correlate")
     # "count", not "cuts": the records themselves are the file's ``cuts`` field, and a header
@@ -225,24 +256,40 @@ def correlate(
 # --- reading the cut --------------------------------------------------------------------------
 
 
+class Cut(NamedTuple):
+    """Everything Resolve answered for, taken in one reading before the job starts."""
+
+    shots: list[Shot]
+    clock: Clock
+    fingerprint: dict[str, Any]
+    name: str
+    visible: dict[str, Any]
+    """How the shots were arrived at — which tracks, and how many gaps became black."""
+
+
 def _read_cut(
     connection: ResolveConnection,
     name: str | None,
-    track: int,
+    track: int | None,
     mix: Path | None = None,
     at: Any | None = None,
-) -> tuple[list[Shot], Clock, dict[str, Any], str]:
+) -> Cut:
     """Everything Resolve has to answer for, taken before the job starts.
 
     A job that reached back into Resolve would be measuring a timeline the director may
     have moved on from, and would need the Resolve lock to do it. One reading up front,
     then arithmetic — and a handle that dies during it fails the *call*, which is the one
     failure the tool layer's single reconnect can still fix.
+
+    The reader is told whether this timeline is the project's current one, because the
+    visible edit is decided partly on track enable-state and that getter answers ``False``
+    for everything off the current timeline (#84). Believing it there would read a whole
+    concert as one black shot.
     """
     project = open_project(connection)
     timeline = find_timeline(project, name)
-    reader = Reader(connection)
     found = name_of(timeline)
+    reader = Reader(connection, current=found == current_name(project))
 
     fps = frame_rate(project, timeline)
     if not fps:
@@ -252,29 +299,130 @@ def _read_cut(
             detail={"timeline": found},
         )
 
-    shots = _shots(reader, timeline, track)
+    shots, visible = _read_shots(reader, timeline, track)
     if not shots:
         raise InvalidRequestError(
-            cause=f"Video track {track} of {found!r} holds no shots to measure.",
-            fix=(
-                "Name the timeline with timeline= and the track the cut sits on with track= "
-                "— inspect_timeline shows which tracks hold what."
+            cause=(
+                f"Video track {track} of {found!r} holds no shots to measure."
+                if track is not None
+                else f"No enabled video track of {found!r} holds a shot to measure."
             ),
-            detail={"timeline": found, "track": int(track)},
+            fix=(
+                "Name the timeline with timeline=, and a single video track with track= if "
+                "you want that track alone rather than the visible edit — inspect_timeline "
+                "shows which tracks hold what."
+            ),
+            detail={"timeline": found, "track": None if track is None else int(track)},
         )
     given = to_frames(at, fps, "audio_at")
     clock = _clock(reader, timeline, fps, mix, given)
-    return shots, clock, fingerprint(reader, timeline), found
+    return Cut(shots, clock, fingerprint(reader, timeline), found, visible)
 
 
-def _shots(reader: Reader, timeline: Any, track: int) -> list[Shot]:
+def _read_shots(
+    reader: Reader, timeline: Any, track: int | None
+) -> tuple[list[Shot], dict[str, Any]]:
+    """The strip of shots to measure, and the reading of where it came from.
+
+    Two different questions, and the reading says which was asked. A measurement of the
+    wrong stack is shaped exactly like a measurement of the right one — every offset
+    well-formed, every clip named — so the one line that separates them travels with it.
+    """
+    tracks = int(read_frames(reader.optional(timeline, "GetTrackCount", 0, "video")) or 0)
+    if track is not None:
+        shots = _shots(reader, timeline, int(track))
+        return shots, _reading("track", tracks, [int(track)], [], reader.reads_current, shots)
+
+    layers: list[Shot] = []
+    measured: list[int] = []
+    skipped: list[int] = []
+    for index in range(1, tracks + 1):
+        if track_enabled(reader, timeline, "video", index) is False:
+            skipped.append(index)
+            continue
+        on_track = _shots(reader, timeline, index, only_enabled=True)
+        if on_track:
+            measured.append(index)
+            layers.extend(on_track)
+    visible = _composite(layers)
+    if skipped:
+        log.info("Video tracks %s are switched off, so nothing on them is visible", skipped)
+    return visible, _reading("visible", tracks, measured, skipped, reader.reads_current, visible)
+
+
+def _reading(
+    mode: str,
+    tracks: int,
+    measured: Sequence[int],
+    skipped: Sequence[int],
+    enabled_known: bool,
+    shots: Sequence[Shot],
+) -> dict[str, Any]:
+    return {
+        "mode": mode,
+        "video_tracks": tracks,
+        "measured": list(measured),
+        "skipped": list(skipped),
+        # False means every track was measured because none could be ruled out (#84), not
+        # that every track was on — the difference matters to anyone reading ``measured``.
+        "enabled_known": enabled_known,
+        "black": sum(1 for shot in shots if shot.clip is None),
+    }
+
+
+def _composite(shots: Sequence[Shot]) -> list[Shot]:
+    """The stacked tracks flattened into the one strip of picture that plays (#142).
+
+    Every frame belongs to the topmost item covering it, so an overlay is a shot and the
+    stretch of the clip beneath it is not — that stretch is not on screen, and attributing
+    the overlay's frames to it describes a cut nobody made.
+
+    Where nothing covers a frame the viewer sees black, and black is a shot: the director
+    who left a gap under an empty V1 chose that, and a gap that vanishes takes both its cuts
+    with it. Only the gaps *between* shots become black — before the first frame of picture
+    and after the last there is no edit, just timeline.
+
+    A clip the overlay interrupts comes back as a second shot, because the frame it comes
+    back on is a cut the viewer sees, whatever the timeline's item list says.
+    """
+    edges = sorted({edge for shot in shots for edge in (shot.record_in, shot.record_out)})
+    runs: list[tuple[Shot | None, int, int]] = []
+    for start, end in zip(edges, edges[1:], strict=False):
+        top = _topmost(shots, start)
+        if runs and runs[-1][0] is top and runs[-1][2] == start:
+            runs[-1] = (top, runs[-1][1], end)
+        else:
+            runs.append((top, start, end))
+    return [
+        Shot(clip=None, record_in=start, duration=end - start, media=False, track=None)
+        if top is None
+        else Shot(
+            clip=top.clip, record_in=start, duration=end - start, media=top.media, track=top.track
+        )
+        for top, start, end in runs
+    ]
+
+
+def _topmost(shots: Sequence[Shot], frame: int) -> Shot | None:
+    """What is on screen at ``frame`` — the highest track holding it, or nothing at all."""
+    covering = [shot for shot in shots if shot.record_in <= frame < shot.record_out]
+    return max(covering, key=lambda shot: shot.track or 0, default=None)
+
+
+def _shots(reader: Reader, timeline: Any, track: int, only_enabled: bool = False) -> list[Shot]:
     """The shots on one video track, in the order they play.
 
     A shot whose position will not read is dropped rather than guessed at: a measurement
     with an invented time in it is worse than one shot short, and the log says which.
+
+    ``only_enabled`` drops the items the editor switched off, which is what the visible edit
+    needs and what measuring a named track deliberately does not do: a track read alone is
+    read as it was laid out.
     """
     found: list[Shot] = []
     for item in items_in_track(timeline, "video", int(track)):
+        if only_enabled and not item_enabled(reader, item):
+            continue
         record_in = read_frames(item.GetStart())
         duration = read_frames(item.GetDuration())
         if record_in is None or duration is None:
@@ -283,7 +431,13 @@ def _shots(reader: Reader, timeline: Any, track: int) -> list[Shot]:
         clip = reader.optional(item, "GetMediaPoolItem", None)
         name = angle_of(reader, item, clip) or str(item.GetName() or "")
         found.append(
-            Shot(clip=name, record_in=record_in, duration=duration, media=clip is not None)
+            Shot(
+                clip=name,
+                record_in=record_in,
+                duration=duration,
+                media=clip is not None,
+                track=int(track),
+            )
         )
     ordered = sorted(found, key=lambda shot: (shot.record_in, not shot.media))
     return _without_transitions(ordered, track)
@@ -600,7 +754,8 @@ def measure(
             {
                 "cut": index,
                 "clip": shot.clip,
-                "role": roles.get(shot.clip),
+                "track": shot.track,
+                "role": None if shot.clip is None else roles.get(shot.clip),
                 "opening": _opens(index, shot, shots),
                 "t": _rounded(seconds),
                 # Dual time for the two timeline positions, because an outlier the agent
@@ -688,6 +843,7 @@ def _front_at(
 def _summary(
     rows: Sequence[dict[str, Any]],
     clock: Clock,
+    visible: dict[str, Any],
     transients: Sequence[float] | None,
     grid: Sequence[float],
     trusted: GridTrust,
@@ -709,6 +865,7 @@ def _summary(
     return {
         "timeline_fps": clock.fps,
         "alignment": clock.reading(),
+        "visible": visible,
         "cuts": len(rows),
         "openings": sum(1 for row in rows if row["opening"]),
         # ``outside_grid`` and ``gated`` are different refusals and neither implies the other:
@@ -782,12 +939,17 @@ def _usage(rows: Sequence[dict[str, Any]], field: str) -> dict[str, dict[str, An
     Counted in both shots and seconds because they answer different questions: a role can
     take a third of the cuts and a tenth of the screen time, and which of those a style
     profile should say is the director's call, not this tool's.
+
+    Black gets its own line rather than falling in with the unlabelled: how much of a cut is
+    empty is a fact about the edit, and how much of it the sidecar has not named yet is a
+    fact about the sidecar. Added together neither is readable.
     """
     total = sum(float(row["seconds"]) for row in rows) or 1.0
     usage: dict[str, dict[str, Any]] = {}
     for row in rows:
         held = row[field]
-        key = UNLABELLED if held is None else str(held)
+        named = UNLABELLED if held is None else str(held)
+        key = BLACK if row["clip"] is None else named
         entry = usage.setdefault(key, {"cuts": 0, "seconds": 0.0, "share": 0.0})
         entry["cuts"] += 1
         entry["seconds"] += float(row["seconds"])

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -78,13 +78,14 @@ UNLABELLED = "unlabelled"
 BLACK = "black"
 """Where the stretches nothing covers are counted — a known absence, not a missing label."""
 
-READING = 2
-"""The shape of the reading this writes; bumped whenever the records or the header change.
+READING = 3
+"""What this measurement *is*; bumped whenever a rerun over unchanged inputs would differ.
 
 The cache is keyed on what was measured, not on the code that measured it, so a call whose
-inputs have not changed is otherwise answered out of a file the *previous* shape wrote — for
+inputs have not changed is otherwise answered out of a file the previous version wrote — for
 #142 that is a report with no track on its records and no ``visible`` on its header, handed
-back as though it were this measurement rather than the one before it.
+back as though it were this measurement rather than the one before it. Both the shape and
+the reading count: 3 rather than 2 because the same shots now resolve to a different strip.
 """
 
 GIVEN = "given"
@@ -188,12 +189,11 @@ def correlate_timeline(
     roles = _roles(angles)
     music = _music(beats, audio, tunes, solos, roles)
     cut = _read_cut(connection, timeline, track, music.audio, audio_at)
-    shots, clock, name = cut.shots, cut.clock, cut.name
 
     params: dict[str, Any] = {
-        "timeline": name,
+        "timeline": cut.name,
         "track": None if track is None else int(track),
-        "audio_at": clock.zero_frame if clock.mode == GIVEN else None,
+        "audio_at": cut.clock.zero_frame if cut.clock.mode == GIVEN else None,
         "beats": _named(beats),
         "audio": _named(audio),
         "tunes": _named(tunes),
@@ -205,7 +205,16 @@ def correlate_timeline(
 
     def work(progress: Progress) -> JobOutput:
         return correlate(
-            shots, clock, name, music, key, params, cut.visible, progress, onsets, config
+            cut.shots,
+            cut.clock,
+            cut.name,
+            music,
+            key,
+            params,
+            cut.visible,
+            progress,
+            onsets,
+            config,
         )
 
     return start_job(KIND, params, work, cache_key=key, refresh=refresh, config=config)
@@ -331,7 +340,10 @@ def _read_shots(
     tracks = int(read_frames(reader.optional(timeline, "GetTrackCount", 0, "video")) or 0)
     if track is not None:
         shots = _shots(reader, timeline, int(track))
-        return shots, _reading("track", tracks, [int(track)], [], reader.reads_current, shots)
+        # ``enabled_known`` is None rather than False here: this branch never asks whether a
+        # track is switched on, and reporting on a getter it did not read would be an answer
+        # to a question nobody put.
+        return shots, _reading("track", tracks, [int(track)], [], None, shots)
 
     layers: list[Shot] = []
     measured: list[int] = []
@@ -340,11 +352,9 @@ def _read_shots(
         if track_enabled(reader, timeline, "video", index) is False:
             skipped.append(index)
             continue
-        on_track = _shots(reader, timeline, index, only_enabled=True)
-        if on_track:
-            measured.append(index)
-            layers.extend(on_track)
-    visible = _composite(layers)
+        measured.append(index)
+        layers.extend(_shots(reader, timeline, index, only_enabled=True))
+    visible = _composite(layers, start_frame(timeline))
     if skipped:
         log.info("Video tracks %s are switched off, so nothing on them is visible", skipped)
     return visible, _reading("visible", tracks, measured, skipped, reader.reads_current, visible)
@@ -355,22 +365,26 @@ def _reading(
     tracks: int,
     measured: Sequence[int],
     skipped: Sequence[int],
-    enabled_known: bool,
+    enabled_known: bool | None,
     shots: Sequence[Shot],
 ) -> dict[str, Any]:
     return {
         "mode": mode,
         "video_tracks": tracks,
+        # Every track this reading took shots from or would have: with ``skipped`` it
+        # accounts for all ``video_tracks``, so a track missing from both is a bug rather
+        # than a track that happened to be empty.
         "measured": list(measured),
         "skipped": list(skipped),
         # False means every track was measured because none could be ruled out (#84), not
         # that every track was on — the difference matters to anyone reading ``measured``.
+        # None means the question was never asked, which is what reading one track does.
         "enabled_known": enabled_known,
         "black": sum(1 for shot in shots if shot.clip is None),
     }
 
 
-def _composite(shots: Sequence[Shot]) -> list[Shot]:
+def _composite(shots: Sequence[Shot], opens_at: int) -> list[Shot]:
     """The stacked tracks flattened into the one strip of picture that plays (#142).
 
     Every frame belongs to the topmost item covering it, so an overlay is a shot and the
@@ -379,17 +393,28 @@ def _composite(shots: Sequence[Shot]) -> list[Shot]:
 
     Where nothing covers a frame the viewer sees black, and black is a shot: the director
     who left a gap under an empty V1 chose that, and a gap that vanishes takes both its cuts
-    with it. Only the gaps *between* shots become black — before the first frame of picture
-    and after the last there is no edit, just timeline.
+    with it. That includes the run-up from ``opens_at``, the timeline's own first frame,
+    when the first picture lands after it — a film that opens on black opens on a held frame
+    somebody chose the length of, and the cut out of it is one of the most deliberate in the
+    edit.
+
+    What is *not* a shot is the black after the last picture. A black shot needs a start and
+    an end the edit decides, and that one has no end: how long it runs is however far
+    whatever else is on the timeline reaches — usually an audio item a frame or an hour
+    longer than the cut — which is a fact about the mix rather than about the cut.
 
     A clip the overlay interrupts comes back as a second shot, because the frame it comes
     back on is a cut the viewer sees, whatever the timeline's item list says.
     """
     edges = sorted({edge for shot in shots for edge in (shot.record_in, shot.record_out)})
+    if edges and opens_at < edges[0]:
+        edges.insert(0, opens_at)
     runs: list[tuple[Shot | None, int, int]] = []
     for start, end in zip(edges, edges[1:], strict=False):
+        # Coverage cannot change inside a run: every frame at which some item starts or ends
+        # is an edge, so what is on top at ``start`` is on top until ``end``.
         top = _topmost(shots, start)
-        if runs and runs[-1][0] is top and runs[-1][2] == start:
+        if runs and runs[-1][0] is top:
             runs[-1] = (top, runs[-1][1], end)
         else:
             runs.append((top, start, end))

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -627,9 +627,7 @@ def _read_track(
         "index": index,
         "name": str(reader.optional(timeline, "GetTrackName", "", *where) or ""),
         # ``None``, not ``False``, off the current timeline — see ``Reader.reads_current``.
-        "enabled": bool(reader.optional(timeline, "GetIsTrackEnabled", True, *where))
-        if readable
-        else None,
+        "enabled": track_enabled(reader, timeline, *where),
         "locked": bool(reader.optional(timeline, "GetIsTrackLocked", False, *where))
         if readable
         else None,
@@ -687,6 +685,28 @@ def items_in_track(timeline: Timeline, track_type: str, index: int) -> list[Time
     return list(timeline.GetItemListInTrack(track_type, index) or [])
 
 
+def track_enabled(reader: Reader, timeline: Timeline, track_type: str, index: int) -> bool | None:
+    """Whether a track is switched on, or ``None`` when the answer cannot be believed.
+
+    Off the project's current timeline ``GetIsTrackEnabled`` answers ``False`` for every
+    track, with no error and no ``None`` to say so (#84 — see ``Reader.reads_current``). A
+    caller reading the value there learns nothing about the track, so "unknown" is the only
+    answer that is not a lie, and a caller that acts on enable-state has to say which it got.
+    """
+    if not reader.reads_current:
+        return None
+    return bool(reader.optional(timeline, "GetIsTrackEnabled", True, track_type, index))
+
+
+def item_enabled(reader: Reader, item: TimelineItem) -> bool:
+    """Whether the item itself is switched on.
+
+    Unlike its track's switch this reads true off the current timeline: the #84 sweep read
+    ``GetClipEnabled`` both ways and it did not drift.
+    """
+    return bool(reader.optional(item, "GetClipEnabled", True))
+
+
 def _marker_count(reader: Reader, timeline: Timeline) -> int:
     markers = reader.optional(timeline, "GetMarkers", None)
     return len(markers) if isinstance(markers, dict) else 0
@@ -721,7 +741,7 @@ def read_item(
         "source": {"in": dual_time(source_in, fps), "out": dual_time(source_out, fps)},
         "sync_offset": dual_time(offset, fps),
         "clip": clip_name(reader, item),
-        "enabled": bool(reader.optional(item, "GetClipEnabled", True)),
+        "enabled": item_enabled(reader, item),
         # ``GetTakesCount``, not ``GetTakeCount``: the plural is the method the scripting
         # README actually declares (line 523), and fusionscript answers an unknown name
         # with ``None`` rather than raising — so the singular read as zero takes forever.

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -21,7 +21,6 @@ from ..analysis import (
     whisper,
 )
 from ..resolve.connection import get_connection
-from ..resolve.timeline import FIRST_TRACK
 from .envelope import tool
 
 
@@ -169,7 +168,7 @@ def correlate_timeline(
     tunes: str | None = None,
     solos: str | None = None,
     angles: dict[str, Any] | None = None,
-    track: int = FIRST_TRACK,
+    track: int | None = None,
     audio_at: Any | None = None,
     refresh: bool = False,
 ) -> dict[str, Any]:
@@ -196,11 +195,19 @@ def correlate_timeline(
     Check alignment in the result: mode "given" is what you asked for, and mode "audio_clip"
     with matched false means the times were taken off a clip nobody vouched for.
 
-    timeline names the cut, defaulting to the open one; track is the video track it sits on.
+    timeline names the cut, defaulting to the open one. What gets measured is the *visible*
+    edit: every frame taken from the topmost enabled video item, so a shot on V2 is a shot
+    and the frames it covers are its own rather than the clip's underneath, and a stretch no
+    track covers is a black shot with clip and role null. Each record says which track it
+    came from, and visible in the result says which tracks were read and how many blacks
+    there were. Pass track=1 to measure one video track alone instead, laid out as the
+    editor left it — a different question, and the one to ask about a single-track cut.
+
     The result names a JSON file of one record per shot — grep it, or read a slice with sed
     — and returns the reading inline: offset statistics with early and late counted apart, a
     histogram of where in the bar the cuts land, shot-duration stats, and how much of the
-    cut each angle and role holds.
+    cut each angle and role holds (black counted on its own line, apart from the angles the
+    sidecar has not named).
 
     Nothing here judges the edit. Two frames late is reported as two frames late; what
     counts as musical belongs in your style profile, not in this server.

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -469,6 +469,44 @@ def test_a_gap_is_a_black_shot_rather_than_nothing(attach: Attach, tmp_path: Pat
     assert result["clips"]["black"] == {"cuts": 1, "seconds": 0.633, "share": 0.203}
 
 
+def test_a_film_that_opens_on_black_opens_on_a_shot(attach: Attach, tmp_path: Path) -> None:
+    """The run-up from the timeline's first frame is held black somebody chose the length of,
+    and the cut out of it is a decision — measured, not written off as an opening."""
+    late = FakeTimeline(
+        "sunset-set v3",
+        FPS,
+        start_frame=100,
+        video=[
+            FakeTrack(
+                "Video 1",
+                [_shot(clip, start + 30, run, source) for clip, start, run, source in SHOTS],
+            )
+        ],
+        audio=[FakeTrack("Master", [_shot("master_mix.wav", 100, 200, 0)])],
+    )
+    attach(studio(timeline=late))
+
+    result = _measured(tmp_path)
+
+    cuts = _rows(result)
+    assert cuts[0]["clip"] is None
+    assert cuts[0]["in"]["frames"] == 100  # the timeline's own first frame, not the picture's
+    assert cuts[0]["seconds"] == 0.5  # 30 frames at 60fps
+    assert cuts[1]["opening"] is False
+    assert result["visible"]["black"] == 1
+
+
+def test_the_black_after_the_last_shot_is_not_a_shot(attach: Attach, tmp_path: Path) -> None:
+    """It has no end the edit decides — how far it runs is however long the audio under it is,
+    which is a fact about the mix rather than about the cut."""
+    attach(studio(timeline=a_cut()))  # the master mix runs one frame past the last shot
+
+    result = _measured(tmp_path)
+
+    assert [one["clip"] for one in _rows(result)] == ["C0012.mp4", "C0031.mp4", "C0012.mp4"]
+    assert result["visible"]["black"] == 0
+
+
 def test_black_is_counted_apart_from_the_clips_nobody_labelled(
     attach: Attach, tmp_path: Path
 ) -> None:

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -84,6 +84,21 @@ def _shot(name: str, start: int, duration: int, source_start: int) -> FakeTimeli
     )
 
 
+def a_stack(*video: FakeTrack, name: str = "sunset-set v3") -> FakeTimeline:
+    """A cut spread over more than one video track — the layout the visible edit resolves."""
+    return FakeTimeline(
+        name,
+        FPS,
+        start_frame=100,
+        video=list(video),
+        audio=[FakeTrack("Master", [_shot("master_mix.wav", 100, 200, 0)])],
+    )
+
+
+def _cut_track(shots: Sequence[tuple[str, int, int, int]] = SHOTS) -> FakeTrack:
+    return FakeTrack("Video 1", [_shot(*shot) for shot in shots])
+
+
 def _a_cut_with(extra: FakeTimelineItem) -> FakeTimeline:
     """The fixture cut with one more item on the cut track — a transition, or a generator."""
     return FakeTimeline(
@@ -209,6 +224,7 @@ def test_every_shot_lands_on_disk_with_its_offsets_bar_and_section(
     assert cuts[1] == {
         "cut": 2,
         "clip": "C0031.mp4",
+        "track": 1,
         "role": None,
         "opening": False,
         "t": 1.033,
@@ -398,8 +414,8 @@ def test_a_dissolve_into_a_generator_does_not_eat_the_generator(
                 [
                     _shot(*SHOTS[0]),
                     _shot(*SHOTS[1]),
-                    _dissolve(start=299, duration=14),
-                    FakeTimelineItem("Solid Color", 299, 30, source_start=0),
+                    _dissolve(start=249, duration=14),
+                    FakeTimelineItem("Solid Color", 249, 30, source_start=0),
                 ],
             )
         ],
@@ -410,6 +426,175 @@ def test_a_dissolve_into_a_generator_does_not_eat_the_generator(
     result = _measured(tmp_path)
 
     assert [one["clip"] for one in _rows(result)] == ["C0012.mp4", "C0031.mp4", "Solid Color"]
+
+
+def test_an_overlay_is_the_shot_the_frame_shows_and_the_covered_clip_resumes(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """What the viewer sees is the topmost item, so a V2 overlay is a shot and V1 is not.
+
+    #142: the #46 director recut put three shots on V2, and a V1-only measurement attributed
+    those frames to the clip underneath — a report that described a cut nobody watched.
+    """
+    over = FakeTrack("Video 2", [_shot("B0001.mp4", 180, 40, 0)])
+    attach(studio(timeline=a_stack(_cut_track(), over)))
+
+    cuts = _rows(_measured(tmp_path))
+
+    assert [(one["clip"], one["in"]["frames"]) for one in cuts] == [
+        ("C0012.mp4", 100),
+        ("C0031.mp4", 162),
+        ("B0001.mp4", 180),
+        ("C0031.mp4", 220),
+        ("C0012.mp4", 249),
+    ]
+    assert [one["track"] for one in cuts] == [1, 1, 2, 1, 1]
+
+
+def test_a_gap_is_a_black_shot_rather_than_nothing(attach: Attach, tmp_path: Path) -> None:
+    """A director who cuts to black cut to something; a vanished gap is a cut left unmeasured."""
+    gapped = (SHOTS[0], ("C0031.mp4", 200, 87, 4200))
+    attach(studio(timeline=a_cut(shots=gapped)))
+
+    result = _measured(tmp_path)
+
+    cuts = _rows(result)
+    assert [(one["clip"], one["track"]) for one in cuts] == [
+        ("C0012.mp4", 1),
+        (None, None),
+        ("C0031.mp4", 1),
+    ]
+    assert cuts[1]["role"] is None
+    assert cuts[1]["seconds"] == 0.633  # 162 to 200 at 60fps
+    assert result["clips"]["black"] == {"cuts": 1, "seconds": 0.633, "share": 0.203}
+
+
+def test_black_is_counted_apart_from_the_clips_nobody_labelled(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A known absence is not a missing label — folding them together hides both."""
+    gapped = (SHOTS[0], ("C0031.mp4", 200, 87, 4200))
+    attach(studio(timeline=a_cut(shots=gapped)))
+
+    result = _measured(tmp_path, angles={"C0012.mp4": "wide"})
+
+    assert result["roles"]["black"]["cuts"] == 1
+    assert result["roles"]["unlabelled"]["cuts"] == 1
+    assert result["roles"]["wide"]["cuts"] == 1
+
+
+def test_a_cut_out_of_black_is_a_cut_rather_than_an_opening(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Black is an outgoing angle, so the frame it hands over on is a decision like any other."""
+    gapped = (SHOTS[0], ("C0031.mp4", 200, 87, 4200))
+    attach(studio(timeline=a_cut(shots=gapped)))
+
+    result = _measured(tmp_path)
+
+    assert [one["opening"] for one in _rows(result)] == [True, False, False]
+    assert result["openings"] == 1
+
+
+def test_an_overlay_filling_a_gap_leaves_no_black(attach: Attach, tmp_path: Path) -> None:
+    """The #46 shape: V1 gaps with V2 shots over some of them, black only where none is."""
+    gapped = (SHOTS[0], ("C0031.mp4", 260, 87, 4200))
+    over = FakeTrack("Video 2", [_shot("B0001.mp4", 162, 38, 0)])
+    attach(studio(timeline=a_stack(_cut_track(gapped), over)))
+
+    result = _measured(tmp_path)
+
+    cuts = _rows(result)
+    assert [one["clip"] for one in cuts] == ["C0012.mp4", "B0001.mp4", None, "C0031.mp4"]
+    assert result["visible"]["black"] == 1
+
+
+def test_a_switched_off_track_is_not_in_the_visible_edit(attach: Attach, tmp_path: Path) -> None:
+    """An overlay the director muted is not on screen, so measuring it would report a cut
+    nobody can watch."""
+    over = FakeTrack("Video 2", [_shot("B0001.mp4", 180, 40, 0)], enabled=False)
+    attach(studio(timeline=a_stack(_cut_track(), over)))
+
+    result = _measured(tmp_path)
+
+    assert [one["clip"] for one in _rows(result)] == ["C0012.mp4", "C0031.mp4", "C0012.mp4"]
+    assert result["visible"]["skipped"] == [2]
+
+
+def test_a_disabled_item_is_not_in_the_visible_edit(attach: Attach, tmp_path: Path) -> None:
+    """``GetClipEnabled`` is the item's own switch and reads true off the current timeline (#84)."""
+    muted = FakeTimelineItem(
+        "B0001.mp4",
+        180,
+        40,
+        source_start=0,
+        media_item=FakeMediaPoolItem("B0001.mp4"),
+        enabled=False,
+    )
+    attach(studio(timeline=a_stack(_cut_track(), FakeTrack("Video 2", [muted]))))
+
+    result = _measured(tmp_path)
+
+    assert [one["clip"] for one in _rows(result)] == ["C0012.mp4", "C0031.mp4", "C0012.mp4"]
+
+
+def test_a_track_whose_switch_cannot_be_read_is_measured_rather_than_dropped(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """#84: off the current timeline every track answers "off", and believing that would
+    measure a whole concert as one black shot."""
+    cut = a_stack(_cut_track(), name="recut v1")
+    cut.getters_need_current = True
+    open_one = FakeTimeline("something else v1", FPS, start_frame=100)
+    attach(studio(timeline=open_one, timelines=[open_one, cut]))
+
+    result = _measured(tmp_path, timeline="recut v1")
+
+    assert [one["clip"] for one in _rows(result)] == ["C0012.mp4", "C0031.mp4", "C0012.mp4"]
+    assert result["visible"]["enabled_known"] is False
+    assert result["visible"]["skipped"] == []
+
+
+def test_naming_a_track_measures_that_track_alone(attach: Attach, tmp_path: Path) -> None:
+    """The old reading is still reachable: what one track holds, overlays and all ignored."""
+    over = FakeTrack("Video 2", [_shot("B0001.mp4", 180, 40, 0)])
+    attach(studio(timeline=a_stack(_cut_track(), over)))
+
+    result = _measured(tmp_path, track=1)
+
+    assert [one["clip"] for one in _rows(result)] == ["C0012.mp4", "C0031.mp4", "C0012.mp4"]
+    assert result["visible"]["mode"] == "track"
+
+
+def test_one_track_read_alone_still_lets_its_gaps_vanish(attach: Attach, tmp_path: Path) -> None:
+    """Track mode measures the track as laid out, so a gap is absence and the next shot opens."""
+    gapped = (SHOTS[0], ("C0031.mp4", 200, 87, 4200))
+    attach(studio(timeline=a_cut(shots=gapped)))
+
+    result = _measured(tmp_path, track=1)
+
+    assert [one["opening"] for one in _rows(result)] == [True, True]
+    assert result["openings"] == 2
+    assert result["beat_offsets"] is None
+
+
+def test_the_report_says_which_tracks_the_reading_came_from(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A measurement of the wrong stack looks exactly like one of the right stack."""
+    over = FakeTrack("Video 2", [_shot("B0001.mp4", 180, 40, 0)])
+    attach(studio(timeline=a_stack(_cut_track(), over)))
+
+    result = _measured(tmp_path)
+
+    assert result["visible"] == {
+        "mode": "visible",
+        "video_tracks": 2,
+        "measured": [1, 2],
+        "skipped": [],
+        "enabled_known": True,
+        "black": 0,
+    }
 
 
 def test_each_multicam_angle_is_its_own_clip(attach: Attach, tmp_path: Path) -> None:
@@ -622,20 +807,6 @@ def test_a_mix_with_a_start_timecode_is_not_read_an_hour_late(
     assert _rows(result)[1]["t"] == 1.033
 
 
-def test_a_shot_that_starts_after_a_gap_opens_rather_than_cuts(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """There is no outgoing angle at that frame, so its distance from the beat says nothing."""
-    gapped = (SHOTS[0], ("C0031.mp4", 200, 87, 4200))
-    attach(studio(timeline=a_cut(shots=gapped)))
-
-    result = _measured(tmp_path)
-
-    assert [one["opening"] for one in _rows(result)] == [True, True]
-    assert result["openings"] == 2
-    assert result["beat_offsets"] is None
-
-
 def test_cuts_past_the_end_of_the_grid_are_counted_rather_than_pinned_quietly(
     attach: Attach, tmp_path: Path
 ) -> None:
@@ -646,7 +817,8 @@ def test_cuts_past_the_end_of_the_grid_are_counted_rather_than_pinned_quietly(
     result = _measured(tmp_path)
 
     assert result["outside_grid"] == 1
-    assert result["cuts"] == 4
+    # Four shots and the black across the run-up to the far one, which is inside the grid.
+    assert result["cuts"] == 5
 
 
 def test_the_head_reads_as_whoever_the_first_change_took_over_from(
@@ -756,6 +928,24 @@ def test_the_second_run_over_an_unchanged_cut_comes_back_from_cache(
 
     assert started["cached"] is True
     assert _result(started)["path"] == first["path"]
+
+
+def test_a_report_the_previous_shape_wrote_is_not_answered_as_this_one(
+    attach: Attach, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cache watches what was measured, not the code — so the shape has to be watched too.
+
+    A stale hit is the worst kind here: the file is well-formed and the reading is confident,
+    and the only thing wrong with it is that it answers an older question (#142).
+    """
+    attach(studio(timeline=a_cut()))
+    first = _measured(tmp_path)
+
+    monkeypatch.setattr(correlate, "READING", correlate.READING + 1)
+    started = _started(tmp_path)
+
+    assert started["cached"] is False
+    assert _result(started)["path"] != first["path"]
 
 
 def test_a_recut_is_a_different_measurement(attach: Attach, tmp_path: Path) -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -1317,18 +1317,20 @@ def test_correlate_measures_a_real_hand_edited_timeline() -> None:
 
     written = json.loads(Path(result["path"]).read_text(encoding="utf-8"))
     cuts = written["cuts"]
-    tracks = inspect_timeline(timeline=named, detail="clips")["tracks"]
-    on_video_one = next(
-        track for track in tracks if track["type"] == "video" and track["index"] == 1
-    )
+    reading = inspect_timeline(timeline=named, detail="clips")
+    tracks = reading["tracks"]
+    video = [track for track in tracks if track["type"] == "video"]
+    on_video_one = next(track for track in video if track["index"] == 1)
 
     assert [one["t"] for one in cuts] == sorted(one["t"] for one in cuts)
-    # #142's AC: the visible edit is one gapless strip of picture, so every shot starts
-    # exactly where the last one ended — the invariant a stacked timeline breaks first, and
-    # the one no fake can prove holds against a real overlay.
-    assert [one["in"]["frames"] for one in cuts[1:]] == [one["out"]["frames"] for one in cuts[:-1]]
+    # #142's AC. The strip runs from the timeline's own first frame — a film that opens on
+    # black opens on a shot — and every track that holds picture is somewhere in it: on the
+    # #46 recut the top track is where three shots live that a V1 reading never saw at all.
+    assert cuts[0]["in"]["frames"] == reading["timeline"]["start"]["frames"]
     measured = set(result["visible"]["measured"])
     assert {one["track"] for one in cuts} <= measured | {None}
+    holding = [track["index"] for track in video if track["item_count"]]
+    assert max(holding) in {one["track"] for one in cuts}, "the top track is not on screen"
     assert result["beat_offsets"] is not None, "no cut measured against the grid"
     print(_render_correlation(result))
 

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -1287,7 +1287,9 @@ def test_correlate_measures_a_real_hand_edited_timeline() -> None:
 
     A hand-edited concert timeline is where the reading is actually hard — titles and
     generators with no media pool item, shots that were trimmed rather than placed, an audio
-    track that may or may not be the mix the analysis ran on. Opt in by pointing the two
+    track that may or may not be the mix the analysis ran on. #142 added the second half:
+    the same cut read as the visible edit, where a stacked track and a gap are the two
+    things a single-track reading got wrong. Opt in by pointing the two
     variables at a real cut and a real beats file, in PowerShell on the Resolve machine:
 
         $env:RESOLVE_MCP_CORRELATE_BEATS = 'C:\\cache\\analysis\\gig-beats.json'
@@ -1314,15 +1316,33 @@ def test_correlate_measures_a_real_hand_edited_timeline() -> None:
     result = record.result
 
     written = json.loads(Path(result["path"]).read_text(encoding="utf-8"))
+    cuts = written["cuts"]
     tracks = inspect_timeline(timeline=named, detail="clips")["tracks"]
     on_video_one = next(
         track for track in tracks if track["type"] == "video" and track["index"] == 1
     )
 
-    assert len(written["cuts"]) == on_video_one["item_count"]
-    assert [one["t"] for one in written["cuts"]] == sorted(one["t"] for one in written["cuts"])
+    assert [one["t"] for one in cuts] == sorted(one["t"] for one in cuts)
+    # #142's AC: the visible edit is one gapless strip of picture, so every shot starts
+    # exactly where the last one ended — the invariant a stacked timeline breaks first, and
+    # the one no fake can prove holds against a real overlay.
+    assert [one["in"]["frames"] for one in cuts[1:]] == [one["out"]["frames"] for one in cuts[:-1]]
+    measured = set(result["visible"]["measured"])
+    assert {one["track"] for one in cuts} <= measured | {None}
     assert result["beat_offsets"] is not None, "no cut measured against the grid"
     print(_render_correlation(result))
+
+    # The same cut read as one track, which is what the tool did before #142: no overlays,
+    # no black, and one shot per item Resolve hands back for V1. Measured without the audio
+    # so the transient decode does not run a second time.
+    alone = correlate_timeline(beats=beats, timeline=named, track=1, refresh=True)
+    assert alone["ok"] is True, alone.get("error")
+    one_track = wait_for(alone["job"]["job_id"], timeout=300.0)
+    assert one_track.state == "completed", one_track.error
+    assert one_track.result is not None
+    assert one_track.result["visible"]["mode"] == "track"
+    assert one_track.result["cuts"] <= on_video_one["item_count"]  # transitions are not shots
+    print(f"track 1:   {one_track.result['cuts']} shots of {on_video_one['item_count']} items")
 
 
 def _render_correlation(result: dict[str, Any]) -> str:
@@ -1331,6 +1351,7 @@ def _render_correlation(result: dict[str, Any]) -> str:
         [
             f"file:      {result['path']}",
             f"alignment: {result['alignment']}",
+            f"visible:   {result['visible']}",
             f"cuts:      {result['cuts']} ({result['openings']} opening)",
             f"beats:     {result['beat_offsets']}",
             f"transients:{result['transient_offsets']}",


### PR DESCRIPTION
Closes #142.

`correlate_timeline` measured one video track, so the #46 director recut — three shots on V2, V1 gaps used as black — came back as a 50-shot reading of the track underneath. The overlays were never shots, the frames they cover were credited to the clip they hide, and the gaps vanished along with both of their cuts.

Every record frame now resolves to the topmost enabled video item. An overlay is a shot; a covered stretch belongs to it; a clip the overlay interrupts comes back as a second shot, because the frame it comes back on is a cut the viewer sees. A stretch no track covers is a black shot with `clip`, `role` and `track` null, counted on its own line in the usage tables rather than folded in with the angles the sidecar has not named yet — how much of a cut is empty and how much of it is unlabelled are different facts.

Each record says which track it came from, and the header's `visible` says which tracks were read, which were switched off, whether the switch could be read at all, and how many blacks there were. A measurement of the wrong stack is shaped exactly like a measurement of the right one, so the line that separates them travels with it.

`track=` still measures one video track alone, unchanged: a track read on its own is read as it was laid out, disabled items and gaps included.

**Where black starts and stops.** A black shot needs a start and an end the edit decides. The run-up from the timeline's own first frame has both, and a film that opens on black opens on a held frame somebody chose the length of — so it is a shot, and the cut out of it is measured instead of written off as an opening. The black *after* the last picture has no end the edit decides: how far it runs is however far whatever else is on the timeline reaches, usually an audio item a frame or an hour longer than the cut. That is a fact about the mix rather than about the cut, so it is not a shot. Both halves have a test.

**Two traps.** Track enable-state is one of the three getters that answer `False` for a timeline that is not the project's current one (#84), and believing it there would read a whole concert as one black shot — so the reader is told whether the timeline is current, an unreadable switch means the track is measured, and `enabled_known` says which happened. And the cache keys on what was measured rather than on the code that measured it, so a reading version now travels in the key; without it a `track=` call whose inputs had not changed is answered out of a file the previous version wrote. That was not theoretical — a mid-review live run came back from cache with the old strip in it.

## Seam

Fake tier, as #142 specifies. `tests/test_correlate_timeline.py` covers stacked tracks, an overlay splitting the clip beneath it, a gap becoming black, an overlay filling a gap, leading black, the tail not being a shot, a switched-off track, a disabled item, a track whose switch cannot be read (#84), `track=` mode and its gaps still vanishing, the header, and the reading-version cache guard.

## Live

Run on the #46 director timeline (Resolve Studio 21.0.3.7, python.org 3.11, Windows 11, `MCP Monkfish Tune 02 v3 - Director`), and `test_correlate_measures_a_real_hand_edited_timeline` **passed** — ran, not skipped.

| | visible edit | `track=1` |
|---|---|---|
| records | 54 | 50 |
| from V1 | 49 | 50 |
| from V2 | 3 | — |
| black | 2 (2.586s + 2.419s) | 0 |
| openings | 1 | 2 |

#142 predicted "53 (three V2 items) plus two blacks". The two blacks are exactly these. The shot is one that V2's third item covers frame for frame — both run 97004..97121 — so that V1 item is never on screen: 50 items, 49 visible shots. Verified against a direct read of the timeline's item spans, not inferred.

## Review

`/code-review` — two axes, parallel sub-agents, against `origin/main`.

**Spec axis — 3 findings, all fixed.**

1. *Leading and trailing black are not shots — partial.* "Gaps become first-class black shots ... rather than vanishing" reaches the run-up before the first picture and the tail after the last. **Fixed for the lead**, which is what the ticket's second black turned out to be; the tail is deliberately excluded on the start-and-end rule above, which is now written down in `_composite` and has its own test rather than being silent.
2. *The live AC's number was not met and a coincidence hid it* — 53 records with 1 black is not 53 shots plus 2 blacks. **Fixed**: with leading black the count is 54 and both blacks are accounted for; the remaining one-shot difference from the ticket's estimate is the exact-cover above, reconciled here rather than left as a bare number.
3. *The live test asserted a tautology* — contiguity holds by construction of the edge sweep, so `in[i+1] == out[i]` can never fail. **Fixed**: replaced with two checks that can fail — the strip starts at the timeline's own first frame, and the topmost picture-holding track appears among the row tracks, which is the assertion a V1-only reading would have failed.

Scope beyond the ticket, all flagged and kept: the `visible` header block, per-record `track`, the `READING` cache key, black's own line in the usage tables, and track-level enable filtering (the ticket says enabled *item*; a switched-off track is the same question one level up).

**Standards axis — no hard violations; 5 judgement calls, 4 fixed.**

1. *`measured` was a mysterious name* — it listed only tracks that yielded a shot, so an enabled-but-empty track appeared in neither list and `video_tracks` did not reconcile. **Fixed**: every non-skipped track is listed, so a track missing from both is a bug.
2. *Dead guard* — `runs[-1][2] == start` in the merge loop is true by construction. **Fixed**: removed, with the reason it was true written down as a comment.
3. *`enabled_known` misleading in track mode* — it reported on a getter that branch never reads. **Fixed**: `None` there, matching the None-means-unknown convention this PR establishes.
4. *Mild feature envy* — `_usage(rows, field)` reads `row["clip"]` whatever `field` is. **Kept**: `clip is None` is what black *is*, and the docstring says so.
5. *Mixed unpacking and attribute access on the cut* — **fixed**, attribute access throughout.

Fix diff re-checked on its own (focused pass, not a second full review): no issues.

CI: fake tier, mypy strict and ruff all green locally.

Review: clean
