### PR TITLE
Phrase-boundary detection: name the cut-placement unit (#143)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,12 @@ timelines. The server measures; Claude decides.
   default) vs `-m live` against a running Resolve Studio. See CLAUDE.md.
 - **stem** — separated audio (mix → vocals/drums/bass/other; drums →
   kick/snare/toms), path is a content hash (ADR 0003).
+- **phrase** — the cut-placement unit (#46, `styles/concert.md` §1): a
+  stretch of the soloist's line between two endings. `analysis/phrases.py`
+  reports the **boundaries**, each with two times — `measured_t`, where the
+  line actually stopped, and `t`, the beat inside the rest that a cut is
+  placed on. Not the `phrase` factor inside `fills`, which is only "how far
+  into a four-bar group does this land".
 - **style layer** — `styles/` at the repo root: layered Markdown style
   profiles (`base.md` + `concert.md`), the corpus record (`corpus.md`) and
   per-project angle sidecars (`angles/*.json`). Agent-authored,
@@ -75,7 +81,11 @@ the CUDA runtime the `analysis` extra ships, so CTranslate2 finds it on Windows;
 pure decisions, #128),
 `decode` (WAV → numpy, no third-party decoder), `drums` (hits per stem), `energy`
 (loudness curves), `fills` (drum-fill candidates), `halves` (shared
-identify/cache/write pattern), `music` (beats + energy + gist job),
+identify/cache/write pattern), `melody` (notes off one melodic stem —
+monophonic pitch + gating, model injected per ADR 0002; the reading `phrases`
+is a rule layer over, as `drums` is to `fills`), `music` (beats + energy + gist
+job), `phrases` (phrase boundaries: where the soloist stops, which is the
+cut-placement unit #46 named, #143),
 `records` (sliceable record files), `silence` (RMS spans), `solos` (front
 of band changes), `structure` (tunes + solo changes job), `transcribe`
 (job), `transcript` (document + Word/Transcription/Transcriber vocabulary),
@@ -146,7 +156,9 @@ module, not the package, and never the whole package at once:
 - `project.py` — `FakeProject`, `FakeProjectManager`
 - `connection.py` — `FakeResolve`, `FakeConnector`, `EXPORT_TYPES`
 - `separator.py` — `FakeSeparator`
-- `fixtures.py` — `write_wav`/`write_clicks`/`write_hits`/`write_sections`/
+- `fixtures.py` — `write_wav`/`write_clicks`/`write_hits`/`write_tones`
+  (a melodic stem: pitched notes of a known length with known gaps)/
+  `write_sections`/
   `write_jpeg`, `ffmpeg_absent`, `ffmpeg_refusing`; and the headers stdlib
   `wave` cannot write, built by hand — `write_float_wav`,
   `write_extensible_pcm_wav`, `write_tagged_wav`

--- a/src/resolve_mcp/analysis/beats.py
+++ b/src/resolve_mcp/analysis/beats.py
@@ -13,7 +13,7 @@ import bisect
 import importlib
 import statistics
 from collections import Counter
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -175,6 +175,30 @@ def nearest(beats: Sequence[float], seconds: float) -> int | None:
     after = bisect.bisect_left(beats, seconds)
     candidates = [one for one in (after - 1, after) if 0 <= one < len(beats)]
     return min(candidates, key=lambda one: abs(beats[one] - seconds))
+
+
+GROUP_BARS = 4
+"""Bars to the group. Western popular music phrases in fours, and the grid can say so."""
+AT_BAR_LINE = 0.6
+MID_BAR = 0.15
+
+
+def bar_line_strength(row: Mapping[str, Any] | None) -> float:
+    """How strong a place to put something this beat is: the top of a four-bar group, an
+    ordinary bar line, or the middle of a bar.
+
+    Public for the same reason ``nearest`` is: more than one reading places an event against
+    the grid and they must agree about what a strong placement is. Drum fills score the beat
+    they resolve into (#39) and phrase boundaries score the beat the ending is called on
+    (#143); the question — where does this beat sit in a four-bar group — is the grid's, not
+    either detector's, and scoring it twice is how the two would drift apart.
+
+    Note this is *hypermeter*, not a phrase boundary: it says a beat is a plausible place for
+    a phrase to turn over, never that one did. ``analysis.phrases`` answers that.
+    """
+    if row is None or not row["downbeat"]:
+        return MID_BAR
+    return 1.0 if (int(row["bar"]) - 1) % GROUP_BARS == 0 else AT_BAR_LINE
 
 
 def gist(grid: BeatGrid, records: Sequence[dict[str, Any]]) -> dict[str, Any]:

--- a/src/resolve_mcp/analysis/fills.py
+++ b/src/resolve_mcp/analysis/fills.py
@@ -70,10 +70,6 @@ TOM_SHARE = 0.5
 """The tom share of a run at which the tom factor is fully convinced."""
 RESOLUTION_BEATS = 0.25
 """How near the resolution point a hit must land to count as landing on it."""
-PHRASE_BARS = 4
-"""Bars to the phrase. A fill into bar 5 of 8 is doing more work than one into bar 4."""
-PHRASE_AT_BAR_LINE = 0.6
-PHRASE_MID_BAR = 0.15
 WEIGHTS = {"density": 0.35, "toms": 0.25, "resolution": 0.15, "phrase": 0.25}
 DEFAULT_MINIMUM_CONFIDENCE = 0.35
 """Below this a candidate is counted but not written — the floor on what is worth reading."""
@@ -232,7 +228,7 @@ def _weighed(reading: Reading, first: int, last: int) -> Candidate:
         "density": _clamp((density / reading.baseline - 1.0) / (STRONG_MULTIPLE - 1.0)),
         "toms": _clamp(counts[TOM_STEM] / total / TOM_SHARE) if total else 0.0,
         "resolution": 1.0 if _hit_near(reading.times, end, tolerance) else 0.0,
-        "phrase": _phrase(into),
+        "phrase": beats_module.bar_line_strength(into),
     }
     return Candidate(
         start=round(start, PLACES),
@@ -251,13 +247,6 @@ def _weighed(reading: Reading, first: int, last: int) -> Candidate:
             _clamp(sum(WEIGHTS[name] * value for name, value in factors.items())), PLACES
         ),
     )
-
-
-def _phrase(into: Mapping[str, Any] | None) -> float:
-    """A fill into the top of a phrase is doing more work than one into any old bar line."""
-    if into is None or not into["downbeat"]:
-        return PHRASE_MID_BAR
-    return 1.0 if (int(into["bar"]) - 1) % PHRASE_BARS == 0 else PHRASE_AT_BAR_LINE
 
 
 def _hit_near(times: Sequence[float], seconds: float, tolerance: float) -> bool:
@@ -335,7 +324,7 @@ def detect_drum_fills(
     config = config or get_config()
     source = _readable(audio)
     found = _stems(stems)
-    _sane_floor(minimum_confidence)
+    halves.sane_floor(minimum_confidence, DEFAULT_MINIMUM_CONFIDENCE)
 
     settings = {"minimum_confidence": float(minimum_confidence)}
     identity = cache.identity(source, config.audio_dir)
@@ -447,15 +436,6 @@ def _all_on_disk(found: Mapping[str, Path]) -> None:
                 "so asking for them redoes the separation."
             ),
             detail={"missing": [str(found[label]) for label in missing]},
-        )
-
-
-def _sane_floor(minimum_confidence: float) -> None:
-    if not 0.0 <= minimum_confidence <= 1.0:
-        raise InvalidRequestError(
-            cause="The confidence floor is a fraction between 0 and 1.",
-            fix=f"The default is {DEFAULT_MINIMUM_CONFIDENCE}; 0 writes every candidate.",
-            detail={"minimum_confidence": minimum_confidence},
         )
 
 

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -43,18 +43,21 @@ def readable(audio: str | Path, fix: str | None = None) -> Path:
     return source
 
 
-def sane_floor(minimum_confidence: float, default: float) -> None:
+def sane_floor(minimum_confidence: float, default: float, writes: str = "candidate") -> None:
     """Refuse a confidence floor that is not a fraction, before a job exists to carry it.
 
     Here beside ``readable`` because it is the same kind of thing: the checks a detector runs
     on what it was *asked for*, rather than on what it read. Every detector that reports
-    candidates with a confidence takes this argument and must refuse the same values, and
-    ``default`` differs per detector only because the advice does.
+    candidates with a confidence takes this argument and must refuse the same values.
+
+    ``default`` and ``writes`` differ per detector because the advice does — a fill job says
+    "0 writes every candidate" and a phrase job "0 writes every boundary", and a reader who
+    got that error should not have to translate.
     """
     if not 0.0 <= minimum_confidence <= 1.0:
         raise InvalidRequestError(
             cause="The confidence floor is a fraction between 0 and 1.",
-            fix=f"The default is {default}; 0 writes every candidate.",
+            fix=f"The default is {default}; 0 writes every {writes}.",
             detail={"minimum_confidence": minimum_confidence},
         )
 

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -43,6 +43,22 @@ def readable(audio: str | Path, fix: str | None = None) -> Path:
     return source
 
 
+def sane_floor(minimum_confidence: float, default: float) -> None:
+    """Refuse a confidence floor that is not a fraction, before a job exists to carry it.
+
+    Here beside ``readable`` because it is the same kind of thing: the checks a detector runs
+    on what it was *asked for*, rather than on what it read. Every detector that reports
+    candidates with a confidence takes this argument and must refuse the same values, and
+    ``default`` differs per detector only because the advice does.
+    """
+    if not 0.0 <= minimum_confidence <= 1.0:
+        raise InvalidRequestError(
+            cause="The confidence floor is a fraction between 0 and 1.",
+            fix=f"The default is {default}; 0 writes every candidate.",
+            detail={"minimum_confidence": minimum_confidence},
+        )
+
+
 def identity(source: Path, config: Config) -> dict[str, Any]:
     """Hash what this server wrote; fingerprint what the director handed over.
 

--- a/src/resolve_mcp/analysis/melody.py
+++ b/src/resolve_mcp/analysis/melody.py
@@ -1,0 +1,348 @@
+"""What the soloist played, and when — one record per note off the melodic stem.
+
+Phrase placement (#143) is a question about the *line*, not about the mix. A director's "cut
+after the sax's phrase" is a statement about where one player stopped, and at that moment the
+mix is still full of band, so nothing measured on the master can see it. Separation (#36)
+already hands over a stem the horns and the piano land in, and reading notes off that stem is
+what turns "the line" into something a rule layer can count.
+
+This is deliberately a **monophonic** reading, and the name says so: these are notes, not a
+transcription. The residual stem is not one instrument — piano comping sits under the tenor
+in the same file — so the pitch track follows whatever is loudest and a chord reads as one
+note. That is enough for phrase boundaries, which are made of note *endings*, rests and
+leaps, and it is not enough to write out a solo. Calling it a transcription would be claiming
+the second thing.
+
+Three choices are worth naming, because each is a place a different method would differ:
+
+* **Pitch is autocorrelation with the taper divided out.** The plain FFT autocorrelation of an
+  N-sample frame falls off as ``(N - lag) / N``, which makes a low note look less certain than
+  a high one purely for being low. Dividing that out costs nothing and makes one clarity
+  threshold mean the same thing across the range. The period is then the *first local peak*
+  within ``OCTAVE_MARGIN`` of the strongest one — because the autocorrelation of anything
+  periodic peaks again at twice the period, and taking the strongest peak outright is how a
+  pitch tracker reports the octave below.
+
+* **Gating is hysteresis on the stem's own peak, not an absolute level.** A stem is quiet or
+  loud according to how the separation scaled it, and the question here is only "is the line
+  sounding", so the note starts at ``ONSET_GATE`` of the stem's loudest frame and does not end
+  until it falls under ``RELEASE_GATE`` — one threshold would chatter a note into pieces
+  across every dip in its own sustain.
+
+* **A frame is dated at its centre**, the way ``solos`` dates an energy window, and the gate
+  therefore opens about half a window *before* the note and closes about half a window after
+  it. That is a known bias with a known size, so the outer edges of a run are pulled back in
+  by half a window; splits *inside* a run are already where the pitch changed and are left
+  alone.
+
+The seam is kept for the reason ``drums`` keeps one (ADR 0002): a real monophonic pitch
+tracker is a plausible upgrade, and the rule layer downstream never knows the difference.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..errors import AnalysisFailedError, ResolveMcpError
+from ..logging_config import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - the worker imports this when it runs
+    from .decode import Audio
+
+log = get_logger("analysis")
+
+FRAME_SECONDS = 0.043
+"""Long enough to hold three periods of the lowest note looked for, short enough to sit inside a
+quaver at any tempo a band actually plays."""
+HOP_SECONDS = 0.01
+MINIMUM_HZ = 80.0
+MAXIMUM_HZ = 2_000.0
+"""The range a horn, a voice, a guitar or a piano's right hand lives in."""
+CLARITY = 0.6
+"""How periodic a frame has to read before its peak is called a pitch rather than a coincidence."""
+OCTAVE_MARGIN = 0.9
+"""A peak this near the strongest is the same peak, and the earlier lag is the real period."""
+
+ONSET_GATE = 0.15
+RELEASE_GATE = 0.06
+"""Fractions of the stem's own loudest frame — see the hysteresis note above."""
+SILENCE = 1e-5
+"""Below this the whole stem is silence, and its peak is no baseline to gate against."""
+MINIMUM_SECONDS = 0.04
+"""Shorter than this is a click or a gate chattering, not a note the line is made of."""
+SPLIT_SEMITONES = 1.0
+"""Wider than vibrato and narrower than a step: what separates two legato notes."""
+CONFIRM_FRAMES = 2
+"""Frames the new pitch has to hold before a split, so one confused frame is not a note."""
+
+PLACES = 3
+
+
+class Note(NamedTuple):
+    """One note in the line: when it started, when it stopped, its pitch, how loud it read.
+
+    ``hz`` is ``0.0`` for an event with no fundamental to find — a rimshot that leaked into
+    the residual, a cymbal wash — which is an honest reading rather than a missing one: it
+    still has a start, an end and a length, and those are what the rest and held cues need.
+    """
+
+    seconds: float
+    end: float
+    hz: float
+    strength: float
+
+    @property
+    def held(self) -> float:
+        """How long the note sounded for."""
+        return round(self.end - self.seconds, PLACES)
+
+
+Reader = Callable[[Path], "tuple[Note, ...]"]
+"""Turn one melodic stem into the notes in it, in any order."""
+
+
+class Frame(NamedTuple):
+    """One analysis frame, dated at its centre: how loud it was and what pitch it held."""
+
+    seconds: float
+    level: float
+    hz: float
+
+
+def read(stem: Path | str, reader: Reader | None = None) -> tuple[Note, ...]:
+    """Every note in the stem, earliest first.
+
+    A reader that falls over is an ``analysis_failed`` rather than an internal error, for the
+    same reason a beat model that falls over is: the agent can act on it, and it is not a bug
+    in this server.
+    """
+    chosen = reader or pitched_reader
+    target = Path(stem)
+    try:
+        notes = chosen(target)
+    except ResolveMcpError:
+        raise
+    except Exception as exc:
+        raise AnalysisFailedError(
+            cause=f"Reading the melodic line failed: {type(exc).__name__}: {exc}.",
+            detail={"stem": str(target)},
+        ) from exc
+    return tuple(sorted(notes, key=lambda one: (one.seconds, one.end)))
+
+
+def pitched_reader(stem: Path) -> tuple[Note, ...]:
+    """The default: frame the stem, gate it on its own peak, and pitch what is sounding."""
+    from . import decode
+
+    audio = decode.read(stem)
+    found = notes(framed(audio))
+    log.info("Read %d notes off the %s stem", len(found), stem.name)
+    return found
+
+
+def pitch(samples: NDArray[np.floating[Any]], sample_rate: int) -> float:
+    """The fundamental of one frame in Hz, or ``0.0`` if it does not read as pitched."""
+    frame = np.asarray(samples, dtype=np.float64)
+    if frame.size < 2 or sample_rate <= 0:
+        return 0.0
+    frame = frame - frame.mean()
+
+    padded = 1 << int(math.ceil(math.log2(frame.size * 2)))
+    spectrum = np.fft.rfft(frame, padded)
+    correlation = np.fft.irfft(spectrum * np.conjugate(spectrum), padded)[: frame.size]
+    if correlation[0] <= 0.0:
+        return 0.0
+
+    lowest = max(int(sample_rate / MAXIMUM_HZ), 1)
+    highest = min(int(sample_rate / MINIMUM_HZ), frame.size - 2)
+    if highest <= lowest:
+        return 0.0
+
+    lags = np.arange(lowest, highest + 1)
+    # The taper divided out, so one clarity threshold means the same thing across the range.
+    normalised = correlation[lowest : highest + 1] / (frame.size - lags)
+
+    peaks = _peaks(normalised)
+    if peaks.size == 0:
+        return 0.0
+    strongest = float(normalised[peaks].max())
+    if strongest < CLARITY * (float(correlation[0]) / frame.size):
+        return 0.0
+
+    qualifying = peaks[normalised[peaks] >= OCTAVE_MARGIN * strongest]
+    return _interpolated(correlation, int(qualifying[0]) + lowest, sample_rate)
+
+
+def _peaks(normalised: NDArray[np.float64]) -> NDArray[np.intp]:
+    """The local maxima, which are the only lags that are candidate periods.
+
+    Peaks and not merely "the first lag above the margin": below about a fifth of the way up
+    the range, the shoulder of the lag-zero peak has not fallen off yet by the time the search
+    starts, so the very first lag looked at is already within the margin of the real peak
+    further out. Taking it reports the bottom of the search range as the pitch of every low
+    note — which is how a G below the stave read as unpitched before this was a rule.
+    """
+    rising = normalised[1:-1] > normalised[:-2]
+    falling = normalised[1:-1] >= normalised[2:]
+    return np.flatnonzero(rising & falling) + 1
+
+
+def _interpolated(correlation: NDArray[np.float64], peak: int, sample_rate: int) -> float:
+    """The peak read off the parabola through it and its neighbours, not off the sample it fell on.
+
+    A lag is a whole sample, which at the top of the range is a semitone wide; the three
+    points around the peak place it far more finely than that for the cost of one division.
+    """
+    left, middle, right = correlation[peak - 1], correlation[peak], correlation[peak + 1]
+    bend = 2.0 * (2.0 * middle - left - right)
+    period = peak + (float(right - left) / bend if bend else 0.0)
+    return float(sample_rate / period) if period > 0.0 else 0.0
+
+
+def framed(audio: Audio) -> tuple[Frame, ...]:
+    """The stem as overlapping frames, each dated at its centre, pitched where it is sounding.
+
+    Pitch is only estimated for frames loud enough to be part of a note, because it is the
+    expensive half and a concert is mostly not this stem playing.
+    """
+    mono = np.asarray(audio.mono(), dtype=np.float64)
+    width = max(int(FRAME_SECONDS * audio.sample_rate), 2)
+    hop = max(int(HOP_SECONDS * audio.sample_rate), 1)
+    if mono.size < width or audio.sample_rate <= 0:
+        return ()
+
+    middle = width / 2.0 / audio.sample_rate
+    starts = range(0, mono.size - width + 1, hop)
+    blocks = [mono[first : first + width] for first in starts]
+    levels = [float(np.sqrt(np.mean(block * block))) for block in blocks]
+    peak = max(levels, default=0.0)
+    if peak <= SILENCE:
+        return ()
+
+    floor = peak * RELEASE_GATE
+    return tuple(
+        Frame(
+            seconds=first / audio.sample_rate + middle,
+            level=level,
+            hz=pitch(block, audio.sample_rate) if level >= floor else 0.0,
+        )
+        for first, block, level in zip(starts, blocks, levels, strict=True)
+    )
+
+
+def notes(frames: Sequence[Frame]) -> tuple[Note, ...]:
+    """The frames grouped into notes: gated into runs, then split where the pitch moves."""
+    peak = max((frame.level for frame in frames), default=0.0)
+    if peak <= SILENCE:
+        return ()
+
+    found: list[Note] = []
+    for first, last in _sounding(frames, peak * ONSET_GATE, peak * RELEASE_GATE):
+        spans = _split(frames, first, last)
+        for index, (begin, end) in enumerate(spans):
+            note = _note(
+                frames,
+                begin,
+                end,
+                opens=index == 0,
+                closes=index == len(spans) - 1,
+            )
+            if note is not None:
+                found.append(note)
+    return tuple(found)
+
+
+def _sounding(
+    frames: Sequence[Frame],
+    start_gate: float,
+    stop_gate: float,
+) -> list[tuple[int, int]]:
+    """Runs of frames the line is sounding in — opened at one gate, closed at the lower one."""
+    runs: list[tuple[int, int]] = []
+    first: int | None = None
+    for index, frame in enumerate(frames):
+        if first is None:
+            if frame.level >= start_gate:
+                first = index
+        elif frame.level < stop_gate:
+            runs.append((first, index - 1))
+            first = None
+    if first is not None:
+        runs.append((first, len(frames) - 1))
+    return runs
+
+
+def _split(frames: Sequence[Frame], first: int, last: int) -> list[tuple[int, int]]:
+    """One sounding run cut where the pitch settles somewhere new — legato notes are still notes.
+
+    The reference is the first pitched frame of the span and is not re-read as the span goes
+    on, so vibrato cannot walk it: a note that wanders half a semitone stays one note, and a
+    line that steps stays two.
+    """
+    spans: list[tuple[int, int]] = []
+    begin = first
+    reference = 0.0
+    moved = 0
+    for index in range(first, last + 1):
+        hertz = frames[index].hz
+        if hertz <= 0.0:
+            moved = 0
+            continue
+        if reference <= 0.0:
+            reference = hertz
+            continue
+        if abs(semitones(reference, hertz)) < SPLIT_SEMITONES:
+            moved = 0
+            continue
+        moved += 1
+        if moved >= CONFIRM_FRAMES:
+            spans.append((begin, index - moved))
+            begin = index - moved + 1
+            reference = hertz
+            moved = 0
+    spans.append((begin, last))
+    return spans
+
+
+def _note(
+    frames: Sequence[Frame],
+    first: int,
+    last: int,
+    opens: bool,
+    closes: bool,
+) -> Note | None:
+    """One span of frames as a note, with the gate's half-window overhang taken back off.
+
+    ``opens`` and ``closes`` say whether this span is at the outer edge of a sounding run. Only
+    there does the gate overhang apply — a split inside a run sits where the pitch changed,
+    which is already the right time.
+    """
+    span = frames[first : last + 1]
+    if not span:
+        return None
+    reach = FRAME_SECONDS / 2.0
+    start = span[0].seconds + (reach if opens else 0.0)
+    end = span[-1].seconds - (reach if closes else 0.0)
+    if end - start < MINIMUM_SECONDS:
+        return None
+    pitched = [one.hz for one in span if one.hz > 0.0]
+    return Note(
+        seconds=round(start, PLACES),
+        end=round(end, PLACES),
+        hz=round(statistics.median(pitched), 2) if pitched else 0.0,
+        strength=round(min(max(one.level for one in span), 1.0), 4),
+    )
+
+
+def semitones(before: float, after: float) -> float:
+    """How far the line moved, in semitones. ``0.0`` when either end has no pitch to move from."""
+    if before <= 0.0 or after <= 0.0:
+        return 0.0
+    return 12.0 * math.log2(after / before)

--- a/src/resolve_mcp/analysis/phrases.py
+++ b/src/resolve_mcp/analysis/phrases.py
@@ -81,7 +81,16 @@ HELD_MULTIPLE = 1.6
 LONG_MULTIPLE = 3.0
 """The ratio at which the held factor is fully convinced."""
 RESET_SEMITONES = 7.0
-"""A fifth. Both the leap that nominates a boundary and the leap that fully convinces one."""
+"""A fifth: the leap at which a contour reset is worth weighing at all."""
+RESET_FULL_SEMITONES = 12.0
+"""An octave, at which the contour factor is as convinced as it gets.
+
+Apart from ``RESET_SEMITONES`` on purpose, the way ``HELD_MULTIPLE`` is apart from
+``LONG_MULTIPLE`` and ``REST_BEATS`` from ``REST_FULL_BEATS``. One threshold doing both jobs
+makes the factor binary — every leap that nominates also saturates — and a cue that is only
+ever 0 or 1 cannot be turned down by any floor. A bare fifth should read as the marginal
+evidence it is.
+"""
 MINIMUM_PHRASE_BEATS = 2.0
 """Half a bar in four. Two endings closer than this are one ending, heard twice."""
 SNAP_BEATS = 1.0
@@ -163,8 +172,7 @@ def boundaries(
     times = [float(row["t"]) for row in rows]
     steps = [later - earlier for earlier, later in zip(times, times[1:], strict=False)]
     usable = [one for one in steps if one > 0]
-    lengths = [one.end - one.seconds for one in played]
-    baseline = statistics.median(lengths)
+    baseline = statistics.median([one.held for one in played])
     if not usable or baseline <= 0:
         # No tempo to measure a rest in, or no note that lasted: nothing here can be read.
         return Detection((), 0, 0, 0.0)
@@ -223,7 +231,7 @@ def _weighed(reading: Reading, index: int, anchor: int) -> Boundary:
     factors = {
         "rest": 1.0 if rest is None else _clamp(rest / (REST_FULL_BEATS * reading.beat)),
         "held": _clamp((note.held / reading.baseline - 1.0) / (LONG_MULTIPLE - 1.0)),
-        "contour": 0.0 if leap is None else _clamp(abs(leap) / RESET_SEMITONES),
+        "contour": 0.0 if leap is None else _clamp(abs(leap) / RESET_FULL_SEMITONES),
         "grid": beats_module.bar_line_strength(row),
     }
     return Boundary(
@@ -301,10 +309,15 @@ def scored(factors: Mapping[str, float]) -> float:
     So the strongest cue carries the reading, the other two add on top when they corroborate
     it, and the grid is scored separately because it is not evidence that a phrase ended at
     all — only that this is a frame worth cutting on.
+
+    The grid's quarter cannot manufacture a boundary out of nothing, because scoring only ever
+    happens to an ending some cue already nominated (``_nominated``). What it can do is carry a
+    marginal cue that lands on a bar line over the floor, and that is the intended reading: a
+    breath at the top of a four-bar group is likelier to be a phrase than the same breath in
+    the middle of bar three.
     """
     ranked = sorted((factors[name] for name in CUES), reverse=True)
-    others = ranked[1:]
-    agreement = sum(others) / len(others) if others else 0.0
+    agreement = sum(ranked[1:]) / (len(CUES) - 1)
     return _clamp(
         CUE_WEIGHT * ranked[0] + AGREEMENT_WEIGHT * agreement + GRID_WEIGHT * factors["grid"]
     )
@@ -393,7 +406,7 @@ def detect_phrases(
     config = config or get_config()
     source = _readable(audio)
     found = _stem(stems, stem)
-    halves.sane_floor(minimum_confidence, DEFAULT_MINIMUM_CONFIDENCE)
+    halves.sane_floor(minimum_confidence, DEFAULT_MINIMUM_CONFIDENCE, writes="boundary")
 
     settings = {"stem": stem, "minimum_confidence": float(minimum_confidence)}
     identity = cache.identity(source, config.audio_dir)

--- a/src/resolve_mcp/analysis/phrases.py
+++ b/src/resolve_mcp/analysis/phrases.py
@@ -84,13 +84,17 @@ RESET_SEMITONES = 7.0
 """A fifth. Both the leap that nominates a boundary and the leap that fully convinces one."""
 MINIMUM_PHRASE_BEATS = 2.0
 """Half a bar in four. Two endings closer than this are one ending, heard twice."""
-PHRASE_BARS = 4
-"""Bars to the phrase, as ``fills`` counts them — an ending into bar 5 of 8 is the strong one."""
-PHRASE_AT_BAR_LINE = 0.6
-PHRASE_MID_BAR = 0.15
 SNAP_BEATS = 1.0
 """How far the called placement may move to reach the grid before it stops being the same event."""
-WEIGHTS = {"rest": 0.35, "held": 0.25, "contour": 0.15, "grid": 0.25}
+
+CUES = ("rest", "held", "contour")
+"""The three ways of hearing an ending. Each stands alone; see ``_scored``."""
+CUE_WEIGHT = 0.55
+"""What the strongest cue is worth by itself — enough to clear any floor worth having."""
+AGREEMENT_WEIGHT = 0.2
+"""What the other two cues add when they agree with it."""
+GRID_WEIGHT = 0.25
+"""What the placement is worth. Scored apart from the cues, because it is not evidence."""
 DEFAULT_MINIMUM_CONFIDENCE = 0.35
 """Below this a boundary is counted but not written — the floor on what is worth reading."""
 
@@ -174,13 +178,13 @@ def boundaries(
         if not _nominated(reading, index):
             continue
         considered += 1
-        candidate = _weighed(reading, index)
+        candidate = _weighed(reading, index, anchor)
         if candidate.confidence < minimum_confidence:
             continue
         if kept and candidate.measured - kept[-1].measured < MINIMUM_PHRASE_BEATS * reading.beat:
             dropped += 1
             continue
-        kept.append(candidate._replace(notes=index - anchor))
+        kept.append(candidate)
         anchor = index
     return Detection(tuple(kept), considered, dropped, baseline)
 
@@ -198,30 +202,29 @@ def _nominated(reading: Reading, index: int) -> bool:
     leap = _interval(reading, index)
     return (
         rest >= REST_BEATS * reading.beat
-        or (note.end - note.seconds) >= HELD_MULTIPLE * reading.baseline
+        or note.held >= HELD_MULTIPLE * reading.baseline
         or (leap is not None and abs(leap) >= RESET_SEMITONES)
     )
 
 
-def _weighed(reading: Reading, index: int) -> Boundary:
+def _weighed(reading: Reading, index: int, anchor: int) -> Boundary:
     """One note ending turned into a boundary: where it is called, and how sure the rules are.
 
-    ``notes`` is filled in by the caller, which is the only thing that knows where the phrase
-    this one closes began.
+    ``anchor`` is the note index the previous boundary closed on, or ``-1`` before there is
+    one — the only thing that knows where the phrase this ending closes began.
     """
     note = reading.notes[index]
     rest = _rest(reading, index)
     resumes = reading.notes[index + 1].seconds if index + 1 < len(reading.notes) else None
     leap = _interval(reading, index)
-    held = note.end - note.seconds
     called, snapped = _placed(reading, note.end, resumes)
     row = _at(reading, called)
 
     factors = {
         "rest": 1.0 if rest is None else _clamp(rest / (REST_FULL_BEATS * reading.beat)),
-        "held": _clamp((held / reading.baseline - 1.0) / (LONG_MULTIPLE - 1.0)),
+        "held": _clamp((note.held / reading.baseline - 1.0) / (LONG_MULTIPLE - 1.0)),
         "contour": 0.0 if leap is None else _clamp(abs(leap) / RESET_SEMITONES),
-        "grid": _phrase(row),
+        "grid": beats_module.bar_line_strength(row),
     }
     return Boundary(
         seconds=round(called, PLACES),
@@ -233,14 +236,12 @@ def _weighed(reading: Reading, index: int) -> Boundary:
         in_bar=int(row["in_bar"]) if row is not None else 0,
         downbeat=bool(row["downbeat"]) if row is not None else False,
         rest=round(rest, PLACES) if rest is not None else None,
-        held=round(held, PLACES),
-        held_ratio=round(held / reading.baseline, PLACES),
+        held=note.held,
+        held_ratio=round(note.held / reading.baseline, PLACES),
         interval=round(leap, 2) if leap is not None else None,
-        notes=0,
+        notes=index - anchor,
         factors={name: round(value, PLACES) for name, value in factors.items()},
-        confidence=round(
-            _clamp(sum(WEIGHTS[name] * value for name, value in factors.items())), PLACES
-        ),
+        confidence=round(scored(factors), PLACES),
     )
 
 
@@ -286,11 +287,27 @@ def _at(reading: Reading, seconds: float) -> Mapping[str, Any] | None:
     return reading.grid[index] if 0 <= index < len(reading.grid) else None
 
 
-def _phrase(row: Mapping[str, Any] | None) -> float:
-    """An ending on the top of a four-bar phrase is a stronger placement than one mid-bar."""
-    if row is None or not row["downbeat"]:
-        return PHRASE_MID_BAR
-    return 1.0 if (int(row["bar"]) - 1) % PHRASE_BARS == 0 else PHRASE_AT_BAR_LINE
+def scored(factors: Mapping[str, float]) -> float:
+    """The confidence. The three cues stand in for each other, so they are not added up.
+
+    ``fills`` sums four weighted factors, and that is right for a drum fill: its density, its
+    tom share and its resolution all describe the same burst *at once*, so a burst missing one
+    of them really is a weaker candidate. The cues here are alternatives. A phrase can end on a
+    rest with no leap and no held note and it has still ended — and under a weighted sum a
+    single saturated cue is divided by the three that were never going to fire, landing below
+    any floor worth having. That is not a timid reading; it is a detector that only hears
+    rests, which is two thirds of what this ticket asked for silently missing.
+
+    So the strongest cue carries the reading, the other two add on top when they corroborate
+    it, and the grid is scored separately because it is not evidence that a phrase ended at
+    all — only that this is a frame worth cutting on.
+    """
+    ranked = sorted((factors[name] for name in CUES), reverse=True)
+    others = ranked[1:]
+    agreement = sum(others) / len(others) if others else 0.0
+    return _clamp(
+        CUE_WEIGHT * ranked[0] + AGREEMENT_WEIGHT * agreement + GRID_WEIGHT * factors["grid"]
+    )
 
 
 def _clamp(value: float) -> float:
@@ -298,7 +315,13 @@ def _clamp(value: float) -> float:
 
 
 def rows(detection: Detection) -> tuple[dict[str, Any], ...]:
-    """One flat record per boundary — both placements, so a cut can use either."""
+    """One flat record per boundary — both placements, so a cut can use either.
+
+    The record keys are ``solos.numbered``'s and not this module's field names: ``t`` for the
+    time an event is called on and ``measured_t`` for where it was seen is what every record
+    file in this stack already says, and a boundary is the same kind of thing as a solo change.
+    A reader who greps one analysis document should not have to learn a second vocabulary.
+    """
     return tuple(
         {
             "t": one.seconds,
@@ -370,7 +393,7 @@ def detect_phrases(
     config = config or get_config()
     source = _readable(audio)
     found = _stem(stems, stem)
-    _sane_floor(minimum_confidence)
+    halves.sane_floor(minimum_confidence, DEFAULT_MINIMUM_CONFIDENCE)
 
     settings = {"stem": stem, "minimum_confidence": float(minimum_confidence)}
     identity = cache.identity(source, config.audio_dir)
@@ -470,15 +493,6 @@ def _collected(directory: Path) -> dict[str, Path]:
         if found:
             return found
     return {}
-
-
-def _sane_floor(minimum_confidence: float) -> None:
-    if not 0.0 <= minimum_confidence <= 1.0:
-        raise InvalidRequestError(
-            cause="The confidence floor is a fraction between 0 and 1.",
-            fix=f"The default is {DEFAULT_MINIMUM_CONFIDENCE}; 0 writes every boundary.",
-            detail={"minimum_confidence": minimum_confidence},
-        )
 
 
 def _key(

--- a/src/resolve_mcp/analysis/phrases.py
+++ b/src/resolve_mcp/analysis/phrases.py
@@ -1,0 +1,546 @@
+"""Phrase boundaries: where the soloist stops talking, which is where a cut goes.
+
+The #46 director round said this more clearly than any spec did: the phrase is the
+cut-placement unit. Ten-plus of its fifty-five notes move a cut to "after the sax's
+phrase" or "between phrases", and transient distance — the thing the stack could
+already measure — turned out to be the *residue* of that rule rather than the rule. Nothing
+in the analysis stack named a phrase, so an authoring agent read them by ear off the mix and
+a reviewing agent could not check phrase placement at all. This is the measurement that makes
+both possible.
+
+A phrase ends when the player stops, and there are three ways to hear that:
+
+* **The rest.** The plainest one and the strongest: the line goes quiet and comes back. The
+  gap is measured in beats rather than seconds, because half a second is a breath at 80 and
+  an entire bar at 200.
+* **The held note.** A phrase very often ends on its longest note — the player leans on the
+  last one and lets it ring. So a note much longer than the median note *of this solo* is
+  evidence of an ending even when the next note comes straight in on top of it.
+* **The contour reset.** A new phrase usually does not start where the last one left off; it
+  jumps, most often up and back to the top of the range. A leap of a fifth or more across a
+  note ending is the third cue, and it is the one that catches an ending with no rest and no
+  ritard at all.
+
+Any single cue nominates; all four factors (the three above plus where the ending lands on
+the grid) then score it, exactly as ``fills`` scores a drum-fill candidate, and for the same
+reason: this file reports a reading with a confidence, and whether a given ending is the end
+of a chorus, a breath mid-sentence or the tenor stopping to let the piano answer is the
+reading agent's call.
+
+Two placements are reported, and the distinction matters for cutting. ``measured`` is where
+the line actually stopped. ``seconds`` is where the cut is *called*: the first beat of the
+grid that falls inside the rest, because that is the frame an editor puts the cut on and a
+phrase ending three hundredths of a beat before it is the same event. When no beat falls in
+the rest the nearest one within ``SNAP_BEATS`` stands in, and past that the measured time is
+reported unsnapped and says so — the same rule ``solos`` uses for a change point, and for the
+same reason.
+
+What no seam here covers: whether these boundaries are the ones a *director* would name. The
+fake tier proves the rules fire on audio whose phrasing is known because it was written; only
+the #46 tune, whose phrase-motivated cut points are annotated record frames, can say whether
+the reading agrees with a human ear. That evaluation is a live-ish pass over real media and
+belongs on the ticket, not in this module's tests.
+"""
+
+from __future__ import annotations
+
+import bisect
+import statistics
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from ..audio import separator, wav
+from ..audio.stems import FOUR_STEMS, MIX_PASS
+from ..config import Config, get_config
+from ..errors import InvalidRequestError
+from ..jobs import cache
+from ..jobs.runner import JobOutput, Progress, start_job
+from ..logging_config import get_logger
+from ..naming import slug
+from . import beats as beats_module
+from . import halves, melody, music, records, solos
+
+log = get_logger("analysis")
+
+KIND = "detect_phrases"
+PHRASES = "phrases"
+PLACES = 3
+
+DEFAULT_STEM = solos.RESIDUAL
+"""``other`` — the stem the horns and the piano land in, which is where a solo is."""
+MELODY_STEMS = (solos.RESIDUAL, "vocals")
+"""The stems a line is plausibly in. Naming another is allowed and logged, not refused."""
+
+REST_BEATS = 0.5
+"""A gap this wide is the player breathing rather than tonguing the next note."""
+REST_FULL_BEATS = 2.0
+"""The gap at which the rest factor is already as convinced as it gets."""
+HELD_MULTIPLE = 1.6
+"""How much longer than the median note a note must be before its length nominates it."""
+LONG_MULTIPLE = 3.0
+"""The ratio at which the held factor is fully convinced."""
+RESET_SEMITONES = 7.0
+"""A fifth. Both the leap that nominates a boundary and the leap that fully convinces one."""
+MINIMUM_PHRASE_BEATS = 2.0
+"""Half a bar in four. Two endings closer than this are one ending, heard twice."""
+PHRASE_BARS = 4
+"""Bars to the phrase, as ``fills`` counts them — an ending into bar 5 of 8 is the strong one."""
+PHRASE_AT_BAR_LINE = 0.6
+PHRASE_MID_BAR = 0.15
+SNAP_BEATS = 1.0
+"""How far the called placement may move to reach the grid before it stops being the same event."""
+WEIGHTS = {"rest": 0.35, "held": 0.25, "contour": 0.15, "grid": 0.25}
+DEFAULT_MINIMUM_CONFIDENCE = 0.35
+"""Below this a boundary is counted but not written — the floor on what is worth reading."""
+
+
+class Boundary(NamedTuple):
+    """One phrase ending. ``seconds`` is where it is called; ``measured`` is where it was heard."""
+
+    seconds: float
+    measured: float
+    resumes: float | None
+    snapped: bool
+    beat: int
+    bar: int
+    in_bar: int
+    downbeat: bool
+    rest: float | None
+    held: float
+    held_ratio: float
+    interval: float | None
+    notes: int
+    factors: dict[str, float]
+    confidence: float
+
+
+class Detection(NamedTuple):
+    """What was kept, what was weighed, and the note length everything was weighed against."""
+
+    boundaries: tuple[Boundary, ...]
+    considered: int
+    dropped: int
+    baseline: float
+
+
+class Reading(NamedTuple):
+    """The solo as the rules see it: the line, the grid, and the two norms they are measured on.
+
+    Every rule needs several of these and all of them come off the same two inputs, so they
+    travel as one thing rather than as five arguments in the same order.
+    """
+
+    notes: Sequence[melody.Note]
+    grid: Sequence[Mapping[str, Any]]
+    times: Sequence[float]
+    beat: float
+    baseline: float
+
+
+# --- the rule layer -----------------------------------------------------------------
+
+
+def boundaries(
+    notes: Sequence[melody.Note],
+    grid: Sequence[Mapping[str, Any]],
+    minimum_confidence: float = DEFAULT_MINIMUM_CONFIDENCE,
+) -> Detection:
+    """Phrase boundaries over ``notes``, placed against the numbered beat ``grid``.
+
+    ``grid`` is what ``beats.numbered`` produces and the beats half writes: one record per
+    beat carrying its time, bar and whether it starts one.
+    """
+    played = sorted(notes, key=lambda one: (one.seconds, one.end))
+    rows = list(grid)
+    if len(played) < 2 or len(rows) < 2:
+        return Detection((), 0, 0, 0.0)
+
+    times = [float(row["t"]) for row in rows]
+    steps = [later - earlier for earlier, later in zip(times, times[1:], strict=False)]
+    usable = [one for one in steps if one > 0]
+    lengths = [one.end - one.seconds for one in played]
+    baseline = statistics.median(lengths)
+    if not usable or baseline <= 0:
+        # No tempo to measure a rest in, or no note that lasted: nothing here can be read.
+        return Detection((), 0, 0, 0.0)
+
+    reading = Reading(played, rows, times, statistics.median(usable), baseline)
+    kept: list[Boundary] = []
+    considered = 0
+    dropped = 0
+    anchor = -1
+    for index in range(len(played)):
+        if not _nominated(reading, index):
+            continue
+        considered += 1
+        candidate = _weighed(reading, index)
+        if candidate.confidence < minimum_confidence:
+            continue
+        if kept and candidate.measured - kept[-1].measured < MINIMUM_PHRASE_BEATS * reading.beat:
+            dropped += 1
+            continue
+        kept.append(candidate._replace(notes=index - anchor))
+        anchor = index
+    return Detection(tuple(kept), considered, dropped, baseline)
+
+
+def _nominated(reading: Reading, index: int) -> bool:
+    """Whether this note ending is worth weighing. Any one of the three cues is enough.
+
+    The last note of the line is always nominated: the player stopped, and whatever else that
+    is, it is the end of a phrase.
+    """
+    rest = _rest(reading, index)
+    if rest is None:
+        return True
+    note = reading.notes[index]
+    leap = _interval(reading, index)
+    return (
+        rest >= REST_BEATS * reading.beat
+        or (note.end - note.seconds) >= HELD_MULTIPLE * reading.baseline
+        or (leap is not None and abs(leap) >= RESET_SEMITONES)
+    )
+
+
+def _weighed(reading: Reading, index: int) -> Boundary:
+    """One note ending turned into a boundary: where it is called, and how sure the rules are.
+
+    ``notes`` is filled in by the caller, which is the only thing that knows where the phrase
+    this one closes began.
+    """
+    note = reading.notes[index]
+    rest = _rest(reading, index)
+    resumes = reading.notes[index + 1].seconds if index + 1 < len(reading.notes) else None
+    leap = _interval(reading, index)
+    held = note.end - note.seconds
+    called, snapped = _placed(reading, note.end, resumes)
+    row = _at(reading, called)
+
+    factors = {
+        "rest": 1.0 if rest is None else _clamp(rest / (REST_FULL_BEATS * reading.beat)),
+        "held": _clamp((held / reading.baseline - 1.0) / (LONG_MULTIPLE - 1.0)),
+        "contour": 0.0 if leap is None else _clamp(abs(leap) / RESET_SEMITONES),
+        "grid": _phrase(row),
+    }
+    return Boundary(
+        seconds=round(called, PLACES),
+        measured=round(note.end, PLACES),
+        resumes=round(resumes, PLACES) if resumes is not None else None,
+        snapped=snapped,
+        beat=int(row["beat"]) if row is not None else 0,
+        bar=int(row["bar"]) if row is not None else 0,
+        in_bar=int(row["in_bar"]) if row is not None else 0,
+        downbeat=bool(row["downbeat"]) if row is not None else False,
+        rest=round(rest, PLACES) if rest is not None else None,
+        held=round(held, PLACES),
+        held_ratio=round(held / reading.baseline, PLACES),
+        interval=round(leap, 2) if leap is not None else None,
+        notes=0,
+        factors={name: round(value, PLACES) for name, value in factors.items()},
+        confidence=round(
+            _clamp(sum(WEIGHTS[name] * value for name, value in factors.items())), PLACES
+        ),
+    )
+
+
+def _rest(reading: Reading, index: int) -> float | None:
+    """Silence between this note's end and the next one's start. ``None`` at the last note."""
+    if index + 1 >= len(reading.notes):
+        return None
+    return max(reading.notes[index + 1].seconds - reading.notes[index].end, 0.0)
+
+
+def _interval(reading: Reading, index: int) -> float | None:
+    """How far the line jumps across this ending, in semitones.
+
+    ``None`` when either side is unpitched: there is no interval to measure, and a made-up one
+    would nominate a cymbal wash as the start of a phrase.
+    """
+    if index + 1 >= len(reading.notes):
+        return None
+    before, after = reading.notes[index].hz, reading.notes[index + 1].hz
+    if before <= 0.0 or after <= 0.0:
+        return None
+    return melody.semitones(before, after)
+
+
+def _placed(reading: Reading, measured: float, resumes: float | None) -> tuple[float, bool]:
+    """Where the cut is called: the first beat inside the rest, or the nearest beat to the ending.
+
+    Inside the rest by preference, because that is the only stretch of the timeline where
+    nothing is playing and a cut there lands between the phrases rather than over one of them.
+    """
+    index = bisect.bisect_left(reading.times, measured)
+    if index < len(reading.times) and (resumes is None or reading.times[index] <= resumes):
+        return reading.times[index], True
+    near = beats_module.nearest(reading.times, measured)
+    if near is not None and abs(reading.times[near] - measured) <= SNAP_BEATS * reading.beat:
+        return reading.times[near], True
+    return measured, False
+
+
+def _at(reading: Reading, seconds: float) -> Mapping[str, Any] | None:
+    """The beat the called placement sits in, so a boundary can be named by bar and beat."""
+    index = bisect.bisect_right(reading.times, seconds) - 1
+    return reading.grid[index] if 0 <= index < len(reading.grid) else None
+
+
+def _phrase(row: Mapping[str, Any] | None) -> float:
+    """An ending on the top of a four-bar phrase is a stronger placement than one mid-bar."""
+    if row is None or not row["downbeat"]:
+        return PHRASE_MID_BAR
+    return 1.0 if (int(row["bar"]) - 1) % PHRASE_BARS == 0 else PHRASE_AT_BAR_LINE
+
+
+def _clamp(value: float) -> float:
+    return min(max(value, 0.0), 1.0)
+
+
+def rows(detection: Detection) -> tuple[dict[str, Any], ...]:
+    """One flat record per boundary — both placements, so a cut can use either."""
+    return tuple(
+        {
+            "t": one.seconds,
+            "measured_t": one.measured,
+            "resumes_t": one.resumes,
+            "snapped": one.snapped,
+            "beat": one.beat,
+            "bar": one.bar,
+            "in_bar": one.in_bar,
+            "downbeat": one.downbeat,
+            "rest_seconds": one.rest,
+            "held_seconds": one.held,
+            "held_ratio": one.held_ratio,
+            "interval_semitones": one.interval,
+            "notes": one.notes,
+            "confidence": one.confidence,
+            "factors": one.factors,
+        }
+        for one in detection.boundaries
+    )
+
+
+def gist(
+    detection: Detection,
+    minimum_confidence: float,
+    stem: str,
+    notes: int,
+) -> dict[str, Any]:
+    """The stats worth returning inline: how many phrases, how long, how sure, and on what."""
+    kept = detection.boundaries
+    strongest = max(kept, key=lambda one: one.confidence) if kept else None
+    spans = [
+        later.measured - earlier.measured for earlier, later in zip(kept, kept[1:], strict=False)
+    ]
+    return {
+        "count": len(kept),
+        "considered": detection.considered,
+        "below_confidence": detection.considered - len(kept) - detection.dropped,
+        "too_soon_dropped": detection.dropped,
+        "minimum_confidence": round(minimum_confidence, PLACES),
+        "median_note_seconds": round(detection.baseline, PLACES),
+        "median_phrase_seconds": round(statistics.median(spans), PLACES) if spans else None,
+        "notes": notes,
+        "stem": stem,
+        "snapped": sum(1 for one in kept if one.snapped),
+        "mean_confidence": (
+            round(statistics.mean(one.confidence for one in kept), PLACES) if kept else None
+        ),
+        "strongest": (
+            {"t": strongest.seconds, "confidence": strongest.confidence} if strongest else None
+        ),
+    }
+
+
+# --- the job ------------------------------------------------------------------------
+
+
+def detect_phrases(
+    stems: Mapping[str, str | Path] | str | Path,
+    audio: str | Path,
+    stem: str = DEFAULT_STEM,
+    minimum_confidence: float = DEFAULT_MINIMUM_CONFIDENCE,
+    refresh: bool = False,
+    detector: beats_module.Detector | None = None,
+    reader: melody.Reader | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Start the phrase job. Returns the job record, not the boundaries."""
+    config = config or get_config()
+    source = _readable(audio)
+    found = _stem(stems, stem)
+    _sane_floor(minimum_confidence)
+
+    settings = {"stem": stem, "minimum_confidence": float(minimum_confidence)}
+    identity = cache.identity(source, config.audio_dir)
+    key = _key(identity, stem, found, settings)
+
+    def work(progress: Progress) -> JobOutput:
+        return detect(
+            source,
+            found,
+            settings,
+            progress,
+            key=key,
+            identity=identity,
+            detector=detector,
+            reader=reader,
+            refresh=refresh,
+            config=config,
+        )
+
+    return start_job(
+        KIND,
+        {"audio": source.name, **settings},
+        work,
+        cache_key=key,
+        refresh=refresh,
+        config=config,
+    )
+
+
+def _readable(audio: str | Path) -> Path:
+    return halves.readable(
+        audio,
+        "Pass the master mix the stems were separated from — the beat grid comes from it, "
+        "and phrase boundaries are placed against that grid.",
+    )
+
+
+def _stem(stems: Mapping[str, str | Path] | str | Path, wanted: str) -> Path:
+    """The one stem the line is read off, from a separation's directory or from named paths.
+
+    One stem and not the kit: a phrase belongs to a player, and mixing two stems back together
+    to look for it would undo exactly what separation was for.
+    """
+    if isinstance(stems, str | Path):
+        found = _collected(Path(stems))
+    else:
+        found = {str(label): Path(path) for label, path in stems.items()}
+
+    chosen = found.get(wanted)
+    if chosen is None:
+        raise InvalidRequestError(
+            cause=f"There is no {wanted} stem to read the line off.",
+            fix=(
+                "Pass the directory a separate_stems job reported — its first pass writes "
+                f"{', '.join(FOUR_STEMS)} — or name one of the stems that is there with the "
+                "stem argument."
+            ),
+            detail={"wanted": wanted, "found": sorted(found)},
+        )
+    if not chosen.is_file():
+        raise InvalidRequestError(
+            cause=f"The {wanted} stem is not on disk: {chosen}.",
+            fix=(
+                "Run separate_stems again — the cache drops an entry whose files went missing, "
+                "so asking for them redoes the separation."
+            ),
+            detail={"stem": str(chosen)},
+        )
+    if wanted not in MELODY_STEMS:
+        # Not refused: a director with a real horn stem should not have to argue with this.
+        # But bass and drums hold a line only in the sense that everything does, and a document
+        # read back weeks later should say which stem produced these phrases.
+        log.warning(
+            "Reading phrases off the %s stem, which is not one of %s — expect a busy reading",
+            wanted,
+            ", ".join(MELODY_STEMS),
+        )
+    return chosen
+
+
+def _collected(directory: Path) -> dict[str, Path]:
+    """The stems under a separation's directory — the four-stem pass, or the parent of it.
+
+    A separation writes its two passes into ``<directory>/mix`` and ``<directory>/drums``, and
+    the job reports the parent. The melodic stems are in the first pass, so that is looked in
+    first; the parent itself is checked too, because a director who copied the stems into a
+    folder of their own should not have to name a subdirectory that is not there.
+    """
+    if not directory.is_dir():
+        raise InvalidRequestError(
+            cause=f"There is no directory at {directory}.",
+            fix="Pass the directory a separate_stems job reported, or the mix pass inside it.",
+            detail={"requested": str(directory)},
+        )
+    for candidate in (directory / MIX_PASS, directory):
+        found = separator.collect(candidate)
+        if found:
+            return found
+    return {}
+
+
+def _sane_floor(minimum_confidence: float) -> None:
+    if not 0.0 <= minimum_confidence <= 1.0:
+        raise InvalidRequestError(
+            cause="The confidence floor is a fraction between 0 and 1.",
+            fix=f"The default is {DEFAULT_MINIMUM_CONFIDENCE}; 0 writes every boundary.",
+            detail={"minimum_confidence": minimum_confidence},
+        )
+
+
+def _key(
+    identity: Mapping[str, Any],
+    stem: str,
+    path: Path,
+    settings: Mapping[str, Any],
+) -> str:
+    """The job's key. One function, because the starter and the worker must agree on it.
+
+    The stem is fingerprinted rather than hashed, which is the one place this pillar departs
+    from "hash what the server wrote" — see ADR 0003.
+    """
+    inputs = [dict(identity), {"stem": stem, **cache.fingerprint(path)}]
+    return cache.cache_key(KIND, inputs, dict(settings))
+
+
+def detect(
+    source: Path,
+    stem: Path,
+    settings: Mapping[str, Any],
+    progress: Progress,
+    key: str | None = None,
+    identity: Mapping[str, Any] | None = None,
+    detector: beats_module.Detector | None = None,
+    reader: melody.Reader | None = None,
+    refresh: bool = False,
+    config: Config | None = None,
+) -> JobOutput:
+    """The worker: the grid, then the line, then the rules over both.
+
+    The grid comes from the half ``analyze_music`` writes, under that half's own key: a master
+    the agent already ran music analysis over does not pay for the beat model a second time
+    (#22, story 26).
+    """
+    config = config or get_config()
+    config.analysis_dir.mkdir(parents=True, exist_ok=True)
+    described = wav.describe(source)
+    known = dict(identity) if identity is not None else cache.identity(source, config.audio_dir)
+    label = str(settings["stem"])
+    key = key or _key(known, label, stem, settings)
+
+    progress(0.05, "reading the beat grid")
+    grid = music.numbered_beats(source, described, known, detector, refresh, config)
+
+    progress(0.25, "reading the melodic line")
+    notes = melody.read(stem, reader)
+
+    progress(0.8, "looking for phrase boundaries")
+    floor = float(settings["minimum_confidence"])
+    detection = boundaries(notes, grid, floor)
+    summary = gist(detection, floor, label, len(notes))
+
+    progress(0.9, "writing the boundaries")
+    target = config.analysis_dir / f"{slug(source.stem, 'analysis')}-{key[:12]}-{PHRASES}.json"
+    header = {
+        "kind": PHRASES,
+        "audio": described["path"],
+        "duration_seconds": described["duration_seconds"],
+        **summary,
+    }
+    records.write(target, header, PHRASES, rows(detection))
+
+    progress(0.95, "written")
+    return JobOutput({"path": str(target), **summary}, (target,))

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -13,6 +13,7 @@ from ..analysis import (
     correlate,
     fills,
     music,
+    phrases,
     silence,
     solos,
     structure,
@@ -258,11 +259,53 @@ def detect_drum_fills(
     }
 
 
+@tool
+def detect_phrases(
+    stems: str,
+    audio: str,
+    stem: str = phrases.DEFAULT_STEM,
+    minimum_confidence: float = phrases.DEFAULT_MINIMUM_CONFIDENCE,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    """Start phrase-boundary detection over the soloist's stem. Returns a job to poll.
+
+    The phrase is the cut-placement unit: a director says "cut after the sax's phrase" far
+    more often than they name a beat. This finds those endings. stems is the directory a
+    separate_stems job reported; stem names which one holds the line, and defaults to other —
+    the stem the horns and the piano land in. audio is the master mix those stems came from:
+    boundaries are placed against its beat grid, and if music analysis already ran over it the
+    beats come from cache rather than the model again.
+
+    The result names one JSON file and summarises it. Every boundary carries two times — t,
+    the frame to cut on, which is the first beat inside the rest; and measured_t, where the
+    line actually stopped — plus the bar and beat it lands on, the length of the rest, how
+    long the ending note was held against the median note of this solo, the leap in semitones
+    into the next phrase, and a 0-1 confidence with the four factors behind it. Inline you get
+    the count, the median phrase length, the mean confidence and the strongest boundary.
+
+    These are candidates, not verdicts, and the reading is monophonic: the residual stem holds
+    piano under horn, so a chord reads as one note and a busy comp reads as a busy line.
+    Endings closer together than half a bar are counted and left out as one ending heard
+    twice. minimum_confidence is the floor on what gets written; refresh redoes work the cache
+    would answer for.
+    """
+    return {
+        "job": phrases.detect_phrases(
+            stems,
+            audio,
+            stem=stem,
+            minimum_confidence=minimum_confidence,
+            refresh=refresh,
+        )
+    }
+
+
 TOOLS: tuple[Any, ...] = (
     transcribe_audio,
     analyze_music,
     analyze_structure,
     detect_drum_fills,
+    detect_phrases,
     correlate_timeline,
 )
 
@@ -272,5 +315,6 @@ __all__ = [
     "analyze_structure",
     "correlate_timeline",
     "detect_drum_fills",
+    "detect_phrases",
     "transcribe_audio",
 ]

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -61,6 +61,7 @@ from .fixtures import write_hits as write_hits
 from .fixtures import write_jpeg as write_jpeg
 from .fixtures import write_sections as write_sections
 from .fixtures import write_tagged_wav as write_tagged_wav
+from .fixtures import write_tones as write_tones
 from .fixtures import write_wav as write_wav
 from .fusion import FakeFusionComp as FakeFusionComp
 from .fusion import FakeFusionInput as FakeFusionInput

--- a/tests/fakes/fixtures.py
+++ b/tests/fakes/fixtures.py
@@ -115,6 +115,43 @@ def write_hits(
     return _write_samples(path, samples, sample_rate, bit_depth, channels)
 
 
+def write_tones(
+    path: Path,
+    notes: Sequence[tuple[float, float, float]],
+    seconds: float | None = None,
+    sample_rate: int = 48_000,
+    bit_depth: int = 24,
+    channels: int = 2,
+    amplitude: float = 0.5,
+    attack_seconds: float = 0.01,
+    release_seconds: float = 0.02,
+) -> Path:
+    """A melodic stem: ``(start, duration, hz)`` notes laid down, silence between them.
+
+    ``write_hits`` is the percussion stem — transients with no pitch to read — and the phrase
+    side needs its opposite: notes that hold a pitch for a knowable length and then stop, so
+    "how long was that note" and "how far did the line jump" are facts about the fixture
+    rather than about the detector that reads it.
+
+    The attack and release live *inside* the note's own duration, so a note really has
+    stopped by ``start + duration`` and a planted gap is the length it says it is.
+    """
+    peak = 2 ** (bit_depth - 1) * amplitude
+    ends = [start + held for start, held, _ in notes]
+    total = int((seconds if seconds is not None else max(ends, default=0.0) + 0.5) * sample_rate)
+    attack = max(int(attack_seconds * sample_rate), 1)
+    release = max(int(release_seconds * sample_rate), 1)
+    samples = [0] * total
+    for start, held, hertz in notes:
+        first = max(int(start * sample_rate), 0)
+        length = min(int(held * sample_rate), max(total - first, 0))
+        for offset in range(length):
+            envelope = min(offset / attack, (length - offset) / release, 1.0)
+            wobble = math.sin(2 * math.pi * hertz * offset / sample_rate)
+            samples[first + offset] = int(peak * envelope * wobble)
+    return _write_samples(path, samples, sample_rate, bit_depth, channels)
+
+
 def write_sections(
     path: Path,
     sections: Sequence[tuple[str, float]],

--- a/tests/test_beat_grid.py
+++ b/tests/test_beat_grid.py
@@ -116,6 +116,43 @@ def test_a_structured_failure_from_a_detector_is_passed_through_unchanged() -> N
         beats.detect(Path("concert.wav"), missing)
 
 
+# --- where a beat sits in a four-bar group ----------------------------------------------------
+#
+# Shared by every reading that places an event against the grid — drum fills score the beat they
+# resolve into (#39), phrase boundaries the beat the ending is called on (#143) — so it is pinned
+# here, once, rather than in each of their test files.
+
+
+def test_the_top_of_a_four_bar_group_is_the_strongest_placement() -> None:
+    records = beats.numbered(_steady(20))
+    tops = [
+        record for record in records if record["downbeat"] and record["bar"] in (1, 5)
+    ]
+
+    assert [beats.bar_line_strength(record) for record in tops] == [1.0, 1.0]
+
+
+def test_an_ordinary_bar_line_reads_weaker_than_the_top_of_the_group() -> None:
+    records = beats.numbered(_steady(20))
+    (second_bar,) = [record for record in records if record["bar"] == 2 and record["downbeat"]]
+
+    assert beats.bar_line_strength(second_bar) == beats.AT_BAR_LINE
+    assert beats.AT_BAR_LINE < 1.0
+
+
+def test_a_beat_inside_a_bar_is_the_weakest_placement() -> None:
+    records = beats.numbered(_steady(20))
+    inside = next(record for record in records if not record["downbeat"])
+
+    assert beats.bar_line_strength(inside) == beats.MID_BAR
+    assert beats.MID_BAR < beats.AT_BAR_LINE
+
+
+def test_no_beat_at_all_scores_as_weakly_as_a_beat_mid_bar() -> None:
+    """A detector whose event fell off the end of the grid gets a number, not a crash."""
+    assert beats.bar_line_strength(None) == beats.MID_BAR
+
+
 # --- how far the grid may be trusted (#112) ---------------------------------------------------
 
 

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -1,0 +1,191 @@
+"""Notes off the melodic stem: the pitch estimate, the gating, and the reading seam (#143).
+
+Pitch is checked on arrays built here rather than on a file, because the thing under test is
+arithmetic and a WAV in the middle only adds a decoder to the list of things that could be
+wrong. The note layer is checked on fixture audio, because *that* is where the decisions
+live — where a note is judged to have started and stopped is the whole input to phrase
+detection, and a fixture whose note times are known is the only way to check it.
+
+Tolerances are stated per assertion and are frame-scale (tens of milliseconds), not
+phrase-scale: the reader is allowed to be half a window out, and the phrase tier that
+consumes it is allowed a few hundred milliseconds on top (#143).
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from resolve_mcp.analysis import melody
+from resolve_mcp.analysis.melody import Note
+from resolve_mcp.errors import AnalysisFailedError
+
+from .fakes import write_sections, write_tones
+
+SAMPLE_RATE = 16_000
+"""Fast fixtures. The reader sizes its window in seconds, so nothing here depends on 48k."""
+
+
+def _tone(
+    hertz: float,
+    seconds: float = 0.1,
+    sample_rate: int = SAMPLE_RATE,
+) -> NDArray[np.float64]:
+    """One frame's worth of a sine, the shape ``pitch`` is handed."""
+    steps = np.arange(int(seconds * sample_rate), dtype=np.float64)
+    return np.sin(2.0 * math.pi * hertz * steps / sample_rate)
+
+
+# --- the pitch estimate -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("hertz", [110.0, 220.0, 440.0, 880.0, 1_320.0])
+def test_a_sine_reads_back_as_its_own_frequency(hertz: float) -> None:
+    """Within 1%: below that the semitone arithmetic downstream stops meaning anything."""
+    assert melody.pitch(_tone(hertz), SAMPLE_RATE) == pytest.approx(hertz, rel=0.01)
+
+
+def test_a_note_with_a_strong_second_harmonic_reads_as_its_fundamental() -> None:
+    """A horn is not a sine. The octave above is the loudest partial and is not the note."""
+    both = _tone(440.0) + _tone(880.0)
+
+    assert melody.pitch(both, SAMPLE_RATE) == pytest.approx(440.0, rel=0.01)
+
+
+def test_silence_is_not_pitched() -> None:
+    assert melody.pitch(np.zeros(1_600), SAMPLE_RATE) == 0.0
+
+
+def test_noise_is_not_pitched() -> None:
+    """A cymbal wash in the residual stem must not be reported as a note with a pitch."""
+    noise = np.random.default_rng(7).normal(size=1_600)
+
+    assert melody.pitch(noise, SAMPLE_RATE) == 0.0
+
+
+def test_a_frame_with_nothing_in_it_is_not_pitched() -> None:
+    assert melody.pitch(np.zeros(1), SAMPLE_RATE) == 0.0
+
+
+# --- notes off a stem ---------------------------------------------------------------
+
+
+def test_three_separated_notes_read_back_as_three_notes(tmp_path: Path) -> None:
+    stem = write_tones(
+        tmp_path / "other.wav",
+        notes=[(0.2, 0.5, 440.0), (1.0, 0.5, 494.0), (1.8, 0.5, 523.0)],
+        seconds=2.6,
+        sample_rate=SAMPLE_RATE,
+    )
+
+    notes = melody.read(stem)
+
+    assert len(notes) == 3
+    assert [one.hz for one in notes] == pytest.approx([440.0, 494.0, 523.0], rel=0.01)
+
+
+def test_a_note_starts_and_stops_where_it_was_written(tmp_path: Path) -> None:
+    """Within 30ms — half the reader's window, which is what dating a frame at its centre costs."""
+    stem = write_tones(
+        tmp_path / "other.wav",
+        notes=[(0.4, 0.8, 440.0)],
+        seconds=1.6,
+        sample_rate=SAMPLE_RATE,
+    )
+
+    (note,) = melody.read(stem)
+
+    assert note.seconds == pytest.approx(0.4, abs=0.03)
+    assert note.end == pytest.approx(1.2, abs=0.03)
+    assert note.held == pytest.approx(0.8, abs=0.05)
+
+
+def test_two_legato_notes_with_no_gap_are_two_notes(tmp_path: Path) -> None:
+    """The pitch step is the only evidence there are two, and phrase length depends on it."""
+    stem = write_tones(
+        tmp_path / "other.wav",
+        notes=[(0.2, 0.6, 440.0), (0.8, 0.6, 587.0)],
+        seconds=1.8,
+        sample_rate=SAMPLE_RATE,
+    )
+
+    notes = melody.read(stem)
+
+    assert len(notes) == 2
+    assert [one.hz for one in notes] == pytest.approx([440.0, 587.0], rel=0.01)
+
+
+def test_one_note_held_across_a_vibrato_sized_wobble_stays_one_note(tmp_path: Path) -> None:
+    """A tenor does not play in tune to the cent, and every wobble must not become a note."""
+    stem = write_tones(
+        tmp_path / "other.wav",
+        notes=[(0.2, 0.4, 440.0), (0.6, 0.4, 447.0), (1.0, 0.4, 440.0)],
+        seconds=1.8,
+        sample_rate=SAMPLE_RATE,
+    )
+
+    assert len(melody.read(stem)) == 1
+
+
+def test_a_stem_the_band_did_not_play_holds_no_notes(tmp_path: Path) -> None:
+    stem = write_tones(tmp_path / "other.wav", notes=[], seconds=1.0, sample_rate=SAMPLE_RATE)
+
+    assert melody.read(stem) == ()
+
+
+def test_an_unpitched_event_still_reads_as_a_note_but_names_no_pitch(tmp_path: Path) -> None:
+    """A cymbal wash in the residual has a start, an end and no fundamental — say all three."""
+    stem = write_sections(
+        tmp_path / "other.wav",
+        sections=[("silence", 0.3), ("noise", 0.4), ("silence", 0.3)],
+    )
+
+    (note,) = melody.read(stem)
+
+    assert note.hz == 0.0
+    assert note.seconds == pytest.approx(0.3, abs=0.05)
+    assert note.end == pytest.approx(0.7, abs=0.05)
+
+
+def test_notes_come_back_earliest_first(tmp_path: Path) -> None:
+    def out_of_order(path: Path) -> tuple[Note, ...]:
+        return (
+            Note(seconds=2.0, end=2.5, hz=440.0, strength=0.5),
+            Note(seconds=0.5, end=1.0, hz=330.0, strength=0.5),
+        )
+
+    notes = melody.read(tmp_path / "unread.wav", out_of_order)
+
+    assert [one.seconds for one in notes] == [0.5, 2.0]
+
+
+def test_held_is_the_length_of_the_note() -> None:
+    assert Note(seconds=1.0, end=2.5, hz=440.0, strength=0.5).held == 1.5
+
+
+# --- the reading seam ---------------------------------------------------------------
+
+
+def test_an_injected_reader_is_used_instead_of_the_default(tmp_path: Path) -> None:
+    """ADR 0002: a better pitch tracker is an upgrade the rule layer never notices."""
+    planted = (Note(seconds=0.0, end=1.0, hz=220.0, strength=0.9),)
+
+    assert melody.read(tmp_path / "never-opened.wav", lambda path: planted) == planted
+
+
+def test_a_reader_that_falls_over_is_an_analysis_failure_not_an_internal_error(
+    tmp_path: Path,
+) -> None:
+    """Same rule as drum transcription: the agent can act on it, and it is not a server bug."""
+
+    def broken(path: Path) -> tuple[Note, ...]:
+        raise RuntimeError("no model")
+
+    with pytest.raises(AnalysisFailedError) as raised:
+        melody.read(tmp_path / "other.wav", broken)
+
+    assert "no model" in raised.value.cause

--- a/tests/test_phrases.py
+++ b/tests/test_phrases.py
@@ -119,27 +119,50 @@ def test_a_gap_shorter_than_the_nomination_floor_is_not_an_ending() -> None:
     assert detection.considered == 1
 
 
-def test_a_note_held_far_longer_than_the_median_ends_a_phrase_with_no_rest_at_all() -> None:
-    """The player leans on the last note and the next phrase comes straight in over the top."""
+def test_a_held_note_ends_a_phrase_at_the_default_floor_with_no_rest_at_all() -> None:
+    """The player leans on the last note and the next phrase comes straight in over the top.
+
+    At the **default** floor, deliberately: the three cues stand in for each other, so a cue
+    that only survives with the floor turned off is a cue this detector does not really have.
+    """
     played = _running(6)
     played[5] = played[5]._replace(end=played[5].seconds + 0.4 * phrases.LONG_MULTIPLE)
     played += _running(6, first=played[5].end)
 
-    detection = phrases.boundaries(played, _grid(), minimum_confidence=0.0)
+    detection = phrases.boundaries(played, _grid())
 
     assert any(one.measured == pytest.approx(played[5].end) for one in detection.boundaries)
 
 
-def test_a_leap_of_a_fifth_ends_a_phrase_with_no_rest_and_no_held_note() -> None:
-    """The contour reset on its own: the new phrase starts somewhere the last one was not."""
+def test_a_leap_of_a_fifth_ends_a_phrase_at_the_default_floor_on_its_own() -> None:
+    """The contour reset with no rest and no held note: the new phrase starts somewhere else."""
     played = _running(6) + _line(
         [6 * BEAT + index * BEAT for index in range(6)],
         hz=440.0 * 2 ** (phrases.RESET_SEMITONES / 12.0),
     )
 
-    detection = phrases.boundaries(played, _grid(), minimum_confidence=0.0)
+    detection = phrases.boundaries(played, _grid())
 
     assert any(one.measured == pytest.approx(5 * BEAT + 0.4) for one in detection.boundaries)
+
+
+@pytest.mark.parametrize("cue", phrases.CUES)
+def test_one_saturated_cue_clears_the_floor_however_weak_the_placement(cue: str) -> None:
+    """Stated directly, because a weighted sum here is what made two of the three cues dead.
+
+    ``grid`` is pinned at zero — weaker than any real placement, since the grid never scores
+    below ``beats.MID_BAR`` — so this is the cue carrying the reading with no help at all.
+    """
+    alone = {name: (1.0 if name == cue else 0.0) for name in phrases.CUES} | {"grid": 0.0}
+
+    assert phrases.scored(alone) > phrases.DEFAULT_MINIMUM_CONFIDENCE
+
+
+def test_cues_that_agree_read_stronger_than_one_cue_on_its_own() -> None:
+    lonely = {"rest": 1.0, "held": 0.0, "contour": 0.0, "grid": 0.0}
+    corroborated = {"rest": 1.0, "held": 1.0, "contour": 1.0, "grid": 0.0}
+
+    assert phrases.scored(corroborated) > phrases.scored(lonely)
 
 
 def test_a_leap_is_not_read_across_a_note_with_no_pitch() -> None:

--- a/tests/test_phrases.py
+++ b/tests/test_phrases.py
@@ -1,0 +1,626 @@
+"""Phrase boundaries: the rule layer, the reading seam, the job, the cache (#143).
+
+The rule layer is where the decisions are, so most of this file is plain functions over notes
+and a beat grid — no audio, no job, no threads. Notes are written out by hand here rather than
+read off a stem, because "a phrase ended at 4.0" has to be a fact about the input before it
+can be a fact about the output; the reader that turns audio into notes is checked in
+``test_melody.py``, and the job on top of both is checked here because that is where the
+caching lives.
+
+One seam is deliberately *not* here: whether these boundaries are the ones a director would
+name. That needs the #46 tune and its annotated cut points, and it is an evaluation on real
+media, not a unit test.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.analysis import melody, music, phrases
+from resolve_mcp.analysis.beats import BeatGrid, Detector, numbered
+from resolve_mcp.analysis.melody import Note
+from resolve_mcp.audio.stems import DRUM_PASS, DRUM_STEMS, FOUR_STEMS, MIX_PASS
+from resolve_mcp.config import get_config
+from resolve_mcp.errors import InvalidRequestError
+from resolve_mcp.jobs.runner import JobOutput, wait_for
+from resolve_mcp.jobs.store import JobRecord
+from resolve_mcp.tools import analysis as analysis_tools
+
+from .fakes import write_clicks, write_hits, write_tones
+
+TEMPO = 120.0
+BEAT = 60.0 / TEMPO
+"""Half a second. Every time in this file is a whole number of these unless it says otherwise."""
+
+
+@pytest.fixture
+def master(tmp_path: Path) -> Path:
+    """The mix the stems were separated from — what the beat grid is read off."""
+    return write_clicks(tmp_path / "media" / "concert.wav", beats_per_minute=TEMPO, seconds=16.0)
+
+
+@pytest.fixture
+def separation(tmp_path: Path) -> Path:
+    """A separation directory as ``separate_stems`` leaves it: two passes, one parent."""
+    directory = tmp_path / "stems" / "concert-abc123def456"
+    for label in FOUR_STEMS:
+        write_hits(directory / MIX_PASS / f"concert_({label.title()})_model.wav", times=(1.0,))
+    for label in DRUM_STEMS:
+        write_hits(directory / DRUM_PASS / f"concert_({label.title()})_model.wav", times=())
+    return directory
+
+
+@pytest.fixture
+def stems(separation: Path) -> dict[str, Path]:
+    """The four-stem mapping, the shape the separation job reports alongside the directory."""
+    return {
+        label: separation / MIX_PASS / f"concert_({label.title()})_model.wav"
+        for label in FOUR_STEMS
+    }
+
+
+# --- a grid and a line to hang the rules on -----------------------------------------
+
+
+def _grid(bars: int = 8, tempo: float = TEMPO, meter: int = 4) -> tuple[dict[str, Any], ...]:
+    """``numbered`` rows for a steady grid — the same shape the beats half writes."""
+    step = 60.0 / tempo
+    beats = tuple(round(index * step, 6) for index in range(bars * meter))
+    downbeats = tuple(beats[index] for index in range(0, len(beats), meter))
+    return numbered(BeatGrid(beats=beats, downbeats=downbeats))
+
+
+def _line(
+    starts: Sequence[float],
+    held: float = 0.4,
+    hz: float = 440.0,
+) -> list[Note]:
+    """Even notes of one length at one pitch — the line to depart from."""
+    return [Note(seconds=one, end=one + held, hz=hz, strength=0.5) for one in starts]
+
+
+def _running(count: int, first: float = 0.0, held: float = 0.4) -> list[Note]:
+    """``count`` notes a beat apart, none of them ending anything."""
+    return _line([first + index * BEAT for index in range(count)], held=held)
+
+
+# --- the rule layer: what nominates a boundary --------------------------------------
+
+
+def test_a_line_that_never_stops_has_no_phrase_boundary_but_its_last_note() -> None:
+    """Notes end-to-end at one pitch and one length: the only ending is the player stopping."""
+    detection = phrases.boundaries(_running(16), _grid())
+
+    assert detection.considered == 1
+    assert len(detection.boundaries) == 1
+    assert detection.boundaries[0].measured == pytest.approx(15 * BEAT + 0.4)
+
+
+def test_a_rest_of_a_beat_ends_a_phrase() -> None:
+    played = _running(8) + _running(8, first=8 * BEAT + BEAT)
+
+    detection = phrases.boundaries(played, _grid())
+
+    assert [one.measured for one in detection.boundaries][0] == pytest.approx(7 * BEAT + 0.4)
+
+
+def test_a_gap_shorter_than_the_nomination_floor_is_not_an_ending() -> None:
+    """Notes are not butt-joined in real playing, and every tongued note must not be a phrase."""
+    small = phrases.REST_BEATS * BEAT / 2.0
+    played = _running(8) + _running(8, first=8 * BEAT + small)
+
+    detection = phrases.boundaries(played, _grid())
+
+    assert detection.considered == 1
+
+
+def test_a_note_held_far_longer_than_the_median_ends_a_phrase_with_no_rest_at_all() -> None:
+    """The player leans on the last note and the next phrase comes straight in over the top."""
+    played = _running(6)
+    played[5] = played[5]._replace(end=played[5].seconds + 0.4 * phrases.LONG_MULTIPLE)
+    played += _running(6, first=played[5].end)
+
+    detection = phrases.boundaries(played, _grid(), minimum_confidence=0.0)
+
+    assert any(one.measured == pytest.approx(played[5].end) for one in detection.boundaries)
+
+
+def test_a_leap_of_a_fifth_ends_a_phrase_with_no_rest_and_no_held_note() -> None:
+    """The contour reset on its own: the new phrase starts somewhere the last one was not."""
+    played = _running(6) + _line(
+        [6 * BEAT + index * BEAT for index in range(6)],
+        hz=440.0 * 2 ** (phrases.RESET_SEMITONES / 12.0),
+    )
+
+    detection = phrases.boundaries(played, _grid(), minimum_confidence=0.0)
+
+    assert any(one.measured == pytest.approx(5 * BEAT + 0.4) for one in detection.boundaries)
+
+
+def test_a_leap_is_not_read_across_a_note_with_no_pitch() -> None:
+    """An unpitched event has no interval to leap by, and inventing one would nominate noise."""
+    played = _running(4) + [Note(seconds=4 * BEAT, end=4 * BEAT + 0.4, hz=0.0, strength=0.5)]
+
+    detection = phrases.boundaries(played, _grid())
+
+    assert detection.boundaries[-1].interval is None
+
+
+def test_two_endings_closer_than_half_a_bar_are_reported_once() -> None:
+    """One ending heard twice — a breath inside a phrase is not the end of another one."""
+    #  Endings at 1.9, 2.7 and 3.4. The first two are 0.8s apart, under half a bar at 120.
+    played = _running(4) + _line([2.3, 3.0])
+
+    detection = phrases.boundaries(played, _grid(), minimum_confidence=0.0)
+
+    assert detection.dropped == 1
+    spacing = [
+        later.measured - earlier.measured
+        for earlier, later in zip(
+            detection.boundaries, detection.boundaries[1:], strict=False
+        )
+    ]
+    assert all(one >= phrases.MINIMUM_PHRASE_BEATS * BEAT for one in spacing)
+
+
+def test_the_confidence_floor_keeps_a_weak_ending_out_of_the_record() -> None:
+    played = _running(8) + _running(8, first=8 * BEAT + BEAT)
+
+    generous = phrases.boundaries(played, _grid(), minimum_confidence=0.0)
+    strict = phrases.boundaries(played, _grid(), minimum_confidence=1.0)
+
+    assert strict.considered == generous.considered
+    assert strict.boundaries == ()
+
+
+def test_a_line_of_one_note_reads_nothing() -> None:
+    assert phrases.boundaries(_running(1), _grid()).boundaries == ()
+
+
+def test_a_grid_with_no_tempo_in_it_reads_nothing() -> None:
+    """No beat to measure a rest in. Better nothing than a rest measured against zero."""
+    flat = numbered(BeatGrid(beats=(0.0, 0.0, 0.0), downbeats=(0.0,)))
+
+    assert phrases.boundaries(_running(8), flat).boundaries == ()
+
+
+def test_notes_with_no_length_read_nothing() -> None:
+    """A median note length of zero is no baseline: every note would be infinitely long."""
+    instant = [
+        Note(seconds=index * BEAT, end=index * BEAT, hz=440.0, strength=0.5)
+        for index in range(8)
+    ]
+
+    assert phrases.boundaries(instant, _grid()).boundaries == ()
+
+
+# --- the rule layer: what a boundary says about itself -------------------------------
+
+
+def test_a_boundary_is_called_on_the_first_beat_inside_the_rest() -> None:
+    """The cut goes where nothing is playing, not on the frame the last note stopped."""
+    played = _running(8, held=0.3) + _running(8, first=8 * BEAT + BEAT)
+    #  the eighth note stops at 3.8s, and the rest runs to 4.5s: beat 4.0 is inside it
+
+    (first, *_) = phrases.boundaries(played, _grid()).boundaries
+
+    assert first.measured == pytest.approx(3.8)
+    assert first.seconds == pytest.approx(4.0)
+    assert first.snapped is True
+
+
+def test_a_boundary_names_the_bar_and_beat_it_is_called_on() -> None:
+    played = _running(8, held=0.3) + _running(8, first=8 * BEAT + BEAT)
+
+    (first, *_) = phrases.boundaries(played, _grid()).boundaries
+
+    assert (first.bar, first.in_bar, first.downbeat) == (3, 1, True)
+
+
+def test_an_ending_far_from_any_beat_is_reported_where_it_was_heard_and_says_so() -> None:
+    """Past the snap tolerance the measured time stands — the same rule solo changes use."""
+    played = _running(4, held=0.3)
+    beyond = _grid()[-1]["t"] + phrases.SNAP_BEATS * BEAT * 4
+    played.append(Note(seconds=beyond, end=beyond + 0.3, hz=440.0, strength=0.5))
+
+    last = phrases.boundaries(played, _grid(), minimum_confidence=0.0).boundaries[-1]
+
+    assert last.snapped is False
+    assert last.seconds == pytest.approx(last.measured)
+
+
+def test_a_boundary_counts_the_notes_in_the_phrase_it_closes() -> None:
+    played = _running(8) + _running(8, first=8 * BEAT + BEAT)
+
+    first, second = phrases.boundaries(played, _grid()).boundaries
+
+    assert (first.notes, second.notes) == (8, 8)
+
+
+def test_the_ending_at_the_top_of_a_four_bar_phrase_outscores_the_one_mid_bar() -> None:
+    """The grid factor, which is the same rule ``fills`` scores its resolution point with."""
+    on_the_phrase = phrases.boundaries(
+        _running(8, held=0.3) + _running(4, first=8 * BEAT + BEAT), _grid(), 0.0
+    ).boundaries[0]
+    mid_bar = phrases.boundaries(
+        _running(9, held=0.3) + _running(4, first=9 * BEAT + BEAT), _grid(), 0.0
+    ).boundaries[0]
+
+    assert on_the_phrase.factors["grid"] > mid_bar.factors["grid"]
+    assert on_the_phrase.confidence > mid_bar.confidence
+
+
+def test_a_longer_rest_reads_as_a_stronger_ending() -> None:
+    short = phrases.boundaries(
+        _running(8) + _running(4, first=8 * BEAT + BEAT), _grid()
+    ).boundaries[0]
+    long = phrases.boundaries(
+        _running(8) + _running(4, first=8 * BEAT + 3 * BEAT), _grid()
+    ).boundaries[0]
+
+    assert long.factors["rest"] > short.factors["rest"]
+
+
+def test_every_factor_and_the_confidence_stay_inside_zero_to_one() -> None:
+    played = _running(4)
+    played[3] = played[3]._replace(end=played[3].seconds + 20.0)
+    played += _running(4, first=played[3].end + 8.0, held=0.4)
+
+    for one in phrases.boundaries(played, _grid(), minimum_confidence=0.0).boundaries:
+        assert all(0.0 <= value <= 1.0 for value in one.factors.values())
+        assert 0.0 <= one.confidence <= 1.0
+
+
+# --- the records and the gist --------------------------------------------------------
+
+
+def test_a_record_carries_both_placements_so_a_cut_can_use_either() -> None:
+    played = _running(8, held=0.3) + _running(8, first=8 * BEAT + BEAT)
+
+    (record, *_) = phrases.rows(phrases.boundaries(played, _grid()))
+
+    assert record["t"] == pytest.approx(4.0)
+    assert record["measured_t"] == pytest.approx(3.8)
+    assert record["resumes_t"] == pytest.approx(4.5)
+
+
+def test_the_gist_reports_the_median_phrase_length() -> None:
+    played = _running(8) + _running(8, first=8 * BEAT + BEAT)
+    detection = phrases.boundaries(played, _grid())
+
+    summary = phrases.gist(detection, phrases.DEFAULT_MINIMUM_CONFIDENCE, "other", len(played))
+
+    assert summary["count"] == 2
+    assert summary["median_phrase_seconds"] == pytest.approx(4.5)
+    assert summary["stem"] == "other"
+
+
+def test_the_gist_accounts_for_every_ending_it_weighed() -> None:
+    """Kept, too weak and too soon must add up to considered, or a number is being lost."""
+    rest = phrases.REST_BEATS * BEAT
+    played = _running(4) + _line([4 * BEAT - BEAT / 4 + rest, 12 * BEAT])
+    detection = phrases.boundaries(played, _grid(), minimum_confidence=0.5)
+
+    summary = phrases.gist(detection, 0.5, "other", len(played))
+
+    assert (
+        summary["count"] + summary["below_confidence"] + summary["too_soon_dropped"]
+        == summary["considered"]
+    )
+
+
+def test_an_empty_detection_still_answers_every_gist_key() -> None:
+    summary = phrases.gist(phrases.boundaries((), _grid()), 0.35, "other", 0)
+
+    assert summary["count"] == 0
+    assert summary["mean_confidence"] is None
+    assert summary["median_phrase_seconds"] is None
+    assert summary["strongest"] is None
+
+
+# --- the job: what lands on disk, what comes back inline ----------------------------
+
+
+def _read(played: Sequence[Note]) -> melody.Reader:
+    """A reader standing in for the soloist: two phrases with a bar's rest between them."""
+
+    def reader(stem: Path) -> tuple[Note, ...]:
+        return tuple(played)
+
+    return reader
+
+
+def _detector_for(rows: Sequence[Mapping[str, Any]]) -> Detector:
+    beats = tuple(row["t"] for row in rows)
+    downbeats = tuple(row["t"] for row in rows if row["downbeat"])
+
+    def detector(path: Path) -> BeatGrid:
+        return BeatGrid(beats=beats, downbeats=downbeats)
+
+    return detector
+
+
+def _finished(record: JobRecord) -> dict[str, Any]:
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    return record.result
+
+
+def _two_phrases() -> list[Note]:
+    return _running(8, held=0.3) + _running(8, first=8 * BEAT + BEAT)
+
+
+def _ran(
+    stems: Mapping[str, Path] | str | Path,
+    audio: Path,
+    rows: Sequence[Mapping[str, Any]],
+    **asked: Any,
+) -> dict[str, Any]:
+    """Run the job to completion with the grid and the line injected."""
+    started = phrases.detect_phrases(
+        stems,
+        audio,
+        reader=_read(_two_phrases()),
+        detector=_detector_for(rows),
+        **asked,
+    )
+    return _finished(wait_for(started["job_id"]))
+
+
+def test_the_job_writes_one_record_per_boundary_and_returns_the_gist(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    result = _ran(stems, master, _grid())
+
+    written = Path(result["path"])
+    assert written.parent == get_config().analysis_dir
+    document = json.loads(written.read_text(encoding="utf-8"))
+    assert document["kind"] == phrases.PHRASES
+    assert len(document[phrases.PHRASES]) == result["count"] == 2
+    assert result["stem"] == phrases.DEFAULT_STEM
+
+
+def test_the_document_holds_one_boundary_per_line(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    result = _ran(stems, master, _grid())
+
+    lines = Path(result["path"]).read_text(encoding="utf-8").splitlines()
+    records = [line for line in lines if line.strip().startswith('{"t"')]
+    assert len(records) == 2
+
+
+def test_the_directory_a_separation_reports_is_accepted(
+    master: Path,
+    separation: Path,
+) -> None:
+    """The job hands back the parent of both passes, so the parent is what this takes."""
+    assert _ran(separation, master, _grid())["count"] == 2
+
+
+def test_the_mix_pass_on_its_own_is_accepted_too(master: Path, separation: Path) -> None:
+    assert _ran(separation / MIX_PASS, master, _grid())["count"] == 2
+
+
+def test_another_stem_can_be_named(master: Path, separation: Path) -> None:
+    """A vocal-led band's line is in vocals, and a director with a horn stem should say so."""
+    assert _ran(separation, master, _grid(), stem="vocals")["stem"] == "vocals"
+
+
+def test_the_worker_reads_the_real_stem_when_no_reader_is_injected(
+    master: Path,
+    tmp_path: Path,
+) -> None:
+    """The one end-to-end pass: audio in, boundaries out, on a line whose phrasing was written.
+
+    Two phrases of four crotchets with a full bar of rest between them. The boundary is
+    asserted to within 0.3s — the tolerance the ticket names — because the reader is allowed
+    half a window and the grid is allowed to pull the placement to the nearest beat.
+    """
+    stem = write_tones(
+        tmp_path / "stems" / "mix" / "concert_(Other)_model.wav",
+        notes=[(index * BEAT, 0.35, 440.0) for index in range(4)]
+        + [(8 * BEAT + index * BEAT, 0.35, 660.0) for index in range(4)],
+        seconds=16.0,
+        sample_rate=16_000,
+    )
+
+    started = phrases.detect_phrases(
+        {phrases.DEFAULT_STEM: stem},
+        master,
+        detector=_detector_for(_grid()),
+    )
+    result = _finished(wait_for(started["job_id"]))
+
+    written = json.loads(Path(result["path"]).read_text(encoding="utf-8"))
+    ends = [record["measured_t"] for record in written[phrases.PHRASES]]
+    assert any(end == pytest.approx(3 * BEAT + 0.35, abs=0.3) for end in ends)
+
+
+def test_progress_only_climbs_and_the_document_is_the_job_artifact(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    steps: list[tuple[float, str]] = []
+
+    output: JobOutput = phrases.detect(
+        master,
+        stems[phrases.DEFAULT_STEM],
+        {"stem": phrases.DEFAULT_STEM, "minimum_confidence": phrases.DEFAULT_MINIMUM_CONFIDENCE},
+        lambda fraction, step: steps.append((fraction, step)),
+        reader=_read(_two_phrases()),
+        detector=_detector_for(_grid()),
+    )
+
+    fractions = [fraction for fraction, _ in steps]
+    assert fractions == sorted(fractions)
+    assert [step for _, step in steps if "phrase" in step]
+    assert output.artifacts == (Path(output.result["path"]),)
+
+
+# --- the cache ----------------------------------------------------------------------
+
+
+def _must_not_run() -> melody.Reader:
+    def reader(stem: Path) -> tuple[Note, ...]:
+        raise AssertionError("the cached result should have answered this")
+
+    return reader
+
+
+def test_asking_twice_answers_from_cache_without_reading_the_stem_again(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    first = _ran(stems, master, _grid())
+
+    again = phrases.detect_phrases(stems, master, reader=_must_not_run())
+
+    assert again["cached"] is True
+    assert again["result"] == first
+
+
+def test_refresh_redoes_the_work_the_cache_would_have_answered(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    _ran(stems, master, _grid())
+
+    started = phrases.detect_phrases(
+        stems,
+        master,
+        reader=_read(_two_phrases()),
+        detector=_detector_for(_grid()),
+        refresh=True,
+    )
+    record = wait_for(started["job_id"])
+
+    assert record.cached is False
+    assert _finished(record)["count"] == 2
+
+
+def test_a_different_stem_is_a_different_key(master: Path, stems: dict[str, Path]) -> None:
+    _ran(stems, master, _grid())
+
+    started = phrases.detect_phrases(
+        stems,
+        master,
+        stem="vocals",
+        reader=_read(_two_phrases()),
+        detector=_detector_for(_grid()),
+    )
+
+    assert started.get("cached") is not True
+
+
+def test_the_beat_grid_is_the_one_analyze_music_already_paid_for(
+    master: Path,
+    stems: dict[str, Path],
+) -> None:
+    """The two jobs share the beats cache entry, so the model runs once per master."""
+    rows = _grid()
+    wait_for(music.analyze_music(master, energy=False, detector=_detector_for(rows))["job_id"])
+
+    def detector_that_must_not_run(path: Path) -> BeatGrid:
+        raise AssertionError("beats were already detected for this audio")
+
+    started = phrases.detect_phrases(
+        stems,
+        master,
+        reader=_read(_two_phrases()),
+        detector=detector_that_must_not_run,
+    )
+
+    assert _finished(wait_for(started["job_id"]))["count"] == 2
+
+
+# --- what the starter refuses -------------------------------------------------------
+
+
+def test_a_missing_master_is_refused_before_a_job_exists(
+    tmp_path: Path,
+    stems: dict[str, Path],
+) -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        phrases.detect_phrases(stems, tmp_path / "nothing.wav")
+
+    assert "nothing.wav" in raised.value.cause
+
+
+def test_a_stem_that_is_not_in_the_separation_is_refused(
+    master: Path,
+    separation: Path,
+) -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        phrases.detect_phrases(separation, master, stem="saxophone")
+
+    assert raised.value.detail["wanted"] == "saxophone"
+    assert sorted(FOUR_STEMS) == raised.value.detail["found"]
+
+
+def test_the_drum_pass_is_not_mistaken_for_the_melodic_stems(
+    master: Path,
+    separation: Path,
+) -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        phrases.detect_phrases(separation / DRUM_PASS, master)
+
+    assert raised.value.detail["found"] == sorted(DRUM_STEMS)
+
+
+def test_a_directory_that_is_not_there_is_refused(tmp_path: Path, master: Path) -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        phrases.detect_phrases(tmp_path / "gone", master)
+
+    assert "gone" in raised.value.cause
+
+
+def test_a_named_stem_that_is_not_on_disk_is_refused(tmp_path: Path, master: Path) -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        phrases.detect_phrases({"other": tmp_path / "gone.wav"}, master)
+
+    assert "gone.wav" in raised.value.cause
+
+
+@pytest.mark.parametrize("floor", [-0.1, 1.1])
+def test_a_confidence_floor_outside_zero_to_one_is_refused(
+    master: Path,
+    stems: dict[str, Path],
+    floor: float,
+) -> None:
+    with pytest.raises(InvalidRequestError) as raised:
+        phrases.detect_phrases(stems, master, minimum_confidence=floor)
+
+    assert raised.value.detail["minimum_confidence"] == floor
+
+
+# --- the tool seam -------------------------------------------------------------------
+
+
+def test_the_tool_returns_a_job_to_poll_inside_an_ok_envelope(
+    master: Path,
+    separation: Path,
+) -> None:
+    envelope = analysis_tools.detect_phrases(str(separation), str(master))
+
+    assert envelope["ok"] is True
+    assert "job_id" in envelope["job"]
+
+
+def test_the_tool_reports_a_bad_request_as_a_structured_error(tmp_path: Path) -> None:
+    envelope = analysis_tools.detect_phrases(str(tmp_path), str(tmp_path / "nothing.wav"))
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["code"] == "invalid_request"
+
+
+def test_the_tool_is_registered_so_the_server_picks_it_up() -> None:
+    """``build_server`` iterates each module's ``TOOLS``; nothing else registers a tool."""
+    assert analysis_tools.detect_phrases in analysis_tools.TOOLS

--- a/tests/test_phrases.py
+++ b/tests/test_phrases.py
@@ -134,16 +134,31 @@ def test_a_held_note_ends_a_phrase_at_the_default_floor_with_no_rest_at_all() ->
     assert any(one.measured == pytest.approx(played[5].end) for one in detection.boundaries)
 
 
-def test_a_leap_of_a_fifth_ends_a_phrase_at_the_default_floor_on_its_own() -> None:
-    """The contour reset with no rest and no held note: the new phrase starts somewhere else."""
-    played = _running(6) + _line(
+def _leaping(semitones: float) -> list[Note]:
+    """Six notes, then six more a given distance away, with no rest and no held note between."""
+    return _running(6) + _line(
         [6 * BEAT + index * BEAT for index in range(6)],
-        hz=440.0 * 2 ** (phrases.RESET_SEMITONES / 12.0),
+        hz=440.0 * 2 ** (semitones / 12.0),
     )
 
-    detection = phrases.boundaries(played, _grid())
+
+def test_a_leap_of_a_fifth_ends_a_phrase_at_the_default_floor_on_its_own() -> None:
+    """The contour reset with no rest and no held note: the new phrase starts somewhere else."""
+    detection = phrases.boundaries(_leaping(phrases.RESET_SEMITONES), _grid())
 
     assert any(one.measured == pytest.approx(5 * BEAT + 0.4) for one in detection.boundaries)
+
+
+def test_a_bare_fifth_reads_weaker_than_an_octave() -> None:
+    """The cue nominates at a fifth and only saturates at an octave, so it stays filterable."""
+    fifth = phrases.boundaries(_leaping(phrases.RESET_SEMITONES), _grid(), 0.0).boundaries[0]
+    octave = phrases.boundaries(
+        _leaping(phrases.RESET_FULL_SEMITONES), _grid(), 0.0
+    ).boundaries[0]
+
+    assert fifth.factors["contour"] < 1.0
+    assert octave.factors["contour"] == 1.0
+    assert fifth.confidence < octave.confidence
 
 
 @pytest.mark.parametrize("cue", phrases.CUES)
@@ -191,14 +206,22 @@ def test_two_endings_closer_than_half_a_bar_are_reported_once() -> None:
     assert all(one >= phrases.MINIMUM_PHRASE_BEATS * BEAT for one in spacing)
 
 
-def test_the_confidence_floor_keeps_a_weak_ending_out_of_the_record() -> None:
-    played = _running(8) + _running(8, first=8 * BEAT + BEAT)
+def test_the_default_floor_keeps_a_marginal_ending_out_of_the_record() -> None:
+    """A rest at the nomination threshold: weighed, counted, and not written.
+
+    The floor is asserted at its shipped value rather than at 1.0. A floor of 1.0 rejects
+    everything by construction and so says nothing about the detector anyone will actually
+    run — which is how two dead cues survived the first pass.
+    """
+    #  The fourth note ends at 1.85 and the line resumes at 2.10 — a rest of exactly REST_BEATS.
+    played = _line([0.0, 0.5, 1.0, 1.5], held=0.35) + _line([2.10, 2.60], held=0.35)
 
     generous = phrases.boundaries(played, _grid(), minimum_confidence=0.0)
-    strict = phrases.boundaries(played, _grid(), minimum_confidence=1.0)
+    default = phrases.boundaries(played, _grid())
 
-    assert strict.considered == generous.considered
-    assert strict.boundaries == ()
+    assert any(one.measured == pytest.approx(1.85) for one in generous.boundaries)
+    assert not any(one.measured == pytest.approx(1.85) for one in default.boundaries)
+    assert default.considered == generous.considered
 
 
 def test_a_line_of_one_note_reads_nothing() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,6 +51,7 @@ def test_registers_the_p1_session_media_timeline_cut_titling_render_and_job_tool
         "analyze_music",
         "analyze_structure",
         "detect_drum_fills",
+        "detect_phrases",
         "correlate_timeline",
         "separate_stems",
         "list_render_presets",


### PR DESCRIPTION
Closes #143.

The #46 director round moved ten-plus of its fifty-five notes to "after the sax's phrase" or "between phrases". Nothing in the analysis stack named a phrase, so an authoring agent read them by ear off the mix and a reviewing agent could not check phrase placement at all.

## What this adds

Two modules, the split `drums`/`fills` already uses:

- **`analysis/melody.py`** — notes off one melodic stem, behind an injected `Reader` (ADR 0002). Autocorrelation pitch with the taper divided out; the period is the first *local* peak within the octave margin, not the strongest, because the strongest is how a pitch tracker reports the octave below. Gating is hysteresis on the stem's own peak. Monophonic and it says so: the residual stem holds piano under horn, so a chord reads as one note — enough for endings, not a transcription.
- **`analysis/phrases.py`** — the rule layer. A note ending is nominated by **a rest**, by **being held far longer than the median note of this solo**, or by **a leap of a fifth into what comes next** — the three cues the ticket names, each sufficient alone. Each is then scored, plus where the ending lands on the grid.

Every boundary carries two times. `measured_t` is where the line actually stopped; `t` is the first beat inside the rest, because that is the frame an editor puts the cut on. Past the snap tolerance the measured time stands and the record says it was not snapped — the rule `solos` already uses.

Also: `detect_phrases` on the tool layer, a `write_tones` fixture (a melodic stem with known note lengths and known gaps), and the `CONTEXT.md` map + vocabulary entry.

## Test seam

**Fake tier**, as the ticket specifies. The rule layer runs on notes written by hand, so "a phrase ended at 4.0" is a fact about the input before it is one about the output. One end-to-end test runs the real reader over `write_tones` audio — two four-note phrases with a bar of rest between them — and asserts the boundary within **0.3s**, inside the "± a few hundred ms" the ticket names.

Fake tier 1373 passed, mypy strict clean, ruff clean.

## Review record

Two-axis review (`/code-review` against `origin/main`), then a focused re-check of each fix diff.

### Spec axis — 1 finding, fixed

**Two of the three cues were dead at the shipped default.** All three nominated, but confidence was a weighted sum `{rest 0.35, held 0.25, contour 0.15, grid 0.25}` and the cues are *alternatives*, not parts of one event. A saturated held-note cue scored 0.287 and a saturated fifth 0.223 — both under `DEFAULT_MINIMUM_CONFIDENCE = 0.35`. Only the rest cue worked. The two tests meant to cover this passed `minimum_confidence=0.0` and so proved nothing about the shipped detector.

Fixed in `c637093`: `scored` lets the strongest cue carry the reading (`CUE_WEIGHT` 0.55), the other two add on top when they corroborate it (`AGREEMENT_WEIGHT` 0.2), and the grid is scored separately (0.25) because a bar line is not evidence that a phrase ended — only that this is a frame worth cutting on. One saturated cue alone now scores 0.5875 at the weakest real placement. Both cue tests run at the default floor, and the rule is pinned per-cue directly.

Spec axis raised no missing requirement and no material scope creep. The artifact shape mirrors `fills` (`Boundary`/`Detection`/`rows`/`gist`/starter/worker, same cache and `records.write` path).

### Standards axis — 6 findings: 4 fixed, 2 answered in code

Fixed in `c637093`:

1. **Duplicated code.** `_phrase` + its three constants and `_sane_floor` were verbatim copies of `fills`. Neither belongs to either detector: "where does this beat sit in a four-bar group" is a fact about the grid, so it moved to `beats.bar_line_strength` beside `nearest` (public for exactly this reason), and the floor check joined `halves.readable`, the sibling validator of what a job was asked for. `fills` now calls both, and `bar_line_strength` gained direct tests in `test_beat_grid.py`.
2. **Mysterious name** — resolved by the move; the function no longer carries fills' `phrase` name into a module where "phrase" means something else.
3. **Placeholder field** — `notes` is passed into `_weighed` rather than repaired afterwards with `._replace`.
4. **Speculative generality** — `Note.held` now has production callers.

Answered rather than changed, with the reasoning in the code:

5. `_clamp` stays duplicated — two lines, and sharing it would couple two rule layers for nothing.
6. `rows` keeps `t`/`measured_t` rather than the field names: that is `solos.numbered`'s vocabulary and every record file in this stack already speaks it. Noted in the `rows` docstring.

### Fix-diff re-check — 5 findings, all fixed

Verified the scoring arithmetic independently, then found what the fix left behind (`d237e45`):

1. **`RESET_SEMITONES` was both the nomination threshold and the saturation denominator**, so the contour factor was 1.0 for every leap that nominated. After the reweighting that made every fifth unfilterable by any floor. It now nominates at a fifth and saturates at an octave, the way rest and held have always had two thresholds.
2. `halves.sane_floor` told a phrase caller "0 writes every candidate" — the fills job's word. It takes the noun now.
3. The floor test asserted at 1.0, which rejects everything by construction. Retargeted to the shipped default against a rest sitting on the nomination threshold.
4. `boundaries` measured its baseline off raw `end - seconds` while every rule downstream used the rounded `Note.held`.
5. Dropped an unreachable branch in `scored`.

The re-check confirmed the `fills` refactor is behaviour-preserving (identical floats, identical error `cause`/`fix`/`detail` once the noun was parameterised) and that `AGREEMENT_WEIGHT` strictly increases the score with the weights summing to exactly 1.0, so the clamp masks nothing.

## Two things the ticket asked for that this does not do

- **The research spike.** The ticket said "worth a research spike before committing to a method". A method was committed to without one. Mitigated rather than resolved: each choice is justified inline in `melody.py` (taper division, the first-local-peak octave guard, hysteresis gating, the frame-centre bias correction), and `Reader` is injectable per ADR 0002, so a better pitch tracker is a drop-in the rule layer never notices.
- **The #46 evaluation.** Deferred, not dropped, and said so in `phrases.py`'s docstring and the commit. No seam here can say whether these are the boundaries a *director* would name — that needs the #46 tune and its annotated cut points, and it is a pass over real media.

Review: clean — spec 1 finding fixed, standards 6 (4 fixed, 2 answered in code), fix-diff re-check 5 fixed; fake tier 1373 passed, mypy strict and ruff clean.

### Merge-train resolution (`9875e1d`)

The merge train landed #144–#149 first; #147's rewrite of `PHRASE_BARS`' docstring in `fills.py` conflicted with this branch having already moved that constant (as `GROUP_BARS`) and its scoring into `beats.bar_line_strength`. Resolution keeps the move, ports #125's settled four-bar reasoning onto `GROUP_BARS`' docstring, repoints `fills.BASELINE_BARS`' docstring at `beats.GROUP_BARS` (a stale reference the textual merge would have left), and unions both `CONTEXT.md` glossary edits. Focused pass over the resolution diff only; repo-wide grep found no other reference to the removed constants.

Review: clean — merge resolution only; fake tier 1425 passed, mypy strict and ruff clean.
