### PR TITLE
Carry a rebuild's markers on the mix, not on the frame numbers (#130)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,7 +102,9 @@ stalling stdio), `store` (one JSON record per job on disk).
 contract), `fusion` (Text+ node, text, opacity fade spline), `interchange`
 (timeline export/import), `loader` (import DaVinciResolveScript +
 direct-attach), `markers` (read/write, review-loop transport), `media`
-(media pool: import, list, inspect, bins, relink), `render` (render
+(media pool: import, list, inspect, bins, relink), `mix` (where the master
+mix sits under a timeline — the one axis a rebuild does not move; read by
+`build`'s marker carry and by `analysis/correlate`), `render` (render
 queue), `camera_sidecar` (camera model off the card's own XML, for media
 Resolve reports no camera metadata for — #94; not an **angle sidecar**),
 `scripting` (`run_python` with handles pre-bound), `session`

--- a/docs/adr/0006-markers-ride-the-mix-across-a-rebuild.md
+++ b/docs/adr/0006-markers-ride-the-mix-across-a-rebuild.md
@@ -1,0 +1,90 @@
+# 0006 — Markers ride the mix across a rebuild, and there is no marker sidecar
+
+**Status:** accepted, 2026-08-08 (#130)
+
+## Context
+
+A titles file survives a rebuild because every event time is an offset from the blue
+marker naming its song, never an absolute frame. The markers themselves did not survive:
+`build_timeline` creates an empty timeline, so each rebuild dropped every hand-placed
+marker and a human had to re-mark every song boundary before the same titles file could be
+re-applied. #42 called that the one manual step left in the re-apply loop.
+
+#130 offered two routes: persist marker positions to a sidecar and re-apply them through
+`set_markers` on rebuild, or write the hand procedure down as a deliberate v1 limitation.
+The sidecar was preferred **if the position source is stable across rebuilds**.
+
+## The measurement that decides it
+
+Nothing a build writes into Resolve carries a segment id or a source frame. A built
+timeline's content is record frames, and record frames are exactly what a rebuild moves:
+re-time one segment and everything after it slides. So a marker's record frame is not a
+position that can be persisted anywhere and re-used — not in a sidecar, not anywhere else.
+
+One coordinate does hold still. A concert cut lays the master mix as a *single continuous
+clip* under the whole timeline, and nobody re-times it. Which frame of the mix sits under a
+given record frame therefore means the same thing on every version of the cut, and the two
+versions' readings of it differ by one constant:
+
+    zero_frame = record_in - source_in          (per version, read off the timeline)
+    new_record = old_record + (zero_new - zero_old)
+
+`analysis/correlate` already derived exactly this constant to turn timeline positions into
+seconds of the analysed mix.
+
+## Decision
+
+**Neither route as written. Markers are carried, and there is no sidecar file.**
+
+`build_timeline` reads the markers off the version it is superseding and writes them onto
+the version it just made, moved by the frame of the mix each one sat over. `carry_markers`
+(default on) turns it off. The reading of where the mix sits is `resolve/mix.py`, shared
+with `correlate` so the two cannot disagree about it.
+
+A sidecar was rejected on three counts, in order of weight:
+
+1. **It would duplicate a source that already exists and is already durable.** A build
+   never touches an earlier version — that is this file's oldest guarantee — so the
+   superseded timeline *is* the persisted copy of its own markers, maintained by Resolve,
+   correct by construction.
+2. **It would go stale silently.** Markers are placed by hand in the GUI, which no server
+   code observes. A sidecar written at marker-set time would diverge from the timeline the
+   moment a human dragged one, and nothing would say so.
+3. **It would be machine-local.** The only place server-written JSON lives is
+   `Config.cache_dir` under `%LOCALAPPDATA%`. A rebuild on another box would find no
+   sidecar and silently carry nothing. The repo's one deliberate project-scoped sidecar —
+   the angle sidecar in `styles/` — is agent-owned data that server code is
+   test-enforced never to read, so it is a precedent against this, not for it.
+
+## The limitation this leaves, deliberately
+
+**A cut with no master mix under it shares no axis with its previous version, and its
+markers are not carried.** That is a rough cut (P4), which has no continuous mix by
+definition. There is no honest derivation available there: without the mix the only
+anchor left is a segment id, and cut files keep no per-version copies, so the previous
+version's document is not on disk to compare against.
+
+Nothing is guessed in that case. The build reports `markers.reason` naming the version
+whose markers were left behind and how many there were, and re-marking by hand before
+applying titles remains the procedure. The same refusal covers a previous version whose
+audio shots disagree about where the mix starts.
+
+**The carry is exact for a marker that means a musical moment and approximate for one that
+means a picture moment.** A blue marker names a song and rides the mix exactly. A
+director's coloured note was put over a *shot*, and a rebuild is precisely what moves
+shots — so it lands on the same music, which may no longer be the same picture. Both are
+carried, because a note at the right moment of the performance beats a note deleted; the
+report splits the count by colour (`markers.by_color`) so an agent can re-read the notes
+without re-reading the anchors.
+
+## Measured, not assumed
+
+One append of a multi-channel clip comes back as **one timeline item per channel**: an
+8-channel MXF laid on a built timeline reads as eight audio shots on A1–A8, same clip, same
+record frame, same source frame (Studio 21.0.3.7, Windows 11, live tier). The first
+implementation asked for exactly one audio item and refused every real concert mix. The
+rule is therefore *agreement*, not arity — `mix.anchor` answers only when every shot of the
+named clip puts the mix's frame 0 on the same record frame, which one placement always does
+however many channels it has, and two placements at different offsets never do.
+
+No fake could have found this: it is Resolve's own answer to an append.

--- a/docs/agents/rough-cut.md
+++ b/docs/agents/rough-cut.md
@@ -145,3 +145,11 @@ about unmarked. Reviewing a rough cut should take minutes.
 Then the review round is the ordinary one: the director's notes come back as markers,
 `list_markers` is your queue, take notes are `swap_take` with the cut file kept in sync, and
 everything else is a new version.
+
+**A rebuild loses the markers here, and that is deliberate** (ADR 0006). On a concert cut
+`build_timeline` carries the previous version's markers onto the new one by the frame of
+the master mix under them — but a rough cut has no continuous mix, so the two versions
+share no axis and nothing honest can be derived. The build says so in `markers.reason`
+rather than guessing. So read the round's markers *before* you rebuild: `list_markers` on
+the version being superseded is the only copy, and it is what you are rebuilding from
+anyway.

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -44,19 +44,18 @@ from ..jobs.runner import JobOutput, Progress, start_job
 from ..logging_config import get_logger
 from ..naming import keyed_name
 from ..resolve.connection import ResolveConnection
+from ..resolve.mix import MixShot, audio_shots
 from ..resolve.session import frame_rate
 from ..resolve.timeline import (
     FIRST_TRACK,
     Reader,
     angle_of,
-    clip_name,
     find_timeline,
     fingerprint,
     items_in_track,
     name_of,
     open_project,
     read_frames,
-    source_bounds,
     start_frame,
 )
 from ..timing import SECONDS_PRECISION, dual_time, to_frames
@@ -384,53 +383,21 @@ def _clock(
     if given is not None:
         return Clock(given, fps, GIVEN, mix.name if mix else None, mix is not None)
 
-    found = _audio_shots(reader, timeline)
+    found = audio_shots(reader, timeline)
     wanted = _matching(found, mix)
     chosen = wanted or (found[0] if found else None)
     if chosen is None:
         return Clock(start_frame(timeline), fps, "timeline_start", None, False)
-    name, record_in, source_in = chosen
-    return Clock(record_in - source_in, fps, "audio_clip", name, wanted is not None)
+    return Clock(chosen.zero_frame, fps, "audio_clip", chosen.name, wanted is not None)
 
 
-def _audio_shots(reader: Reader, timeline: Any) -> list[tuple[str, int, int]]:
-    """Every audio shot that will say where it sits: its clip name, record in and mix in.
-
-    The mix in is counted from the *start of the file*, not from the clip's own start
-    timecode: a WAV stamped 01:00:00:00 reports source frames an hour in, and subtracting
-    that stamp is the difference between a correct reading and one shifted by an hour.
-    """
-    count = int(read_frames(reader.optional(timeline, "GetTrackCount", 0, "audio")) or 0)
-    found: list[tuple[str, int, int]] = []
-    for index in range(1, count + 1):
-        for item in items_in_track(timeline, "audio", index):
-            record_in = read_frames(item.GetStart())
-            source_in, _ = source_bounds(reader, item, read_frames(item.GetDuration()))
-            if record_in is None or source_in is None:
-                continue
-            name = clip_name(reader, item) or str(item.GetName() or "")
-            found.append((name, record_in, source_in - _media_start(reader, item)))
-    return found
-
-
-def _media_start(reader: Reader, item: Any) -> int:
-    """The first frame of the media itself, which is not zero on anything with a start stamp."""
-    clip = reader.optional(item, "GetMediaPoolItem", None)
-    if clip is None:
-        return 0
-    return read_frames(reader.optional(clip, "GetClipProperty", None, "Start")) or 0
-
-
-def _matching(
-    found: Sequence[tuple[str, int, int]],
-    mix: Path | None,
-) -> tuple[str, int, int] | None:
+def _matching(found: Sequence[MixShot], mix: Path | None) -> MixShot | None:
     """The audio shot holding the file the analysis ran on, by name or by stem."""
     if mix is None:
         return None
     names = {mix.name.casefold(), mix.stem.casefold()}
     for shot in found:
-        if shot[0].casefold() in names or Path(shot[0]).stem.casefold() in names:
+        if shot.name.casefold() in names or Path(shot.name).stem.casefold() in names:
             return shot
     return None
 

--- a/src/resolve_mcp/naming.py
+++ b/src/resolve_mcp/naming.py
@@ -99,6 +99,16 @@ def latest_version(base: str, existing: Iterable[str]) -> int:
     return max(numbers, default=0)
 
 
+def version_name(base: str, number: int) -> str:
+    """What version ``number`` of ``base`` is called.
+
+    One owner for the format, because it is read back as well as written: a caller naming
+    the version a build supersedes has to spell it exactly as the build that made it did,
+    and two f-strings agreeing today is not the same as one that cannot drift.
+    """
+    return f"{base} v{number}"
+
+
 def next_version_name(base: str, existing: Iterable[str]) -> str:
     """The name the next build takes: ``<base> v<latest + 1>``."""
-    return f"{base} v{latest_version(base, existing) + 1}"
+    return version_name(base, latest_version(base, existing) + 1)

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -239,22 +239,22 @@ def _carry_markers(
     if not found:
         return _no_carry(f"{previous} carries no markers.", previous)
 
-    here = mix.audio_shots(reader, built)
-    if len(here) != 1:
+    here = mix.anchor(mix.audio_shots(reader, built))
+    if here is None:
         return _no_carry(
             f"This cut has no single master mix under it, so it shares no axis with "
             f"{previous}: its {len(found)} marker(s) have to be placed by hand.",
             previous,
         )
-    there = mix.named(mix.audio_shots(reader, earlier), here[0].name)
+    there = mix.anchor(mix.audio_shots(reader, earlier), here.name)
     if there is None:
         return _no_carry(
-            f"{previous} does not carry exactly one {here[0].name} under it, so there is no "
+            f"{previous} does not agree where {here.name} starts under it, so there is no "
             f"reading of where its {len(found)} marker(s) sit in the mix.",
             previous,
         )
 
-    shift = here[0].zero_frame - there.zero_frame
+    shift = here.zero_frame - there.zero_frame
     entries = [_carried(marker, shift) for marker in found]
     results = markers.set_markers(connection, entries, name=name)["results"]
     refused = [

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -33,12 +33,13 @@ from dataclasses import dataclass
 from typing import Any, Final
 
 from ..cut.validate import locked_track_finding, overlay_positions, placements
-from ..errors import BuildFailedError, CutInvalidError
+from ..errors import BuildFailedError, CutInvalidError, TimelineNotFoundError
 from ..logging_config import get_logger
-from ..naming import next_version_name
-from . import cut, media, takes
+from ..naming import latest_version, next_version_name
+from . import cut, markers, media, mix, takes
 from . import timeline as timeline_read
 from .connection import ResolveConnection
+from .session import frame_rate
 
 log = get_logger("build")
 
@@ -58,6 +59,9 @@ AUDIO_TRACK_TYPE: Final = "stereo"
 
 MISPLACED_CAP: Final = 20
 """A drifted build misplaces everything downstream of the blockage; the count says how many."""
+
+REFUSED_MARKER_CAP: Final = 20
+"""Carried markers that would not land are listed, not just counted — up to this many."""
 
 
 @dataclass(frozen=True)
@@ -119,6 +123,7 @@ def build_timeline(
     connection: ResolveConnection,
     cut_file: str,
     min_segment_frames: int = cut.MIN_SEGMENT_FRAMES,
+    carry_markers: bool = True,
 ) -> dict[str, Any]:
     """Build ``cut_file`` as a fresh ``<name> v<N>`` timeline and report what landed."""
     checked = cut.preflight(connection, cut_file, min_segment_frames)
@@ -138,10 +143,12 @@ def build_timeline(
 
     project = timeline_read.open_project(connection)
     pool = media.media_pool(connection)
-    name = next_version_name(
-        str(doc["timeline"]["name"]),
-        timeline_read.timeline_names(project),
-    )
+    base = str(doc["timeline"]["name"])
+    existing = timeline_read.timeline_names(project)
+    # Read before the build, because creating the new version is what makes it the latest:
+    # the version being superseded is the one holding the markers a human placed by hand.
+    superseded = latest_version(base, existing)
+    name = next_version_name(base, existing)
     clips = cut.clips_by_alias(checked)
     _unlock_stills(clips)
 
@@ -155,6 +162,14 @@ def build_timeline(
     # read back — a selector on a shot that slid somewhere else would be alternates for a
     # shot the cut file does not have.
     made = takes.attach_takes(built, _selectors(doc, clips, shots), name)
+    carried = _carry_markers(
+        connection,
+        project,
+        built,
+        name,
+        f"{base} v{superseded}" if superseded else None,
+        carry_markers,
+    )
 
     log.info("Built %s: %d clips from %s", name, len(shots), checked.loaded.content_hash)
     return {
@@ -167,6 +182,7 @@ def build_timeline(
             "audio": bool(_count(shots, A1)),
             "selectors": made,
         },
+        "markers": carried,
         "warnings": [finding.as_dict() for finding in checked.warnings],
     }
 
@@ -174,6 +190,125 @@ def build_timeline(
 def _count(shots: list[Shot], track: Track) -> int:
     """How many of this build's appends one track took — segments and overlays are both V."""
     return sum(1 for shot in shots if shot.track == track)
+
+
+# --- markers --------------------------------------------------------------------------------
+
+
+def _carry_markers(
+    connection: ResolveConnection,
+    project: Project,
+    built: Timeline,
+    name: str,
+    previous: str | None,
+    asked: bool,
+) -> dict[str, Any]:
+    """Move the superseded version's markers onto the new one, through the mix under both.
+
+    Blue markers name the songs a titles file anchors its events to, and a human places
+    them by hand. A rebuild makes an *empty* timeline, so before #130 every rebuild cost
+    another pass of hand re-marking every song boundary before the titles file could be
+    re-applied — the one manual step left in that loop.
+
+    The carry is a derivation, not a copy. Record frames are exactly what a rebuild moves:
+    re-time one segment and everything after it slides, which is the whole reason a build
+    makes a new version. What does not move is the master mix — one continuous clip nobody
+    re-times — so a marker is carried by *the frame of the mix it sat over*, and the two
+    versions' readings of that (:mod:`resolve_mcp.resolve.mix`) differ by one constant.
+
+    A cut with no mix under it has no such shared axis. There is no honest answer for where
+    its markers go, so nothing is carried and the report says why: markers landing at
+    positions that merely look plausible would be worse than markers a human knows are
+    missing. Same for a previous version whose mix is a different clip, or two clips of the
+    same name — an anchor that cannot be identified is not an anchor.
+    """
+    if not asked:
+        return _no_carry("carry_markers was off, so the earlier version's markers stayed there.")
+    if previous is None:
+        return _no_carry("Nothing to carry: this is the first version of this cut.")
+
+    reader = timeline_read.Reader(connection)
+    try:
+        earlier = timeline_read.find_timeline(project, previous)
+    except TimelineNotFoundError:
+        # The name came off this project moments ago, so this is a timeline deleted mid-build
+        # rather than a mistake — and a build that placed every clip must not fail over it.
+        return _no_carry(f"{previous} was gone by the time its markers were read.", previous)
+
+    found = markers.markers_on(connection, earlier, frame_rate(project, earlier))
+    if not found:
+        return _no_carry(f"{previous} carries no markers.", previous)
+
+    here = mix.audio_shots(reader, built)
+    if len(here) != 1:
+        return _no_carry(
+            f"This cut has no single master mix under it, so it shares no axis with "
+            f"{previous}: its {len(found)} marker(s) have to be placed by hand.",
+            previous,
+        )
+    there = mix.named(mix.audio_shots(reader, earlier), here[0].name)
+    if there is None:
+        return _no_carry(
+            f"{previous} does not carry exactly one {here[0].name} under it, so there is no "
+            f"reading of where its {len(found)} marker(s) sit in the mix.",
+            previous,
+        )
+
+    shift = here[0].zero_frame - there.zero_frame
+    entries = [_carried(marker, shift) for marker in found]
+    results = markers.set_markers(connection, entries, name=name)["results"]
+    refused = [
+        {
+            "name": entry["name"],
+            "color": entry["color"],
+            "record": entry["frame"],
+            "error": result.get("error"),
+        }
+        for entry, result in zip(entries, results, strict=True)
+        if not result.get("ok")
+    ]
+    log.info(
+        "Carried %d of %d markers from %s onto %s, shifted %+d frames",
+        len(entries) - len(refused),
+        len(entries),
+        previous,
+        name,
+        shift,
+    )
+    return {
+        "carried": len(entries) - len(refused),
+        "skipped": len(refused),
+        "from": previous,
+        "shift": shift,
+        # A marker whose moment was cut out of this version lands outside the timeline and is
+        # refused by name, because "which song lost its marker" is the actionable half.
+        "refused": refused[:REFUSED_MARKER_CAP],
+        "reason": None,
+    }
+
+
+def _no_carry(reason: str, source: str | None = None) -> dict[str, Any]:
+    """The same shape as a carry that happened — a reader parses one block, not two."""
+    return {
+        "carried": 0,
+        "skipped": 0,
+        "from": source,
+        "shift": None,
+        "refused": [],
+        "reason": reason,
+    }
+
+
+def _carried(marker: dict[str, Any], shift: int) -> dict[str, Any]:
+    """One read marker as the write that puts it over the same moment of the mix."""
+    return {
+        "frame": marker["record"]["frames"] + shift,
+        "color": marker["color"],
+        "name": marker["name"],
+        "note": marker["note"],
+        "duration": marker["duration"]["frames"],
+        "custom_data": marker["custom_data"],
+    }
 
 
 # --- placement ------------------------------------------------------------------------------

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -35,7 +35,7 @@ from typing import Any, Final
 from ..cut.validate import locked_track_finding, overlay_positions, placements
 from ..errors import BuildFailedError, CutInvalidError, TimelineNotFoundError
 from ..logging_config import get_logger
-from ..naming import latest_version, next_version_name
+from ..naming import latest_version, next_version_name, version_name
 from . import cut, markers, media, mix, takes
 from . import timeline as timeline_read
 from .connection import ResolveConnection
@@ -167,7 +167,7 @@ def build_timeline(
         project,
         built,
         name,
-        f"{base} v{superseded}" if superseded else None,
+        version_name(base, superseded) if superseded else None,
         carry_markers,
     )
 
@@ -255,7 +255,7 @@ def _carry_markers(
         )
 
     shift = here.zero_frame - there.zero_frame
-    entries = [_carried(marker, shift) for marker in found]
+    entries = [_write_entry(marker, shift) for marker in found]
     results = markers.set_markers(connection, entries, name=name)["results"]
     refused = [
         {
@@ -275,11 +275,18 @@ def _carry_markers(
         name,
         shift,
     )
+    landed = [entry for entry, result in zip(entries, results, strict=True) if result.get("ok")]
     return {
-        "carried": len(entries) - len(refused),
+        "carried": len(landed),
         "skipped": len(refused),
         "from": previous,
         "shift": shift,
+        # Not decoration: the carry is exact for a marker that means a *musical* moment and
+        # only approximate for one that means a *picture* moment, and the two are told apart
+        # by colour alone. Blue names a song and rides the mix exactly; a director's coloured
+        # note was put over a shot, and this rebuild is what moved the shots. Splitting the
+        # count is what lets an agent re-read the notes without re-reading the anchors.
+        "by_color": _colours(landed),
         # A marker whose moment was cut out of this version lands outside the timeline and is
         # refused by name, because "which song lost its marker" is the actionable half.
         "refused": refused[:REFUSED_MARKER_CAP],
@@ -294,12 +301,21 @@ def _no_carry(reason: str, source: str | None = None) -> dict[str, Any]:
         "skipped": 0,
         "from": source,
         "shift": None,
+        "by_color": {},
         "refused": [],
         "reason": reason,
     }
 
 
-def _carried(marker: dict[str, Any], shift: int) -> dict[str, Any]:
+def _colours(entries: list[dict[str, Any]]) -> dict[str, int]:
+    """How many of each colour came across, the same histogram ``list_markers`` reports."""
+    counts: dict[str, int] = {}
+    for entry in entries:
+        counts[entry["color"]] = counts.get(entry["color"], 0) + 1
+    return counts
+
+
+def _write_entry(marker: dict[str, Any], shift: int) -> dict[str, Any]:
     """One read marker as the write that puts it over the same moment of the mix."""
     return {
         "frame": marker["record"]["frames"] + shift,

--- a/src/resolve_mcp/resolve/markers.py
+++ b/src/resolve_mcp/resolve/markers.py
@@ -220,6 +220,25 @@ def _colors(markers: list[dict[str, Any]]) -> dict[str, int]:
     return counts
 
 
+def markers_on(
+    connection: ResolveConnection,
+    timeline: Timeline,
+    fps: float | None,
+) -> list[dict[str, Any]]:
+    """Every marker on a timeline in record time, in frame order and uncapped.
+
+    ``list_markers`` is the agent's view and caps at :data:`DEFAULT_MARKER_LIMIT`, spilling
+    the rest to a file — right for something being read, wrong for something being *moved*,
+    where a cap would silently drop the markers past the two hundredth and the timeline
+    would look successfully carried. Callers moving markers take this instead and are
+    expected to report every one they touched.
+    """
+    clock = MarkerClock(connection, timeline, fps)
+    return [
+        _marker(relative, detail, clock) for relative, detail in sorted(_reported(clock).items())
+    ]
+
+
 def markers_by_name(
     connection: ResolveConnection,
     timeline: Timeline,

--- a/src/resolve_mcp/resolve/markers.py
+++ b/src/resolve_mcp/resolve/markers.py
@@ -160,6 +160,13 @@ def _reported(clock: MarkerClock) -> dict[int, dict[str, Any]]:
     return markers
 
 
+def _all(clock: MarkerClock) -> list[dict[str, Any]]:
+    """Every readable marker on one clock, in frame order — what both readers start from."""
+    return [
+        _marker(relative, detail, clock) for relative, detail in sorted(_reported(clock).items())
+    ]
+
+
 def list_markers(
     connection: ResolveConnection,
     name: str | None = None,
@@ -174,9 +181,7 @@ def list_markers(
     timeline = find_timeline(project, name)
     clock = MarkerClock(connection, timeline, frame_rate(project, timeline))
 
-    markers = [
-        _marker(relative, detail, clock) for relative, detail in sorted(_reported(clock).items())
-    ]
+    markers = _all(clock)
     window = frame_window(start, end, clock.fps)
     wanted = [marker for marker in markers if _matches(marker, color) and _touches(marker, window)]
 
@@ -225,18 +230,20 @@ def markers_on(
     timeline: Timeline,
     fps: float | None,
 ) -> list[dict[str, Any]]:
-    """Every marker on a timeline in record time, in frame order and uncapped.
+    """Every readable marker on a timeline in record time, in frame order and uncapped.
 
     ``list_markers`` is the agent's view and caps at :data:`DEFAULT_MARKER_LIMIT`, spilling
     the rest to a file — right for something being read, wrong for something being *moved*,
     where a cap would silently drop the markers past the two hundredth and the timeline
-    would look successfully carried. Callers moving markers take this instead and are
-    expected to report every one they touched.
+    would look successfully carried. Callers moving markers take this instead.
+
+    "Readable" is the one thing it does not promise past: a marker whose frame will not
+    parse is logged and left out by :func:`_reported`, exactly as it is for ``list_markers``,
+    because a marker that cannot be placed on either clock cannot be moved to a third. A
+    caller reporting counts is reporting what it could read, and the log is where a
+    difference between that and what the GUI shows gets diagnosed.
     """
-    clock = MarkerClock(connection, timeline, fps)
-    return [
-        _marker(relative, detail, clock) for relative, detail in sorted(_reported(clock).items())
-    ]
+    return _all(MarkerClock(connection, timeline, fps))
 
 
 def markers_by_name(

--- a/src/resolve_mcp/resolve/mix.py
+++ b/src/resolve_mcp/resolve/mix.py
@@ -1,0 +1,90 @@
+"""Where the master mix sits under a timeline — the one axis a rebuild does not move.
+
+A concert cut is one continuous mix clip with the pictures laid over it (#22: the cutting
+substrate). Every *record* frame on such a timeline is provisional: tighten a segment near
+the head and everything downstream slides, which is why a rebuild produces a new version
+rather than editing the reviewed one. The mix's own frames do not slide, because the mix is
+one clip nobody re-times — so "which frame of the mix is under this record frame" is the
+only coordinate two versions of the same cut agree on.
+
+That reading is a single number, :attr:`MixShot.zero_frame`: the record frame the mix's own
+first frame lands on. Everything built from it is addition. Two callers need it and must
+never disagree about it — ``correlate_timeline`` turns timeline positions into seconds of
+the analysed mix, and ``build_timeline`` carries hand-placed markers from the previous
+version onto the one it just made — so the reading lives here once rather than in each.
+
+The subtlety worth the module: a source frame is counted from the *start of the media
+file*, not from the clip's own start timecode. A WAV stamped 01:00:00:00 reports source
+frames an hour in, and forgetting to subtract that stamp shifts every derived time by an
+hour — a failure that looks like a plausible reading rather than an error.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+from .timeline import Reader, clip_name, items_in_track, read_frames, source_bounds
+
+Timeline = Any
+TimelineItem = Any
+
+
+class MixShot(NamedTuple):
+    """One audio clip, in the two numbers that place it against its own media."""
+
+    name: str
+    record_in: int
+    source_in: int
+    """Counted from the first frame of the file, with any start stamp already subtracted."""
+
+    @property
+    def zero_frame(self) -> int:
+        """The record frame this clip's own frame 0 lands on, extended past its in point.
+
+        The number is not a position on the timeline — for a clip that starts part-way into
+        its media it is before the clip, and may be before the timeline's own start. It is
+        the constant that converts in both directions, which is all a caller wants from it.
+        """
+        return self.record_in - self.source_in
+
+
+def audio_shots(reader: Reader, timeline: Timeline) -> list[MixShot]:
+    """Every audio shot that will say where it sits, in track then timeline order.
+
+    A shot that cannot answer both numbers is left out rather than guessed at: a caller
+    choosing an anchor from this list must be choosing between readings it can trust.
+    """
+    count = int(read_frames(reader.optional(timeline, "GetTrackCount", 0, "audio")) or 0)
+    found: list[MixShot] = []
+    for index in range(1, count + 1):
+        for item in items_in_track(timeline, "audio", index):
+            record_in = read_frames(item.GetStart())
+            source_in, _ = source_bounds(reader, item, read_frames(item.GetDuration()))
+            if record_in is None or source_in is None:
+                continue
+            name = clip_name(reader, item) or str(item.GetName() or "")
+            found.append(MixShot(name, record_in, source_in - media_start(reader, item)))
+    return found
+
+
+def media_start(reader: Reader, item: TimelineItem) -> int:
+    """The first frame of the media itself, which is not zero on anything with a start stamp."""
+    clip = reader.optional(item, "GetMediaPoolItem", None)
+    if clip is None:
+        return 0
+    return read_frames(reader.optional(clip, "GetClipProperty", None, "Start")) or 0
+
+
+def named(shots: list[MixShot], name: str) -> MixShot | None:
+    """The one shot carrying ``name``, or ``None`` when none or several do.
+
+    Ambiguity is answered the same way as absence on purpose. A caller asking for *the* mix
+    on a timeline that holds two clips of the same name cannot be told which one was meant,
+    and picking the first would put a whole timeline's worth of derived positions on a
+    coin toss.
+    """
+    matched = [shot for shot in shots if shot.name == name]
+    return matched[0] if len(matched) == 1 else None
+
+
+__all__ = ["MixShot", "audio_shots", "media_start", "named"]

--- a/src/resolve_mcp/resolve/mix.py
+++ b/src/resolve_mcp/resolve/mix.py
@@ -8,10 +8,20 @@ one clip nobody re-times — so "which frame of the mix is under this record fra
 only coordinate two versions of the same cut agree on.
 
 That reading is a single number, :attr:`MixShot.zero_frame`: the record frame the mix's own
-first frame lands on. Everything built from it is addition. Two callers need it and must
-never disagree about it — ``correlate_timeline`` turns timeline positions into seconds of
-the analysed mix, and ``build_timeline`` carries hand-placed markers from the previous
-version onto the one it just made — so the reading lives here once rather than in each.
+first frame lands on. Everything built from it is addition. Two callers need it —
+``correlate_timeline`` turns timeline positions into seconds of the analysed mix, and
+``build_timeline`` carries hand-placed markers from the previous version onto the one it
+just made — so the reading lives here once rather than in each, and cannot come out
+differently in the two.
+
+What is deliberately *not* shared is how hard each caller insists on it. Reading and
+writing carry different costs for being wrong. ``correlate`` is producing a measurement to
+look at: if nothing matches the file it analysed it falls back to the first audio clip and
+labels the result ``matched: False``, so an assumed anchor is still useful and says it was
+assumed. The carry is producing *marker writes*: there is nowhere to put a caveat on a
+marker in the GUI, so it takes :func:`anchor`, which answers only when the shots agree, and
+otherwise carries nothing. Same reading, two risk postures — that difference is the point,
+not a drift between them.
 
 The subtlety worth the module: a source frame is counted from the *start of the media
 file*, not from the clip's own start timecode. A WAV stamped 01:00:00:00 reports source
@@ -64,11 +74,11 @@ def audio_shots(reader: Reader, timeline: Timeline) -> list[MixShot]:
             if record_in is None or source_in is None:
                 continue
             name = clip_name(reader, item) or str(item.GetName() or "")
-            found.append(MixShot(name, record_in, source_in - media_start(reader, item)))
+            found.append(MixShot(name, record_in, source_in - _media_start(reader, item)))
     return found
 
 
-def media_start(reader: Reader, item: TimelineItem) -> int:
+def _media_start(reader: Reader, item: TimelineItem) -> int:
     """The first frame of the media itself, which is not zero on anything with a start stamp."""
     clip = reader.optional(item, "GetMediaPoolItem", None)
     if clip is None:
@@ -98,4 +108,4 @@ def anchor(shots: Sequence[MixShot], name: str | None = None) -> MixShot | None:
     return wanted[0]
 
 
-__all__ = ["MixShot", "anchor", "audio_shots", "media_start"]
+__all__ = ["MixShot", "anchor", "audio_shots"]

--- a/src/resolve_mcp/resolve/mix.py
+++ b/src/resolve_mcp/resolve/mix.py
@@ -21,6 +21,7 @@ hour — a failure that looks like a plausible reading rather than an error.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, NamedTuple
 
 from .timeline import Reader, clip_name, items_in_track, read_frames, source_bounds
@@ -75,16 +76,26 @@ def media_start(reader: Reader, item: TimelineItem) -> int:
     return read_frames(reader.optional(clip, "GetClipProperty", None, "Start")) or 0
 
 
-def named(shots: list[MixShot], name: str) -> MixShot | None:
-    """The one shot carrying ``name``, or ``None`` when none or several do.
+def anchor(shots: Sequence[MixShot], name: str | None = None) -> MixShot | None:
+    """The placement these shots agree on, or ``None`` when they do not agree on one.
 
-    Ambiguity is answered the same way as absence on purpose. A caller asking for *the* mix
-    on a timeline that holds two clips of the same name cannot be told which one was meant,
-    and picking the first would put a whole timeline's worth of derived positions on a
-    coin toss.
+    Counting items would be the obvious rule and is the wrong one. Resolve spreads a
+    multi-channel clip across one track per channel, so a *single* append of an eight-channel
+    mix reads back as eight shots — same clip, same record frame, same source frame, on A1
+    to A8. Measured live on Studio 21.0.3.7 with an 8-channel MXF; a rule that wanted one
+    item would refuse the commonest concert mix there is.
+
+    What decides the question is not how many items there are but whether they agree where
+    the mix begins. So the shots are narrowed to ``name`` when the caller knows which clip
+    it wants, and answered only when every remaining one puts the mix's frame 0 on the same
+    record frame. Disagreement is answered like absence: a timeline carrying the same clip
+    at two offsets cannot say which one a derived position should be counted from, and
+    picking the first would put every one of them on a coin toss.
     """
-    matched = [shot for shot in shots if shot.name == name]
-    return matched[0] if len(matched) == 1 else None
+    wanted = [shot for shot in shots if name is None or shot.name == name]
+    if not wanted or len({(shot.name, shot.zero_frame) for shot in wanted}) != 1:
+        return None
+    return wanted[0]
 
 
-__all__ = ["MixShot", "audio_shots", "media_start", "named"]
+__all__ = ["MixShot", "anchor", "audio_shots", "media_start"]

--- a/src/resolve_mcp/titles/schema.py
+++ b/src/resolve_mcp/titles/schema.py
@@ -11,8 +11,9 @@ re-runnable rather than merely automatic:
 
 * **Event times are offsets from the song's blue marker, never absolute frames.** The
   marker name is the song key, which is the explicit join between the file and the
-  timeline (#14 §1). A rebuild makes a new timeline version; re-marking the songs on it
-  is all that is needed for the same titles file to land correctly again. Absolute
+  timeline (#14 §1). A rebuild makes a new timeline version, and ``build_timeline``
+  carries the song markers onto it by the frame of the master mix each one sat over
+  (#130), so the same titles file lands correctly again with nothing re-marked. Absolute
   frames would silently point at the wrong music the moment a segment's length changed.
 * **Titles are not in the cut file, and the cut file is not read here.** The two files
   together describe a deliverable, and each owns its own tracks — ``build_timeline``
@@ -100,7 +101,10 @@ _ANCHORS: Final = """\
 A song's `key` is the *name* of a blue marker on the target timeline; every
 event's `in`/`out` counts frames forward from that marker. So the join between
 this file and the timeline is explicit and survives a rebuild: build the new
-version, mark the songs on it, re-apply this file unchanged.
+version and re-apply this file unchanged. `build_timeline` carries the previous
+version's markers onto the one it makes, riding the master mix underneath, so
+the songs are already marked; check `markers` in the build report before
+re-applying, because a cut with no master mix under it is carried by hand.
 
 Exactly one blue marker must carry each key (T7). A blue marker with no matching
 song is reported as a warning, never an error — a set list is often titled a song

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -105,6 +105,11 @@ def build_timeline(
     `carry_markers=False` to leave them behind. A cut with no master mix has no shared axis
     with the earlier version: nothing is carried, and `markers.reason` says so.
 
+    Read `markers.by_color` before trusting the coloured ones. A blue marker names a song
+    and lands exactly, because the music is what it was anchored to. A note put over a
+    *shot* lands on the same music, and moving the shots is what this build just did — so
+    re-read those against the new cut.
+
     The validate_cut rules run first: a single error aborts before any timeline is created,
     and comes back with the same per-segment findings. The report echoes the cut file's
     content hash, which is what ties the timeline back to the exact cut that made it —

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -86,6 +86,7 @@ def virtual_transcript(
 def build_timeline(
     cut_file: str,
     min_segment_frames: int = cut.MIN_SEGMENT_FRAMES,
+    carry_markers: bool = True,
 ) -> dict[str, Any]:
     """Build a cut file into a new `<name> v<N>` timeline and report what landed.
 
@@ -95,6 +96,15 @@ def build_timeline(
     land on V2 at their anchor segment's start plus the offset — never a frame you state —
     so tightening a segment and rebuilding leaves every overlay over the same content.
 
+    The version being superseded usually carries hand-placed markers — the blue song
+    anchors a titles file is written against, and the director's coloured notes. They are
+    carried onto the new version by the frame of the master mix each one sat over, so they
+    stay on the same musical moment however much the picture above moved, and a titles file
+    re-applies without anyone re-marking the songs. `markers` in the report says how many
+    came across, how far they shifted, and names any the new version has no room for. Pass
+    `carry_markers=False` to leave them behind. A cut with no master mix has no shared axis
+    with the earlier version: nothing is carried, and `markers.reason` says so.
+
     The validate_cut rules run first: a single error aborts before any timeline is created,
     and comes back with the same per-segment findings. The report echoes the cut file's
     content hash, which is what ties the timeline back to the exact cut that made it —
@@ -102,7 +112,7 @@ def build_timeline(
     partially built version, if one was made, is scrap and can be deleted.
     """
     connection = get_connection()
-    return build.build_timeline(connection, cut_file, min_segment_frames)
+    return build.build_timeline(connection, cut_file, min_segment_frames, carry_markers)
 
 
 @tool

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -431,7 +431,22 @@ def test_a_cut_with_no_master_mix_refuses_to_guess_where_the_markers_go(
     assert built(resolve, "sunset-set v4").GetMarkers() == {}
 
 
-def test_an_earlier_version_carrying_two_clips_of_the_same_mix_is_not_an_anchor(
+def test_a_multi_channel_mix_on_the_earlier_version_is_one_anchor_not_eight(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Live, an 8-channel MXF appends as one item per channel across A1-A8 — one placement
+    said eight times. Counting items instead of reading them refuses a real concert mix."""
+    earlier = _earlier({60: _a_marker("sunset boulevard")}, mix=[_mix(source=40)] * 8)
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["carried"] == 1
+    assert result["markers"]["shift"] == 40
+    assert _carried(built(resolve, "sunset-set v4")) == [(100.0, "Blue", "sunset boulevard")]
+
+
+def test_an_earlier_version_that_lays_the_mix_at_two_offsets_is_not_an_anchor(
     attach: Attach, tmp_path: Path
 ) -> None:
     """Which of the two says where the mix sits? Nothing answers that, so nothing guesses."""
@@ -441,7 +456,7 @@ def test_an_earlier_version_carrying_two_clips_of_the_same_mix_is_not_an_anchor(
     result = _rebuild(resolve, tmp_path, attach)
 
     assert result["markers"]["carried"] == 0
-    assert "does not carry exactly one" in result["markers"]["reason"]
+    assert "does not agree where" in result["markers"]["reason"]
 
 
 def test_an_earlier_version_over_a_different_mix_is_not_an_anchor(

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -313,6 +313,41 @@ def test_a_carried_marker_keeps_the_colour_note_and_custom_data_it_had(
     }
 
 
+def test_the_report_splits_the_carry_by_colour(attach: Attach, tmp_path: Path) -> None:
+    """The blue anchor rode the music and is exact; the note was put over a shot, and moving
+    the shots is what this build did. One count for both would hide which needs an eye."""
+    earlier = _earlier(
+        {
+            100: _a_marker("sunset boulevard"),
+            140: _a_marker("night ferry"),
+            180: _a_marker("tighten this", "Red"),
+        }
+    )
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["carried"] == 3
+    assert result["markers"]["by_color"] == {"Blue": 2, "Red": 1}
+
+
+def test_a_marker_that_did_not_land_is_left_out_of_the_colour_count(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """`by_color` counts what is on the timeline, not what was attempted — an agent reads it
+    to decide what to re-check, and a refused marker is not there to re-check."""
+    earlier = _earlier(
+        {100: _a_marker("sunset boulevard"), 400: _a_marker("tighten this", "Red")},
+        end_frame=500,
+    )
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["by_color"] == {"Blue": 1}
+    assert result["markers"]["skipped"] == 1
+
+
 def test_a_marker_lands_on_the_mix_frame_it_sat_over_not_the_record_frame_it_had(
     attach: Attach, tmp_path: Path
 ) -> None:
@@ -382,6 +417,7 @@ def test_the_first_version_of_a_cut_has_nothing_to_carry(attach: Attach, tmp_pat
         "skipped": 0,
         "from": None,
         "shift": None,
+        "by_color": {},
         "refused": [],
         "reason": "Nothing to carry: this is the first version of this cut.",
     }

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -215,6 +215,298 @@ def test_another_cuts_versions_do_not_move_this_ones_number(
     assert build_timeline(a_cut(tmp_path, valid_doc()))["timeline"]["name"] == "sunset-set v1"
 
 
+# --- markers across a rebuild (#130) ------------------------------------------------------
+#
+# The markers on a reviewed version are hand-placed — blue ones name the songs a titles file
+# anchors to — and a rebuild makes an empty timeline. Carrying them is the one thing that
+# stops a rebuild costing a human another pass of re-marking every song boundary.
+#
+# What makes it correct is *not* copying the frame numbers. Record frames are exactly what a
+# rebuild moves. The master mix underneath does not move, so a marker is carried by the frame
+# of the mix it sat over, and these tests pin that: the same musical moment, wherever the
+# picture above it went.
+
+
+MIX = "sunset-master.wav"
+
+
+def _mix(record: int = 0, source: int = 0, stamp: str = "0", name: str = MIX) -> FakeTimelineItem:
+    """The master mix as it sits under an earlier version — the axis the carry reads."""
+    return FakeTimelineItem(
+        name,
+        record,
+        240,
+        source_start=source,
+        media_item=FakeMediaPoolItem(name, properties={"Start": stamp}),
+    )
+
+
+def _earlier(
+    markers: dict[Any, dict[str, Any]] | None = None,
+    mix: list[FakeTimelineItem] | None = None,
+    name: str = "sunset-set v3",
+    end_frame: int | None = None,
+) -> FakeTimeline:
+    """``sunset-set v3``: the reviewed version a rebuild supersedes, marked up by hand."""
+    return FakeTimeline(
+        name,
+        "59.94",
+        video=[FakeTrack("Video 1", [FakeTimelineItem("C0012.mp4", 0, 240)])],
+        audio=[FakeTrack("Master", [_mix()] if mix is None else mix)],
+        markers=markers,
+        end_frame=end_frame,
+    )
+
+
+def _a_marker(name: str, color: str = "Blue", note: str = "", custom: str = "") -> dict[str, Any]:
+    return {"color": color, "name": name, "note": note, "duration": 1, "customData": custom}
+
+
+def _carried(timeline: FakeTimeline) -> list[tuple[float, str, str]]:
+    """What landed on the new version: where, what colour, and which song it names."""
+    return sorted(
+        (frame, marker["color"], marker["name"]) for frame, marker in timeline.GetMarkers().items()
+    )
+
+
+def _rebuild(resolve: Any, tmp_path: Path, attach: Attach, **kwargs: Any) -> dict[str, Any]:
+    attach(resolve)
+    return build_timeline(a_cut(tmp_path, valid_doc()), **kwargs)
+
+
+def test_a_rebuild_carries_the_hand_placed_markers_onto_the_new_version(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The whole point: the song anchors survive, so a titles file re-applies untouched."""
+    earlier = _earlier({100: _a_marker("sunset boulevard"), 180: _a_marker("night ferry")})
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["carried"] == 2
+    assert result["markers"]["from"] == "sunset-set v3"
+    assert result["markers"]["reason"] is None
+    assert _carried(built(resolve, "sunset-set v4")) == [
+        (100.0, "Blue", "sunset boulevard"),
+        (180.0, "Blue", "night ferry"),
+    ]
+
+
+def test_a_carried_marker_keeps_the_colour_note_and_custom_data_it_had(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A director's note is only worth carrying with the words on it (#42: the join is data)."""
+    note = _a_marker("tighten this", "Red", "comes in late", "songs.json:sunset")
+    earlier = _earlier({120: note})
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    _rebuild(resolve, tmp_path, attach)
+
+    assert built(resolve, "sunset-set v4").GetMarkers() == {
+        120.0: {
+            "color": "Red",
+            "name": "tighten this",
+            "note": "comes in late",
+            "duration": 1,
+            "customData": "songs.json:sunset",
+        }
+    }
+
+
+def test_a_marker_lands_on_the_mix_frame_it_sat_over_not_the_record_frame_it_had(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """v3's mix started 40 frames in; this cut's starts at 0, so every marker moves 40 later.
+
+    This is the test the whole feature turns on. A copy would leave the marker at 60 and put
+    the song anchor 40 frames before the song.
+    """
+    earlier = _earlier({60: _a_marker("sunset boulevard")}, mix=[_mix(source=40)])
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["shift"] == 40
+    assert _carried(built(resolve, "sunset-set v4")) == [(100.0, "Blue", "sunset boulevard")]
+
+
+def test_a_start_stamp_on_the_mix_does_not_shift_the_carry(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A WAV stamped 01:00:00:00 reports source frames an hour in; forgetting to subtract
+    that stamp would shift every carried marker by an hour and still look like a reading."""
+    earlier = _earlier(
+        {60: _a_marker("sunset boulevard")},
+        mix=[_mix(source=216040, stamp="216000")],
+    )
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["shift"] == 40
+    assert _carried(built(resolve, "sunset-set v4")) == [(100.0, "Blue", "sunset boulevard")]
+
+
+def test_the_earlier_version_keeps_the_markers_it_was_reviewed_with(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A carry is a copy forward, never a move: v3 is what a reviewer already signed off."""
+    earlier = _earlier({100: _a_marker("sunset boulevard")})
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    _rebuild(resolve, tmp_path, attach)
+
+    assert _carried(earlier) == [(100.0, "Blue", "sunset boulevard")]
+
+
+def test_markers_come_from_the_version_being_superseded_not_the_oldest_one(
+    attach: Attach, tmp_path: Path
+) -> None:
+    earlier = _earlier({100: _a_marker("sunset boulevard")})
+    stale = _earlier({40: _a_marker("an abandoned pass")}, name="sunset-set v1")
+    resolve = studio(timeline=None, timelines=[stale, earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["from"] == "sunset-set v3"
+    assert _carried(built(resolve, "sunset-set v4")) == [(100.0, "Blue", "sunset boulevard")]
+
+
+def test_the_first_version_of_a_cut_has_nothing_to_carry(attach: Attach, tmp_path: Path) -> None:
+    resolve = empty_project(a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"] == {
+        "carried": 0,
+        "skipped": 0,
+        "from": None,
+        "shift": None,
+        "refused": [],
+        "reason": "Nothing to carry: this is the first version of this cut.",
+    }
+
+
+def test_carry_markers_off_leaves_the_earlier_versions_markers_where_they_are(
+    attach: Attach, tmp_path: Path
+) -> None:
+    earlier = _earlier({100: _a_marker("sunset boulevard")})
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach, carry_markers=False)
+
+    assert result["markers"]["carried"] == 0
+    assert "carry_markers was off" in result["markers"]["reason"]
+    assert built(resolve, "sunset-set v4").GetMarkers() == {}
+
+
+def test_an_earlier_version_that_was_never_marked_up_says_so(
+    attach: Attach, tmp_path: Path
+) -> None:
+    resolve = studio(timeline=None, timelines=[_earlier()], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["carried"] == 0
+    assert result["markers"]["reason"] == "sunset-set v3 carries no markers."
+
+
+def test_a_cut_with_no_master_mix_refuses_to_guess_where_the_markers_go(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A rough cut has no continuous mix, so the two versions share no axis. Markers that
+    merely look plausible are worse than markers the agent knows it has to place."""
+    doc = valid_doc()
+    del doc["audio"]
+    earlier = _earlier({100: _a_marker("sunset boulevard")})
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["markers"]["carried"] == 0
+    assert result["markers"]["from"] == "sunset-set v3"
+    assert "no single master mix" in result["markers"]["reason"]
+    assert "placed by hand" in result["markers"]["reason"]
+    assert built(resolve, "sunset-set v4").GetMarkers() == {}
+
+
+def test_an_earlier_version_carrying_two_clips_of_the_same_mix_is_not_an_anchor(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Which of the two says where the mix sits? Nothing answers that, so nothing guesses."""
+    earlier = _earlier({100: _a_marker("sunset boulevard")}, mix=[_mix(), _mix(record=300)])
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["carried"] == 0
+    assert "does not carry exactly one" in result["markers"]["reason"]
+
+
+def test_an_earlier_version_over_a_different_mix_is_not_an_anchor(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A hand-edited version over camera scratch shares no clock with this cut's mix."""
+    earlier = _earlier({100: _a_marker("sunset boulevard")}, mix=[_mix(name="C0012.mp4")])
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["carried"] == 0
+    assert built(resolve, "sunset-set v4").GetMarkers() == {}
+
+
+def test_a_marker_this_version_has_no_room_for_is_named_not_silently_dropped(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The tightening cut the marker sat in is gone. Which song lost its anchor is the
+    actionable half — a count alone would send someone diffing two timelines to find out."""
+    earlier = _earlier(
+        {100: _a_marker("sunset boulevard"), 400: _a_marker("night ferry")},
+        end_frame=500,
+    )
+    resolve = studio(timeline=None, timelines=[earlier], pool=a_pool())
+
+    result = _rebuild(resolve, tmp_path, attach)
+
+    assert result["markers"]["carried"] == 1
+    assert result["markers"]["skipped"] == 1
+    refused = result["markers"]["refused"]
+    assert [entry["name"] for entry in refused] == ["night ferry"]
+    assert refused[0]["record"] == 400
+    assert refused[0]["error"] is not None
+    assert _carried(built(resolve, "sunset-set v4")) == [(100.0, "Blue", "sunset boulevard")]
+
+
+def test_a_version_deleted_mid_build_does_not_sink_a_build_that_landed(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The name came off this project moments earlier, so this is a race, not a mistake —
+    and every clip is already on the timeline by the time the markers are read."""
+    earlier = _earlier({100: _a_marker("sunset boulevard")})
+    pool = a_pool()
+    resolve = studio(timeline=None, timelines=[earlier], pool=pool)
+    attach(resolve)
+    create = pool.CreateEmptyTimeline
+
+    project = resolve.current_project
+    assert project is not None
+
+    def create_and_lose_the_earlier_version(name: str) -> Any:
+        made = create(name)
+        project.remove_timeline(earlier)
+        return made
+
+    pool.CreateEmptyTimeline = create_and_lose_the_earlier_version
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is True
+    assert result["markers"]["carried"] == 0
+    assert "gone by the time" in result["markers"]["reason"]
+
+
 # --- pre-flight: nothing starts on a bad file ---------------------------------------------
 
 

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -61,6 +61,7 @@ from resolve_mcp.tools.timeline import (
     inspect_timeline,
     list_markers,
     list_timelines,
+    set_markers,
 )
 from resolve_mcp.tools.titles import apply_titles, edit_title, list_titles
 from resolve_mcp.tools.video import detect_scene_cuts, grab_frames
@@ -80,6 +81,9 @@ SCENE_SCAN_CLIP_ENV = "RESOLVE_MCP_SCENE_SCAN_CLIP"
 """Opt-in for #34's live AC: a pool clip with hard cuts, so the scan has cuts to map."""
 
 SMOKE_CUT = "resolve-mcp-smoke"
+
+SMOKE_SONG = "resolve-mcp-130"
+"""The blue marker #130's carry moves — named so a leftover in the GUI says where it came from."""
 """Every build here materialises a new version of this name; delete them when you are done."""
 
 LOCKED_TRACK_PROBE = """
@@ -446,11 +450,18 @@ def a_smoke_cut(
     source: dict[str, Any],
     durations: tuple[int, ...],
     alternate_at: int | None = None,
+    audio_in: int | None = None,
+    name: str = "smoke.cut.json",
 ) -> str:
     """A rough-cut shaped file (no master audio) built from one real clip.
 
     ``alternate_at`` gives every segment one equal-duration alternate starting there — the
     same clip is a legitimate alternate source, and one clip is all a smoke run can count on.
+
+    ``audio_in`` turns it into a concert-shaped cut instead, laying the same clip's audio
+    under the whole thing from that source frame — the continuous substrate #130's marker
+    carry rides. Whether the clip has audio at all is the pool's business, so the caller
+    validates and skips rather than this guessing.
     """
     at = source["start"]
     segments: list[dict[str, Any]] = []
@@ -470,13 +481,15 @@ def a_smoke_cut(
     angle = {"clip": source["name"]}
     if source["bin"] is not None:
         angle["bin"] = source["bin"]
-    doc = {
+    doc: dict[str, Any] = {
         "schema": 1,
         "timeline": {"name": SMOKE_CUT, "fps": source["fps"]},
         "sources": {"angle": angle},
         "segments": segments,
     }
-    path = tmp_path / "smoke.cut.json"
+    if audio_in is not None:
+        doc["audio"] = {"source": "angle", "in": audio_in, "out": audio_in + sum(durations)}
+    path = tmp_path / name
     path.write_text(json.dumps(doc), encoding="utf-8")
     return str(path)
 
@@ -506,6 +519,54 @@ def test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it(tmp_path: 
     timeline_start = built["timeline"]["start"]["frames"]
     assert [item["record"]["duration"]["frames"] for item in video["items"]] == list(durations)
     assert starts == [timeline_start, timeline_start + 48, timeline_start + 72]
+
+
+def test_a_real_rebuild_carries_the_song_markers_onto_the_new_version(tmp_path: Path) -> None:
+    """#130 end to end, and the part no fake can settle: whether a frame derived from
+    Resolve's own reading of where the mix sits is a frame Resolve will take a marker at.
+
+    A blue marker names a song, and a human places it. The rebuild has to move it by the
+    frame of the master mix under it rather than by copying the number — so this second cut
+    starts its mix 24 frames later and reorders the shots underneath. 24 frames earlier is
+    then the only correct answer, and copying, or re-deriving off the picture, gives another.
+
+    Leaves two more ``resolve-mcp-smoke`` versions behind, as every build test here does.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    source = a_source_clip()
+    first = a_smoke_cut(tmp_path, source, (48, 24, 36), audio_in=source["start"], name="a.cut.json")
+    checked = validate_cut(first)
+    if not checked["valid"]:
+        pytest.skip(f"No pool clip this cut can lay a master mix from: {checked['errors']}")
+
+    made = build_timeline(first)
+    assert made["ok"] is True, made.get("error")
+    earlier = str(made["timeline"]["name"])
+    marked = set_markers(
+        [{"frame": made["timeline"]["start"]["frames"] + 60, "color": "Blue", "name": SMOKE_SONG}],
+        timeline=earlier,
+    )
+    assert marked["ok"] is True and marked["added"] == 1, marked
+
+    second = a_smoke_cut(
+        tmp_path,
+        source,
+        (36, 48, 24),
+        audio_in=source["start"] + 24,
+        name="b.cut.json",
+    )
+    rebuilt = build_timeline(second)
+
+    assert rebuilt["ok"] is True, rebuilt.get("error")
+    assert rebuilt["markers"]["from"] == earlier
+    assert rebuilt["markers"]["carried"] == 1, rebuilt["markers"]
+    assert rebuilt["markers"]["shift"] == -24
+    carried = list_markers(rebuilt["timeline"]["name"], color="Blue")
+    assert carried["ok"] is True
+    assert [(one["record"]["frames"], one["name"]) for one in carried["markers"]] == [
+        (rebuilt["timeline"]["start"]["frames"] + 36, SMOKE_SONG)
+    ]
 
 
 def test_a_real_take_selector_swaps_the_angle_without_moving_the_shot(tmp_path: Path) -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -81,10 +81,10 @@ SCENE_SCAN_CLIP_ENV = "RESOLVE_MCP_SCENE_SCAN_CLIP"
 """Opt-in for #34's live AC: a pool clip with hard cuts, so the scan has cuts to map."""
 
 SMOKE_CUT = "resolve-mcp-smoke"
+"""Every build here materialises a new version of this name; delete them when you are done."""
 
 SMOKE_SONG = "resolve-mcp-130"
 """The blue marker #130's carry moves — named so a leftover in the GUI says where it came from."""
-"""Every build here materialises a new version of this name; delete them when you are done."""
 
 LOCKED_TRACK_PROBE = """
 pool = project.GetMediaPool()

--- a/tests/test_mix.py
+++ b/tests/test_mix.py
@@ -1,0 +1,76 @@
+"""Where the master mix sits under a timeline — the axis a rebuild's marker carry rides.
+
+The reading itself is exercised through its callers (``build_timeline`` carrying markers,
+``correlate_timeline`` reading seconds off a cut). What is pinned here is the one decision
+the callers delegate and neither can restate: **when do a timeline's audio shots agree on a
+single mix, and when do they refuse to answer.**
+
+That question has a live-measured answer behind it, which is why it is a test of its own.
+A single append of a multi-channel clip comes back as one shot *per channel* — eight tracks
+for an eight-channel MXF, all naming the same clip at the same frame. The obvious rule,
+"exactly one audio item", reads that as an ambiguous timeline and refuses the commonest
+concert mix there is. Agreement, not arity, is the thing.
+"""
+
+from __future__ import annotations
+
+from resolve_mcp.resolve.mix import MixShot, anchor
+
+MIX = "sunset-master.wav"
+
+
+def _shot(name: str = MIX, record: int = 86400, source: int = 0) -> MixShot:
+    return MixShot(name, record, source)
+
+
+def test_the_mix_zero_is_the_record_frame_its_own_first_frame_lands_on() -> None:
+    """A clip starting 24 frames into its media extends backwards to reach frame 0."""
+    assert _shot(record=86400, source=24).zero_frame == 86376
+
+
+def test_one_shot_is_the_anchor() -> None:
+    assert anchor([_shot()]) == _shot()
+
+
+def test_no_audio_at_all_answers_nothing_rather_than_a_default() -> None:
+    """A rough cut has no mix. Counting from the timeline start instead would be a guess
+    that reads exactly like a measurement."""
+    assert anchor([]) is None
+
+
+def test_the_channels_of_one_multi_channel_mix_are_one_anchor() -> None:
+    """Measured live on Studio 21.0.3.7: appending an 8-channel MXF as one clip lands one
+    item on each of A1-A8, same clip, same record frame, same source frame. That is one
+    placement said eight times, and the whole reason the rule is agreement and not arity."""
+    channels = [_shot() for _ in range(8)]
+
+    assert anchor(channels) == _shot()
+
+
+def test_the_same_clip_laid_at_two_offsets_is_not_an_anchor() -> None:
+    """Which one is the mix? Nothing here answers that, so nothing is derived from either."""
+    assert anchor([_shot(source=0), _shot(source=24)]) is None
+
+
+def test_two_clips_at_the_same_offset_are_still_not_an_anchor() -> None:
+    """Agreeing by accident is not agreeing: the caller asked which *clip* the mix is."""
+    assert anchor([_shot(), _shot(name="scratch.wav")]) is None
+
+
+def test_naming_the_clip_ignores_the_camera_scratch_beside_it() -> None:
+    """A hand-edited concert routinely carries scratch audio the mix has no relation to."""
+    scratch = _shot(name="C0012.MP4", record=86400, source=5000)
+
+    assert anchor([scratch, _shot(source=24)], MIX) == _shot(source=24)
+
+
+def test_naming_a_clip_the_timeline_does_not_carry_answers_nothing() -> None:
+    assert anchor([_shot(name="C0012.MP4")], MIX) is None
+
+
+def test_every_channel_of_the_named_mix_still_has_to_agree() -> None:
+    """Narrowing by name is not a licence to take the first: two placements of the named
+    clip disagree about where the mix starts however many channels each of them has."""
+    shots = [_shot(source=0), _shot(source=0), _shot(source=24), _shot(name="C0012.MP4")]
+
+    assert anchor(shots, MIX) is None


### PR DESCRIPTION
Closes #130.

## The decision

#130 offered two routes — persist marker positions to a sidecar and re-apply through `set_markers`, or write the hand procedure down as a v1 limitation — and preferred the sidecar **if the position source is stable across rebuilds**.

**Neither as written.** The position source is stable, and it is already persisted: the superseded timeline itself, which a build never touches. A sidecar would duplicate it, go stale silently the moment a human dragged a marker in the GUI, and live under `%LOCALAPPDATA%` where a rebuild on another box would find nothing.

What is *not* stable is the record frame — sliding those is precisely what a rebuild does. What holds still is the master mix: one continuous clip nobody re-times, so the frame of the mix under a marker means the same thing on every version, and two versions' readings differ by one constant. `analysis/correlate` already derived that constant; `resolve/mix.py` now owns the reading so the two callers cannot disagree about it.

`build_timeline` gains `carry_markers` (default on) and a `markers` report block: how many came across, how far they shifted, `by_color`, and by name any the new version has no room for. **ADR 0006** records the decision and the limitation.

The limitation half of the ticket lands too: a cut with no master mix (a rough cut) shares no axis with its previous version, so nothing is carried, `markers.reason` says which version was left behind and how many markers were on it, and `docs/agents/rough-cut.md` tells the P4 pillar to read its markers before rebuilding.

## Seams

Per the ticket: fake tier for the decisions, one live smoke for the round trip.

- **Fake tier** — 16 cases in `tests/test_build_timeline.py` (carry, the mix-frame derivation, start-stamp subtraction, colour split, refusals, first version, off-switch, no-mix, mid-build deletion) and 9 in `tests/test_mix.py` for the agreement rule. Full tier green.
- **Live smoke** — `test_a_real_rebuild_carries_the_song_markers_onto_the_new_version`. **Ran and passed**: Windows 11, Resolve Studio 21.0.3.7, python.org 3.11. A real build, a hand-written blue marker, and a rebuild whose mix starts 24 frames later carrying it exactly 24 frames earlier. `test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it`, `test_a_rebuild_makes_the_next_version_and_leaves_the_last_one_alone`, `test_a_real_take_selector_swaps_the_angle_without_moving_the_shot` and `test_hand_placed_markers_read_back_on_the_clock_the_agent_plans_in` also pass after the change.

**The live tier earned its keep on the first run.** One append of an 8-channel MXF comes back as *eight* timeline items, one per channel on A1–A8. The first implementation asked for exactly one audio item, read eight, and refused to carry anything. The rule is now agreement, not arity. No fake could have found that — it is Resolve's own answer to an append.

## Review

`/code-review` — two axes, parallel sub-agents (Standards + Spec), run on the branch against `origin/main` before this PR existed.

**Standards — 7 findings, all resolved or answered:**

1. *(hard)* `SMOKE_CUT` lost its docstring when `SMOKE_SONG` was inserted above it, leaving the cleanup warning as a stray string documenting the wrong constant — **fixed**, order restored.
2. *Duplicated Code* — `markers_on` repeated `list_markers`' comprehension verbatim — **fixed**, both read through one `_all(clock)`.
3. *Duplicated Code* — the `<base> v<N>` format spelled a second time in `build` — **fixed**, `naming.version_name` owns it and `next_version_name` goes through it.
4. *Speculative Generality* — `mix.media_start` public with one caller three lines away — **fixed**, private.
5. *Divergent rule* — `correlate._matching` (casefold, name-or-stem, falls back to the first clip) vs `mix.anchor` (exact, all-must-agree) — **answered, not changed.** Not drift: `correlate` produces a measurement and labels an assumed anchor `matched: False`, while the carry produces marker *writes* and there is nowhere to put a caveat on a marker in the GUI, so it refuses instead. `mix.py`'s docstring now states the two risk postures rather than claiming the callers agree on everything.
6. *Data Clumps* — `_carry_markers`' six parameters — **declined**, a dataclass for one call site is ceremony.
7. *Mysterious Name* — `_carried` meant two things across src and tests — **fixed**, the build's helper is `_write_entry`.

**Spec — 6 findings:**

1. *(missing)* The "record the hand procedure as a deliberate v1 limitation" half was reported at runtime but never written down — **fixed**, ADR 0006 plus the `rough-cut.md` paragraph.
2. *(scope / correctness)* Every colour was carried and counted as one number, so a director's red note — anchored to a *picture* moment that this very rebuild moved — read identically to an exactly-placed song anchor. **Fixed** with `markers.by_color`, counted off what landed, and the tool docstring now says to re-read the coloured notes. Notes are still carried rather than dropped: a note at the right moment of the performance beats a note deleted.
3. *(scope)* `carry_markers` as unasked-for API surface — **kept**, and argued: the carry writes to a timeline, and an automatic write wants an off-switch, following #44's "an explicit override always wins. Never enforced."
4. Same as Standards 5 — answered above.
5. *(correctness)* A marker whose frame will not parse is dropped by the reader with only a log line, so `carried`/`skipped` count what could be read — **docstring corrected** rather than plumbed. The drop is pre-existing shared behaviour that `list_markers` has too; making the carry stricter than the repo's own read would be inconsistent, and the log is where the difference gets diagnosed (CLAUDE.md).
6. Duplicate of Standards 1 — fixed.

Fix diff re-checked on its own (focused pass, not a second full review): no issues.

Gates: `ruff check` clean, `mypy --strict` clean on 161 source files, fake tier green, live tier as recorded above.

Review: clean


### Merge-train resolution (`91b4650`)

The merge train landed #144–#149 first; #149 added a `current_name` import to `analysis/correlate.py`'s `resolve.timeline` import list while this branch had removed `clip_name` from the same list (its use moved into `resolve/mix.py`). Resolution keeps `current_name` and drops `clip_name` — the merged body uses only the former; the two sides touch disjoint functions, and a repo-wide grep found no stale reference. Focused pass over the resolution diff only.

Review: clean — merge resolution only; fake tier 1379 passed, mypy strict and ruff clean.
