### PR TITLE
recursive= on the media tools: an address for a clip a subfolder shadows (#134)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,8 +29,11 @@ timelines. The server measures; Claude decides.
   tool addressing one clip by name: omitted is the whole pool, a name is
   that bin and everything nested inside it, `""` is the root folder alone
   — the value `list_media` reports for a root clip, so a listing reads
-  back verbatim (#122). `list_media` itself takes the same paths but says
-  how deep to walk with its own `recursive` flag.
+  back verbatim (#122). Each media tool taking a bin — `list_media`,
+  `inspect_clip`, `relink_media`, and per item on `set_clip_metadata` and
+  `organize_media`'s `move_clips` — also takes `recursive`, false meaning
+  that bin's own clips alone: the address of a copy a subfolder shadows
+  (#134). The analysis and video tools keep the recursive lookup only.
 - **the seam** — `resolve/connection.py` singleton, substituted by
   `tests/fakes/` via `set_connection()`; the only place fakes attach.
 - **fake tier / live tier** — `pytest -m 'not live'` against fakes (the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,8 @@ timelines. The server measures; Claude decides.
   `inspect_clip`, `relink_media`, and per item on `set_clip_metadata` and
   `organize_media`'s `move_clips` — also takes `recursive`, false meaning
   that bin's own clips alone: the address of a copy a subfolder shadows
-  (#134). The analysis and video tools keep the recursive lookup only.
+  (#134). The analysis and video tools resolve a clip by name too but take
+  no flag, so their refusals never offer the shallow form.
 - **the seam** — `resolve/connection.py` singleton, substituted by
   `tests/fakes/` via `set_connection()`; the only place fakes attach.
 - **fake tier / live tier** — `pytest -m 'not live'` against fakes (the

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -166,22 +166,36 @@ class ClipNotFoundError(ResolveMcpError):
 class AmbiguousClipError(ResolveMcpError):
     code = "ambiguous_clip"
 
-    def __init__(self, name: str, bins: list[str], addressable: list[str]) -> None:
-        """``bins`` is the bin of every matching clip; ``addressable`` those that work.
+    def __init__(
+        self,
+        name: str,
+        bins: list[str],
+        addressable: list[str],
+        shallow: list[str] | None = None,
+    ) -> None:
+        """``bins`` is the bin of every matching clip; the rest are the values that work.
 
-        Only an addressable bin is offered. A value that lands back on this same refusal is
-        not a fix (#122), and the empty string is offered like any other because it
-        addresses the pool root itself.
+        Only a value that reaches one clip is offered. One that lands back on this same
+        refusal is not a fix (#122), and the empty string is offered like any other because
+        it addresses the pool root itself. ``shallow`` holds the bins that single a copy out
+        only once the search stops descending, which is what ``recursive=False`` asks for
+        (#134); the remainder — a bin holding two of the name — no lookup can answer.
         """
+        offered = []
         if addressable:
             listed = ", ".join(f'bin="{path}"' for path in addressable)
             root = ' (bin="" is the pool root itself)' if "" in addressable else ""
-            fix = f"Pass one of these to say which: {listed}{root}."
+            offered.append(f"Pass one of these to say which: {listed}{root}.")
+        if shallow:
+            listed = ", ".join(f'bin="{path}"' for path in shallow)
+            lead = "Or" if offered else "Pass"
+            offered.append(f"{lead} {listed} with recursive=false for the copy in that bin itself.")
+        if offered:
+            fix = " ".join(offered)
         else:
             fix = (
-                "No bin singles one out — they share a bin, or the one holding each also "
-                "holds another of the name. Rename one in the Resolve GUI, or work from "
-                "the file paths list_media reports."
+                "No lookup singles one out — one bin holds two clips of the name. Rename "
+                "one in the Resolve GUI, or work from the file paths list_media reports."
             )
         super().__init__(
             cause=f"{len(bins)} clips are named {name!r}, so the reference is ambiguous.",

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -171,7 +171,7 @@ class AmbiguousClipError(ResolveMcpError):
         name: str,
         bins: list[str],
         addressable: list[str],
-        shallow: list[str] | None = None,
+        shallow: list[str],
     ) -> None:
         """``bins`` is the bin of every matching clip; the rest are the values that work.
 
@@ -179,7 +179,9 @@ class AmbiguousClipError(ResolveMcpError):
         refusal is not a fix (#122), and the empty string is offered like any other because
         it addresses the pool root itself. ``shallow`` holds the bins that single a copy out
         only once the search stops descending, which is what ``recursive=False`` asks for
-        (#134); the remainder — a bin holding two of the name — no lookup can answer.
+        (#134) — empty when the caller has no such flag to pass, since an argument the tool
+        does not take is no more of a fix than a bin that refuses. What neither list holds —
+        a bin with two of the name in it — no lookup can answer.
         """
         offered = []
         if addressable:

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -244,11 +244,22 @@ def _clips_under(where: LocatedBin, recursive: bool) -> Iterator[LocatedClip]:
             yield LocatedClip(path, clip)
 
 
-def _searched_label(bin_path: str | None, where: LocatedBin) -> str:
-    """What a clip_not_found says it looked in — the caller's own words for a named bin."""
-    if bin_path is None:
+def _searched_label(bin_path: str | None, where: LocatedBin, deep: bool) -> str:
+    """What a clip_not_found says it looked in — the caller's own words for a named bin.
+
+    A shallow search says ``alone`` so the refusal points at the flag: the clip may well
+    be one folder down, and dropping ``recursive`` is then the fix, not renaming anything.
+    """
+    if not deep and where.path:
+        return f"the bin {bin_path!r} alone"
+    if bin_path is None and deep:
         return "the media pool"
     return f"the bin {bin_path!r}" if where.path else "the media pool root"
+
+
+def _shadowed(path: str, bins: list[str]) -> bool:
+    """Whether a bin nested inside ``path`` holds another copy, so a deep search sees both."""
+    return bool(path) and any(other.startswith(f"{path}{BIN_SEPARATOR}") for other in bins)
 
 
 def _addressable(bins: list[str]) -> list[str]:
@@ -261,14 +272,29 @@ def _addressable(bins: list[str]) -> list[str]:
     """
     counted = Counter(bins)
     return sorted(
-        path
-        for path, times in counted.items()
-        if times == 1
-        and not (path and any(other.startswith(f"{path}{BIN_SEPARATOR}") for other in bins))
+        path for path, times in counted.items() if times == 1 and not _shadowed(path, bins)
     )
 
 
-def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> LocatedClip:
+def _shallow_only(bins: list[str]) -> list[str]:
+    """Which bins reach one clip only once the search stops descending (#134).
+
+    A bin whose subfolder holds another copy of the name has no deep address, but it holds
+    exactly one itself — so ``recursive=False`` singles that copy out. Only a bin holding
+    two of the name is beyond both forms.
+    """
+    counted = Counter(bins)
+    return sorted(
+        path for path, times in counted.items() if times == 1 and _shadowed(path, bins)
+    )
+
+
+def find_clip(
+    pool: Pool,
+    name: str,
+    bin_path: str | None = None,
+    recursive: bool = True,
+) -> LocatedClip:
     """One clip by exact name.
 
     ``None`` searches the whole pool. A named bin searches that bin and everything nested
@@ -277,18 +303,29 @@ def find_clip(pool: Pool, name: str, bin_path: str | None = None) -> LocatedClip
     clip whose name a bin also used with no expressible address at all (#122). The empty
     string is what :func:`summarise` reports for a root clip, so the ``bin`` value a
     listing gives back always reads the clip it described.
+
+    ``recursive=False`` stops the search descending, so the clips a bin holds *itself* are
+    all that is looked at — the address of a copy shadowed by another of the name filed
+    deeper (#134). It narrows the root the same way :func:`list_media` does, which is what
+    the root already does on its own; the root case therefore ignores it.
     """
     where = find_bin(pool, bin_path)
     the_root_itself = bin_path is not None and not where.path
-    searched = list(_clips_under(where, recursive=not the_root_itself))
+    deep = recursive and not the_root_itself
+    searched = list(_clips_under(where, deep))
     matches = [found for found in searched if str(found.clip.GetName() or "") == name]
     if not matches:
         available = sorted({str(found.clip.GetName() or "") for found in searched})
-        raise ClipNotFoundError(name, _searched_label(bin_path, where), available)
+        raise ClipNotFoundError(name, _searched_label(bin_path, where, deep), available)
     if len(matches) > 1:
         found_in = [found.bin_path for found in matches]
-        raise AmbiguousClipError(name, found_in, _addressable(found_in))
+        raise AmbiguousClipError(name, found_in, _addressable(found_in), _shallow_only(found_in))
     return matches[0]
+
+
+def _wants_recursion(item: dict[str, Any]) -> bool:
+    """A batch item's optional ``recursive`` key — deep unless it says otherwise (#134)."""
+    return bool(item.get("recursive", True))
 
 
 def clip_at_path(pool: Pool, bin_path: str, file_path: str) -> LocatedClip | None:
@@ -879,10 +916,11 @@ def inspect_clip(
     connection: ResolveConnection,
     name: str,
     bin_path: str | None = None,
+    recursive: bool = True,
 ) -> dict[str, Any]:
     """Everything worth knowing about one clip before cutting with it."""
     pool = media_pool(connection)
-    found_in, clip = find_clip(pool, name, bin_path)
+    found_in, clip = find_clip(pool, name, bin_path, recursive)
     reported = properties(clip)
     metadata = clip.GetMetadata()
     return {
@@ -948,7 +986,7 @@ def _apply_fields(pool: Pool, item: dict[str, Any]) -> dict[str, Any]:
             ).payload(),
         }
     try:
-        located = find_clip(pool, name, item.get("bin"))
+        located = find_clip(pool, name, item.get("bin"), _wants_recursion(item))
     except (ClipNotFoundError, AmbiguousClipError, BinNotFoundError) as exc:
         return {"clip": name, "bin": None, "ok": False, "error": exc.payload()}
 
@@ -1026,7 +1064,8 @@ def _move_clips(pool: Pool, operation: dict[str, Any]) -> dict[str, Any]:
             fix='Example: {"op": "move_clips", "clips": ["C0012.mp4"], "to_bin": "Angles"}.',
         )
     source = operation.get("from_bin")
-    found = [find_clip(pool, str(name), source) for name in names]
+    deep = _wants_recursion(operation)
+    found = [find_clip(pool, str(name), source, deep) for name in names]
     target = ensure_bin(pool, str(target_path))
     if not pool.MoveClips([located.clip for located in found], target.folder):
         raise MediaOperationError(
@@ -1045,6 +1084,7 @@ def relink_media(
     clips: list[str],
     path: str,
     bin_path: str | None = None,
+    recursive: bool = True,
 ) -> dict[str, Any]:
     """Point clips at media that has moved.
 
@@ -1064,7 +1104,7 @@ def relink_media(
     if not target.exists():
         raise RelinkFailedError(cause=f"Nothing exists at {path!r} on this machine.")
 
-    found = [find_clip(pool, str(name), bin_path) for name in clips]
+    found = [find_clip(pool, str(name), bin_path, recursive) for name in clips]
     was_offline = [
         is_offline(properties(located.clip).get(FILE_PATH, "")) for located in found
     ]

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -250,50 +250,35 @@ def _searched_label(bin_path: str | None, where: LocatedBin, deep: bool) -> str:
     A shallow search says ``alone`` so the refusal points at the flag: the clip may well
     be one folder down, and dropping ``recursive`` is then the fix, not renaming anything.
     """
-    if not deep and where.path:
-        return f"the bin {bin_path!r} alone"
-    if bin_path is None and deep:
-        return "the media pool"
-    return f"the bin {bin_path!r}" if where.path else "the media pool root"
+    if not where.path:
+        return "the media pool" if bin_path is None and deep else "the media pool root"
+    return f"the bin {bin_path!r}" if deep else f"the bin {bin_path!r} alone"
 
 
-def _shadowed(path: str, bins: list[str]) -> bool:
-    """Whether a bin nested inside ``path`` holds another copy, so a deep search sees both."""
-    return bool(path) and any(other.startswith(f"{path}{BIN_SEPARATOR}") for other in bins)
-
-
-def _addressable(bins: list[str]) -> list[str]:
-    """Which bins holding a duplicated name would, passed on their own, reach one clip.
+def _addressing(bins: list[str]) -> tuple[list[str], list[str]]:
+    """Which bins holding a duplicated name reach one clip: passed alone, then passed shallow.
 
     One entry per matching clip comes in, so a repeat means one bin holds two of the name —
-    passing it lands back on the same refusal. So does naming a bin whose subfolders hold
-    another copy, because a named bin is searched right through. The root is the exception:
-    ``""`` is the root folder alone, so a copy filed deeper never shadows it.
+    no lookup singles those out, and neither list offers them. A bin whose subfolder holds
+    another copy has no address of its own either, because a named bin is searched right
+    through; it does hold exactly one clip itself, so ``recursive=False`` reaches that one
+    (#134). The root is never shadowed: ``""`` is the root folder alone (#122).
     """
     counted = Counter(bins)
-    return sorted(
-        path for path, times in counted.items() if times == 1 and not _shadowed(path, bins)
-    )
-
-
-def _shallow_only(bins: list[str]) -> list[str]:
-    """Which bins reach one clip only once the search stops descending (#134).
-
-    A bin whose subfolder holds another copy of the name has no deep address, but it holds
-    exactly one itself — so ``recursive=False`` singles that copy out. Only a bin holding
-    two of the name is beyond both forms.
-    """
-    counted = Counter(bins)
-    return sorted(
-        path for path, times in counted.items() if times == 1 and _shadowed(path, bins)
-    )
+    alone = {path for path, times in counted.items() if times == 1}
+    shadowed = {
+        path
+        for path in alone
+        if path and any(other.startswith(f"{path}{BIN_SEPARATOR}") for other in bins)
+    }
+    return sorted(alone - shadowed), sorted(shadowed)
 
 
 def find_clip(
     pool: Pool,
     name: str,
     bin_path: str | None = None,
-    recursive: bool = True,
+    recursive: bool | None = None,
 ) -> LocatedClip:
     """One clip by exact name.
 
@@ -306,12 +291,17 @@ def find_clip(
 
     ``recursive=False`` stops the search descending, so the clips a bin holds *itself* are
     all that is looked at — the address of a copy shadowed by another of the name filed
-    deeper (#134). It narrows the root the same way :func:`list_media` does, which is what
-    the root already does on its own; the root case therefore ignores it.
+    deeper (#134). With no bin it narrows to the root, the way :func:`list_media` does;
+    ``bin=""`` and the root's own name are already that search, so they are unaffected.
+
+    ``recursive=None`` is a caller with no such flag of its own to pass on — the video and
+    analysis tools, which resolve a clip by name but take no ``recursive``. It searches
+    deep like ``True``, and an ambiguity is not offered the shallow form, because a fix
+    naming an argument its caller cannot accept is the #122 defect one axis over.
     """
     where = find_bin(pool, bin_path)
     the_root_itself = bin_path is not None and not where.path
-    deep = recursive and not the_root_itself
+    deep = recursive is not False and not the_root_itself
     searched = list(_clips_under(where, deep))
     matches = [found for found in searched if str(found.clip.GetName() or "") == name]
     if not matches:
@@ -319,13 +309,30 @@ def find_clip(
         raise ClipNotFoundError(name, _searched_label(bin_path, where, deep), available)
     if len(matches) > 1:
         found_in = [found.bin_path for found in matches]
-        raise AmbiguousClipError(name, found_in, _addressable(found_in), _shallow_only(found_in))
+        deep_address, shallow_address = _addressing(found_in)
+        raise AmbiguousClipError(
+            name,
+            found_in,
+            deep_address,
+            shallow_address if recursive is not None else [],
+        )
     return matches[0]
 
 
 def _wants_recursion(item: dict[str, Any]) -> bool:
-    """A batch item's optional ``recursive`` key — deep unless it says otherwise (#134)."""
-    return bool(item.get("recursive", True))
+    """A batch item's optional ``recursive`` key — deep unless it says otherwise (#134).
+
+    A batch item is free-form JSON, so the key is checked rather than coerced: ``bool()``
+    would read the string ``"false"`` as True and quietly search the opposite of what was
+    asked, which is the kind of silence a lookup flag cannot afford.
+    """
+    wanted = item.get("recursive", True)
+    if not isinstance(wanted, bool):
+        raise InvalidRequestError(
+            cause=f"recursive must be true or false, not {wanted!r}.",
+            fix='Pass a JSON boolean: "recursive": false to search the named bin alone.',
+        )
+    return wanted
 
 
 def clip_at_path(pool: Pool, bin_path: str, file_path: str) -> LocatedClip | None:
@@ -987,7 +994,7 @@ def _apply_fields(pool: Pool, item: dict[str, Any]) -> dict[str, Any]:
         }
     try:
         located = find_clip(pool, name, item.get("bin"), _wants_recursion(item))
-    except (ClipNotFoundError, AmbiguousClipError, BinNotFoundError) as exc:
+    except (ClipNotFoundError, AmbiguousClipError, BinNotFoundError, InvalidRequestError) as exc:
         return {"clip": name, "bin": None, "ok": False, "error": exc.payload()}
 
     reported = properties(located.clip)

--- a/src/resolve_mcp/tools/media.py
+++ b/src/resolve_mcp/tools/media.py
@@ -79,6 +79,7 @@ def list_media(
 def inspect_clip(
     clip: str,
     bin: str | None = None,  # noqa: A002
+    recursive: bool = True,
 ) -> dict[str, Any]:
     """Read one clip in full: properties, metadata, audio mapping, markers, in/out bounds.
 
@@ -90,15 +91,18 @@ def inspect_clip(
     bin: omit it to search the whole pool, name a bin to search it and its subfolders, or
     pass "" for the pool root alone — the form that names a root clip whose name is also
     used inside a bin. list_media's reported bin is always the value to pass here.
+    recursive=false stops the search descending, so only the clips the named bin holds
+    itself are looked at — the way to reach a copy that a subfolder also holds a copy of.
     """
     connection = get_connection()
-    return media.inspect_clip(connection, clip, bin_path=bin)
+    return media.inspect_clip(connection, clip, bin_path=bin, recursive=recursive)
 
 
 @tool
 def set_clip_metadata(items: list[dict[str, Any]]) -> dict[str, Any]:
     """Apply a batch of metadata writes: [{"clip": name, "bin": optional, "fields": {...}}].
 
+    An item may add "recursive": false to keep its bin lookup out of that bin's subfolders.
     Each field is routed by what the clip itself reports: a key Resolve lists as a clip
     property (FPS, Super Scale, Out …) is written as one, everything else becomes clip
     metadata. The route taken comes back per field in applied. One item failing never sinks
@@ -116,7 +120,8 @@ def organize_media(operations: list[dict[str, Any]]) -> dict[str, Any]:
       {"op": "create_bin", "bin": "Concert/Angles"} — creates missing parents, and is
         happy if the bin already exists (created says which happened);
       {"op": "move_clips", "clips": ["C0012.mp4"], "to_bin": "Concert/Angles",
-        "from_bin": optional} — moves clips, creating the target bin if needed.
+        "from_bin": optional, "recursive": optional} — moves clips, creating the target
+        bin if needed. recursive: false keeps the from_bin lookup out of its subfolders.
     """
     connection = get_connection()
     return media.organize_media(connection, operations)
@@ -127,6 +132,7 @@ def relink_media(
     clips: list[str],
     path: str,
     bin: str | None = None,  # noqa: A002
+    recursive: bool = True,
 ) -> dict[str, Any]:
     """Point offline clips at media that has moved, and report what came back online.
 
@@ -136,9 +142,10 @@ def relink_media(
     The file route also renames the pool clip after the new file — Resolve's behaviour,
     not ours — so follow-up calls must use the name the result reports, not the one
     passed in.
+    recursive=false keeps the bin lookup out of that bin's subfolders.
     """
     connection = get_connection()
-    return media.relink_media(connection, clips, path, bin_path=bin)
+    return media.relink_media(connection, clips, path, bin_path=bin, recursive=recursive)
 
 
 TOOLS: tuple[Any, ...] = (

--- a/tests/test_frame_grabs.py
+++ b/tests/test_frame_grabs.py
@@ -404,6 +404,27 @@ def test_the_tool_shapes_a_refusal_rather_than_raising(attach: Attach, fixture_v
     assert "context" in envelope
 
 
+def test_a_tool_without_the_flag_is_never_told_to_pass_recursive(
+    attach: Attach, fixture_video: Path
+) -> None:
+    """#134: grab_frames resolves a clip by name but takes no recursive, so it is not offered.
+
+    The bins here are the shadowed shape the flag exists for — a media tool would be told
+    to pass recursive=false. This one cannot, and a fix naming an argument the tool does
+    not take is the #122 defect over again.
+    """
+    holder = FakeMediaPoolItem(fixture_video.name, file_path=str(fixture_video))
+    nested = FakeMediaPoolItem(fixture_video.name, file_path=str(fixture_video))
+    attach(studio(pool=media_pool({"Angles": [holder], "Angles/Cam A": [nested]})))
+
+    envelope = video_tools.grab_frames(fixture_video.name, [0], bin="Angles")
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["code"] == "ambiguous_clip"
+    assert 'bin="Angles/Cam A"' in envelope["error"]["fix"]
+    assert "recursive" not in envelope["error"]["fix"]
+
+
 # --- against real ffmpeg -----------------------------------------------------------------------
 
 

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -992,6 +992,32 @@ def test_organize_moves_the_copy_a_shallow_from_bin_names(
     assert len(angles.GetSubFolderList()[0].GetClipList()) == 1  # the nested copy stayed
 
 
+def test_a_recursive_key_that_is_not_a_boolean_is_refused_not_coerced(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A JSON string reads as True under bool(), which would search the opposite way."""
+    pool = a_shallow_copy_pool(tmp_path)
+    attach(studio(pool=pool))
+
+    result = set_clip_metadata(
+        [
+            {
+                "clip": "C0012.mp4",
+                "bin": "Angles",
+                "recursive": "false",
+                "fields": {"Description": "no"},
+            },
+            {"clip": "C0012.mp4", "bin": "Angles/Cam A", "fields": {"Description": "yes"}},
+        ]
+    )
+
+    first, second = result["results"]
+    assert first["ok"] is False
+    assert first["error"]["code"] == "invalid_request"
+    assert second["ok"] is True  # one bad item never sinks the batch
+    assert pool.GetRootFolder().GetSubFolderList()[0].GetClipList()[0].property_writes == []
+
+
 def test_relink_takes_the_shallow_form_too(attach: Attach, tmp_path: Path) -> None:
     moved = a_file(tmp_path, "new/C0012.mp4")
     attach(

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -798,8 +798,9 @@ def test_an_ambiguity_offers_only_the_bins_that_reach_one_clip(
     assert result["ok"] is False
     assert result["error"]["code"] == "ambiguous_clip"
     assert result["error"]["fix"] == (
-        'Pass one of these to say which: bin="Angles/Cam A".'
-    )  # not bin="Angles": searching it reaches the nested copy too
+        'Pass one of these to say which: bin="Angles/Cam A". Or bin="Angles" with '
+        "recursive=false for the copy in that bin itself."
+    )  # bin="Angles" alone reaches the nested copy too, so it is only offered shallow
     assert inspect_clip("C0012.mp4", bin="Angles/Cam A")["ok"] is True
 
 
@@ -815,6 +816,7 @@ def test_two_copies_in_one_bin_are_refused_with_advice_that_is_not_a_bin(
     assert result["ok"] is False
     assert result["error"]["code"] == "ambiguous_clip"
     assert "bin=" not in result["error"]["fix"]
+    assert "recursive" not in result["error"]["fix"]  # a shallow lookup cannot answer either
     assert "Rename one in the Resolve GUI" in result["error"]["fix"]
 
 
@@ -848,6 +850,167 @@ def test_inspect_of_a_missing_root_clip_says_it_searched_the_root(
     assert result["ok"] is False
     assert result["error"]["code"] == "clip_not_found"
     assert result["error"]["detail"]["searched"] == "the media pool root"
+
+
+# --- recursive -------------------------------------------------------------------------
+
+
+def a_shallow_copy_pool(tmp_path: Path) -> FakeMediaPool:
+    """The #134 shape: one clip name held by a bin *and* by a bin nested inside it."""
+    same = a_file(tmp_path, "C0012.mp4")
+    return media_pool(
+        bins={
+            "Angles": [a_clip(same, Description="in Angles")],
+            "Angles/Cam A": [a_clip(same, Description="nested")],
+        }
+    )
+
+
+def test_a_shallow_lookup_reaches_the_copy_held_by_the_named_bin_itself(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """#134: recursive=False says this bin alone, so the shadowed copy has an address."""
+    attach(studio(pool=a_shallow_copy_pool(tmp_path)))
+
+    result = inspect_clip("C0012.mp4", bin="Angles", recursive=False)
+
+    assert result["ok"] is True
+    assert result["clip"]["bin"] == "Angles"
+    assert result["properties"]["Description"] == "in Angles"
+
+
+def test_a_named_bin_stays_recursive_unless_recursive_is_passed(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The flag is opt-in: the default keeps searching what is nested inside the bin."""
+    attach(studio(pool=a_shallow_copy_pool(tmp_path)))
+
+    assert inspect_clip("C0012.mp4", bin="Angles")["error"]["code"] == "ambiguous_clip"
+    assert inspect_clip("C0012.mp4", bin="Angles/Cam A", recursive=False)["ok"] is True
+
+
+def test_an_ambiguity_offers_the_shallow_form_when_that_is_what_reaches_a_copy(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Every value the fix names must work — including the one that needs recursive=false."""
+    attach(studio(pool=a_shallow_copy_pool(tmp_path)))
+
+    fix = inspect_clip("C0012.mp4", bin="Angles")["error"]["fix"]
+
+    assert 'bin="Angles/Cam A"' in fix
+    assert "recursive=false" in fix
+    assert inspect_clip("C0012.mp4", bin="Angles/Cam A")["ok"] is True
+    assert inspect_clip("C0012.mp4", bin="Angles", recursive=False)["ok"] is True
+
+
+def test_a_shallow_lookup_without_a_bin_stays_in_the_root(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """No bin means the root, and recursive=False narrows it the way list_media does."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(
+        studio(
+            pool=media_pool(
+                bins={
+                    "": [a_clip(same, Description="at the root")],
+                    "Angles": [a_clip(same, Description="filed away")],
+                }
+            )
+        )
+    )
+
+    result = inspect_clip("C0012.mp4", recursive=False)
+
+    assert result["ok"] is True
+    assert result["clip"]["bin"] == ""
+    assert result["properties"]["Description"] == "at the root"
+
+
+def test_a_shallow_lookup_that_finds_nothing_says_it_did_not_descend(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The refusal names what was searched, so the fix is to drop the flag, not the bin."""
+    attach(studio(pool=media_pool(bins={"Angles/Cam A": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
+
+    result = inspect_clip("C0012.mp4", bin="Angles", recursive=False)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "clip_not_found"
+    assert result["error"]["detail"]["searched"] == "the bin 'Angles' alone"
+
+
+def test_metadata_writes_to_the_copy_a_shallow_item_names(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = a_shallow_copy_pool(tmp_path)
+    attach(studio(pool=pool))
+
+    result = set_clip_metadata(
+        [
+            {
+                "clip": "C0012.mp4",
+                "bin": "Angles",
+                "recursive": False,
+                "fields": {"Description": "the shallow copy"},
+            }
+        ]
+    )
+
+    assert result["results"][0]["ok"] is True
+    assert result["results"][0]["bin"] == "Angles"
+    angles = pool.GetRootFolder().GetSubFolderList()[0]
+    assert angles.GetClipList()[0].property_writes == [("Description", "the shallow copy")]
+    nested = angles.GetSubFolderList()[0].GetClipList()[0]
+    assert nested.property_writes == []
+    assert nested.metadata_writes == []
+
+
+def test_organize_moves_the_copy_a_shallow_from_bin_names(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = a_shallow_copy_pool(tmp_path)
+    attach(studio(pool=pool))
+
+    result = organize_media(
+        [
+            {
+                "op": "move_clips",
+                "clips": ["C0012.mp4"],
+                "from_bin": "Angles",
+                "recursive": False,
+                "to_bin": "Broll",
+            }
+        ]
+    )
+
+    assert result["results"][0]["ok"] is True
+    root = pool.GetRootFolder()
+    angles = root.GetSubFolderList()[0]
+    broll = [sub for sub in root.GetSubFolderList() if sub.GetName() == "Broll"][0]
+    assert angles.GetClipList() == []  # the copy Angles held itself
+    assert [item.GetName() for item in broll.GetClipList()] == ["C0012.mp4"]
+    assert len(angles.GetSubFolderList()[0].GetClipList()) == 1  # the nested copy stayed
+
+
+def test_relink_takes_the_shallow_form_too(attach: Attach, tmp_path: Path) -> None:
+    moved = a_file(tmp_path, "new/C0012.mp4")
+    attach(
+        studio(
+            pool=media_pool(
+                bins={
+                    "Angles": [a_clip(tmp_path / "old" / "C0012.mp4")],
+                    "Angles/Cam A": [a_clip(tmp_path / "old" / "C0012.mp4")],
+                }
+            )
+        )
+    )
+
+    result = relink_media(["C0012.mp4"], str(moved.parent), bin="Angles", recursive=False)
+
+    assert result["ok"] is True
+    assert result["results"][0]["bin"] == "Angles"
+    assert result["results"][0]["offline"] is False
+    assert list_media(offline_only=True)["count"] == 1  # the nested copy is still offline
 
 
 # --- metadata --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #134.

A clip named `X` in `Angles` had no expressible address when `Angles/Cam A` held an `X`
too: a named bin is searched right through, so `bin="Angles"` saw both copies and refused
as ambiguous, and only the nested one could be named. #122 gave the root case an address;
this is its residual — an explicit `recursive=` flag, false meaning the bin's own clips
alone.

## What changed

- `find_clip` takes `recursive`. With no bin it narrows to the root, the way `list_media`
  already does; `bin=""` and the root's own name are that search already, so they are
  unaffected.
- Exposed on the media tools that resolve a clip by name: `inspect_clip` and `relink_media`
  as a parameter, `set_clip_metadata` items and `organize_media`'s `move_clips` as a
  per-item `"recursive"` key.
- `AmbiguousClipError` offers the new form, because every value its `fix` names has to work
  (#122 AC3): a bin holding one copy while a subfolder holds another is now offered with
  `recursive=false`. That leaves exactly one shape no lookup answers — two copies in a
  single bin — so the no-value-works branch says that instead of the case the flag solved.

**Seam: fake tier.** The fakes model nested bins, so the shadowed shape and every address
the refusal offers verify there. No live AC: nothing here reaches Resolve behaviour that
the fakes do not model. `uv run pytest -m 'not live'` — 1462 passed; mypy strict and ruff
clean.

## Review findings and resolutions

**Spec axis — high: the fix text named an argument the calling tool cannot pass.**
`AmbiguousClipError` is raised inside `find_clip`, which the analysis, stems and video
tools also call — none of which expose `recursive`. Hit the shadowed shape through
`grab_frames` and the refusal advised `recursive=false`: the #122 dishonest-fix defect one
axis over. Fixed — `recursive` is tri-state, and `None` (the default, and what those
callers pass) means "no flag of my own to offer": it searches deep and its ambiguities are
never offered the shallow form. Threading the flag through those tools instead would have
reached their job and cache layers, well outside this ticket; their residual is noted in
`CONTEXT.md`. Covered by a new test in `tests/test_frame_grabs.py`.

**Spec axis: `bool("false")` is True.** A batch item's `"recursive"` was coerced, so a JSON
string would have searched the opposite of what the item asked, silently. Fixed — the key
is type-checked and refused per item as `invalid_request`; one bad item still never sinks
the batch.

**Spec axis: `bin=None` + `recursive=False` searching the root only was not asked for.**
Kept — it is what the flag means everywhere else and it matches `list_media`'s existing
behaviour. The `find_clip` docstring that contradicted itself about the two root cases is
fixed.

**Standards axis — duplicated code.** `_addressable` and `_shallow_only` were the same
comprehension twice, differing by a `not`. Fixed — one `_addressing` partition returns both
lists, so the halves cannot drift.

**Standards axis — speculative generality.** `AmbiguousClipError`'s `shallow` argument was
optional with a single caller. Fixed — required.

**Standards axis — readability.** `_searched_label` branched on a condition the reader had
to simulate; it now branches on the bin it found. `find_clip`'s docstring said "the root
case ignores it" of two different root cases.

Standards axis found no hard violations of a documented standard. The fix diff was
re-checked on its own: no problems, all four fixes behaviour-verified against what they
replaced.

Review: clean
