### PR TITLE
Live suite builds its own project state instead of assuming it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -185,8 +185,9 @@ substrate: one talking head said twice, its transcript, and the b-roll that
 covers the join), `tests/otio.py` (hand-edited OTIO with a dissolve),
 `tests/text_plus_probe.py` (Text+ probe fixtures), `tests/live_state.py` (the
 state the live tier builds for itself: `sweep_suite_timelines()` clears the
-previous run's leftovers, `write_hard_cut_clip()` generates the clip the scene
-scan needs — decisions covered by `test_live_state.py` in the fake tier).
+previous run's leftovers, `restore_current()` leaves the director's cut open,
+`write_hard_cut_clip()` generates the clip the scene scan needs — decisions
+covered by `test_live_state.py` in the fake tier).
 
 Test files pair 1:1 with the module they cover (`test_cut_validate.py` ↔
 `cut/validate.py`, `test_timeline_tools.py` ↔ `tools/timeline.py` +

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -203,7 +203,10 @@ see. Live tier: `test_live_smoke.py` (module-level
 project state it can build itself (#135): a session-scoped sweep clears the last
 run's timelines, `a_known_cut` builds and makes current the short cut the export
 and round-trip tests read, and `a_clip_with_hard_cuts` generates the scan clip
-unless `RESOLVE_MCP_SCENE_SCAN_CLIP` names a real one.
+unless `RESOLVE_MCP_SCENE_SCAN_CLIP` names a real one. That variable is
+**unset on the live box**: its pool was checked in #135 and holds no flattened
+render, only raw continuous angles — so the generated clip is the default there,
+and the variable is for a project that does have an edit to scan.
 
 ## Docs
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -183,7 +183,10 @@ hermetic `Config` around every test). Other helpers: `tests/cutfile.py`
 (miniature concert cut file + media pool), `tests/roughcut.py` (the P4
 substrate: one talking head said twice, its transcript, and the b-roll that
 covers the join), `tests/otio.py` (hand-edited OTIO with a dissolve),
-`tests/text_plus_probe.py` (Text+ probe fixtures).
+`tests/text_plus_probe.py` (Text+ probe fixtures), `tests/live_state.py` (the
+state the live tier builds for itself: `sweep_suite_timelines()` clears the
+previous run's leftovers, `write_hard_cut_clip()` generates the clip the scene
+scan needs — decisions covered by `test_live_state.py` in the fake tier).
 
 Test files pair 1:1 with the module they cover (`test_cut_validate.py` ↔
 `cut/validate.py`, `test_timeline_tools.py` ↔ `tools/timeline.py` +
@@ -195,7 +198,11 @@ covers no single module, walking the P4 pillar across `cut`, `build`, `takes`
 and `virtual` in one pass because the joins are what a per-module test cannot
 see. Live tier: `test_live_smoke.py` (module-level
 `pytest.mark.live`) and two `@pytest.mark.live` tests in
-`test_live_analysis.py`; everything else is fake-tier.
+`test_live_analysis.py`; everything else is fake-tier. The live tier assumes no
+project state it can build itself (#135): a session-scoped sweep clears the last
+run's timelines, `a_known_cut` builds and makes current the short cut the export
+and round-trip tests read, and `a_clip_with_hard_cuts` generates the scan clip
+unless `RESOLVE_MCP_SCENE_SCAN_CLIP` names a real one.
 
 ## Docs
 

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -95,7 +95,7 @@ def open_project(connection: ResolveConnection) -> Project:
     return current_project(connection, "No project is open, so there are no timelines to read.")
 
 
-def _timelines(project: Project) -> list[Timeline]:
+def timelines_of(project: Project) -> list[Timeline]:
     """Every timeline the project holds, in Resolve's own order.
 
     ``GetTimelineByIndex`` is one-based and hands back ``None`` for an index it cannot
@@ -130,7 +130,7 @@ def find_timeline(project: Project, name: str | None) -> Timeline:
                 cause="No timeline is open in the project, and none was named.",
             )
         return current
-    held = _timelines(project)
+    held = timelines_of(project)
     for timeline in held:
         if name_of(timeline) == name:
             return timeline
@@ -139,7 +139,7 @@ def find_timeline(project: Project, name: str | None) -> Timeline:
 
 def timeline_names(project: Project) -> list[str]:
     """Every timeline name the project holds — what a new name must not collide with."""
-    return [name_of(timeline) for timeline in _timelines(project)]
+    return [name_of(timeline) for timeline in timelines_of(project)]
 
 
 def current_name(project: Project) -> str | None:
@@ -398,7 +398,8 @@ def list_timelines(
     reader = Reader(connection)
     current = current_name(project)
 
-    timelines = [summarise(reader, timeline, project, current) for timeline in _timelines(project)]
+    held = timelines_of(project)
+    timelines = [summarise(reader, timeline, project, current) for timeline in held]
 
     cap = max(int(limit), 0)
     truncated = len(timelines) > cap

--- a/tests/fakes/pool.py
+++ b/tests/fakes/pool.py
@@ -326,14 +326,18 @@ class FakeMediaPool:
         off it first would leave it behind and never hear why.
         """
         self._check("DeleteTimelines")
-        self.deleted_timelines.extend(timelines)
         if any(timeline in self.refuse_deleting for timeline in timelines):
             return False
         project = self._reached_project()
+        if project is not None and any(
+            timeline is project.GetCurrentTimeline() for timeline in timelines
+        ):
+            return False
+        # Recorded only once the refusals are past: a cut Resolve would not delete has not
+        # been deleted, and a fake that says otherwise lets a caller assert its own bug.
+        self.deleted_timelines.extend(timelines)
         if project is None:
             return True
-        if any(timeline is project.GetCurrentTimeline() for timeline in timelines):
-            return False
         for timeline in timelines:
             project.remove_timeline(timeline)
         return True

--- a/tests/fakes/pool.py
+++ b/tests/fakes/pool.py
@@ -61,6 +61,10 @@ class FakeMediaPool:
         self.refuses_create_timeline = False
         self.switches_current_timeline = True
         self.deleted_timelines: list[FakeTimeline] = []
+        # Timelines this pool answers ``False`` for. Resolve refuses a delete for reasons
+        # a caller cannot see — a timeline open in another page, one inside a compound —
+        # and the refusal is the only word it gives, so a sweep has to survive one.
+        self.refuse_deleting: set[FakeTimeline] = set()
         self.deleted_folders: list[FakeFolder] = []
         self.delete_folders_result = True
 
@@ -323,6 +327,8 @@ class FakeMediaPool:
         """
         self._check("DeleteTimelines")
         self.deleted_timelines.extend(timelines)
+        if any(timeline in self.refuse_deleting for timeline in timelines):
+            return False
         project = self._reached_project()
         if project is None:
             return True

--- a/tests/live_state.py
+++ b/tests/live_state.py
@@ -123,6 +123,27 @@ class ClipGenerationError(RuntimeError):
     """ffmpeg refused to generate the scan clip. Scaffolding, so not a server error."""
 
 
+class NamedClipMissingError(AssertionError):
+    """The env var names a clip the pool does not hold, or cannot decode."""
+
+
+def named_scan_clip(footage: Sequence[dict[str, Any]], named: str) -> dict[str, Any] | None:
+    """The pool entry the scan was pointed at, or ``None`` when it was pointed at nothing.
+
+    An empty or unset variable means "build one" rather than "scan anything", which is the
+    whole difference between this and the old "shortest clip in the pool" rule. A variable
+    that names a clip the pool cannot offer is a mistake worth stopping on: silently
+    generating a clip instead would report a pass for a scan the director never asked for.
+    """
+    wanted = named.strip()
+    if not wanted:
+        return None
+    for entry in footage:
+        if entry["name"] == wanted:
+            return entry
+    raise NamedClipMissingError(f"{wanted!r} names no decodable pool clip")
+
+
 HARD_CUT_COLOURS = ("red", "green", "blue", "white")
 """One solid colour per segment, so every boundary is a whole frame changing at once.
 
@@ -135,6 +156,7 @@ HARD_CUT_SIZE = "320x240"
 
 HARD_CUT_FPS = 24
 HARD_CUT_SECONDS = 1
+"""A second a colour: long enough that a cut lands on a frame boundary either way."""
 
 
 def hard_cut_argv(
@@ -143,7 +165,6 @@ def hard_cut_argv(
     colours: Sequence[str] = HARD_CUT_COLOURS,
     fps: int = HARD_CUT_FPS,
     size: str = HARD_CUT_SIZE,
-    seconds: int = HARD_CUT_SECONDS,
 ) -> list[str]:
     """The command that builds a clip whose only content is hard cuts.
 
@@ -152,7 +173,7 @@ def hard_cut_argv(
     """
     argv = [ffmpeg, "-y"]
     for colour in colours:
-        argv += ["-f", "lavfi", "-i", f"color=c={colour}:s={size}:r={fps}:d={seconds}"]
+        argv += ["-f", "lavfi", "-i", f"color=c={colour}:s={size}:r={fps}:d={HARD_CUT_SECONDS}"]
     streams = "".join(f"[{index}:v]" for index in range(len(colours)))
     argv += [
         "-filter_complex",
@@ -173,7 +194,6 @@ def write_hard_cut_clip(
     colours: Sequence[str] = HARD_CUT_COLOURS,
     fps: int = HARD_CUT_FPS,
     size: str = HARD_CUT_SIZE,
-    seconds: int = HARD_CUT_SECONDS,
 ) -> Path:
     """Generate the clip, raising what says why if ffmpeg will not.
 
@@ -182,7 +202,7 @@ def write_hard_cut_clip(
     an exit code.
     """
     binary = ffmpeg if ffmpeg is not None else get_config().ffmpeg
-    argv = hard_cut_argv(binary, destination, colours, fps, size, seconds)
+    argv = hard_cut_argv(binary, destination, colours, fps, size)
     finished = invoke(argv, runner=runner)
     if finished.returncode != 0:
         raise ClipGenerationError(

--- a/tests/live_state.py
+++ b/tests/live_state.py
@@ -1,0 +1,161 @@
+"""State the live suite builds for itself, rather than assuming the project has it (#135).
+
+The live tier runs against a working project on a real machine, and for a long time it read
+that project as a given: a still it hoped was in the pool, whatever timeline the last test
+left current, a clip it hoped had cuts in it. Every one of those was a failure waiting for
+the day the project changed, and #119 §B found four of them at once.
+
+So the suite builds what it needs. Two things it needs cannot be built by the tools under
+test — a project clear of the *previous* run's leftovers, and a clip with hard cuts in it —
+and both live here. The decisions they make (which names are the suite's own, what to do
+when Resolve is sitting on one of them, what command generates the clip) are settled in
+``tests/test_live_state.py`` against the fakes; what is left for the live tier is whether
+Resolve and ffmpeg take the calls.
+
+Cleanup stays at the timeline and bin level. ``DeleteProject`` is refused on the live box
+(#119 §B), so a scratch *project* is not an option and the suite tidies inside the one that
+is open.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from resolve_mcp.config import get_config
+from resolve_mcp.ffmpeg import STDERR_TAIL, Runner, invoke
+from resolve_mcp.resolve.timeline import name_of, same_timeline, timelines_of
+
+Pool = Any
+Project = Any
+Timeline = Any
+
+SUITE_TIMELINE = re.compile(r"^resolve-mcp[- ]")
+"""Every timeline the suite builds is named from this prefix.
+
+``resolve-mcp-smoke v<n>`` (every build), ``resolve-mcp-lock-probe`` (the locked-track
+probe) and ``resolve-mcp smoke <what> <hhmmss>`` (the round-trip and dissolve imports) all
+start this way, and the separator has to be part of the match: a sweep is a delete with no
+undo, so a director's cut that merely *starts* with the same letters must not qualify, and
+neither must one that mentions the prefix further along.
+"""
+
+
+class Swept(NamedTuple):
+    """What the sweep managed, by name — ``kept`` is what Resolve would not let go of."""
+
+    deleted: list[str]
+    kept: list[str]
+
+
+def is_suite_timeline(name: str) -> bool:
+    """Whether this name is one the live suite built and is free to delete."""
+    return SUITE_TIMELINE.match(name) is not None
+
+
+def sweep_suite_timelines(pool: Pool, project: Project) -> Swept:
+    """Delete the previous run's leftovers, so this run builds onto a known project.
+
+    Resolve will not delete the timeline it is sitting on, and says so only by returning
+    ``False`` — and a run ends on its own last build, so the current timeline is normally
+    one of ours. Moving to a cut the suite did not build is therefore the first step; a
+    project holding nothing else has nowhere to move to, and the one left behind is
+    reported rather than swallowed.
+
+    One call per timeline, not one batch call: a batch answers ``False`` for the whole
+    list, which would leave the sweep unable to say which cut stuck.
+    """
+    held = timelines_of(project)
+    ours = [timeline for timeline in held if is_suite_timeline(name_of(timeline))]
+    if not ours:
+        return Swept([], [])
+
+    current = project.GetCurrentTimeline()
+    if any(same_timeline(current, timeline) for timeline in ours):
+        elsewhere = next(
+            (timeline for timeline in held if not is_suite_timeline(name_of(timeline))), None
+        )
+        if elsewhere is not None:
+            project.SetCurrentTimeline(elsewhere)
+
+    deleted: list[str] = []
+    kept: list[str] = []
+    for timeline in ours:
+        name = name_of(timeline)
+        (deleted if pool.DeleteTimelines([timeline]) else kept).append(name)
+    return Swept(deleted, kept)
+
+
+class ClipGenerationError(RuntimeError):
+    """ffmpeg refused to generate the scan clip. Scaffolding, so not a server error."""
+
+
+HARD_CUT_COLOURS = ("red", "green", "blue", "white")
+"""One solid colour per segment, so every boundary is a whole frame changing at once.
+
+Four colours means three cuts. The live assertion is "at least one", so a detector that
+misses a boundary still proves the clip-clock mapping rather than turning the tier red.
+"""
+
+HARD_CUT_SIZE = "320x240"
+"""Small enough that generating, importing and decoding it are all instant."""
+
+HARD_CUT_FPS = 24
+HARD_CUT_SECONDS = 1
+
+
+def hard_cut_argv(
+    ffmpeg: str,
+    destination: Path,
+    colours: Sequence[str] = HARD_CUT_COLOURS,
+    fps: int = HARD_CUT_FPS,
+    size: str = HARD_CUT_SIZE,
+    seconds: int = HARD_CUT_SECONDS,
+) -> list[str]:
+    """The command that builds a clip whose only content is hard cuts.
+
+    ``-y`` because ffmpeg prompts on an existing output, and a prompt in a test run is a
+    hang rather than a failure.
+    """
+    argv = [ffmpeg, "-y"]
+    for colour in colours:
+        argv += ["-f", "lavfi", "-i", f"color=c={colour}:s={size}:r={fps}:d={seconds}"]
+    streams = "".join(f"[{index}:v]" for index in range(len(colours)))
+    argv += [
+        "-filter_complex",
+        f"{streams}concat=n={len(colours)}:v=1:a=0[cut]",
+        "-map",
+        "[cut]",
+        "-pix_fmt",
+        "yuv420p",
+        str(destination),
+    ]
+    return argv
+
+
+def write_hard_cut_clip(
+    destination: Path,
+    runner: Runner | None = None,
+    ffmpeg: str | None = None,
+    colours: Sequence[str] = HARD_CUT_COLOURS,
+    fps: int = HARD_CUT_FPS,
+    size: str = HARD_CUT_SIZE,
+    seconds: int = HARD_CUT_SECONDS,
+) -> Path:
+    """Generate the clip, raising what says why if ffmpeg will not.
+
+    A missing binary comes back as ``FfmpegUnavailableError`` from ``invoke`` — the same
+    shape every other route gets — so the live fixture can skip on it rather than reading
+    an exit code.
+    """
+    binary = ffmpeg if ffmpeg is not None else get_config().ffmpeg
+    argv = hard_cut_argv(binary, destination, colours, fps, size, seconds)
+    finished = invoke(argv, runner=runner)
+    if finished.returncode != 0:
+        raise ClipGenerationError(
+            f"ffmpeg refused to generate {destination.name} (exit {finished.returncode}): "
+            f"{finished.stderr[-STDERR_TAIL:]}"
+        )
+    return destination

--- a/tests/live_state.py
+++ b/tests/live_state.py
@@ -58,34 +58,65 @@ def is_suite_timeline(name: str) -> bool:
 def sweep_suite_timelines(pool: Pool, project: Project) -> Swept:
     """Delete the previous run's leftovers, so this run builds onto a known project.
 
-    Resolve will not delete the timeline it is sitting on, and says so only by returning
-    ``False`` — and a run ends on its own last build, so the current timeline is normally
-    one of ours. Moving to a cut the suite did not build is therefore the first step; a
-    project holding nothing else has nowhere to move to, and the one left behind is
-    reported rather than swallowed.
+    The timeline Resolve is sitting on is left where it is. Resolve refuses to delete it
+    anyway, but the reason it is not moved off first is worse than a refusal: switching
+    away and deleting in the same breath is what Resolve Studio 21.0.3 was doing when it
+    logged ``Internal undo error 3`` and wrote a crash dump, in the autosave the deletions
+    triggered (#135). So the sweep takes what it can reach and reports the rest, and
+    :func:`restore_current` is what stops the leftover being permanent — a session that
+    ends on the director's own cut leaves nothing current for the next sweep to refuse.
 
     One call per timeline, not one batch call: a batch answers ``False`` for the whole
     list, which would leave the sweep unable to say which cut stuck.
     """
-    held = timelines_of(project)
-    ours = [timeline for timeline in held if is_suite_timeline(name_of(timeline))]
+    ours = [timeline for timeline in timelines_of(project) if is_suite_timeline(name_of(timeline))]
     if not ours:
         return Swept([], [])
 
-    current = project.GetCurrentTimeline()
-    if any(same_timeline(current, timeline) for timeline in ours):
-        elsewhere = next(
-            (timeline for timeline in held if not is_suite_timeline(name_of(timeline))), None
-        )
-        if elsewhere is not None:
-            project.SetCurrentTimeline(elsewhere)
+    delete = getattr(pool, "DeleteTimelines", None)
+    if not callable(delete):
+        # A handle Resolve has dropped answers None for every method rather than raising,
+        # so an unswept project is what a dying Resolve looks like from here. Reporting it
+        # beats a TypeError out of a session fixture, which errors every test at setup and
+        # buries the one message that says Resolve is gone.
+        return Swept([], [name_of(timeline) for timeline in ours])
 
+    current = project.GetCurrentTimeline()
     deleted: list[str] = []
     kept: list[str] = []
     for timeline in ours:
         name = name_of(timeline)
-        (deleted if pool.DeleteTimelines([timeline]) else kept).append(name)
+        if same_timeline(current, timeline):
+            kept.append(name)
+            continue
+        (deleted if delete([timeline]) else kept).append(name)
     return Swept(deleted, kept)
+
+
+def restore_current(project: Project, timeline: Timeline) -> bool:
+    """Leave the project on a cut the suite did not build.
+
+    A run that ends on its own build leaves a timeline the next sweep cannot delete — and
+    leaves whoever opens the GUI looking at a smoke test. ``timeline`` is what was open
+    when the session started and is normally the answer.
+
+    When the session *found* one of the suite's own cuts open, putting that back would make
+    the leftover permanent: it is current, so the sweep skips it, and the run after that
+    finds it current again. So any cut the suite did not build is preferred, and the
+    leftover goes on the next run instead of surviving every one.
+    """
+    switch = getattr(project, "SetCurrentTimeline", None)
+    if not callable(switch):
+        return False
+    target = timeline
+    if target is None or is_suite_timeline(name_of(target)):
+        held = timelines_of(project)
+        target = next((one for one in held if not is_suite_timeline(name_of(one))), target)
+    if target is None:
+        return False
+    if same_timeline(project.GetCurrentTimeline(), target):
+        return True
+    return bool(switch(target))
 
 
 class ClipGenerationError(RuntimeError):

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -73,7 +73,7 @@ from resolve_mcp.tools.video import detect_scene_cuts, grab_frames
 
 from . import otio
 from .fakes import write_wav
-from .live_state import sweep_suite_timelines, write_hard_cut_clip
+from .live_state import restore_current, sweep_suite_timelines, write_hard_cut_clip
 from .text_plus_probe import TEMPLATE_ENV, probe_template_append
 
 pytestmark = pytest.mark.live
@@ -102,12 +102,18 @@ SMOKE_SONG = "resolve-mcp-130"
 """The blue marker #130's carry moves — named so a leftover in the GUI says where it came from."""
 
 LOCKED_TRACK_PROBE = """
+def under(folder):
+    found = list(folder.GetClipList() or [])
+    for sub in (folder.GetSubFolderList() or []):
+        found += under(sub)
+    return found
+
 pool = project.GetMediaPool()
 was_on = project.GetCurrentTimeline()
 timeline = pool.CreateEmptyTimeline("resolve-mcp-lock-probe")
 project.SetCurrentTimeline(timeline)
 timeline.SetTrackLock("video", 1, True)
-clips = [c for c in pool.GetRootFolder().GetClipList() if c.GetName() == {name}]
+clips = [c for c in under(pool.GetRootFolder()) if c.GetName() == {name}]
 returned = pool.AppendToTimeline([
     {{"mediaPoolItem": clips[0], "startFrame": {start}, "endFrame": {end},
       "mediaType": 1, "trackIndex": 1, "recordFrame": timeline.GetStartFrame()}}
@@ -121,6 +127,10 @@ result = {{
 result["swept"] = bool(result["put_back"] and pool.DeleteTimelines([timeline]))
 """
 """Spike #18 (d), reduced to its claim: a locked track reports a placement it did not make.
+
+The clip is looked for through the whole pool rather than in its root folder: a project that
+keeps its footage in bins — every real one — has an empty root, and the probe skipped on it,
+so the footgun this guards went unmeasured on the machine it guards (#135).
 
 The probe puts Resolve back on the timeline it found open and deletes its own empty cut
 before it answers. Leaving Resolve sitting on an empty locked timeline is what made the
@@ -139,8 +149,8 @@ def _requires_resolve() -> None:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _a_project_without_the_last_runs_leftovers() -> None:
-    """Delete the timelines the previous run built, before this run builds onto them.
+def _a_project_without_the_last_runs_leftovers() -> Iterator[None]:
+    """Delete the timelines the previous run built, and leave the director's cut open.
 
     Every build here materialises a new ``resolve-mcp-smoke`` version and every OTIO import
     materialises another named cut, so a project the suite has run against a few times holds
@@ -148,16 +158,31 @@ def _a_project_without_the_last_runs_leftovers() -> None:
     scene scan ended up picking a timeline, and how the locked-track probe met a name it had
     already created.
 
-    A run against an unreachable Resolve sweeps nothing and says nothing: the per-test
-    fixture is what reports that, and this one must not turn it into an error.
+    Both halves are housekeeping, and neither may sink the run: a failure here would error
+    *every* test at setup and bury the one message that says why — which is exactly what a
+    dying Resolve did to the first run of this fixture (#135). ``_requires_resolve`` is what
+    reports an unreachable Resolve, per test, with a cause.
     """
     if not get_status()["ok"]:
+        yield
         return
     connection = get_connection()
     project = current_project(connection, "No project is open, so there is nothing to sweep.")
-    swept = sweep_suite_timelines(media_pool(connection), project)
-    if swept.deleted or swept.kept:
-        print(f"\nswept {len(swept.deleted)} leftover timeline(s); kept {swept.kept}")
+    was_on = project.GetCurrentTimeline()
+    try:
+        swept = sweep_suite_timelines(media_pool(connection), project)
+    except Exception as unswept:  # noqa: BLE001 - see the docstring: never sink the run
+        print(f"\nnothing swept: {unswept}")
+    else:
+        if swept.deleted or swept.kept:
+            print(f"\nswept {len(swept.deleted)} leftover timeline(s); kept {swept.kept}")
+
+    yield
+
+    try:
+        restore_current(project, was_on)
+    except Exception as stuck:  # noqa: BLE001 - a departed Resolve must not fail the run
+        print(f"\nleft Resolve where the last test put it: {stuck}")
 
 
 def test_attaches_to_resolve_and_reports_a_version() -> None:
@@ -875,15 +900,17 @@ def test_the_locked_track_footgun_is_still_real(tmp_path: Path) -> None:
     assert probe["ok"] is True, probe.get("error")
     # run_python renders its value with repr, so the probe's dict comes back as source text.
     reported = ast.literal_eval(probe["result"])
-    if not reported["found"]:
-        pytest.skip("The chosen clip is not in the root folder, so the probe could not run")
-    assert reported["returned_truthy"] is True
-    assert reported["items_on_track"] == 0
-    # The probe is the one test here that moves Resolve, and the tests after it read the
-    # current timeline — so where it left the GUI is part of what it has to get right.
+    # Asserted before the skip below: the probe moves Resolve and creates a timeline
+    # whether or not it finds a clip to append, and the tests after it read the current
+    # timeline — so where it left the GUI is part of what it has to get right, on every
+    # path out of here.
     assert reported["put_back"] is True, "the probe left Resolve on its own empty timeline"
     assert reported["swept"] is True, "the probe left its empty timeline in the project"
     assert list_timelines()["current"] != "resolve-mcp-lock-probe"
+    if not reported["found"]:
+        pytest.skip("The chosen clip is nowhere in the media pool, so the probe could not run")
+    assert reported["returned_truthy"] is True
+    assert reported["items_on_track"] == 0
 
 
 def test_an_invalid_cut_creates_no_timeline_on_a_real_project(tmp_path: Path) -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -28,7 +28,7 @@ import zlib
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import pytest
 
@@ -73,7 +73,12 @@ from resolve_mcp.tools.video import detect_scene_cuts, grab_frames
 
 from . import otio
 from .fakes import write_wav
-from .live_state import restore_current, sweep_suite_timelines, write_hard_cut_clip
+from .live_state import (
+    named_scan_clip,
+    restore_current,
+    sweep_suite_timelines,
+    write_hard_cut_clip,
+)
 from .text_plus_probe import TEMPLATE_ENV, probe_template_append
 
 pytestmark = pytest.mark.live
@@ -122,9 +127,11 @@ result = {{
     "found": bool(clips),
     "returned_truthy": bool(returned),
     "items_on_track": len(timeline.GetItemListInTrack("video", 1) or []),
-    "put_back": bool(was_on is not None and project.SetCurrentTimeline(was_on)),
+    "was_open": was_on is not None,
+    "put_back": bool(was_on is None or project.SetCurrentTimeline(was_on)),
 }}
-result["swept"] = bool(result["put_back"] and pool.DeleteTimelines([timeline]))
+result["swept"] = bool(result["was_open"] and result["put_back"]
+                       and pool.DeleteTimelines([timeline]))
 """
 """Spike #18 (d), reduced to its claim: a locked track reports a placement it did not make.
 
@@ -167,9 +174,12 @@ def _a_project_without_the_last_runs_leftovers() -> Iterator[None]:
         yield
         return
     connection = get_connection()
-    project = current_project(connection, "No project is open, so there is nothing to sweep.")
-    was_on = project.GetCurrentTimeline()
+    project = was_on = None
     try:
+        # Inside the guard, not before it: a Resolve that is up with no project open raises
+        # NoProjectOpenError here, and that is the shape this fixture exists not to have.
+        project = current_project(connection, "No project is open, so there is nothing to sweep.")
+        was_on = project.GetCurrentTimeline()
         swept = sweep_suite_timelines(media_pool(connection), project)
     except Exception as unswept:  # noqa: BLE001 - see the docstring: never sink the run
         print(f"\nnothing swept: {unswept}")
@@ -179,6 +189,8 @@ def _a_project_without_the_last_runs_leftovers() -> Iterator[None]:
 
     yield
 
+    if project is None:
+        return
     try:
         restore_current(project, was_on)
     except Exception as stuck:  # noqa: BLE001 - a departed Resolve must not fail the run
@@ -394,7 +406,7 @@ def _smoke_name(what: str) -> str:
 
 
 def test_an_otio_round_trip_preserves_the_timeline_structure(
-    tmp_path: Path, a_known_cut: dict[str, Any]
+    tmp_path: Path, a_known_cut: KnownCut
 ) -> None:
     """AC: export to OTIO, import it back, and the cut is the same cut.
 
@@ -405,10 +417,10 @@ def test_an_otio_round_trip_preserves_the_timeline_structure(
     many are in whatever was open — ``_shape`` refuses a timeline too long to read in one
     go, and a concert-length edit is exactly that (#135).
     """
-    before = _shape(a_known_cut["name"])
+    before = _shape(a_known_cut.name)
 
     exported = export_timeline(
-        timeline=a_known_cut["name"], path=str(tmp_path / "round-trip.otio")
+        timeline=a_known_cut.name, path=str(tmp_path / "round-trip.otio")
     )
     assert exported["ok"] is True, exported.get("error")
     assert exported["export_type"] == "EXPORT_OTIO"
@@ -423,7 +435,7 @@ def test_an_otio_round_trip_preserves_the_timeline_structure(
 
 
 def test_a_hand_injected_dissolve_imports_as_a_transition(
-    tmp_path: Path, a_known_cut: dict[str, Any]
+    tmp_path: Path, a_known_cut: KnownCut
 ) -> None:
     """AC: a dissolve edited into an exported OTIO comes back as a real transition.
 
@@ -436,7 +448,7 @@ def test_a_hand_injected_dissolve_imports_as_a_transition(
     The cut it injects into is the suite's own three-shot build (#135): two cuts, both
     between shots long enough to carry six frames of dissolve, every run.
     """
-    exported = export_timeline(timeline=a_known_cut["name"], path=str(tmp_path / "injected.otio"))
+    exported = export_timeline(timeline=a_known_cut.name, path=str(tmp_path / "injected.otio"))
     assert exported["ok"] is True, exported.get("error")
     document = json.loads(Path(exported["path"]).read_text(encoding="utf-8"))
 
@@ -575,8 +587,15 @@ def a_smoke_cut(
     return str(path)
 
 
+class KnownCut(NamedTuple):
+    """The cut :func:`a_known_cut` built, and whether a mix went under it."""
+
+    name: str
+    audio: bool
+
+
 @pytest.fixture
-def a_known_cut(tmp_path: Path) -> Iterator[dict[str, Any]]:
+def a_known_cut(tmp_path: Path) -> Iterator[KnownCut]:
     """A short cut of the suite's own making, current for the length of one test.
 
     Three tests here work on *the current timeline* — the OTIO round trip, the dissolve
@@ -610,7 +629,7 @@ def a_known_cut(tmp_path: Path) -> Iterator[dict[str, Any]]:
 
     project = current_project(get_connection())
     with current_timeline(project, find_timeline(project, name)):
-        yield {"name": name, "audio": with_audio, "durations": durations}
+        yield KnownCut(name=name, audio=with_audio)
 
 
 def test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it(tmp_path: Path) -> None:
@@ -856,15 +875,13 @@ def test_a_still_lands_at_the_duration_the_cut_asked_for(tmp_path: Path) -> None
         pytest.skip("No still image in the media pool")
     still = stills[0]
     fps = get_status()["context"]["fps"] or 24.0
-    # Verbatim, the way ``a_smoke_cut`` passes it: a still that also sits in the pool root
-    # is two clips of one name, and a source naming no bin cannot say which (#122).
-    source: dict[str, Any] = {"clip": still["name"]}
-    if still["bin"] is not None:
-        source["bin"] = still["bin"]
     doc = {
         "schema": 1,
         "timeline": {"name": SMOKE_CUT, "fps": fps},
-        "sources": {"still": source},
+        # Verbatim, not ``or None``: a still that also sits in the pool root is two clips
+        # of one name, a source naming no bin cannot say which, and "" is the root itself
+        # — which is where this project's duplicates live (#122).
+        "sources": {"still": {"clip": still["name"], "bin": still["bin"]}},
         "segments": [{"id": "s000", "source": "still", "in": 0, "out": 90}],
     }
     path = tmp_path / "still.cut.json"
@@ -905,8 +922,12 @@ def test_the_locked_track_footgun_is_still_real(tmp_path: Path) -> None:
     # timeline — so where it left the GUI is part of what it has to get right, on every
     # path out of here.
     assert reported["put_back"] is True, "the probe left Resolve on its own empty timeline"
-    assert reported["swept"] is True, "the probe left its empty timeline in the project"
-    assert list_timelines()["current"] != "resolve-mcp-lock-probe"
+    if reported["was_open"]:
+        assert reported["swept"] is True, "the probe left its empty timeline in the project"
+        assert list_timelines()["current"] != "resolve-mcp-lock-probe"
+    # A session that had no timeline open has nowhere to move to, and Resolve will not
+    # delete the cut it is sitting on — so the probe's timeline stays, and the next run's
+    # sweep is what takes it. Failing here instead would report a leak as a broken probe.
     if not reported["found"]:
         pytest.skip("The chosen clip is nowhere in the media pool, so the probe could not run")
     assert reported["returned_truthy"] is True
@@ -930,7 +951,7 @@ def test_an_invalid_cut_creates_no_timeline_on_a_real_project(tmp_path: Path) ->
     assert {entry["name"] for entry in list_timelines()["timelines"]} == before
 
 
-def test_the_render_queue_exports_the_real_timeline_mix(a_known_cut: dict[str, Any]) -> None:
+def test_the_render_queue_exports_the_real_timeline_mix(a_known_cut: KnownCut) -> None:
     """The AC no seam can check: that these render-settings keys are the ones Resolve takes.
 
     The fakes prove the job machinery, the caching and the failure shaping. Whether
@@ -943,7 +964,7 @@ def test_the_render_queue_exports_the_real_timeline_mix(a_known_cut: dict[str, A
     was an empty timeline with no mix on it at all (#119 §B). It now renders a cut this
     suite built, with a master mix laid under it — four seconds rather than a whole concert.
     """
-    if not a_known_cut["audio"]:
+    if not a_known_cut.audio:
         pytest.skip("No pool clip this suite can lay a master mix from, so there is no mix")
 
     started = acquire_timeline_audio(get_connection())
@@ -1084,11 +1105,9 @@ def a_clip_with_hard_cuts(tmp_path: Path) -> Iterator[dict[str, Any]]:
     listing = list_media()
     if not listing["ok"]:
         pytest.skip("No project open in Resolve")
-    named = os.environ.get(SCENE_SCAN_CLIP_ENV, "").strip()
-    if named:
-        matches = [one for one in _decodable(listing["clips"]) if one["name"] == named]
-        assert matches, f"{SCENE_SCAN_CLIP_ENV}={named!r} names no decodable pool clip"
-        yield matches[0]
+    named = named_scan_clip(_decodable(listing["clips"]), os.environ.get(SCENE_SCAN_CLIP_ENV, ""))
+    if named is not None:
+        yield named
         return
 
     try:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -25,6 +25,7 @@ import json
 import os
 import shutil
 import zlib
+from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -34,6 +35,7 @@ import pytest
 from resolve_mcp.audio.acquire import acquire_timeline_audio
 from resolve_mcp.audio.stems import DRUM_STEMS, FOUR_STEMS, separation_params, two_pass
 from resolve_mcp.config import get_config
+from resolve_mcp.errors import BinNotFoundError, FfmpegUnavailableError
 from resolve_mcp.jobs import cache
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.naming import timestamped_name
@@ -43,11 +45,14 @@ from resolve_mcp.resolve.media import (
     apply_still_workaround,
     audio_channels,
     ensure_bin,
+    find_bin,
     find_clip,
     import_into,
     media_pool,
     properties,
 )
+from resolve_mcp.resolve.session import current_project
+from resolve_mcp.resolve.timeline import current_timeline, find_timeline
 from resolve_mcp.tools.analysis import correlate_timeline
 from resolve_mcp.tools.cut import build_timeline, swap_take, validate_cut
 from resolve_mcp.tools.escape_hatch import run_python
@@ -68,6 +73,7 @@ from resolve_mcp.tools.video import detect_scene_cuts, grab_frames
 
 from . import otio
 from .fakes import write_wav
+from .live_state import sweep_suite_timelines, write_hard_cut_clip
 from .text_plus_probe import TEMPLATE_ENV, probe_template_append
 
 pytestmark = pytest.mark.live
@@ -78,7 +84,16 @@ CORRELATE_AUDIO_ENV = "RESOLVE_MCP_CORRELATE_AUDIO"
 """Opt-in for #40's live AC: a real beats file, and the hand-edited cut to measure with it."""
 
 SCENE_SCAN_CLIP_ENV = "RESOLVE_MCP_SCENE_SCAN_CLIP"
-"""Opt-in for #34's live AC: a pool clip with hard cuts, so the scan has cuts to map."""
+"""Override for #34's live AC: a pool clip with hard cuts, so the scan has cuts to map.
+
+Leave it unset and the suite builds its own — see :func:`a_clip_with_hard_cuts`. Set it to
+scan a real edit instead, which is the stronger check when the project has a flattened
+render in the pool: a generated clip proves the mapping on synthetic cuts, a real one
+proves it on the cuts a camera and an editor made.
+"""
+
+SCAN_BIN = "resolve-mcp-scratch"
+"""Where the generated scan clip is imported. Deleted with its clip when the test ends."""
 
 SMOKE_CUT = "resolve-mcp-smoke"
 """Every build here materialises a new version of this name; delete them when you are done."""
@@ -88,6 +103,7 @@ SMOKE_SONG = "resolve-mcp-130"
 
 LOCKED_TRACK_PROBE = """
 pool = project.GetMediaPool()
+was_on = project.GetCurrentTimeline()
 timeline = pool.CreateEmptyTimeline("resolve-mcp-lock-probe")
 project.SetCurrentTimeline(timeline)
 timeline.SetTrackLock("video", 1, True)
@@ -100,9 +116,19 @@ result = {{
     "found": bool(clips),
     "returned_truthy": bool(returned),
     "items_on_track": len(timeline.GetItemListInTrack("video", 1) or []),
+    "put_back": bool(was_on is not None and project.SetCurrentTimeline(was_on)),
 }}
+result["swept"] = bool(result["put_back"] and pool.DeleteTimelines([timeline]))
 """
-"""Spike #18 (d), reduced to its claim: a locked track reports a placement it did not make."""
+"""Spike #18 (d), reduced to its claim: a locked track reports a placement it did not make.
+
+The probe puts Resolve back on the timeline it found open and deletes its own empty cut
+before it answers. Leaving Resolve sitting on an empty locked timeline is what made the
+audio export downstream render nothing (#119 §B) — the probe's currency switch is the
+cause, so undoing it belongs here rather than in the tests that trip over it. Both
+outcomes travel back in the result, because a silent failure to put it back would be the
+same bug wearing a fix.
+"""
 
 
 @pytest.fixture(autouse=True)
@@ -110,6 +136,28 @@ def _requires_resolve() -> None:
     result = get_status()
     if not result["ok"]:
         pytest.skip(f"Resolve unreachable: {result['error']['cause']}")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _a_project_without_the_last_runs_leftovers() -> None:
+    """Delete the timelines the previous run built, before this run builds onto them.
+
+    Every build here materialises a new ``resolve-mcp-smoke`` version and every OTIO import
+    materialises another named cut, so a project the suite has run against a few times holds
+    dozens of them — and the run after that reads the pool through them. That is how #34's
+    scene scan ended up picking a timeline, and how the locked-track probe met a name it had
+    already created.
+
+    A run against an unreachable Resolve sweeps nothing and says nothing: the per-test
+    fixture is what reports that, and this one must not turn it into an error.
+    """
+    if not get_status()["ok"]:
+        return
+    connection = get_connection()
+    project = current_project(connection, "No project is open, so there is nothing to sweep.")
+    swept = sweep_suite_timelines(media_pool(connection), project)
+    if swept.deleted or swept.kept:
+        print(f"\nswept {len(swept.deleted)} leftover timeline(s); kept {swept.kept}")
 
 
 def test_attaches_to_resolve_and_reports_a_version() -> None:
@@ -320,17 +368,23 @@ def _smoke_name(what: str) -> str:
     return f"resolve-mcp smoke {what} {datetime.now().strftime('%H%M%S')}"
 
 
-def test_an_otio_round_trip_preserves_the_timeline_structure(tmp_path: Path) -> None:
+def test_an_otio_round_trip_preserves_the_timeline_structure(
+    tmp_path: Path, a_known_cut: dict[str, Any]
+) -> None:
     """AC: export to OTIO, import it back, and the cut is the same cut.
 
     The fakes prove the naming and the error shaping; only Resolve proves that what it
     wrote is what it reads back, which is the whole basis of the transition route.
-    """
-    if get_status()["context"]["timeline"] is None:
-        pytest.skip("No timeline open in Resolve")
-    before = _shape()
 
-    exported = export_timeline(path=str(tmp_path / "round-trip.otio"))
+    Read on a cut this suite built, so the comparison is three shots rather than however
+    many are in whatever was open — ``_shape`` refuses a timeline too long to read in one
+    go, and a concert-length edit is exactly that (#135).
+    """
+    before = _shape(a_known_cut["name"])
+
+    exported = export_timeline(
+        timeline=a_known_cut["name"], path=str(tmp_path / "round-trip.otio")
+    )
     assert exported["ok"] is True, exported.get("error")
     assert exported["export_type"] == "EXPORT_OTIO"
 
@@ -343,7 +397,9 @@ def test_an_otio_round_trip_preserves_the_timeline_structure(tmp_path: Path) -> 
         assert after["tracks"].get(track) == shots, f"{track} came back differently"
 
 
-def test_a_hand_injected_dissolve_imports_as_a_transition(tmp_path: Path) -> None:
+def test_a_hand_injected_dissolve_imports_as_a_transition(
+    tmp_path: Path, a_known_cut: dict[str, Any]
+) -> None:
     """AC: a dissolve edited into an exported OTIO comes back as a real transition.
 
     Transitions are the wall this route exists to get around, and the scripting API has no
@@ -351,11 +407,11 @@ def test_a_hand_injected_dissolve_imports_as_a_transition(tmp_path: Path) -> Non
     and rebuilt the cut from it. **The dissolve and the fade to black themselves are
     confirmed by eye in the Resolve GUI on the imported timeline**, and the result goes on
     the ticket; a run that stops at green here has verified half the AC.
-    """
-    if get_status()["context"]["timeline"] is None:
-        pytest.skip("No timeline open in Resolve")
 
-    exported = export_timeline(path=str(tmp_path / "injected.otio"))
+    The cut it injects into is the suite's own three-shot build (#135): two cuts, both
+    between shots long enough to carry six frames of dissolve, every run.
+    """
+    exported = export_timeline(timeline=a_known_cut["name"], path=str(tmp_path / "injected.otio"))
     assert exported["ok"] is True, exported.get("error")
     document = json.loads(Path(exported["path"]).read_text(encoding="utf-8"))
 
@@ -492,6 +548,44 @@ def a_smoke_cut(
     path = tmp_path / name
     path.write_text(json.dumps(doc), encoding="utf-8")
     return str(path)
+
+
+@pytest.fixture
+def a_known_cut(tmp_path: Path) -> Iterator[dict[str, Any]]:
+    """A short cut of the suite's own making, current for the length of one test.
+
+    Three tests here work on *the current timeline* — the OTIO round trip, the dissolve
+    import and the audio export — and for a long time that meant whatever the test before
+    them left open. Suite ordering decided it, so the audio export was measuring an empty
+    locked probe timeline and the round trip was comparing a concert-length edit shot by
+    shot (#119 §B). None of them is about that timeline; each is about what Resolve does
+    with one, so the suite builds one and says which.
+
+    Master audio is laid under it when the source clip has any, because the export test
+    needs a mix to render — ``validate_cut`` answers that, and a pool of silent clips
+    leaves the picture-only cut, which still serves the other two.
+
+    The director's timeline goes back afterwards: the later render tests need a long one,
+    and somebody may be sitting in front of the GUI.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    source = a_source_clip()
+    durations = (48, 24, 36)
+    path = a_smoke_cut(tmp_path, source, durations, audio_in=source["start"], name="known.cut.json")
+    with_audio = bool(validate_cut(path)["valid"])
+    if not with_audio:
+        path = a_smoke_cut(tmp_path, source, durations, name="known.cut.json")
+        checked = validate_cut(path)
+        assert checked["valid"] is True, checked["errors"]
+
+    built = build_timeline(path)
+    assert built["ok"] is True, built.get("error")
+    name = str(built["timeline"]["name"])
+
+    project = current_project(get_connection())
+    with current_timeline(project, find_timeline(project, name)):
+        yield {"name": name, "audio": with_audio, "durations": durations}
 
 
 def test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it(tmp_path: Path) -> None:
@@ -724,19 +818,28 @@ def test_a_still_lands_at_the_duration_the_cut_asked_for(tmp_path: Path) -> None
     if get_status()["context"]["project"] is None:
         pytest.skip("No project open in Resolve")
     listing = list_media()
+    # Resolve's own type name, not the suffix: a PNG *sequence* is a multi-frame clip with
+    # a ``.png`` path, and asking one for 90 frames is not the one-time Out write this test
+    # is about — it is a request for frames the clip does not have (#135).
     stills = [
         entry
         for entry in listing["clips"]
-        if Path(str(entry.get("file_path") or "")).suffix.lower() in {".png", ".jpg", ".jpeg"}
+        if entry["type"] == "Still"
+        and Path(str(entry.get("file_path") or "")).suffix.lower() in {".png", ".jpg", ".jpeg"}
     ]
     if not stills:
         pytest.skip("No still image in the media pool")
     still = stills[0]
     fps = get_status()["context"]["fps"] or 24.0
+    # Verbatim, the way ``a_smoke_cut`` passes it: a still that also sits in the pool root
+    # is two clips of one name, and a source naming no bin cannot say which (#122).
+    source: dict[str, Any] = {"clip": still["name"]}
+    if still["bin"] is not None:
+        source["bin"] = still["bin"]
     doc = {
         "schema": 1,
         "timeline": {"name": SMOKE_CUT, "fps": fps},
-        "sources": {"still": {"clip": still["name"]}},
+        "sources": {"still": source},
         "segments": [{"id": "s000", "source": "still", "in": 0, "out": 90}],
     }
     path = tmp_path / "still.cut.json"
@@ -776,6 +879,11 @@ def test_the_locked_track_footgun_is_still_real(tmp_path: Path) -> None:
         pytest.skip("The chosen clip is not in the root folder, so the probe could not run")
     assert reported["returned_truthy"] is True
     assert reported["items_on_track"] == 0
+    # The probe is the one test here that moves Resolve, and the tests after it read the
+    # current timeline — so where it left the GUI is part of what it has to get right.
+    assert reported["put_back"] is True, "the probe left Resolve on its own empty timeline"
+    assert reported["swept"] is True, "the probe left its empty timeline in the project"
+    assert list_timelines()["current"] != "resolve-mcp-lock-probe"
 
 
 def test_an_invalid_cut_creates_no_timeline_on_a_real_project(tmp_path: Path) -> None:
@@ -795,16 +903,21 @@ def test_an_invalid_cut_creates_no_timeline_on_a_real_project(tmp_path: Path) ->
     assert {entry["name"] for entry in list_timelines()["timelines"]} == before
 
 
-def test_the_render_queue_exports_the_real_timeline_mix() -> None:
+def test_the_render_queue_exports_the_real_timeline_mix(a_known_cut: dict[str, Any]) -> None:
     """The AC no seam can check: that these render-settings keys are the ones Resolve takes.
 
     The fakes prove the job machinery, the caching and the failure shaping. Whether
     ``SetRenderSettings`` accepts ``ExportVideo``/``AudioBitDepth``/``AudioSampleRate`` under
     those names, and whether an audio-only wav/lpcm job renders at all, is only answerable
-    here. Slow: this renders the open timeline's audio in full.
+    here.
+
+    The queue renders the *current* timeline, so what is current is the whole input: this
+    used to render whatever the test before it left open, which after the locked-track probe
+    was an empty timeline with no mix on it at all (#119 §B). It now renders a cut this
+    suite built, with a master mix laid under it — four seconds rather than a whole concert.
     """
-    if get_status()["context"]["timeline"] is None:
-        pytest.skip("No timeline open in Resolve")
+    if not a_known_cut["audio"]:
+        pytest.skip("No pool clip this suite can lay a master mix from, so there is no mix")
 
     started = acquire_timeline_audio(get_connection())
     record = wait_for(started["job_id"], timeout=1800.0)
@@ -918,31 +1031,72 @@ def test_a_real_frame_grab_lands_on_the_moment_resolve_numbers_it_at() -> None:
     assert again["cached"] is True, "unchanged media must be a cache hit"
 
 
-def test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock() -> None:
-    """The other half of the clock check: pts_time counts from the file, cuts from the clip.
+def _sweep_scan_bin(pool: Any) -> None:
+    """Delete the scan bin a crashed run left behind, so the import lands one clip not two."""
+    try:
+        located = find_bin(pool, SCAN_BIN)
+    except BinNotFoundError:
+        return
+    pool.DeleteFolders([located.folder])
 
-    Slow — this decodes a whole clip, so it takes the shortest one in the pool. What it is
-    for is the mapping the fakes replay rather than produce: that ffmpeg's reported times
-    become frame numbers inside the bounds ``inspect_clip`` reports for the same clip.
 
-    The shortest pool clip is usually a continuous take (or a still), and a clip with no
-    cuts passes the mapping loop vacuously — the half of #34 this test exists for goes
-    unchecked. ``RESOLVE_MCP_SCENE_SCAN_CLIP`` names a pool clip known to contain hard
-    cuts; when set, that clip is scanned instead and the scan must find at least one cut.
+@pytest.fixture
+def a_clip_with_hard_cuts(tmp_path: Path) -> Iterator[dict[str, Any]]:
+    """A pool clip the scan is guaranteed to find cuts in, built here unless one is named.
+
+    This used to be "the shortest clip in the pool", which is how the scan ended up on a
+    27-frame PNG sequence with nothing to detect — a clip with no cuts passes the mapping
+    loop vacuously, so the half of #34 the test exists for went unchecked every run (#119
+    §B). A shot log is not something a project owes the suite, and the live box's pool
+    holds only raw continuous angles, so the suite generates what it needs: four solid
+    colours a second apart, which is three cuts no detector can miss.
+
+    ``RESOLVE_MCP_SCENE_SCAN_CLIP`` still names a real pool clip to scan instead, which is
+    the stronger check where a project has a flattened render to point it at.
     """
     listing = list_media()
     if not listing["ok"]:
         pytest.skip("No project open in Resolve")
-    footage = _decodable(listing["clips"])
-    if not footage:
-        pytest.skip("No online clip with a frame rate in the media pool")
     named = os.environ.get(SCENE_SCAN_CLIP_ENV, "").strip()
     if named:
-        matches = [one for one in footage if one["name"] == named]
+        matches = [one for one in _decodable(listing["clips"]) if one["name"] == named]
         assert matches, f"{SCENE_SCAN_CLIP_ENV}={named!r} names no decodable pool clip"
-        chosen = matches[0]
-    else:
-        chosen = min(footage, key=lambda one: one["frames"])
+        yield matches[0]
+        return
+
+    try:
+        generated = write_hard_cut_clip(tmp_path / "resolve-mcp-hard-cuts.mp4")
+    except FfmpegUnavailableError as unavailable:
+        pytest.skip(f"No ffmpeg to build a scan clip with: {unavailable.cause}")
+
+    pool = media_pool(get_connection())
+    _sweep_scan_bin(pool)
+    target = ensure_bin(pool, SCAN_BIN)
+    try:
+        assert import_into(pool, [str(generated)], target), (
+            f"Resolve imported nothing from {generated}"
+        )
+        entries = _decodable(list_media(bin=SCAN_BIN)["clips"])
+        assert entries, "the generated clip did not read back as decodable footage"
+        yield entries[0]
+    finally:
+        # The bin goes, and the clip with it: the file itself lives in tmp_path and is
+        # about to vanish, and a pool entry pointing at a deleted file reads as offline
+        # media in the GUI for whoever opens the project next.
+        pool.DeleteFolders([target.folder])
+
+
+def test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock(
+    a_clip_with_hard_cuts: dict[str, Any],
+) -> None:
+    """The other half of the clock check: pts_time counts from the file, cuts from the clip.
+
+    What it is for is the mapping the fakes replay rather than produce: that ffmpeg's
+    reported times become frame numbers inside the bounds ``inspect_clip`` reports for the
+    same clip. That needs a clip with cuts in it, which is what the fixture guarantees — so
+    finding none is now a failure rather than a skip.
+    """
+    chosen = a_clip_with_hard_cuts
     bounds = inspect_clip(chosen["name"], bin=chosen["bin"])["bounds"]["media"]
 
     started = detect_scene_cuts(chosen["name"], bin=chosen["bin"])
@@ -952,18 +1106,13 @@ def test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock() -> None:
     assert record.state == "completed", record.error
     assert record.result is not None
     assert Path(record.result["path"]).exists()
-    if named:
-        assert record.result["first_cuts"], (
-            f"{named!r} was named as a clip with hard cuts, but the scan found none — "
-            "the clip-clock mapping went unexercised"
-        )
+    assert record.result["first_cuts"], (
+        f"{chosen['name']!r} was chosen for its hard cuts and the scan found none — "
+        "the clip-clock mapping went unexercised"
+    )
     for cut in record.result["first_cuts"]:
         assert bounds["in"]["frames"] < cut["frames"] < bounds["out"]["frames"]
-    if not record.result["first_cuts"]:
-        pytest.skip(
-            f"scan completed but {chosen['name']!r} has no cuts — the mapping went "
-            f"unexercised; set {SCENE_SCAN_CLIP_ENV} to a pool clip with hard cuts"
-        )
+
 
 def test_the_preset_list_is_the_one_in_the_deliver_page() -> None:
     """#33: whether ``GetRenderPresetList`` answers at all, and with what spelling.

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -1,0 +1,229 @@
+"""The decisions behind the state the live suite builds for itself (#135).
+
+The live tier is the only place these helpers run for real, and it is the one tier that
+cannot be run in CI — so every *decision* they make is settled here instead: which names
+are the suite's own, what happens when the timeline Resolve is sitting on is one of them,
+and what command generates the hard-cut clip the scene scan needs. What is left for the
+live tier is whether Resolve and ffmpeg accept the calls, which is exactly the split
+CLAUDE.md draws.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.errors import FfmpegUnavailableError
+from resolve_mcp.ffmpeg import Completed
+from resolve_mcp.resolve.timeline import timelines_of
+
+from .fakes import FakeMediaPool, FakeProject, FakeTimeline
+from .live_state import (
+    HARD_CUT_COLOURS,
+    ClipGenerationError,
+    hard_cut_argv,
+    is_suite_timeline,
+    sweep_suite_timelines,
+    write_hard_cut_clip,
+)
+
+# --- which names are the suite's own -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "resolve-mcp-smoke v1",
+        "resolve-mcp-smoke v27",
+        "resolve-mcp-lock-probe",
+        "resolve-mcp smoke round-trip 043551",
+        "resolve-mcp smoke dissolve 065705",
+    ],
+)
+def test_every_name_the_suite_builds_reads_as_the_suites_own(name: str) -> None:
+    assert is_suite_timeline(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "MCP Monkfish Tune 02 v5",
+        "Monkfish Main",
+        "Zinc - Set 2 Main",
+        # The prefix has to end at a separator, or a director's own name that merely starts
+        # the same way would be swept.
+        "resolve-mcpx",
+        "resolve-mcp",
+        # A sweep that matched anywhere in the name would take a cut somebody kept on
+        # purpose, and there is no undo for a deleted timeline.
+        "keep resolve-mcp-smoke v1",
+        "",
+    ],
+)
+def test_a_name_the_suite_did_not_build_is_never_swept(name: str) -> None:
+    assert is_suite_timeline(name) is False
+
+
+# --- the sweep ------------------------------------------------------------------------------
+
+
+def a_project(
+    *names: str,
+    current: str | None = None,
+) -> tuple[FakeMediaPool, FakeProject, dict[str, FakeTimeline]]:
+    """A project holding one timeline per name, with ``current`` the one Resolve sits on."""
+    timelines = {name: FakeTimeline(name) for name in names}
+    pool = FakeMediaPool()
+    project = FakeProject(
+        "2026-06_Zinc_and_Monkfish",
+        timeline=timelines[current] if current else None,
+        media_pool=pool,
+        timelines=list(timelines.values()),
+    )
+    return pool, project, timelines
+
+
+def test_the_sweep_deletes_the_suites_leftovers_and_leaves_the_directors_cuts() -> None:
+    pool, project, timelines = a_project(
+        "Monkfish Main",
+        "resolve-mcp-smoke v1",
+        "MCP Monkfish Tune 02 v5",
+        "resolve-mcp-lock-probe",
+        current="MCP Monkfish Tune 02 v5",
+    )
+
+    swept = sweep_suite_timelines(pool, project)
+
+    assert swept.deleted == ["resolve-mcp-smoke v1", "resolve-mcp-lock-probe"]
+    assert swept.kept == []
+    assert timelines_of(project) == [
+        timelines["Monkfish Main"],
+        timelines["MCP Monkfish Tune 02 v5"],
+    ]
+
+
+def test_a_project_with_no_leftovers_is_left_entirely_alone() -> None:
+    pool, project, _ = a_project("Monkfish Main", current="Monkfish Main")
+
+    swept = sweep_suite_timelines(pool, project)
+
+    assert swept.deleted == []
+    assert swept.kept == []
+    assert pool.deleted_timelines == []
+    assert project.timeline_switches == []
+
+
+def test_resolve_is_moved_off_a_leftover_before_the_sweep_deletes_it() -> None:
+    """Resolve refuses to delete the timeline it is sitting on, and says so only by
+    returning ``False`` — so a sweep that did not move first would leave the cut behind
+    and never hear why. A previous run ends on its own build, so this is the normal case.
+    """
+    pool, project, timelines = a_project(
+        "Monkfish Main",
+        "resolve-mcp-smoke v1",
+        current="resolve-mcp-smoke v1",
+    )
+
+    swept = sweep_suite_timelines(pool, project)
+
+    assert project.GetCurrentTimeline() is timelines["Monkfish Main"]
+    assert swept.deleted == ["resolve-mcp-smoke v1"]
+    assert swept.kept == []
+
+
+def test_the_last_leftover_survives_when_it_is_the_only_cut_left_to_sit_on() -> None:
+    """A project holding nothing but the suite's own builds has nowhere to move to, so one
+    of them stays. It is reported rather than swallowed: the next run's version numbers
+    carry on from it, and a caller that assumed a clean project would be wrong."""
+    pool, project, _ = a_project(
+        "resolve-mcp-smoke v1",
+        "resolve-mcp-smoke v2",
+        current="resolve-mcp-smoke v2",
+    )
+
+    swept = sweep_suite_timelines(pool, project)
+
+    assert swept.deleted == ["resolve-mcp-smoke v1"]
+    assert swept.kept == ["resolve-mcp-smoke v2"]
+
+
+def test_one_cut_resolve_will_not_delete_does_not_stop_the_rest_from_going() -> None:
+    """Deleting one at a time is what makes this reportable: a single batch call answers
+    ``False`` for the whole list, and the sweep could not say which one stuck."""
+    pool, project, timelines = a_project(
+        "Monkfish Main",
+        "resolve-mcp-smoke v1",
+        "resolve-mcp-smoke v2",
+        current="Monkfish Main",
+    )
+    stuck = timelines["resolve-mcp-smoke v1"]
+    pool.refuse_deleting = {stuck}
+
+    swept = sweep_suite_timelines(pool, project)
+
+    assert swept.deleted == ["resolve-mcp-smoke v2"]
+    assert swept.kept == ["resolve-mcp-smoke v1"]
+
+
+# --- the hard-cut clip the scene scan needs ------------------------------------------------
+
+
+def test_the_generated_clip_is_one_solid_colour_per_cut_concatenated_in_order() -> None:
+    """Solid colours are the point: a scene score has to clear its threshold on every cut
+    for the clip to be worth scanning, and nothing clears it like a whole frame changing.
+    """
+    argv = hard_cut_argv("ffmpeg", Path("C:/scratch/hard-cut.mp4"), colours=("red", "green"))
+
+    assert argv[0] == "ffmpeg"
+    assert argv.count("lavfi") == 2
+    assert "color=c=red:s=320x240:r=24:d=1" in argv
+    assert "color=c=green:s=320x240:r=24:d=1" in argv
+    assert "[0:v][1:v]concat=n=2:v=1:a=0[cut]" in argv
+    assert argv[-1] == str(Path("C:/scratch/hard-cut.mp4"))
+
+
+def test_the_generated_clip_overwrites_rather_than_asking() -> None:
+    """ffmpeg prompts on an existing output, and a prompt in a test run is a hang."""
+    argv = hard_cut_argv("ffmpeg", Path("out.mp4"))
+
+    assert "-y" in argv
+    assert argv.count("lavfi") == len(HARD_CUT_COLOURS)
+
+
+def test_the_default_clip_carries_more_cuts_than_the_one_the_scan_has_to_find() -> None:
+    """The live assertion is "at least one cut"; four colours means three, so a detector
+    that misses one still proves the mapping rather than turning the tier red."""
+    assert len(HARD_CUT_COLOURS) >= 3
+
+
+def test_writing_the_clip_names_the_frame_size_and_rate_the_scan_reads_it_on() -> None:
+    seen: list[list[str]] = []
+
+    def runner(argv: object) -> Completed:
+        seen.append(list(argv))  # type: ignore[call-overload]
+        return Completed(0, "")
+
+    write_hard_cut_clip(Path("out.mp4"), runner=runner, ffmpeg="ffmpeg", fps=30, size="640x360")
+
+    assert "color=c=red:s=640x360:r=30:d=1" in seen[0]
+
+
+def test_a_refused_generation_says_what_ffmpeg_said_about_it() -> None:
+    def runner(argv: object) -> Completed:
+        return Completed(1, "Unknown filter 'concat'")
+
+    with pytest.raises(ClipGenerationError) as raised:
+        write_hard_cut_clip(Path("out.mp4"), runner=runner, ffmpeg="ffmpeg")
+
+    assert "Unknown filter 'concat'" in str(raised.value)
+
+
+def test_a_missing_ffmpeg_is_the_error_that_names_the_binary() -> None:
+    """Shaped by ``ffmpeg.invoke`` rather than here, so the live fixture can skip on it."""
+
+    def runner(argv: object) -> Completed:
+        raise FileNotFoundError
+
+    with pytest.raises(FfmpegUnavailableError):
+        write_hard_cut_clip(Path("out.mp4"), runner=runner, ffmpeg="ffmpeg")

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -24,6 +24,7 @@ from .live_state import (
     ClipGenerationError,
     hard_cut_argv,
     is_suite_timeline,
+    restore_current,
     sweep_suite_timelines,
     write_hard_cut_clip,
 )
@@ -114,38 +115,86 @@ def test_a_project_with_no_leftovers_is_left_entirely_alone() -> None:
     assert project.timeline_switches == []
 
 
-def test_resolve_is_moved_off_a_leftover_before_the_sweep_deletes_it() -> None:
-    """Resolve refuses to delete the timeline it is sitting on, and says so only by
-    returning ``False`` — so a sweep that did not move first would leave the cut behind
-    and never hear why. A previous run ends on its own build, so this is the normal case.
-    """
+def test_the_leftover_resolve_is_sitting_on_is_reported_rather_than_moved_off_and_deleted() -> None:
+    """Resolve refuses the delete anyway, but the reason the sweep does not move off first
+    is worse than a refusal: switching away and deleting in the same breath is what Resolve
+    Studio 21.0.3 was doing when it crashed the run this was written for. So the cut stays,
+    and :func:`restore_current` is what stops it being permanent."""
+    pool, project, timelines = a_project(
+        "Monkfish Main",
+        "resolve-mcp-smoke v1",
+        "resolve-mcp-smoke v2",
+        current="resolve-mcp-smoke v1",
+    )
+
+    swept = sweep_suite_timelines(pool, project)
+
+    assert project.GetCurrentTimeline() is timelines["resolve-mcp-smoke v1"]
+    assert project.timeline_switches == []
+    assert swept.deleted == ["resolve-mcp-smoke v2"]
+    assert swept.kept == ["resolve-mcp-smoke v1"]
+
+
+def test_a_pool_that_answers_nothing_reports_every_leftover_kept() -> None:
+    """A handle Resolve has dropped answers ``None`` for every method rather than raising.
+    Calling that is a ``TypeError`` out of a session fixture, which errors every test at
+    setup and buries the message that says Resolve is gone."""
+    pool, project, _ = a_project("Monkfish Main", "resolve-mcp-smoke v1", current="Monkfish Main")
+    setattr(pool, "DeleteTimelines", None)  # noqa: B010 - the assignment is the point
+
+    swept = sweep_suite_timelines(pool, project)
+
+    assert swept.deleted == []
+    assert swept.kept == ["resolve-mcp-smoke v1"]
+
+
+# --- putting the director's cut back --------------------------------------------------------
+
+
+def test_the_session_ends_on_the_cut_it_found_open() -> None:
     pool, project, timelines = a_project(
         "Monkfish Main",
         "resolve-mcp-smoke v1",
         current="resolve-mcp-smoke v1",
     )
 
-    swept = sweep_suite_timelines(pool, project)
-
+    assert restore_current(project, timelines["Monkfish Main"]) is True
     assert project.GetCurrentTimeline() is timelines["Monkfish Main"]
-    assert swept.deleted == ["resolve-mcp-smoke v1"]
-    assert swept.kept == []
 
 
-def test_the_last_leftover_survives_when_it_is_the_only_cut_left_to_sit_on() -> None:
-    """A project holding nothing but the suite's own builds has nowhere to move to, so one
-    of them stays. It is reported rather than swallowed: the next run's version numbers
-    carry on from it, and a caller that assumed a clean project would be wrong."""
-    pool, project, _ = a_project(
-        "resolve-mcp-smoke v1",
-        "resolve-mcp-smoke v2",
-        current="resolve-mcp-smoke v2",
+def test_a_session_that_found_one_of_the_suites_own_cuts_open_moves_off_it_instead() -> None:
+    """Putting it back would make the leftover permanent: it is current, so the sweep
+    skips it, and the run after that finds it current again."""
+    _, project, timelines = a_project(
+        "Monkfish Main",
+        "resolve-mcp-smoke v14",
+        current="resolve-mcp-smoke v14",
     )
 
-    swept = sweep_suite_timelines(pool, project)
+    assert restore_current(project, timelines["resolve-mcp-smoke v14"]) is True
+    assert project.GetCurrentTimeline() is timelines["Monkfish Main"]
 
-    assert swept.deleted == ["resolve-mcp-smoke v1"]
-    assert swept.kept == ["resolve-mcp-smoke v2"]
+
+def test_a_session_that_found_nothing_open_still_leaves_a_directors_cut_current() -> None:
+    _, project, timelines = a_project("Monkfish Main", "resolve-mcp-smoke v1")
+
+    assert restore_current(project, None) is True
+    assert project.GetCurrentTimeline() is timelines["Monkfish Main"]
+
+
+def test_a_project_holding_only_the_suites_own_cuts_is_left_where_it_is() -> None:
+    """Nowhere to move to. The leftover survives, and the sweep has already said so."""
+    _, project, _ = a_project("resolve-mcp-smoke v1", "resolve-mcp-smoke v2")
+
+    assert restore_current(project, None) is False
+
+
+def test_a_cut_already_current_is_left_alone_rather_than_switched_to_itself() -> None:
+    """A redundant switch is the call that crashed the sweep; it is not made twice."""
+    _, project, timelines = a_project("Monkfish Main", current="Monkfish Main")
+
+    assert restore_current(project, timelines["Monkfish Main"]) is True
+    assert project.timeline_switches == []
 
 
 def test_one_cut_resolve_will_not_delete_does_not_stop_the_rest_from_going() -> None:

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -11,6 +11,7 @@ CLAUDE.md draws.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -22,8 +23,10 @@ from .fakes import FakeMediaPool, FakeProject, FakeTimeline
 from .live_state import (
     HARD_CUT_COLOURS,
     ClipGenerationError,
+    NamedClipMissingError,
     hard_cut_argv,
     is_suite_timeline,
+    named_scan_clip,
     restore_current,
     sweep_suite_timelines,
     write_hard_cut_clip,
@@ -266,6 +269,38 @@ def test_a_refused_generation_says_what_ffmpeg_said_about_it() -> None:
         write_hard_cut_clip(Path("out.mp4"), runner=runner, ffmpeg="ffmpeg")
 
     assert "Unknown filter 'concat'" in str(raised.value)
+
+
+# --- which clip the scan is pointed at ------------------------------------------------------
+
+
+def a_pool() -> list[dict[str, Any]]:
+    return [
+        {"name": "A016C002_260618Y6.MXF", "bin": "Monkfish/FX6"},
+        {"name": "Monkfish Flattened.mov", "bin": "Monkfish/Renders"},
+    ]
+
+
+@pytest.mark.parametrize("named", ["", "   "])
+def test_an_unset_variable_means_build_a_clip_rather_than_scan_anything(named: str) -> None:
+    """The old rule was "scan the shortest clip in the pool", which is how the scan ended
+    up on a PNG sequence with nothing to detect. Nothing named means nothing chosen."""
+    assert named_scan_clip(a_pool(), named) is None
+
+
+def test_a_named_clip_is_the_one_scanned() -> None:
+    chosen = named_scan_clip(a_pool(), "Monkfish Flattened.mov")
+
+    assert chosen is not None
+    assert chosen["bin"] == "Monkfish/Renders"
+
+
+def test_a_variable_naming_a_clip_the_pool_cannot_offer_stops_the_run() -> None:
+    """Generating a clip instead would report a pass for a scan nobody asked for."""
+    with pytest.raises(NamedClipMissingError) as raised:
+        named_scan_clip(a_pool(), "Monkfish Flattened.mp4")
+
+    assert "Monkfish Flattened.mp4" in str(raised.value)
 
 
 def test_a_missing_ffmpeg_is_the_error_that_names_the_binary() -> None:


### PR DESCRIPTION
Closes #135.

The live tier read the project as a given, and #119 §B found four failures that were all
the same habit. Each is now something the suite builds.

- **`a_still_lands`** took whatever image the pool listed first and named no bin, so a
  duplicated pool-root name was ambiguous. It now passes the listing's bin verbatim, and
  picks an entry Resolve types `Still` — a PNG *sequence* is a 27-frame clip with a `.png`
  path, and asking one for 90 frames is not the one-time Out write the test is about.
- **`render_queue_exports`** rendered whatever timeline the test before it left current,
  which after the locked-track probe was an empty locked one with no mix on it. A new
  `a_known_cut` fixture builds a short cut with a master mix under it, makes it current,
  and puts the director's timeline back — the same fixture serves the OTIO round trip and
  the dissolve import, which were comparing a concert-length edit shot by shot.
- **`locked_track_footgun`** met the name it had created on the run before. A
  session-scoped sweep deletes the previous run's timelines first, and the probe now puts
  Resolve back where it found it and deletes its own empty cut.
- **Scene scan** took the shortest clip in the pool — in this project a PNG sequence with
  no cuts — so the half of #34 it exists for passed vacuously every run. Per the ticket's
  branch: **the live box's pool was checked and holds no flattened Monkfish render**, only
  raw continuous angles, so the suite generates its own clip (four solid colours a second
  apart, three cuts) and imports it into a scratch bin it deletes afterwards.
  `RESOLVE_MCP_SCENE_SCAN_CLIP` stays as the override for a project that does have an edit
  to scan, and is documented as unset on the live box. Finding no cuts is now a failure
  rather than a skip.

`tests/live_state.py` holds what the tools under test cannot build — the sweep, the
generated clip, the name predicate — so the ticket's seam line holds: every decision
(which names are the suite's own, what happens when Resolve is sitting on one, what
command builds the clip, what an env var naming a missing clip means) settles in
`tests/test_live_state.py` against the fakes.

## Resolve crashed on the first live run

Worth reading before merging. The sweep's first live run took Resolve Studio 21.0.3 down:
it switched off a leftover timeline, deleted it, and Resolve logged `Internal undo error 3`
and wrote a crash dump inside the autosave the deletions triggered. The project survived —
`2026-06_Zinc_and_Monkfish` was intact after a restart — but the run did not, and neither
did the 34 tests that errored at setup, because a dropped handle answers `None` for every
method rather than raising.

So the sweep no longer moves off before deleting. The timeline Resolve is sitting on is
reported as `kept`, and `restore_current()` leaves the session on a cut the suite did not
build so the next run's sweep can take the leftover instead of it surviving forever. Two
consecutive full runs confirm the cycle: the first swept 13 and kept none, the second the
same.

## Scope beyond the four bullets, and why

- `resolve/timeline.py`'s `_timelines` is now `timelines_of`. The sweep needs the same
  enumeration, and CLAUDE.md forbids reaching for a symbol through a module that merely
  imports it — a private cross-module import is worse than naming it.
- The probe searches the whole pool rather than its root folder. Every real project keeps
  footage in bins, so the probe skipped on the machine it guards, and the footgun went
  unmeasured. This was observed live, not guessed: the test skipped on one run and passed
  on the next depending on what the listing returned.
- `restore_current()` prefers a cut the suite did not build. Putting a leftover back would
  make it permanent — it is current, so the sweep skips it, and the run after finds it
  current again.

## Review

Two-axis `/code-review` against `origin/main`, Standards and Spec as parallel sub-agents.

**Standards — no hard violations.** `CONTEXT.md` updated in the same PR for the new module,
the seam split honoured, `timelines_of` imported from its defining module, the
`getattr(x, "Method", None)` guard matching the existing dropped-handle idiom in
`resolve/apply.py`. Four judgement calls, all taken:

1. *Fake fidelity* — `FakeMediaPool.DeleteTimelines` recorded a refused delete in
   `deleted_timelines`, so the attribute no longer meant what its name said. Now recorded
   only once the refusals are past. (Pre-existing for the current-timeline refusal; the new
   knob made it visible.)
2. *Speculative Generality* — `a_known_cut` yielded a `durations` field nothing read.
   Dropped.
3. *Primitive Obsession* — the fixture returned `dict[str, Any]` for a two-field concept
   while the same diff introduced `Swept` as a NamedTuple. It is now `KnownCut`.
4. *Data Clumps / Speculative Generality* — `seconds` travelled through both hard-cut
   functions and was never overridden. Dropped to a module constant.

A fifth (mild Feature Envy in `sweep_suite_timelines(pool, project)`) was noted and left:
it is inherent to this repo's wrapper style over the foreign API.

**Spec — the four bullets are implemented; two real bugs found and fixed.**

1. The session fixture called `current_project` *outside* its own `try`, so a Resolve that
   is up with no project open would raise `NoProjectOpenError` and error every test at
   setup — precisely the shape the fixture's docstring says it exists to prevent. Moved
   inside the guard, with the teardown skipped when no project was reached.
2. `LOCKED_TRACK_PROBE` reported `put_back` as false when no timeline was open, so the test
   failed for correct probe behaviour *and* leaked `resolve-mcp-lock-probe` — the leftover
   this ticket exists to stop. "Nothing to put back" now counts as put back, the sweep
   assertion is conditional on a timeline having been open, and the comment says why the
   next run's sweep is the right place for that rare leak.
3. The still test's `if still["bin"] is not None` guard never fired — the listing's bin is
   a `str`, `""` for the pool root. Passed unconditionally now, matching `a_source_clip`'s
   documented "verbatim, not `or None`" rule from #122.
4. *Seam* — the scan-clip selection decision (env override vs generate, and what a variable
   naming a missing clip means) lived only in the live file. Extracted to
   `named_scan_clip()` with fake-tier tests, which is what the ticket's seam line asks for.
5. *Documented default* — the negative pool finding is now stated in `CONTEXT.md`, not just
   in a docstring.

Two spec notes accepted without change: `a_known_cut`'s audio-fallback branch delegates to
`validate_cut`, which is itself fake-tested, and the scope items above are justified in
their own section.

Fix diff re-checked as a focused pass; no new review.

## Test record

- **Fake tier** — `uv run pytest -m 'not live'`: 1481 passed, 0 failed.
- **mypy strict** — clean, 167 source files. **ruff** — clean.
- **Live tier** — Windows 11, DaVinci Resolve Studio 21.0.3.7, python.org CPython 3.12.10,
  project `mcp-tests-zinc`: **29 passed, 8 skipped, 0 failed**, run three times. All six
  tests this ticket touches pass, including the scene scan finding real cuts. The eight
  skips are dependency- or human-gated, not state: `beat_this`/`panns_inference`/the
  analysis extra not installed, four opt-in env vars, and one that needs a marker placed by
  hand in the GUI.

The live tier ran in `mcp-tests-zinc` rather than the client project, per the ticket's own
note about scratch cleanup — and, after the crash above, because a sweep that deletes
timelines does not belong in a client project unattended.

## Known follow-up, not fixed here

`test_a_range_render_covers_the_frames_it_was_given` still skips with "The open timeline is
too short to render two ranges out of". It needs a timeline of 13s or more and reads
whichever one is current, so an earlier build test leaves a 108-frame smoke cut under it.
Same disease, different direction — it wants a *long* known timeline where `a_known_cut`
gives a short one — and the ticket did not name it. It skipped before this PR too.

Review: clean — two-axis review against origin/main; five Standards judgement calls and
five Spec findings, including two real bugs, all resolved above; fix diff re-checked.
