### PR TITLE
Cut schema: gaps (black) on V1 and overlay track index

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -197,10 +197,13 @@ Test files pair 1:1 with the module they cover (`test_cut_validate.py` ↔
 `resolve/timeline.py`, …). `test_wav_container.py` ↔ `audio/riff.py` is the
 exception that earns its keep: the headers it covers are read by `audio/wav.py`,
 `analysis/decode.py` and `analysis/silence.py` alike, and #110 was a bug in what
-all three agreed about. `test_rough_cut_pillar.py` is the other exception: it
-covers no single module, walking the P4 pillar across `cut`, `build`, `takes`
-and `virtual` in one pass because the joins are what a per-module test cannot
-see. Live tier: `test_live_smoke.py` (module-level
+all three agreed about. `test_rough_cut_pillar.py` is one of two other
+exceptions: it covers no single module, walking the P4 pillar across `cut`,
+`build`, `takes` and `virtual` in one pass because the joins are what a
+per-module test cannot see. `test_cut_devices.py` (#141) is the second, for the
+same reason: gaps and overlay tracks are one device each across `cut/validate`,
+`resolve/build`, `resolve/takes` and `analysis/virtual`, and the interesting
+failures are the disagreements between them. Live tier: `test_live_smoke.py` (module-level
 `pytest.mark.live`) and two `@pytest.mark.live` tests in
 `test_live_analysis.py`; everything else is fake-tier.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -112,8 +112,11 @@ IEEE float and extensible headers, because stdlib `wave` opens PCM only),
 separation), `wav` (header facts + the one unreadable-WAV error).
 
 `cut/` — cut-file schema v1: `document` (read off disk), `schema`
-(verbatim, served by `get_cut_schema`), `validate` (11 errors + 2
-warnings, shared by dry run and build pre-flight).
+(verbatim, served by `get_cut_schema`), `validate` (11 errors + W1, W2,
+W8 — W3-W7 are `virtual_transcript`'s over the same document — shared by
+dry run and build pre-flight). A `segments` entry is a shot or a **gap**
+(`{"id", "gap": <frames>}`, literal black); `is_gap`/`entry_duration`/
+`overlay_track` are the accessors every walker of that array shares.
 
 `jobs/` — `cache` (hash-keyed results), `runner` (start heavy work without
 stalling stdio), `store` (one JSON record per job on disk).

--- a/docs/agents/rough-cut.md
+++ b/docs/agents/rough-cut.md
@@ -128,7 +128,9 @@ subject rather than the shot.
 5. **Cover the jump cuts.** Two segments from the same source, back to back, are a visible
    jump. Anchor an overlay from the catalog over the earlier segment at an offset that puts
    it across the seam — anchored, so it survives a tightening pass. Cutting from one camera
-   to another is not a jump cut and needs no cover.
+   to another is not a jump cut and needs no cover. Neither is a cut with black between it:
+   a `gap` entry breaks the join, and `virtual_transcript` will not ask you to cover one.
+   Two covers that want the same frames go on different `track`s rather than colliding.
 6. **`validate_cut`, then `build_timeline`.** Every revision is a new `<name> v<N>`.
 7. **Self-review with `virtual_transcript`.** Below.
 8. **Fix what it found, rebuild, and mark the rest** as the cut report.

--- a/docs/agents/rough-cut.md
+++ b/docs/agents/rough-cut.md
@@ -156,8 +156,9 @@ Then work the warnings. There are no errors; this refuses nothing:
 | W7 | an uncovered seam between two shots of one source | a jump cut with no b-roll over it |
 
 The numbering starts at W3 because `validate_cut` already owns W1 and W2 **for the same cut
-file**. One document, one numbering — two W2s meaning different things would be a trap in a
-session holding both results.
+file** (and W8, added after these, for a cut that ends on uncovered black). One document,
+one numbering — two W2s meaning different things would be a trap in a session holding both
+results.
 
 W4 is the one to take seriously: a cut file that keeps a false start in front of the good
 take is structurally perfect — it validates, it builds, it plays — and only reading the

--- a/src/resolve_mcp/analysis/virtual.py
+++ b/src/resolve_mcp/analysis/virtual.py
@@ -32,7 +32,7 @@ from typing import Any, Final
 
 from ..config import Config, get_config
 from ..cut.document import read_cut_file
-from ..cut.validate import overlay_positions, positions, total_frames
+from ..cut.validate import is_gap, overlay_positions, positions, total_frames
 from ..document import LoadedDocument
 from ..errors import InvalidRequestError
 from ..findings import Finding, ordered
@@ -85,7 +85,8 @@ def virtual_transcript(
         )
     doc = loaded.doc
     fps = _fps(doc, loaded.path.name)
-    segments = _segments(doc, loaded.path.name)
+    entries = _entries(doc, loaded.path.name)
+    segments = _segments(entries)
     sources = dict(transcripts or {})
 
     words_by_source = {alias: _words_of(path) for alias, path in sources.items()}
@@ -140,7 +141,7 @@ def virtual_transcript(
         read_back.append(_read(id, alias, at, duration, fps, [word for word, _ in kept]))
 
     findings.extend(_repeats(read_back))
-    seams = _seams(segments, placed, doc, fps, loaded.path.name)
+    seams = _seams(entries, placed, doc, fps, loaded.path.name)
     findings.extend(_uncovered(seams))
     total = total_frames(doc)
 
@@ -259,16 +260,21 @@ def _repeats(read_back: Sequence[Mapping[str, Any]]) -> list[Finding]:
 
 
 def _seams(
-    segments: Sequence[Mapping[str, Any]],
+    entries: Sequence[Mapping[str, Any]],
     placed: Mapping[str, tuple[int, int]],
     doc: Any,
     fps: float,
     name: str,
 ) -> list[dict[str, Any]]:
-    """Every join between two segments, and whether an overlay rides across it.
+    """Every join between two adjacent segments, and whether an overlay rides across it.
 
     Only a join between two shots of the *same* source is a jump cut: cutting from one
     camera to another is an ordinary edit, and covering it would be covering nothing.
+
+    Black between two shots is not a join at all, which is why this walks the entries as
+    authored rather than the picture alone: cutting away to nothing and back is a device in
+    its own right, and reporting it as an uncovered jump cut would send an agent to cover a
+    seam that the gap has already broken.
 
     Both sides of the question come from the cut module's own placement — the seam from
     :func:`positions` and the overlay from :func:`overlay_positions`, the same two functions
@@ -276,7 +282,9 @@ def _seams(
     """
     spans = _overlay_spans(doc, name)
     seams: list[dict[str, Any]] = []
-    for earlier, later in zip(segments, segments[1:], strict=False):
+    for earlier, later in zip(entries, entries[1:], strict=False):
+        if is_gap(earlier) or is_gap(later):
+            continue
         at = placed[str(later.get("id"))][0]
         jump = str(earlier.get("source")) == str(later.get("source"))
         covering = [id for id, (start, length) in spans.items() if start < at < start + length]
@@ -355,7 +363,8 @@ def _fps(doc: Any, name: str) -> float:
     return float(fps)
 
 
-def _segments(doc: Any, name: str) -> list[Mapping[str, Any]]:
+def _entries(doc: Any, name: str) -> list[Mapping[str, Any]]:
+    """``segments`` as authored — picture and black, in order, because adjacency matters."""
     segments = doc.get("segments") if isinstance(doc, Mapping) else None
     if not isinstance(segments, list) or not segments:
         raise InvalidRequestError(
@@ -364,6 +373,11 @@ def _segments(doc: Any, name: str) -> list[Mapping[str, Any]]:
             detail={"cut_file": name},
         )
     return [segment for segment in segments if isinstance(segment, Mapping)]
+
+
+def _segments(entries: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    """Only the entries that play a clip: black has no source, so it contains no words."""
+    return [entry for entry in entries if not is_gap(entry)]
 
 
 def _placed(doc: Any, name: str) -> dict[str, tuple[int, int]]:

--- a/src/resolve_mcp/cut/schema.py
+++ b/src/resolve_mcp/cut/schema.py
@@ -44,15 +44,20 @@ ANNOTATED_EXAMPLE: Final = """\
         { "source": "keys_wide", "in": 8100, "out": 8278 }
       ],
       "note": "drum fill response"   // free text; server ignores; feeds cut report
-    }
+    },
+
+    // A gap: literal black on V1. Takes record time, places nothing, and so moves
+    // everything after it. id + gap + optional note, and nothing else (§1).
+    { "id": "g001", "gap": 58, "note": "false ending before the landing shot" }
   ],
 
   "overlays": [
     {
-      "id": "b03",                   // ids share one namespace with segments
+      "id": "b03",                   // ids share one namespace with segments and gaps
       "source": "broll_pan",
       "in": 1200, "out": 1440,
       "over": { "segment": "s014", "offset": 24 },  // anchor + frames into it
+      "track": 2,                    // optional; V2 by default, 2-8 (§4)
       "note": "cover retake seam"
     }
   ]
@@ -62,10 +67,21 @@ ANNOTATED_EXAMPLE: Final = """\
 _PLACEMENT: Final = """\
 ## 1. Placement model: sequential V1, positioned overlays
 
-V1 segments are butt-joined in array order; record positions computed at build.
-Gaps/flash-frame positions unrepresentable rather than checked; sidesteps the
-unclamped-recordFrame footgun; duration edits never require downstream position
-fixes. Only overlays carry position — anchored, not absolute (§4)."""
+V1 entries run in array order; record positions computed at build, never stated.
+Duration edits therefore never require downstream position fixes, and no entry can
+name a frame that is wrong.
+
+An entry is a **segment** (plays a clip) or a **gap** (literal black: `{"id", "gap":
+<frames>}`, plus an optional `note`, and nothing else — no source, in, out, audio or
+alternates). A gap places nothing and occupies record time, so it moves everything
+after it. That is how a cut opens cold, stages a false ending, or ends on black.
+
+Two things follow. An overlay may anchor **over a gap** — a V2 shot bridging black
+into the first picture is one anchor, not a special case. And black at the *end* of
+a cut is real only if an overlay covers it: nothing is appended for a gap, and a
+timeline ends at its last item (W8 says so).
+
+Only overlays carry position — anchored, not absolute (§4)."""
 
 _TAKES: Final = """\
 ## 3. Takes
@@ -89,9 +105,13 @@ _OVERLAYS: Final = """\
 
 Anchored to `{segment, offset}`, never absolute timeline frames — they ride with
 the content they cover through tightening passes; build computes absolute
-position = segment's computed start + offset. May run past the anchor's end
-(seam coverage), must land inside the total V1 span. Video only, audio always
-omitted, no alternates, V2."""
+position = segment's computed start + offset. The anchor may be a gap as readily
+as a segment. May run past the anchor's end (seam coverage), must land inside the
+total V1 span. Video only, audio always omitted, no alternates.
+
+`track` is optional and defaults to 2. It is the video track the overlay rides on,
+between V2 and V8; V1 belongs to the segments. Two overlays may cover the same
+frames only on different tracks (E10) — that is what a second layer is for."""
 
 _TITLES: Final = """\
 ## 5. Titles: not in the cut file
@@ -121,9 +141,10 @@ ceil out) at the tool boundary."""
 _RULES: Final = """\
 ## 7. Validation
 
-11 hard errors (E1-E11) block a build; 2 warnings (W1-W2) never do. The list is
-identical in the `validate_cut` dry run and `build_timeline`'s pre-flight, and a
-failing file aborts before Resolve is touched. Every finding is
+11 hard errors (E1-E11) block a build; 3 warnings (W1, W2, W8) never do. W3-W7 are
+`virtual_transcript`'s and describe the same cut file — one document, one numbering.
+The list is identical in the `validate_cut` dry run and `build_timeline`'s pre-flight,
+and a failing file aborts before Resolve is touched. Every finding is
 `{rule, id, message, fix_hint}` — see the `rules` field of this result."""
 
 SCHEMA_DOC: Final = "\n\n".join(

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -39,36 +39,52 @@ DEFAULT_MIN_SEGMENT_FRAMES: Final = 12
 FPS_TOLERANCE: Final = 0.01
 """Reported rates carry float noise; real rate differences (23.976 vs 24) are far wider."""
 
+FIRST_OVERLAY_TRACK: Final = 2
+"""V1 is the sequential cut's own track, so the lowest an overlay can claim is V2."""
+
+MAX_OVERLAY_TRACK: Final = 8
+"""A ceiling on ``track``, because the build adds every track below the one it is given.
+
+Not a Resolve limit — a typo guard. ``"track": 99`` is an author slip, and without this it
+would grow a 99-track timeline and report success. Eight layers is far past what the
+pillar has ever used; a cut that genuinely needs more is a conversation, not a typo.
+"""
+
 RULE_DESCRIPTIONS: Final[dict[str, str]] = {
     "E1": "JSON parses; schema-valid; schema version supported",
-    "E2": "ids unique across segments and overlays (one namespace)",
-    "E3": "in < out everywhere",
+    "E2": "ids unique across segments, gaps and overlays (one namespace)",
+    "E3": "in < out everywhere; a gap runs at least one frame",
     "E4": "every alias resolves to exactly one media-pool clip",
     "E5": "in/out inside clip media bounds",
     "E6": "source fps matches timeline fps (stills exempt)",
     "E7": "audio block resolves, has audio, bounds valid",
     "E8": "alternate duration equals main duration",
     "E9": "overlay anchor exists; offset inside anchor; span inside the total V1",
-    "E10": "overlays do not overlap each other",
+    "E10": "overlays on one track do not overlap each other",
     "E11": "build-time: target tracks unlocked; connection and creation failures",
-    "W1": "segment shorter than min_segment_frames (flash-frame guard)",
+    "W1": "segment or gap shorter than min_segment_frames (flash-frame guard)",
     "W2": "V1 total does not match the master-audio span",
+    "W8": "the cut ends on black that no overlay covers, so nothing materialises there",
 }
 
 _FIX_HINTS: Final[dict[str, str]] = {
     "E1": "Call get_cut_schema and match the annotated example exactly.",
-    "E2": "Give every segment and overlay its own id — they share one namespace.",
-    "E3": "Ranges are half-open [in, out); make out strictly greater than in.",
+    "E2": "Give every segment, gap and overlay its own id — they share one namespace.",
+    "E3": "Ranges are half-open [in, out); make out strictly greater than in. A gap's "
+    "frame count is the black itself, so it must be at least 1.",
     "E4": "Fix the alias in sources, or import the clip and re-run validate_cut.",
     "E5": "Call inspect_clip for the clip's media bounds and pull the range inside them.",
     "E6": "Conform the source first, or set timeline.fps to the rate the sources are at.",
     "E7": "Point audio.source at a clip that has audio and keep its range inside the media.",
     "E8": "Alternates must match the main take frame for frame — swap_take cannot ripple.",
     "E9": "Anchor the overlay to a segment that exists, at an offset inside it.",
-    "E10": "Move one overlay or shorten it — only one overlay may cover a frame.",
+    "E10": "Move one overlay, shorten it, or put it on its own 'track' — one track holds "
+    "one clip per frame.",
     "E11": "Unlock the track in Resolve's timeline header and build again.",
-    "W1": "Lengthen the segment, or keep it if the flash is deliberate.",
+    "W1": "Lengthen the segment or gap, or keep it if the flash is deliberate.",
     "W2": "Expected when the cut opens cold or runs past the mix; otherwise check the ends.",
+    "W8": "Anchor an overlay over the trailing gap to make the black real, or drop the "
+    "gap if the cut is meant to end on picture.",
 }
 
 
@@ -214,6 +230,8 @@ def _segments_errors(doc: dict[str, Any]) -> Iterator[Finding]:
     if not isinstance(segments, list) or not segments:
         yield _finding("E1", None, "'segments' must be a non-empty array; a cut needs content.")
         return
+    picture = 0
+    black = 0
     for index, segment in enumerate(segments):
         where = f"segments[{index}]"
         if not isinstance(segment, dict):
@@ -222,6 +240,11 @@ def _segments_errors(doc: dict[str, Any]) -> Iterator[Finding]:
         id = segment.get("id") if isinstance(segment.get("id"), str) else None
         if not id:
             yield _finding("E1", None, f"'{where}.id' must be a non-empty string.")
+        if is_gap(segment):
+            black += 1
+            yield from _gap_shape_errors(segment, where, id)
+            continue
+        picture += 1
         if not isinstance(segment.get("source"), str):
             yield _finding("E1", id, f"'{where}.source' must be a source alias.")
         yield from _range_shape_errors(segment, where, id)
@@ -230,6 +253,37 @@ def _segments_errors(doc: dict[str, Any]) -> Iterator[Finding]:
         if "note" in segment and not isinstance(segment["note"], str):
             yield _finding("E1", id, f"'{where}.note' must be a string.")
         yield from _alternates_errors(segment, where, id)
+    if black and not picture:
+        yield _finding(
+            "E1",
+            None,
+            "'segments' is nothing but gaps; a cut needs at least one picture segment for "
+            "the black to be an absence of.",
+        )
+
+
+_GAP_FORBIDS: Final = ("source", "in", "out", "audio", "alternates")
+"""Everything a gap cannot carry, because black plays no clip and holds no take."""
+
+
+def _gap_shape_errors(segment: dict[str, Any], where: str, id: str | None) -> Iterator[Finding]:
+    """A gap is an id, a frame count, and nothing else — a half-gap is an author mid-edit."""
+    if not _is_int(segment["gap"]):
+        yield _finding(
+            "E1",
+            id,
+            f"'{where}.gap' must be an integer frame count, got {segment['gap']!r}.",
+        )
+    for field in _GAP_FORBIDS:
+        if field in segment:
+            yield _finding(
+                "E1",
+                id,
+                f"'{where}' is a gap, so it must not carry '{field}': black plays no clip. "
+                f"Drop '{field}', or drop 'gap' and make it a segment.",
+            )
+    if "note" in segment and not isinstance(segment["note"], str):
+        yield _finding("E1", id, f"'{where}.note' must be a string.")
 
 
 def _alternates_errors(segment: dict[str, Any], where: str, id: str | None) -> Iterator[Finding]:
@@ -268,6 +322,30 @@ def _overlays_errors(doc: dict[str, Any]) -> Iterator[Finding]:
             yield _finding("E1", id, f"'{where}.source' must be a source alias.")
         yield from _range_shape_errors(overlay, where, id)
         yield from _anchor_shape_errors(overlay, where, id)
+        yield from _track_shape_errors(overlay, where, id)
+
+
+def _track_shape_errors(overlay: dict[str, Any], where: str, id: str | None) -> Iterator[Finding]:
+    """The layer an overlay rides on: optional, defaults to V2, never V1.
+
+    The bounds are shape rather than a rule of their own because they are answerable from
+    the one value — nothing else in the document has to be consulted to know that V1 is the
+    segments' track and that V99 is a typo.
+    """
+    if "track" not in overlay:
+        return
+    track = overlay["track"]
+    if not _is_int(track):
+        yield _finding("E1", id, f"'{where}.track' must be an integer track index.")
+        return
+    if not FIRST_OVERLAY_TRACK <= track <= MAX_OVERLAY_TRACK:
+        yield _finding(
+            "E1",
+            id,
+            f"'{where}.track' is {track}; overlays ride above the cut, so the index must be "
+            f"between {FIRST_OVERLAY_TRACK} (V{FIRST_OVERLAY_TRACK}, the default) and "
+            f"{MAX_OVERLAY_TRACK}. V1 belongs to the segments.",
+        )
 
 
 def _anchor_shape_errors(overlay: dict[str, Any], where: str, id: str | None) -> Iterator[Finding]:
@@ -311,12 +389,51 @@ def validate_structure(
     findings += _overlay_errors(doc)
     findings += _segment_length_warnings(doc, min_segment_frames)
     findings += _audio_span_warnings(doc)
+    findings += _trailing_black_warnings(doc)
     return ordered(findings)
 
 
+def is_gap(entry: Any) -> bool:
+    """Whether a ``segments`` entry is black rather than a shot.
+
+    Public because the build, the swap and the read-back all walk the same array and each
+    has to answer this the same way: a second definition of what black looks like is how a
+    gap ends up placed on one side of the seam and ignored on the other.
+    """
+    return isinstance(entry, dict) and "gap" in entry
+
+
+def entry_duration(entry: dict[str, Any]) -> int:
+    """How much record time one ``segments`` entry takes — a gap's is the black itself."""
+    if is_gap(entry):
+        return int(entry["gap"])
+    return duration_frames(entry["in"], entry["out"])
+
+
+def overlay_track(overlay: dict[str, Any]) -> int:
+    """Which video track an overlay rides on. Absent means V2, the layer above the cut."""
+    track = overlay.get("track")
+    return int(track) if _is_int(track) else FIRST_OVERLAY_TRACK
+
+
+def _entries(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """``segments`` as authored: picture and black, in the order that lays out the V1."""
+    entries: list[dict[str, Any]] = doc["segments"]
+    return entries
+
+
 def _segments(doc: dict[str, Any]) -> list[dict[str, Any]]:
-    segments: list[dict[str, Any]] = doc["segments"]
-    return segments
+    """Only the entries that place a clip.
+
+    Every rule about *media* — aliases, bounds, rates, takes — reads this rather than the
+    raw array, so a gap is skipped by all of them at once instead of by a guard each of
+    them could be written without.
+    """
+    return [entry for entry in _entries(doc) if not is_gap(entry)]
+
+
+def _gaps(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    return [entry for entry in _entries(doc) if is_gap(entry)]
 
 
 def _overlays(doc: dict[str, Any]) -> list[dict[str, Any]]:
@@ -325,10 +442,10 @@ def _overlays(doc: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _id_errors(doc: dict[str, Any]) -> list[Finding]:
-    """E2: segments and overlays share one id namespace."""
+    """E2: segments, gaps and overlays share one id namespace."""
     seen: set[str] = set()
     findings: list[Finding] = []
-    for item in (*_segments(doc), *_overlays(doc)):
+    for item in (*_entries(doc), *_overlays(doc)):
         id = str(item["id"])
         if id in seen:
             findings.append(_finding("E2", id, f"The id {id!r} is used more than once."))
@@ -347,6 +464,8 @@ def _range_errors(doc: dict[str, Any]) -> list[Finding]:
             )
     for overlay in _overlays(doc):
         findings += _range_error(overlay, str(overlay["id"]), "Overlay")
+    for gap in _gaps(doc):
+        findings += _gap_length_error(gap)
     audio = doc.get("audio")
     if isinstance(audio, dict):
         findings += _range_error(audio, None, "The audio block")
@@ -363,6 +482,22 @@ def _range_error(item: dict[str, Any], id: str | None, subject: str) -> list[Fin
             id,
             f"{named} has in={item['in']} and out={item['out']}; a half-open range "
             f"names no frames unless in < out.",
+        )
+    ]
+
+
+def _gap_length_error(gap: dict[str, Any]) -> list[Finding]:
+    """E3 for black: no frames of it is not a device, it is a line that does nothing."""
+    frames = int(gap["gap"])
+    if frames >= 1:
+        return []
+    id = str(gap["id"])
+    return [
+        _finding(
+            "E3",
+            id,
+            f"Gap {id!r} runs {frames} frames; black has to run at least one frame to be "
+            f"anything at all.",
         )
     ]
 
@@ -427,17 +562,22 @@ def _alternate_duration_errors(doc: dict[str, Any]) -> list[Finding]:
 
 
 def positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
-    """Each segment id to its computed ``(start, duration)`` — sequential V1, butt-joined.
+    """Each ``segments`` id to its computed ``(start, duration)`` — sequential V1, in order.
 
     The overlay rules and the build both place against these numbers, and they have to be
     the same numbers: an offset validated against one layout and built against another
     would put the overlay somewhere nobody checked.
+
+    A gap is here with the rest. It places no clip, but it occupies record time and so it
+    moves everything after it — and an overlay may anchor over it, which is what makes a
+    V2 bridge across black expressible at all. Positions stay *computed* either way: black
+    is a duration in the array, never a frame number an author had to keep up to date.
     """
     placed: dict[str, tuple[int, int]] = {}
     at = 0
-    for segment in _segments(doc):
-        duration = duration_frames(segment["in"], segment["out"])
-        placed[str(segment["id"])] = (at, duration)
+    for entry in _entries(doc):
+        duration = entry_duration(entry)
+        placed[str(entry["id"])] = (at, duration)
         at += duration
     return placed
 
@@ -455,8 +595,8 @@ def placements(doc: dict[str, Any], start: int) -> dict[str, tuple[int, int]]:
 
 
 def total_frames(doc: dict[str, Any]) -> int:
-    """The V1 span: sequential segments, so the sum of their durations."""
-    return sum(duration_frames(s["in"], s["out"]) for s in _segments(doc))
+    """The V1 span: sequential entries, so the sum of their durations, black included."""
+    return sum(entry_duration(entry) for entry in _entries(doc))
 
 
 def overlay_positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
@@ -494,7 +634,7 @@ def _overlay_errors(doc: dict[str, Any]) -> list[Finding]:
     placed = positions(doc)
     total = total_frames(doc)
     findings: list[Finding] = []
-    spans: list[tuple[str, int, int]] = []
+    spans: dict[int, list[tuple[str, int, int]]] = {}
 
     for overlay, resolved in _anchored(doc):
         id = str(overlay["id"])
@@ -531,14 +671,18 @@ def _overlay_errors(doc: dict[str, Any]) -> list[Finding]:
                 )
             )
             continue
-        spans.append((id, at, at + duration))
+        spans.setdefault(overlay_track(overlay), []).append((id, at, at + duration))
 
-    findings += _overlap_errors(spans)
+    for track in sorted(spans):
+        findings += _overlap_errors(spans[track], track)
     return findings
 
 
-def _overlap_errors(spans: list[tuple[str, int, int]]) -> list[Finding]:
-    """E10: overlays share one V2 track, and Resolve will not overwrite on overlap.
+def _overlap_errors(spans: list[tuple[str, int, int]], track: int) -> list[Finding]:
+    """E10: one track holds one clip per frame, and Resolve will not overwrite on overlap.
+
+    Judged per track, because that is the constraint being modelled: two inserts that
+    would collide on V2 are an ordinary stack once one of them names V3.
 
     Swept against the span reaching furthest right rather than the previous one: a short
     overlay sitting wholly inside a long one is not adjacent to it once sorted, and
@@ -554,7 +698,7 @@ def _overlap_errors(spans: list[tuple[str, int, int]]) -> list[Finding]:
                     "E10",
                     span[0],
                     f"Overlays {furthest[0]!r} ({furthest[1]}-{furthest[2]}) and {span[0]!r} "
-                    f"({span[1]}-{span[2]}) cover the same frames.",
+                    f"({span[1]}-{span[2]}) cover the same frames of V{track}.",
                 )
             )
         if furthest is None or span[2] > furthest[2]:
@@ -563,16 +707,21 @@ def _overlap_errors(spans: list[tuple[str, int, int]]) -> list[Finding]:
 
 
 def _segment_length_warnings(doc: dict[str, Any], minimum: int) -> list[Finding]:
-    """W1: a flash frame is usually a typo, occasionally the point. Never a block."""
+    """W1: a flash frame is usually a typo, occasionally the point. Never a block.
+
+    Black is measured by the same guard as picture: two frames of it reads as a slip in a
+    duration far more often than as a device.
+    """
     findings: list[Finding] = []
-    for segment in _segments(doc):
-        duration = duration_frames(segment["in"], segment["out"])
+    for entry in _entries(doc):
+        duration = entry_duration(entry)
         if duration < minimum:
+            subject = "Gap" if is_gap(entry) else "Segment"
             findings.append(
                 _finding(
                     "W1",
-                    str(segment["id"]),
-                    f"Segment {segment['id']!r} runs {duration} frames, under the "
+                    str(entry["id"]),
+                    f"{subject} {entry['id']!r} runs {duration} frames, under the "
                     f"{minimum}-frame flash guard.",
                 )
             )
@@ -595,6 +744,52 @@ def _audio_span_warnings(doc: dict[str, Any]) -> list[Finding]:
             f"The cut runs {total} frames over a {span}-frame master-audio span.",
         )
     ]
+
+
+def _trailing_black_warnings(doc: dict[str, Any]) -> list[Finding]:
+    """W8: black at the end of a cut is real only if something is laid over it.
+
+    A gap places nothing, so a trailing one is record time with no clip anywhere on it —
+    and a timeline ends at its last item. Ending on black therefore takes an overlay over
+    the gap, which is exactly how #46's ending inserts worked. Without one the built
+    timeline simply stops at the last picture and the device silently is not there.
+
+    A warning rather than an error: the tail is the author's call, and a cut that ends a
+    little long on purpose should not be blocked over it.
+    """
+    tail = _trailing_black(doc)
+    if tail is None:
+        return []
+    at, total = tail
+    covered = [
+        (start, length)
+        for start, length in overlay_positions(doc).values()
+        if start < total and start + length > at
+    ]
+    if covered:
+        return []
+    return [
+        _finding(
+            "W8",
+            None,
+            f"The cut ends with {total - at} frames of black that no overlay covers; the "
+            f"built timeline will end at frame {at}, on the last picture.",
+        )
+    ]
+
+
+def _trailing_black(doc: dict[str, Any]) -> tuple[int, int] | None:
+    """``(frame the last picture ends on, the cut's total)``, or ``None`` if they are equal."""
+    placed = positions(doc)
+    ends = [
+        start + duration
+        for entry in _entries(doc)
+        if not is_gap(entry)
+        for start, duration in [placed[str(entry["id"])]]
+    ]
+    total = total_frames(doc)
+    last = max(ends, default=0)
+    return None if last >= total else (last, total)
 
 
 # --- the project pass -------------------------------------------------------------------
@@ -768,10 +963,15 @@ def _audio_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[F
 
 __all__ = [
     "DEFAULT_MIN_SEGMENT_FRAMES",
+    "FIRST_OVERLAY_TRACK",
+    "MAX_OVERLAY_TRACK",
     "RULE_DESCRIPTIONS",
     "ClipFacts",
+    "entry_duration",
+    "is_gap",
     "locked_track_finding",
     "overlay_positions",
+    "overlay_track",
     "parse_failure_finding",
     "placements",
     "positions",

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -767,14 +767,19 @@ def _trailing_black_warnings(doc: dict[str, Any]) -> list[Finding]:
     if tail is None:
         return []
     at, total = tail
-    if any(start + length > at for start, length in _appended_spans(doc)):
+    # Where the built timeline actually ends: the furthest of the last picture and anything
+    # laid off V1. Measured against the total rather than against the last picture, because
+    # a tail *half* covered loses the rest just as silently as one covered by nothing.
+    ends = max((start + length for start, length in _appended_spans(doc)), default=0)
+    reach = max(at, ends)
+    if reach >= total:
         return []
     return [
         _finding(
             "W8",
             None,
-            f"The cut ends with {total - at} frames of black that nothing runs under; the "
-            f"built timeline will end at frame {at}, on the last picture.",
+            f"The cut ends with {total - reach} frames of black that nothing runs under; "
+            f"the built timeline will end at frame {reach}, not {total}.",
         )
     ]
 

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -1,4 +1,4 @@
-"""The cut-file validation rules: 11 hard errors, 2 warnings, one implementation.
+"""The cut-file validation rules: 11 hard errors, 3 warnings, one implementation.
 
 The list is identical in the ``validate_cut`` dry run and in ``build_timeline``'s
 pre-flight, so it lives here once and both call it. A failing file must abort before
@@ -8,7 +8,8 @@ Two passes, because they need different things:
 
 * :func:`validate_structure` reads the document alone — no project, no connection. It
   answers everything about shape, ids, ranges, takes and overlay anchoring (E1-E4 for
-  undeclared aliases, E7 for an undeclared audio alias, E8-E10, W1-W2).
+  undeclared aliases, E7 for an undeclared audio alias, E8-E10, W1-W2, W8). W3-W7 are
+  ``virtual_transcript``'s over this same document — one file, one numbering.
 * :func:`validate_project` takes clip facts already gathered from the media pool and
   answers everything about the media behind the aliases (E4-E7). It is a pure function
   over those facts, so every rule in this file is unit-testable without Resolve.
@@ -64,7 +65,7 @@ RULE_DESCRIPTIONS: Final[dict[str, str]] = {
     "E11": "build-time: target tracks unlocked; connection and creation failures",
     "W1": "segment or gap shorter than min_segment_frames (flash-frame guard)",
     "W2": "V1 total does not match the master-audio span",
-    "W8": "the cut ends on black that no overlay covers, so nothing materialises there",
+    "W8": "the cut ends on black that nothing runs under, so it materialises as nothing",
 }
 
 _FIX_HINTS: Final[dict[str, str]] = {
@@ -83,8 +84,8 @@ _FIX_HINTS: Final[dict[str, str]] = {
     "E11": "Unlock the track in Resolve's timeline header and build again.",
     "W1": "Lengthen the segment or gap, or keep it if the flash is deliberate.",
     "W2": "Expected when the cut opens cold or runs past the mix; otherwise check the ends.",
-    "W8": "Anchor an overlay over the trailing gap to make the black real, or drop the "
-    "gap if the cut is meant to end on picture.",
+    "W8": "Anchor an overlay over the trailing gap, or let the master mix run past the "
+    "last picture — either makes the black real. Otherwise drop the gap.",
 }
 
 
@@ -422,17 +423,20 @@ def _entries(doc: dict[str, Any]) -> list[dict[str, Any]]:
     return entries
 
 
-def _segments(doc: dict[str, Any]) -> list[dict[str, Any]]:
-    """Only the entries that place a clip.
+def shots(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """Only the entries that place a clip — *not* the same list as ``doc["segments"]``.
 
     Every rule about *media* — aliases, bounds, rates, takes — reads this rather than the
     raw array, so a gap is skipped by all of them at once instead of by a guard each of
-    them could be written without.
+    them could be written without. Public alongside :func:`gaps` because the build and the
+    summaries need the same two counts, and counting them by hand at each call site is how
+    one of them ends up disagreeing about what black is.
     """
     return [entry for entry in _entries(doc) if not is_gap(entry)]
 
 
-def _gaps(doc: dict[str, Any]) -> list[dict[str, Any]]:
+def gaps(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """Only the entries that are black."""
     return [entry for entry in _entries(doc) if is_gap(entry)]
 
 
@@ -456,7 +460,7 @@ def _id_errors(doc: dict[str, Any]) -> list[Finding]:
 def _range_errors(doc: dict[str, Any]) -> list[Finding]:
     """E3: half-open ranges need in < out, or they name no frames at all."""
     findings: list[Finding] = []
-    for segment in _segments(doc):
+    for segment in shots(doc):
         findings += _range_error(segment, str(segment["id"]), "Segment")
         for index, alternate in enumerate(segment.get("alternates") or []):
             findings += _range_error(
@@ -464,7 +468,7 @@ def _range_errors(doc: dict[str, Any]) -> list[Finding]:
             )
     for overlay in _overlays(doc):
         findings += _range_error(overlay, str(overlay["id"]), "Overlay")
-    for gap in _gaps(doc):
+    for gap in gaps(doc):
         findings += _gap_length_error(gap)
     audio = doc.get("audio")
     if isinstance(audio, dict):
@@ -530,7 +534,7 @@ def _declared_alias_errors(doc: dict[str, Any]) -> list[Finding]:
 
 def _alias_uses(doc: dict[str, Any]) -> Iterator[tuple[str, str]]:
     """Every (alias, owning id) the cut references, audio block excluded."""
-    for segment in _segments(doc):
+    for segment in shots(doc):
         yield str(segment["source"]), str(segment["id"])
         for alternate in segment.get("alternates") or []:
             yield str(alternate["source"]), str(segment["id"])
@@ -545,7 +549,7 @@ def _listed(names: Sequence[str]) -> str:
 def _alternate_duration_errors(doc: dict[str, Any]) -> list[Finding]:
     """E8: a take selector cannot change length, so an alternate cannot either."""
     findings: list[Finding] = []
-    for segment in _segments(doc):
+    for segment in shots(doc):
         main = duration_frames(segment["in"], segment["out"])
         for index, alternate in enumerate(segment.get("alternates") or []):
             alternate_duration = duration_frames(alternate["in"], alternate["out"])
@@ -747,12 +751,14 @@ def _audio_span_warnings(doc: dict[str, Any]) -> list[Finding]:
 
 
 def _trailing_black_warnings(doc: dict[str, Any]) -> list[Finding]:
-    """W8: black at the end of a cut is real only if something is laid over it.
+    """W8: black at the end of a cut is real only if something else runs under it.
 
-    A gap places nothing, so a trailing one is record time with no clip anywhere on it —
-    and a timeline ends at its last item. Ending on black therefore takes an overlay over
-    the gap, which is exactly how #46's ending inserts worked. Without one the built
-    timeline simply stops at the last picture and the device silently is not there.
+    A gap places nothing, so a trailing one is record time with no clip on V1 — and a
+    timeline ends at its last item, on any track. Ending on black therefore takes
+    something that outlives the last picture: an overlay over the gap, as #46's ending
+    inserts were, or the master mix still playing under it, which is the ordinary concert
+    shape. With neither, the built timeline simply stops at the last picture and the
+    device silently is not there.
 
     A warning rather than an error: the tail is the author's call, and a cut that ends a
     little long on purpose should not be blocked over it.
@@ -761,21 +767,28 @@ def _trailing_black_warnings(doc: dict[str, Any]) -> list[Finding]:
     if tail is None:
         return []
     at, total = tail
-    covered = [
-        (start, length)
-        for start, length in overlay_positions(doc).values()
-        if start < total and start + length > at
-    ]
-    if covered:
+    if any(start + length > at for start, length in _appended_spans(doc)):
         return []
     return [
         _finding(
             "W8",
             None,
-            f"The cut ends with {total - at} frames of black that no overlay covers; the "
+            f"The cut ends with {total - at} frames of black that nothing runs under; the "
             f"built timeline will end at frame {at}, on the last picture.",
         )
     ]
+
+
+def _appended_spans(doc: dict[str, Any]) -> Iterator[tuple[int, int]]:
+    """Every ``(start, duration)`` the build places off V1, in the cut's own frames.
+
+    Only the tracks that can outlive the picture: overlays above the cut, and the master
+    mix, which starts at the cut's first frame and runs its own declared length.
+    """
+    yield from overlay_positions(doc).values()
+    audio = doc.get("audio")
+    if isinstance(audio, dict):
+        yield (0, duration_frames(audio["in"], audio["out"]))
 
 
 def _trailing_black(doc: dict[str, Any]) -> tuple[int, int] | None:
@@ -863,7 +876,7 @@ def resolve_aliases(
 def _bounds_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[Finding]:
     """E5: every range has to name frames the media actually has."""
     findings: list[Finding] = []
-    for segment in _segments(doc):
+    for segment in shots(doc):
         id = str(segment["id"])
         findings += _bounds_error(segment, resolved, id, f"Segment {id!r}")
         for index, alternate in enumerate(segment.get("alternates") or []):
@@ -968,6 +981,7 @@ __all__ = [
     "RULE_DESCRIPTIONS",
     "ClipFacts",
     "entry_duration",
+    "gaps",
     "is_gap",
     "locked_track_finding",
     "overlay_positions",
@@ -976,6 +990,7 @@ __all__ = [
     "placements",
     "positions",
     "resolve_aliases",
+    "shots",
     "total_frames",
     "validate_project",
     "validate_structure",

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -1,4 +1,4 @@
-"""Materialising a cut file: sequential V1 and anchored V2, over one master-audio clip.
+"""Materialising a cut file: a sequential V1 and anchored overlays, over one master mix.
 
 The one write primitive Resolve gives us is append-with-exact-placement, and the #18 spike
 found it full of silent failures. Everything in this file exists to make one guarantee:
@@ -8,11 +8,16 @@ found it full of silent failures. Everything in this file exists to make one gua
   run here first, over the same pool reading, and a single error aborts before a timeline
   is created — a timeline missing part of its own cut is the half-built outcome the
   pre-flight exists to prevent.
-* **Overlays are placed, never positioned.** An overlay states an anchor segment and an
-  offset, so its V2 record frame is computed from the same layout E9 validated against
-  (``overlay_positions``). Re-timing an earlier segment and rebuilding therefore leaves
-  every overlay over the content it was anchored to, which is the whole point of the
-  anchor: an absolute frame would have to be re-authored on every tightening pass.
+* **Overlays are placed, never positioned.** An overlay states an anchor entry and an
+  offset, so its record frame is computed from the same layout E9 validated against
+  (``overlay_positions``); the track it lands on is its own ``track``, V2 by default.
+  Re-timing an earlier segment and rebuilding therefore leaves every overlay over the
+  content it was anchored to, which is the whole point of the anchor: an absolute frame
+  would have to be re-authored on every tightening pass.
+* **A gap is an append that does not happen.** Black on V1 takes record time and places
+  nothing, so it appears here only as the reason the next shot's ``recordFrame`` jumps —
+  which is precisely the unclamped-``recordFrame`` case below, and why the read-back
+  matters more for a cut with gaps than for one without.
 * **A new version every time.** The name is ``<base> v<N+1>`` scanned off the project's
   existing names, so no build ever writes into a timeline someone has already reviewed.
 * **Resolve's answer is never the evidence.** An append onto a locked track returns
@@ -32,6 +37,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Final
 
+from ..cut.validate import gaps as cut_gaps
 from ..cut.validate import (
     is_gap,
     locked_track_finding,
@@ -186,7 +192,11 @@ def build_timeline(
         "timeline": timeline_read.summarise(timeline_read.Reader(connection), built, project, name),
         "placed": {
             "segments": _count(shots, V1),
-            "gaps": sum(1 for entry in doc["segments"] if is_gap(entry)),
+            # Read off the document rather than the track, because black is the one thing
+            # here that has no item to read back. What proves the hole is real is the
+            # shots on either side of it: ``_verify`` has already confirmed they landed on
+            # the record frames the gap put them at.
+            "gaps": len(cut_gaps(doc)),
             "overlays": _overlay_count(shots),
             "audio": bool(_count(shots, A1)),
             "selectors": made,

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -32,7 +32,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Final
 
-from ..cut.validate import locked_track_finding, overlay_positions, placements
+from ..cut.validate import (
+    is_gap,
+    locked_track_finding,
+    overlay_positions,
+    overlay_track,
+    placements,
+)
 from ..errors import BuildFailedError, CutInvalidError, TimelineNotFoundError
 from ..logging_config import get_logger
 from ..naming import latest_version, next_version_name, version_name
@@ -82,10 +88,12 @@ class Track:
 
 
 V1: Final = Track("video", 1)
-"""The sequential cut: segments butt-joined in document order."""
+"""The sequential cut: segments in document order, with black where a gap says so.
 
-V2: Final = Track("video", 2)
-"""Overlays ride above the cut here, so covering a seam never displaces the segments."""
+The only track this module names. An overlay's is whatever its ``track`` says, defaulting
+to V2 in ``overlay_track`` — one definition of "the layer above the cut", in the module
+that validates it, rather than a constant here that could drift from the rule.
+"""
 
 A1: Final = Track("audio", 1)
 """One continuous master mix under the whole cut."""
@@ -178,7 +186,8 @@ def build_timeline(
         "timeline": timeline_read.summarise(timeline_read.Reader(connection), built, project, name),
         "placed": {
             "segments": _count(shots, V1),
-            "overlays": _count(shots, V2),
+            "gaps": sum(1 for entry in doc["segments"] if is_gap(entry)),
+            "overlays": _overlay_count(shots),
             "audio": bool(_count(shots, A1)),
             "selectors": made,
         },
@@ -190,6 +199,11 @@ def build_timeline(
 def _count(shots: list[Shot], track: Track) -> int:
     """How many of this build's appends one track took — segments and overlays are both V."""
     return sum(1 for shot in shots if shot.track == track)
+
+
+def _overlay_count(shots: list[Shot]) -> int:
+    """Every video append above the cut's own track, however many layers they spread over."""
+    return sum(1 for shot in shots if shot.track.type == "video" and shot.track != V1)
 
 
 # --- markers --------------------------------------------------------------------------------
@@ -335,6 +349,11 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
     placed = placements(doc, start)
     shots = []
     for segment in doc["segments"]:
+        if is_gap(segment):
+            # Black is the absence of a clip, so a gap is an append that does not happen.
+            # It is still in ``placed``, which is what makes the next shot start late: the
+            # hole comes from the record frames on either side of it, never from a clip.
+            continue
         id = str(segment["id"])
         record, duration = placed[id]
         shots.append(
@@ -356,7 +375,7 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
         shots.append(
             _shot(
                 id=id,
-                track=V2,
+                track=Track("video", overlay_track(overlay)),
                 located=clips[str(overlay["source"])],
                 source_in=int(overlay["in"]),
                 record=start + offset,

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -22,8 +22,9 @@ from ..cut.validate import (
     DEFAULT_MIN_SEGMENT_FRAMES,
     RULE_DESCRIPTIONS,
     ClipFacts,
-    is_gap,
+    gaps,
     resolve_aliases,
+    shots,
     total_frames,
     validate_project,
     validate_structure,
@@ -205,8 +206,8 @@ def _summary(doc: dict[str, Any] | None) -> dict[str, Any] | None:
     fps = float(doc["timeline"]["fps"])
     return {
         "timeline": doc["timeline"]["name"],
-        "segments": sum(1 for entry in doc["segments"] if not is_gap(entry)),
-        "gaps": sum(1 for entry in doc["segments"] if is_gap(entry)),
+        "segments": len(shots(doc)),
+        "gaps": len(gaps(doc)),
         "overlays": len(doc.get("overlays") or []),
         "duration": dual_time(total_frames(doc), fps),
     }

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -22,6 +22,7 @@ from ..cut.validate import (
     DEFAULT_MIN_SEGMENT_FRAMES,
     RULE_DESCRIPTIONS,
     ClipFacts,
+    is_gap,
     resolve_aliases,
     total_frames,
     validate_project,
@@ -204,7 +205,8 @@ def _summary(doc: dict[str, Any] | None) -> dict[str, Any] | None:
     fps = float(doc["timeline"]["fps"])
     return {
         "timeline": doc["timeline"]["name"],
-        "segments": len(doc["segments"]),
+        "segments": sum(1 for entry in doc["segments"] if not is_gap(entry)),
+        "gaps": sum(1 for entry in doc["segments"] if is_gap(entry)),
         "overlays": len(doc.get("overlays") or []),
         "duration": dual_time(total_frames(doc), fps),
     }

--- a/src/resolve_mcp/resolve/takes.py
+++ b/src/resolve_mcp/resolve/takes.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 from typing import Any, Final
 
 from ..cut.document import read_cut_file
-from ..cut.validate import placements, validate_structure
+from ..cut.validate import is_gap, placements, validate_structure
 from ..document import LoadedDocument
 from ..errors import (
     BuildFailedError,
@@ -233,10 +233,22 @@ def _checked_cut(cut_file: str) -> LoadedDocument:
 
 def _segment(doc: dict[str, Any], segment: str) -> dict[str, Any]:
     for candidate in doc["segments"]:
-        if str(candidate["id"]) == segment:
-            found: dict[str, Any] = candidate
-            return found
-    available = [str(candidate["id"]) for candidate in doc["segments"]]
+        if str(candidate["id"]) != segment:
+            continue
+        if is_gap(candidate):
+            # A gap places no clip, so there is no shot on the timeline to hold a selector.
+            # Refused by name rather than falling through to "no such segment": the id is
+            # real and the cut file is fine, so the answer has to say what is actually wrong.
+            raise InvalidRequestError(
+                cause=f"{segment!r} is a gap — {candidate['gap']} frames of black — so it "
+                f"has no takes to swap between.",
+                fix="Swap a take on the segment either side of the black, or make the gap a "
+                "segment in the cut file and build a new version.",
+                detail={"requested": segment, "gap": int(candidate["gap"])},
+            )
+        found: dict[str, Any] = candidate
+        return found
+    available = [str(candidate["id"]) for candidate in doc["segments"] if not is_gap(candidate)]
     raise InvalidRequestError(
         cause=f"The cut file has no segment {segment!r}.",
         fix=f"Segment ids come from the cut file and must match exactly: {', '.join(available)}.",

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -91,10 +91,16 @@ def build_timeline(
     """Build a cut file into a new `<name> v<N>` timeline and report what landed.
 
     Every build makes a new version and never touches an earlier one, so rebuilding after
-    an edit is always safe. The segments land butt-joined in document order over one
-    continuous master-audio clip; positions are computed, so gaps cannot happen. Overlays
-    land on V2 at their anchor segment's start plus the offset — never a frame you state —
-    so tightening a segment and rebuilding leaves every overlay over the same content.
+    an edit is always safe. The segments land in document order over one continuous
+    master-audio clip; positions are computed, never stated, so no entry can name a frame
+    that is wrong. A `gap` entry is literal black: nothing is appended for it, and it moves
+    everything after it. Overlays land at their anchor's start plus the offset — on V2, or
+    on the `track` they name — so tightening a segment and rebuilding leaves every overlay
+    over the same content.
+
+    Black at the end of a cut only exists if an overlay covers it: a timeline ends at its
+    last item, so a trailing gap with nothing over it is a device that will not be there.
+    W8 says so before the build rather than after.
 
     The version being superseded usually carries hand-placed markers — the blue song
     anchors a titles file is written against, and the director's coloured notes. They are

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -125,7 +125,13 @@ def test_a_cut_without_audio_builds_video_alone(attach: Attach, tmp_path: Path) 
     result = build_timeline(a_cut(tmp_path, doc))
 
     assert result["ok"] is True
-    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": False, "selectors": 0}
+    assert result["placed"] == {
+        "segments": 3,
+        "gaps": 0,
+        "overlays": 0,
+        "audio": False,
+        "selectors": 0,
+    }
     assert placements(built(resolve, "sunset-set v1"), "audio") == []
 
 
@@ -151,7 +157,13 @@ def test_the_built_timeline_reports_its_own_span(attach: Attach, tmp_path: Path)
 
     assert result["timeline"]["duration"]["frames"] == TOTAL_FRAMES
     assert result["timeline"]["fps"] == 59.94
-    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": True, "selectors": 0}
+    assert result["placed"] == {
+        "segments": 3,
+        "gaps": 0,
+        "overlays": 0,
+        "audio": True,
+        "selectors": 0,
+    }
 
 
 def test_the_build_opens_the_timeline_it_made(attach: Attach, tmp_path: Path) -> None:
@@ -736,7 +748,13 @@ def test_the_report_counts_the_overlays_apart_from_the_segments(
 
     result = build_timeline(a_cut(tmp_path, with_overlay()))
 
-    assert result["placed"] == {"segments": 3, "overlays": 1, "audio": True, "selectors": 0}
+    assert result["placed"] == {
+        "segments": 3,
+        "gaps": 0,
+        "overlays": 1,
+        "audio": True,
+        "selectors": 0,
+    }
 
 
 def test_a_cut_without_overlays_builds_no_second_video_track(
@@ -748,7 +766,13 @@ def test_a_cut_without_overlays_builds_no_second_video_track(
 
     result = build_timeline(a_cut(tmp_path, valid_doc()))
 
-    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": True, "selectors": 0}
+    assert result["placed"] == {
+        "segments": 3,
+        "gaps": 0,
+        "overlays": 0,
+        "audio": True,
+        "selectors": 0,
+    }
     assert built(resolve, "sunset-set v1").GetTrackCount("video") == 1
 
 
@@ -956,7 +980,13 @@ def test_the_report_counts_the_selectors_it_made(attach: Attach, tmp_path: Path)
     result = build_timeline(a_cut(tmp_path, doc_with_alternates()))
 
     assert result["ok"] is True
-    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": True, "selectors": 2}
+    assert result["placed"] == {
+        "segments": 3,
+        "gaps": 0,
+        "overlays": 0,
+        "audio": True,
+        "selectors": 2,
+    }
 
 
 def test_a_cut_without_alternates_makes_no_selectors(attach: Attach, tmp_path: Path) -> None:

--- a/tests/test_cut_devices.py
+++ b/tests/test_cut_devices.py
@@ -1,0 +1,461 @@
+"""The two devices the #46 director recut needed and the schema could not say (#141).
+
+1. **Black on V1** — a gap entry in ``segments``: ``{"id": "g001", "gap": 58}``. It takes
+   record time and places nothing, so a cut can stage a false ending or open cold.
+2. **Overlays above V2** — an optional ``track`` on an overlay, so two inserts can share
+   frames on different layers instead of colliding on one.
+
+Both verify at the fake tier, which is where every decision in them lives: the rules are
+pure functions over a document, and the build's half is what it hands ``AppendToTimeline``.
+The one thing no seam here covers is whether Resolve honours a ``recordFrame`` past the end
+of a track's media rather than sliding the clip back — that is the live smoke AC, and
+``_verify``'s read-back is what would catch it going wrong.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.cut.validate import (
+    overlay_positions,
+    positions,
+    total_frames,
+    validate_structure,
+)
+from resolve_mcp.findings import Finding
+from resolve_mcp.tools.cut import (
+    build_timeline,
+    get_cut_schema,
+    swap_take,
+    virtual_transcript,
+)
+
+from .conftest import Attach
+from .cutfile import a_cut, a_pool, built, empty_project, placements, valid_doc
+
+# --- helpers ------------------------------------------------------------------------------
+
+
+def rules(findings: list[Finding]) -> list[str]:
+    return [finding.rule for finding in findings]
+
+
+def pure_doc(**overrides: Any) -> dict[str, Any]:
+    """A cut with no media pool behind it — enough for every structural rule.
+
+    No ``audio`` block, because W2 compares the master span against the V1 total and every
+    gap in this file changes that total; a warning about the mix would drown the one under
+    test.
+    """
+    doc: dict[str, Any] = {
+        "schema": 1,
+        "timeline": {"name": "sunset-set", "fps": 59.94},
+        "sources": {
+            "gtr_close": {"clip": "C0012.mp4"},
+            "keys_wide": {"clip": "C0013.mp4"},
+            "broll_pan": {"clip": "C0014.mp4"},
+        },
+        "segments": [
+            {"id": "s001", "source": "gtr_close", "in": 1000, "out": 1200},
+            {"id": "s002", "source": "keys_wide", "in": 2000, "out": 2200},
+        ],
+    }
+    doc.update(overrides)
+    return doc
+
+
+def with_gap(gap: int = 58, at: int = 1, **overrides: Any) -> dict[str, Any]:
+    """:func:`pure_doc` with ``gap`` frames of black spliced in at index ``at``."""
+    doc = pure_doc(**overrides)
+    doc["segments"].insert(at, {"id": "g001", "gap": gap})
+    return doc
+
+
+def overlay(id: str = "b01", **fields: Any) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "id": id,
+        "source": "broll_pan",
+        "in": 1200,
+        "out": 1300,
+        "over": {"segment": "s001", "offset": 24},
+    }
+    entry.update(fields)
+    return entry
+
+
+# --- gaps: shape --------------------------------------------------------------------------
+
+
+def test_a_gap_between_two_segments_is_a_valid_cut() -> None:
+    assert validate_structure(with_gap()) == []
+
+
+def test_a_gap_needs_no_source_alias() -> None:
+    """Black plays no clip, so a gap is not an alias use and E4 has nothing to resolve."""
+    doc = with_gap()
+    doc["sources"].pop("broll_pan")
+
+    assert rules(validate_structure(doc)) == []
+
+
+def test_a_gap_may_carry_a_note() -> None:
+    assert validate_structure(with_gap()) == []
+    doc = with_gap()
+    doc["segments"][1]["note"] = "false ending"
+
+    assert validate_structure(doc) == []
+
+
+def test_a_gap_duration_must_be_an_integer() -> None:
+    assert rules(validate_structure(with_gap(gap="58"))) == ["E1"]  # type: ignore[arg-type]
+
+
+def test_a_gap_must_run_at_least_one_frame() -> None:
+    """Zero frames of black is no black at all — the same emptiness E3 refuses in a range."""
+    findings = validate_structure(with_gap(gap=0))
+
+    # E3 plus the same zero-length W1 cascade a zero-length segment already produces.
+    assert rules(findings) == ["E3", "W1"]
+    assert findings[0].id == "g001"
+
+
+def test_a_gap_may_not_also_be_a_shot() -> None:
+    """Half a gap and half a segment is an author mid-edit, not a device."""
+    doc = with_gap()
+    doc["segments"][1]["source"] = "gtr_close"
+
+    findings = validate_structure(doc)
+    assert rules(findings) == ["E1"]
+    assert "source" in findings[0].message
+
+
+def test_a_gap_may_not_carry_alternates() -> None:
+    doc = with_gap()
+    doc["segments"][1]["alternates"] = [{"source": "gtr_close", "in": 1, "out": 59}]
+
+    assert rules(validate_structure(doc)) == ["E1"]
+
+
+def test_a_cut_of_nothing_but_black_is_refused() -> None:
+    """A timeline of pure black is not a cut; ``segments`` needs picture in it."""
+    findings = validate_structure(pure_doc(segments=[{"id": "g001", "gap": 58}]))
+
+    assert rules(findings) == ["E1"]
+    assert "picture" in findings[0].message
+
+
+def test_a_gap_shares_the_one_id_namespace() -> None:
+    doc = with_gap()
+    doc["segments"][1]["id"] = "s001"
+
+    assert rules(validate_structure(doc)) == ["E2"]
+
+
+def test_a_flash_of_black_trips_the_flash_guard() -> None:
+    """W1 reads a two-frame gap the way it reads a two-frame shot: usually a typo."""
+    findings = validate_structure(with_gap(gap=2))
+
+    assert rules(findings) == ["W1"]
+    assert findings[0].id == "g001"
+
+
+# --- gaps: layout -------------------------------------------------------------------------
+
+
+def test_a_gap_pushes_everything_after_it_later() -> None:
+    """The whole point: record positions stay computed, and black takes record time."""
+    assert positions(with_gap()) == {"s001": (0, 200), "g001": (200, 58), "s002": (258, 200)}
+
+
+def test_a_leading_gap_opens_the_cut_on_black() -> None:
+    assert positions(with_gap(at=0))["s001"] == (58, 200)
+
+
+def test_a_gap_counts_toward_the_total() -> None:
+    assert total_frames(with_gap()) == 458
+    assert total_frames(pure_doc()) == 400
+
+
+def test_the_master_audio_span_is_measured_against_the_black_too() -> None:
+    """W2 compares the mix to the V1 span, and black is part of that span."""
+    doc = with_gap(audio={"source": "master_mix", "in": 0, "out": 458})
+    doc["sources"]["master_mix"] = {"clip": "sunset-master.wav"}
+
+    assert validate_structure(doc) == []
+
+
+# --- gaps under overlays --------------------------------------------------------------------
+
+
+def test_an_overlay_can_be_anchored_over_black() -> None:
+    """#46's opening: a moving-cam shot on V2 bridging black and the first picture."""
+    doc = with_gap(at=0, overlays=[overlay(over={"segment": "g001", "offset": 10})])
+
+    assert validate_structure(doc) == []
+    assert overlay_positions(doc) == {"b01": (10, 100)}
+
+
+def test_an_overlay_over_black_may_run_on_into_the_picture() -> None:
+    doc = with_gap(at=0, overlays=[overlay(out=1400, over={"segment": "g001", "offset": 10})])
+
+    assert validate_structure(doc) == []
+    assert overlay_positions(doc)["b01"] == (10, 200)
+
+
+def test_an_offset_past_the_end_of_the_black_is_refused() -> None:
+    """E9's offset leg reads a gap's duration exactly as it reads a segment's."""
+    doc = with_gap(at=0, overlays=[overlay(over={"segment": "g001", "offset": 58})])
+
+    findings = validate_structure(doc)
+    assert rules(findings) == ["E9"]
+    assert "58 frames" in findings[0].message
+
+
+# --- ending on black ------------------------------------------------------------------------
+
+
+def test_trailing_black_that_nothing_covers_is_warned_about() -> None:
+    """Nothing is appended over a bare tail gap, so the built timeline just ends early."""
+    findings = validate_structure(with_gap(at=2))
+
+    assert rules(findings) == ["W8"]
+    assert "58" in findings[0].message
+
+
+def test_trailing_black_under_an_overlay_is_not_warned_about() -> None:
+    """#46's ending: inserts on V2 are what make the black after the crash exist at all."""
+    doc = with_gap(at=2, overlays=[overlay(over={"segment": "s002", "offset": 150})])
+
+    assert validate_structure(doc) == []
+
+
+def test_a_cut_that_ends_on_picture_is_not_warned_about() -> None:
+    assert validate_structure(with_gap()) == []
+
+
+# --- overlays above V2 ------------------------------------------------------------------------
+
+
+def test_an_overlay_track_must_be_an_integer() -> None:
+    assert rules(validate_structure(pure_doc(overlays=[overlay(track="2")]))) == ["E1"]
+
+
+def test_v1_is_not_an_overlay_track() -> None:
+    """V1 belongs to the segments; an overlay claiming it would collide with the cut."""
+    findings = validate_structure(pure_doc(overlays=[overlay(track=1)]))
+
+    assert rules(findings) == ["E1"]
+    assert "2" in findings[0].message
+
+
+def test_an_out_of_range_overlay_track_is_refused() -> None:
+    """A typo'd index would have the build silently add every track below it."""
+    assert rules(validate_structure(pure_doc(overlays=[overlay(track=99)]))) == ["E1"]
+
+
+def test_two_overlays_on_one_track_may_not_share_frames() -> None:
+    doc = pure_doc(overlays=[overlay("b01"), overlay("b02", **{"in": 1, "out": 101})])
+
+    assert rules(validate_structure(doc)) == ["E10"]
+
+
+def test_two_overlays_on_different_tracks_may_share_frames() -> None:
+    """E10 exists because one track cannot hold two clips at once; two tracks can."""
+    doc = pure_doc(
+        overlays=[overlay("b01"), overlay("b02", track=3, **{"in": 1, "out": 101})]
+    )
+
+    assert validate_structure(doc) == []
+
+
+# --- the build --------------------------------------------------------------------------------
+
+
+def a_built_gap(gap: int = 58, at: int = 1, **overrides: Any) -> dict[str, Any]:
+    """:func:`cutfile.valid_doc` — three shots over a master mix — with black spliced in."""
+    doc = valid_doc(**overrides)
+    doc["segments"].insert(at, {"id": "g001", "gap": gap})
+    doc["audio"]["out"] = total_frames(doc)
+    return doc
+
+
+def test_a_gap_leaves_a_hole_in_the_v1(attach: Attach, tmp_path: Path) -> None:
+    """The device: 58 frames of nothing between the second and third shots."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, a_built_gap(at=2)))
+
+    assert result["ok"] is True
+    assert placements(built(resolve, "sunset-set v1")) == [
+        ("C0012.mp4", 0, 100),
+        ("C0031.mp4", 100, 80),
+        ("C0012.mp4", 238, 60),
+    ]
+
+
+def test_a_gap_appends_nothing(attach: Attach, tmp_path: Path) -> None:
+    """Black is the absence of a clip, not a clip: nothing is sent for it."""
+    pool = a_pool()
+    attach(empty_project(pool))
+
+    build_timeline(a_cut(tmp_path, a_built_gap(at=2)))
+
+    assert [append["recordFrame"] for append in pool.appends if append["mediaType"] == 1] == [
+        0,
+        100,
+        238,
+    ]
+
+
+def test_the_report_counts_the_black(attach: Attach, tmp_path: Path) -> None:
+    attach(empty_project(a_pool()))
+
+    result = build_timeline(a_cut(tmp_path, a_built_gap(at=2)))
+
+    assert result["placed"]["segments"] == 3
+    assert result["placed"]["gaps"] == 1
+
+
+def test_a_swap_after_a_gap_finds_the_shot_the_gap_moved(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """One derivation of the layout, so a swap reads the record the build wrote."""
+    doc = a_built_gap(at=1)
+    doc["segments"][2]["alternates"] = [{"source": "keys_wide", "in": 4500, "out": 4580}]
+    resolve = empty_project(a_pool())
+    attach(resolve)
+    cut_file = a_cut(tmp_path, doc)
+    build_timeline(cut_file)
+
+    result = swap_take(cut_file, "s002", 2, timeline="sunset-set v1")
+
+    # The swap finds its shot by record frame alone, so it only succeeds if the layout it
+    # computed put s002 at 158 — where the gap moved it — rather than at 100.
+    assert result["ok"] is True
+    assert result["changed"] is True
+
+
+def test_black_cannot_be_swapped(attach: Attach, tmp_path: Path) -> None:
+    """A gap has no source and no selector; asking to swap one is a mistake, not a no-op."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+    cut_file = a_cut(tmp_path, a_built_gap(at=1))
+    build_timeline(cut_file)
+
+    result = swap_take(cut_file, "g001", 2, timeline="sunset-set v1")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_request"
+    assert "g001" in result["error"]["cause"]
+
+
+def test_an_overlay_lands_on_the_track_it_names(attach: Attach, tmp_path: Path) -> None:
+    resolve = empty_project(a_pool())
+    attach(resolve)
+    doc = valid_doc(
+        overlays=[
+            {
+                "id": "b01",
+                "source": "gtr_close",
+                "in": 3000,
+                "out": 3030,
+                "over": {"segment": "s002", "offset": 10},
+                "track": 3,
+            }
+        ]
+    )
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is True
+    assert placements(built(resolve, "sunset-set v1"), "video", 3) == [("C0012.mp4", 110, 30)]
+    assert placements(built(resolve, "sunset-set v1"), "video", 2) == []
+    assert result["placed"]["overlays"] == 1
+
+
+def test_the_director_recut_shape_builds(attach: Attach, tmp_path: Path) -> None:
+    """#46 in miniature: open on black under a V2 bridge, and end on black under an insert.
+
+    This is the whole ticket in one document — neither half of it could be written before,
+    and the two interact: the ending insert is only legal because the trailing gap is part
+    of the cut's total span.
+    """
+    doc = valid_doc(
+        overlays=[
+            {
+                "id": "bridge",
+                "source": "keys_wide",
+                "in": 6000,
+                "out": 6100,
+                "over": {"segment": "g_open", "offset": 0},
+            },
+            {
+                "id": "insert",
+                "source": "keys_wide",
+                "in": 7000,
+                "out": 7040,
+                "over": {"segment": "g_end", "offset": 0},
+            },
+        ]
+    )
+    doc["segments"].insert(0, {"id": "g_open", "gap": 40, "note": "cold open"})
+    doc["segments"].append({"id": "g_end", "gap": 58, "note": "end on black"})
+    doc["audio"]["out"] = total_frames(doc)
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is True
+    assert result["placed"]["gaps"] == 2
+    # V1 opens 40 frames late and stops at 280; V2 covers the black at both ends.
+    assert placements(built(resolve, "sunset-set v1"))[0] == ("C0012.mp4", 40, 100)
+    assert placements(built(resolve, "sunset-set v1"), "video", 2) == [
+        ("C0031.mp4", 0, 100),
+        ("C0031.mp4", 280, 40),
+    ]
+
+
+# --- reading the cut back ------------------------------------------------------------------------
+
+
+def test_black_between_two_shots_of_one_source_is_not_a_jump_cut(tmp_path: Path) -> None:
+    """W7 exists to catch two takes butt-joined; 58 frames of black is not that join."""
+    doc = valid_doc()
+    doc["segments"] = [
+        {"id": "s001", "source": "gtr_close", "in": 1000, "out": 1100},
+        {"id": "g001", "gap": 58},
+        {"id": "s002", "source": "gtr_close", "in": 2500, "out": 2560},
+    ]
+    doc["audio"]["out"] = total_frames(doc)
+
+    result = virtual_transcript(a_cut(tmp_path, doc))
+
+    assert result["ok"] is True
+    assert result["seams"] == []
+    assert [read["id"] for read in result["segments"]] == ["s001", "s002"]
+
+
+def test_a_reading_places_words_after_the_black(tmp_path: Path) -> None:
+    """The read-back positions come from ``positions``, so black moves the words too."""
+    doc = valid_doc()
+    doc["segments"].insert(1, {"id": "g001", "gap": 58})
+    doc["audio"]["out"] = total_frames(doc)
+
+    result = virtual_transcript(a_cut(tmp_path, doc))
+
+    assert result["ok"] is True
+    assert result["segments"][1]["at"]["frames"] == 158
+
+
+@pytest.mark.parametrize("field", ['"gap"', '"track"'])
+def test_the_served_example_shows_the_new_field(field: str) -> None:
+    """An agent authors against the served example alone; an unshown field is unusable."""
+    result = get_cut_schema()
+
+    assert result["ok"] is True
+    assert field in result["annotated_example"]

--- a/tests/test_cut_devices.py
+++ b/tests/test_cut_devices.py
@@ -226,9 +226,28 @@ def test_trailing_black_that_nothing_covers_is_warned_about() -> None:
 
 def test_trailing_black_under_an_overlay_is_not_warned_about() -> None:
     """#46's ending: inserts on V2 are what make the black after the crash exist at all."""
-    doc = with_gap(at=2, overlays=[overlay(over={"segment": "s002", "offset": 150})])
+    doc = with_gap(
+        at=2,
+        overlays=[overlay(out=1258, over={"segment": "g001", "offset": 0})],
+    )
 
     assert validate_structure(doc) == []
+
+
+def test_black_only_half_covered_is_warned_about_for_the_rest() -> None:
+    """Half a tail is lost as silently as all of it, so the rule measures the whole gap.
+
+    The insert covers 40 of the 58 trailing frames, so the timeline ends at 440 and the
+    last 18 frames of authored black are not there.
+    """
+    doc = with_gap(
+        at=2,
+        overlays=[overlay(out=1240, over={"segment": "g001", "offset": 0})],
+    )
+
+    findings = validate_structure(doc)
+    assert rules(findings) == ["W8"]
+    assert "18 frames" in findings[0].message
 
 
 def test_trailing_black_under_the_master_mix_is_not_warned_about() -> None:
@@ -414,7 +433,7 @@ def test_the_director_recut_shape_builds(attach: Attach, tmp_path: Path) -> None
                 "id": "insert",
                 "source": "keys_wide",
                 "in": 7000,
-                "out": 7040,
+                "out": 7058,
                 "over": {"segment": "g_end", "offset": 0},
             },
         ]
@@ -433,8 +452,10 @@ def test_the_director_recut_shape_builds(attach: Attach, tmp_path: Path) -> None
     assert placements(built(resolve, "sunset-set v1"))[0] == ("C0012.mp4", 40, 100)
     assert placements(built(resolve, "sunset-set v1"), "video", 2) == [
         ("C0031.mp4", 0, 100),
-        ("C0031.mp4", 280, 40),
+        ("C0031.mp4", 280, 58),
     ]
+    # The insert covers the trailing black exactly, so nothing is silently lost.
+    assert result["warnings"] == []
 
 
 # --- reading the cut back ------------------------------------------------------------------------

--- a/tests/test_cut_devices.py
+++ b/tests/test_cut_devices.py
@@ -102,7 +102,6 @@ def test_a_gap_needs_no_source_alias() -> None:
 
 
 def test_a_gap_may_carry_a_note() -> None:
-    assert validate_structure(with_gap()) == []
     doc = with_gap()
     doc["segments"][1]["note"] = "false ending"
 
@@ -232,8 +231,26 @@ def test_trailing_black_under_an_overlay_is_not_warned_about() -> None:
     assert validate_structure(doc) == []
 
 
-def test_a_cut_that_ends_on_picture_is_not_warned_about() -> None:
-    assert validate_structure(with_gap()) == []
+def test_trailing_black_under_the_master_mix_is_not_warned_about() -> None:
+    """The ordinary concert shape: the music plays on over the black, so the black is real.
+
+    A timeline ends at its last item on *any* track, and the mix is appended to A1 for its
+    own declared length — so a cut whose master audio runs past the last picture ends on
+    black whether or not anything is on V2.
+    """
+    doc = with_gap(at=2, audio={"source": "master_mix", "in": 0, "out": 458})
+    doc["sources"]["master_mix"] = {"clip": "sunset-master.wav"}
+
+    assert validate_structure(doc) == []
+
+
+def test_a_mix_that_stops_at_the_last_picture_does_not_make_the_black_real() -> None:
+    """The warning turns on what outlives the picture, not on whether audio exists at all."""
+    doc = with_gap(at=2, audio={"source": "master_mix", "in": 0, "out": 400})
+    doc["sources"]["master_mix"] = {"clip": "sunset-master.wav"}
+
+    # W2 too: the 400-frame mix no longer matches the 458-frame V1 span.
+    assert rules(validate_structure(doc)) == ["W2", "W8"]
 
 
 # --- overlays above V2 ------------------------------------------------------------------------

--- a/tests/test_cut_tools.py
+++ b/tests/test_cut_tools.py
@@ -83,7 +83,12 @@ def test_the_schema_lists_every_rule_with_its_severity(attach: Attach) -> None:
     assert [rule for rule, severity in rules.items() if severity == "error"] == [
         f"E{number}" for number in range(1, 12)
     ]
-    assert [rule for rule, severity in rules.items() if severity == "warning"] == ["W1", "W2"]
+    # W3-W7 are virtual_transcript's over the same document, so this list skips to W8.
+    assert [rule for rule, severity in rules.items() if severity == "warning"] == [
+        "W1",
+        "W2",
+        "W8",
+    ]
 
 
 def test_the_schema_serves_without_resolve(attach: Attach) -> None:
@@ -118,6 +123,7 @@ def test_a_valid_cut_file_reports_what_it_describes(attach: Attach, tmp_path: Pa
     assert result["cut"] == {
         "timeline": "sunset-set",
         "segments": 1,
+        "gaps": 0,
         "overlays": 0,
         "duration": {
             "frames": 178,

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -527,6 +527,98 @@ def test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it(tmp_path: 
     assert starts == [timeline_start, timeline_start + 48, timeline_start + 72]
 
 
+def a_device_cut(tmp_path: Path, source: dict[str, Any]) -> str:
+    """#141's two devices in one real cut: black on V1, and overlays on V2 and V3.
+
+    Two shots with 30 frames of black between them, so the second is appended at a
+    ``recordFrame`` 30 frames past the end of V1's media — the one thing about gaps no
+    fake can settle, because Resolve is free to slide it back to the free frame instead.
+    The overlays reuse the same clip's opening frames, so the run needs no second source.
+    """
+    at = source["start"]
+    angle: dict[str, Any] = {"clip": source["name"]}
+    if source["bin"] is not None:
+        angle["bin"] = source["bin"]
+    doc: dict[str, Any] = {
+        "schema": 1,
+        "timeline": {"name": SMOKE_CUT, "fps": source["fps"]},
+        "sources": {"angle": angle},
+        "segments": [
+            {"id": "s000", "source": "angle", "in": at, "out": at + 48},
+            {"id": "g001", "gap": 30, "note": "false ending"},
+            {"id": "s001", "source": "angle", "in": at + 48, "out": at + 84},
+        ],
+        "overlays": [
+            # Over the black itself, which is only expressible because the gap is.
+            {
+                "id": "b01",
+                "source": "angle",
+                "in": at,
+                "out": at + 24,
+                "over": {"segment": "g001", "offset": 0},
+            },
+            # V3, and deliberately over the same frames b01 would want if it shared a
+            # track — the per-track E10 reading, checked against a real timeline.
+            {
+                "id": "b02",
+                "source": "angle",
+                "in": at + 24,
+                "out": at + 44,
+                "over": {"segment": "s000", "offset": 40},
+                "track": 3,
+            },
+        ],
+    }
+    path = tmp_path / "devices.cut.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def test_a_real_build_leaves_black_on_v1_and_stacks_overlays_above_it(tmp_path: Path) -> None:
+    """#141's live AC: a real timeline holds a gap and the overlays over it.
+
+    The gap is the risk. Every other placement in a cut is butt-joined, so this is the
+    first time the build sends a ``recordFrame`` past the end of what is on the track —
+    and #18 found Resolve willing to slide an append it cannot honour while reporting
+    success. If it slides, the second shot lands at 48 instead of 78 and this fails; the
+    build's own read-back would fail it too, which is the point of having both.
+
+    Leaves one more ``resolve-mcp-smoke`` version behind, as every build test here does.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    source = a_source_clip()
+    cut_file = a_device_cut(tmp_path, source)
+    assert validate_cut(cut_file)["valid"] is True
+
+    result = build_timeline(cut_file)
+
+    assert result["ok"] is True, result.get("error")
+    assert result["placed"] == {
+        "segments": 2,
+        "gaps": 1,
+        "overlays": 2,
+        "audio": False,
+        "selectors": 0,
+    }
+    built = inspect_timeline(result["timeline"]["name"], detail="clips")
+    assert built["ok"] is True
+    start = built["timeline"]["start"]["frames"]
+    video = [track for track in built["tracks"] if track["type"] == "video"]
+    assert len(video) == 3, "the V3 overlay should have grown the timeline to three tracks"
+    placed = [
+        [
+            (item["record"]["in"]["frames"] - start, item["record"]["duration"]["frames"])
+            for item in track["items"]
+        ]
+        for track in video
+    ]
+    # V1: 48 frames of picture, 30 of nothing, then 36 more — the hole is the device.
+    assert placed[0] == [(0, 48), (78, 36)]
+    assert placed[1] == [(48, 24)]
+    assert placed[2] == [(40, 20)]
+
+
 def test_a_real_rebuild_carries_the_song_markers_onto_the_new_version(tmp_path: Path) -> None:
     """#130 end to end, and the part no fake can settle: whether a frame derived from
     Resolve's own reading of where the mix sits is a frame Resolve will take a marker at.

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -511,7 +511,13 @@ def test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it(tmp_path: 
     result = build_timeline(cut_file)
 
     assert result["ok"] is True, result.get("error")
-    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": False, "selectors": 0}
+    assert result["placed"] == {
+        "segments": 3,
+        "gaps": 0,
+        "overlays": 0,
+        "audio": False,
+        "selectors": 0,
+    }
     built = inspect_timeline(result["timeline"]["name"], detail="clips")
     assert built["ok"] is True
     video = [track for track in built["tracks"] if track["type"] == "video"][0]
@@ -590,7 +596,13 @@ def test_a_real_take_selector_swaps_the_angle_without_moving_the_shot(tmp_path: 
     result = build_timeline(cut_file)
 
     assert result["ok"] is True, result.get("error")
-    assert result["placed"] == {"segments": 3, "overlays": 0, "audio": False, "selectors": 3}
+    assert result["placed"] == {
+        "segments": 3,
+        "gaps": 0,
+        "overlays": 0,
+        "audio": False,
+        "selectors": 3,
+    }
     name = result["timeline"]["name"]
     before = _video_items(name)
     assert [item["takes"] for item in before] == [2, 2, 2]


### PR DESCRIPTION
Closes #141.

The #46 director recut used two devices the cut schema had no words for. This gives it both.

## The design pass the ticket asked for

The ticket proposed `"black": true` segments *or* explicit `gap` entries, and an `overlays[]` list "with a track index". Two decisions came out of reading the code:

**Gaps are their own entry kind, not a flag on a segment.** `{"id": "g001", "gap": 58}` and nothing else — no source, in, out, audio or alternates, because black plays no clip. A `"black": true` segment would have made three required fields optional and every source-facing rule conditional; a distinct entry keeps the segment shape intact and is unambiguous to detect. They live *in* `segments[]` because their position in the array is what places them.

**`overlays[]` on V2 already existed.** The ticket read as though it needed inventing (it noted the rough-cut pillar has one and wondered whether the concert schema could reuse the vocabulary). It is one list, already anchored, already landing on V2, already covered by E9/E10. So the real delta for overlays was two things: making an overlay anchorable **over a gap** — which is what #46's opening bridge across black actually needed — and the optional `track` index.

Positions stay computed, never stated. A gap is a duration in the array, so the "unclamped-recordFrame footgun" the schema doc used to sidestep is now met head-on rather than avoided — and the build's existing read-back is what catches it if Resolve declines.

## What changed

- **`cut/schema.py`** — the served contract: gap entries, the `track` field, and the rewritten placement model. This is what agents author against, so it is the load-bearing half.
- **`cut/validate.py`** — gap shape (E1), positive duration (E3), one id namespace (E2), the flash guard over black (W1), E10 judged **per track**, and `positions`/`total_frames` walking every entry through one `entry_duration`. `shots()`/`gaps()`/`is_gap()`/`overlay_track()` are the shared accessors; redefining the picture-only list is what makes the media rules skip gaps all at once.
- **`resolve/build.py`** — a gap is an append that does not happen; an overlay takes the track it names.
- **`resolve/takes.py`** — `swap_take` refuses a gap by name rather than reporting "no such segment".
- **`analysis/virtual.py`** — black between two shots of one source is no longer read as an uncovered jump cut. It is not a join.

**New rule, W8**, for the failure the design pass surfaced: nothing is appended for a gap and a timeline ends at its last item, so trailing black is real only if something outlives the picture — an overlay over it, or the master mix still playing. Without that, the device silently is not there. It is a warning, never a block.

Two things were added that the ticket did not ask for, both deliberate: W8 itself, and `MAX_OVERLAY_TRACK = 8` (the build adds every track below the one it is given, so `"track": 99` would grow a 99-track timeline and report success).

## Review

Two-axis review on the branch before this PR existed, pinned to `origin/main`.

**Standards axis — 4 findings, all fixed.** The `CONTEXT.md` test map did not list the new cross-module test file; `build.py`'s module docstring still said "sequential V1 and anchored V2" after the V2 constant was removed; `rough-cut.md`'s W-numbering note still said `validate_cut` owns only W1 and W2; and the live AC was claimed in a docstring but never written. Plus three judgement calls, all taken: `_segments()` returning something other than `doc["segments"]` was a trap for the next reader (now `shots()`), the gap count was open-coded at three sites (now shared), and two tests restated a third.

**Spec axis — 1 real bug, 1 missing requirement, both fixed.**

- *Bug:* W8 consulted only the overlays, so it warned that trailing black would not materialise even when the master mix ran past the last picture — which is the ordinary concert shape and exactly what #46's ending was. The rule now asks what outlives the picture across every track the build appends to.
- *Missing:* "one live smoke AC to confirm a real timeline builds a gap and a V2 item" was claimed and not written.

The spec axis confirmed the record arithmetic reconciles (one derivation feeds W2, E9's total-span leg and `swap_take`'s record lookup alike) and that "`swap_take` and validation stay V1-only" is respected.

A focused re-check of the fix diff found one more: W8 caught "you lose all the tail" but not "you lose most of it" — a gap covered for 40 of its 58 frames passed silently. It now measures where the timeline actually ends against where the cut says it ends.

## Seam

**Fake tier**, as the ticket specifies. `tests/test_cut_devices.py` (38 tests) covers both devices across `cut/validate`, `resolve/build`, `resolve/takes` and `analysis/virtual`, including the #46 shape end to end. Full tier: 1500 passed, mypy strict clean, ruff clean.

**Live smoke: run and passed.** `test_a_real_build_leaves_black_on_v1_and_stacks_overlays_above_it` — Windows 11, Resolve Studio, python.org 3.12.10 interpreter, 2026-08-08. It is the only check that could settle the gap: the second shot is appended 30 frames past the end of V1's media, the one placement in a cut that is not butt-joined, and #18 found Resolve willing to slide an append it cannot honour while reporting success. **It does not slide** — V1 read back as `[(0,48),(78,36)]`, with the overlays at `(48,24)` on V2 and `(40,20)` on V3.

The full live tier was run from this branch and from the main checkout for comparison: 4 failures on the branch, 3 on main, and the sets differ run to run. Two (`still_lands`, `render_queue`) fail identically on `main` — ambiguous clip names in the open project's pool, and a current timeline with no audio. The other two pass in isolation. None are in code this PR touches; the runs were against the currently-open project rather than `mcp-tests-zinc`, which is where the green baseline was measured.

Review: clean — two-axis review found 4 standards findings, 1 spec bug and 1 missing live AC; all fixed, fix diff re-checked, one further W8 correctness gap found and fixed.
