### PR TITLE
Third separation pass: split the other stem into wind and comp

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,8 +108,11 @@ self-review, warnings only, touches no Resolve handle), `whisper`
 `audio/` — concert audio out of Resolve onto disk: `acquire` (both routes),
 `ffmpeg` (per-source-clip route), `riff` (the WAV container itself: PCM,
 IEEE float and extensible headers, because stdlib `wave` opens PCM only),
-`separator` (python-audio-separator out of process), `stems` (two-pass
-separation), `wav` (header facts + the one unreadable-WAV error).
+`separator` (python-audio-separator out of process), `stems` (two passes —
+mix into four, then the drum stem into the kit — plus an opt-in third,
+`split_wind`, splitting `other` into `wind` and `comp`; `comp` is
+accompaniment, never a piano stem), `wav` (header facts + the one
+unreadable-WAV error).
 
 `cut/` — cut-file schema v1: `document` (read off disk), `schema`
 (verbatim, served by `get_cut_schema`), `validate` (11 errors + W1, W2,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,11 @@ timelines. The server measures; Claude decides.
 - **stem** — separated audio (mix → vocals/drums/bass/other; drums →
   kick/snare/toms/ride/crash), path is a content hash (ADR 0003). The drum
   model writes `hh` too; it is not collected (#125).
+- **wind / comp** — the two halves of the opt-in third pass over `other`
+  (#153). `wind` is horns and reeds; `comp` is accompaniment — piano,
+  guitar, vibes, percussion, and the bass line itself on a capture whose
+  `bass` stem came back near-silent (#126). `comp` is **never** a piano
+  stem and nothing may name it one.
 - **phrase** — the cut-placement unit (#46, `styles/concert.md` §1): a
   stretch of the soloist's line between two endings. `analysis/phrases.py`
   reports the **boundaries**, each with two times — `measured_t`, where the

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ scene-cut detection, the render/deliver tools, and the `run_python` escape hatch
 | `edit_title` | Fixes one placed title in place — its words or its exposed params, neighbours untouched |
 | `grab_frames` | Grabs chosen moments on a clip as JPEGs (≤1568px) the agent reads off disk |
 | `detect_scene_cuts` | Job: catalogs where a clip changes shot, gist inline and the full list on disk |
-| `separate_stems` | Two-pass GPU stem separation: mix → 4 stems, drums → kick/snare/toms/ride/crash |
+| `separate_stems` | GPU stem separation: mix → 4 stems, drums → kick/snare/toms/ride/crash, and on `split_wind` other → wind/comp |
 | `list_render_presets` | The project's render presets, spelled the way `render_timeline` needs |
 | `render_timeline` | Renders a timeline or a range of one as a background job |
 | `get_job` | Polls one background job: progress, result, or a structured failure |

--- a/src/resolve_mcp/analysis/fills.py
+++ b/src/resolve_mcp/analysis/fills.py
@@ -518,8 +518,9 @@ def _stems(stems: Mapping[str, str | Path] | str | Path) -> dict[str, Path]:
 def _collected(directory: Path) -> dict[str, Path]:
     """The drum stems under a separation's directory — the pass's own, or the parent of it.
 
-    A separation writes its two passes into ``<directory>/mix`` and ``<directory>/drums``,
-    and the job reports the parent. That parent is what an agent has in hand, so it is what
+    A separation writes a directory per pass — ``<directory>/mix``, ``<directory>/drums``, and
+    ``<directory>/other`` when the wind split was asked for — and the job reports the parent
+    of all of them. That parent is what an agent has in hand, so it is what
     this accepts, and the drum pass inside it is looked in first. The parent itself is
     checked too, because a director who copied three stems into a folder of their own is
     doing something reasonable and should not have to name a subdirectory that is not there.

--- a/src/resolve_mcp/analysis/phrases.py
+++ b/src/resolve_mcp/analysis/phrases.py
@@ -490,8 +490,9 @@ def _stem(stems: Mapping[str, str | Path] | str | Path, wanted: str) -> Path:
 def _collected(directory: Path) -> dict[str, Path]:
     """The stems under a separation's directory — the four-stem pass, or the parent of it.
 
-    A separation writes its two passes into ``<directory>/mix`` and ``<directory>/drums``, and
-    the job reports the parent. The melodic stems are in the first pass, so that is looked in
+    A separation writes a directory per pass — ``<directory>/mix``, ``<directory>/drums``, and
+    ``<directory>/other`` when the wind split was asked for — and the job reports the parent of
+    all of them. The melodic stems are in the first pass, so that is looked in
     first; the parent itself is checked too, because a director who copied the stems into a
     folder of their own should not have to name a subdirectory that is not there.
     """

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -103,14 +103,18 @@ OTHER_PASS = "other"
 ACQUIRE_FLOOR = 0.02
 ACQUIRE_CEILING = 0.25
 PASS_ONE_CEILING = 0.6
-PASS_TWO_CEILING = 0.8
+WIND_FLOOR = 0.8
+"""Where the drum pass hands over to the wind pass — a boundary, not a ceiling.
+
+The optional third pass splits the back half rather than extending it, so this is where pass
+two stops only when pass three is coming. With the pass off, pass two runs the whole way to
+``SEPARATED`` instead.
+"""
 SEPARATED = 0.9
 """Where the last pass ends, whichever pass that is.
 
-The optional third pass splits the back half rather than extending it: with it off pass two
-runs to ``SEPARATED``, with it on pass two stops at ``PASS_TWO_CEILING`` and pass three
-carries on to ``SEPARATED``. A bar that ended somewhere different depending on a flag would
-have the cheaper job look unfinished at the point the expensive one is done.
+A bar that finished somewhere different depending on a flag would have the cheaper two-pass
+job look unfinished at exactly the point the expensive one reads as done.
 """
 COLLECTING = 0.95
 
@@ -132,7 +136,9 @@ def separate_stems(
     """Start a separation job. Returns the job record, not the stems.
 
     ``split_wind`` adds the third pass over ``other``. It is a job param but not a stems-key
-    param, so asking for it on audio already separated runs that pass alone.
+    param, so it stays in one stems directory rather than separating the same audio twice —
+    but a directory missing the pass this run wants is partial, and partial is redone whole,
+    so turning it on for audio already separated re-runs the earlier passes too.
 
     ``runner`` and ``ffmpeg_runner`` are the two subprocess seams: the default shells out
     for real, and a caller can hand in its own to exercise the route without the models or
@@ -247,15 +253,15 @@ def multi_pass(
     directory = config.stems_dir / f"{slug(Path(str(audio['path'])).stem, 'stems')}-{key[:12]}"
     mix_dir = directory / MIX_PASS
     drums_dir = directory / DRUM_PASS
-    wind_dir = directory / OTHER_PASS
-    drums_ceiling = PASS_TWO_CEILING if split_wind else SEPARATED
+    other_dir = directory / OTHER_PASS
+    drums_ceiling = WIND_FLOOR if split_wind else SEPARATED
 
-    reused = reuse and _already_separated(mix_dir, drums_dir, wind_dir if split_wind else None)
+    reused = reuse and _already_separated(mix_dir, drums_dir, other_dir if split_wind else None)
     if reused:
         log.info("Stems for %s are already on disk at %s", audio["path"], directory)
         stems = separator.collect(mix_dir)
         drums = separator.collect(drums_dir)
-        wind = separator.collect(wind_dir) if split_wind else {}
+        other = separator.collect(other_dir) if split_wind else {}
     else:
         stems = separator.separate(
             audio["path"],
@@ -276,15 +282,15 @@ def multi_pass(
             runner=runner,
             config=config,
         )
-        wind = {}
+        other = {}
         if split_wind:
-            progress(PASS_TWO_CEILING, "splitting the winds out of the other stem")
-            wind = separator.separate(
+            progress(WIND_FLOOR, "splitting the winds out of the other stem")
+            other = separator.separate(
                 stems[OTHER_SOURCE],
-                wind_dir,
+                other_dir,
                 config.wind_model,
                 WIND_STEMS,
-                progress=_pass(progress, PASS_TWO_CEILING, SEPARATED, "splitting the winds"),
+                progress=_pass(progress, WIND_FLOOR, SEPARATED, "splitting the winds"),
                 runner=runner,
                 config=config,
             )
@@ -302,24 +308,28 @@ def multi_pass(
     if split_wind:
         # Keyed like ``drums`` is: the name of the stem this pass took apart. Absent rather
         # than empty when the pass is off, so the envelope never offers a stem nobody made.
-        result[OTHER_PASS] = {WIND_KEYS.get(name, name): str(path) for name, path in wind.items()}
+        # Only the two mapped halves go out — anything else the model wrote has no name here,
+        # and a raw model label leaking into the envelope is worse than a file left on disk.
+        result[OTHER_PASS] = {
+            WIND_KEYS[name]: str(path) for name, path in other.items() if name in WIND_KEYS
+        }
         result["models"][OTHER_PASS] = config.wind_model
-    artifacts = tuple([*stems.values(), *drums.values(), *wind.values()])
+    artifacts = tuple([*stems.values(), *drums.values(), *other.values()])
     log.info("Separated %s into %d stems at %s", audio["path"], len(artifacts), directory)
     return JobOutput(result, artifacts)
 
 
-def _already_separated(mix_dir: Path, drums_dir: Path, wind_dir: Path | None = None) -> bool:
+def _already_separated(mix_dir: Path, drums_dir: Path, other_dir: Path | None = None) -> bool:
     """Every pass this run was asked for is on disk in full — a partial run is worth redoing.
 
-    ``wind_dir`` is ``None`` when the third pass is off, and then a two-pass directory is
+    ``other_dir`` is ``None`` when the third pass is off, and then a two-pass directory is
     complete rather than partial. The flag is not part of the stems key, so both shapes share
     a directory: what completeness means has to come from what was asked for, or a job with
     the pass off would rerun everything to fill a directory it does not want.
     """
     if separator.missing_from(mix_dir, FOUR_STEMS) or separator.missing_from(drums_dir, DRUM_STEMS):
         return False
-    return wind_dir is None or not separator.missing_from(wind_dir, WIND_STEMS)
+    return other_dir is None or not separator.missing_from(other_dir, WIND_STEMS)
 
 
 def _pass(progress: Progress, floor: float, ceiling: float, step: str) -> separator.Fraction:

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -1,11 +1,17 @@
-"""Two passes, because fill detection needs near-clean drums.
+"""Two passes, because fill detection needs near-clean drums — and an opt-in third.
 
 Pass one splits the mix into four stems; pass two takes the drum stem alone and decomposes
 it into the pieces of the kit. Running the drum model on the full mix is what the second
 pass exists to avoid — it has bass and vocals bleeding into every hit, and a fill detector
 reading that is reading the band, not the drummer.
 
-Three decisions worth knowing:
+Pass three does the same to ``other``, the stem that holds everything no model has a stem
+for, splitting the winds out of it so a solo detector reading brightness has one instrument
+family to track rather than horns and piano mixed together. It is off unless the caller asks
+for it (#126): on a band with no piano ``other`` is already the wind candidate, and the pass
+recovers nothing for the compute it costs.
+
+Four decisions worth knowing:
 
 * **The job's key and the stems' key are not the same key, on purpose.** The job is keyed
   the way its acquisition is keyed — a timeline fingerprint, a clip's path/size/mtime —
@@ -25,6 +31,14 @@ Three decisions worth knowing:
 * **Each pass writes into its own directory.** Pass two reads the drum stem pass one
   wrote; sharing a directory would have the decomposition land beside — and, with a model
   that labels its output ``(Drums)``, on top of — the file it is reading.
+
+* **The third pass is a flag on the job, not on the stems key.** Which models could run is
+  part of what the stems on disk *are* and keys the directory; whether the optional one was
+  asked for this time is not, so both shapes land in one directory rather than separating
+  the same audio into two. That makes completeness depend on the flag — a two-pass directory
+  is complete with the pass off and partial with it on — and a partial directory is redone
+  whole rather than topped up, which is the existing rule and costs a re-run of passes one
+  and two the first time the flag is turned on for audio already separated.
 """
 
 from __future__ import annotations
@@ -63,16 +77,41 @@ rather than the first one to run.
 DRUM_SOURCE = "drums"
 """Which of the four stems the second pass decomposes."""
 
-SEPARATION = ("model", "drum_model", "stems", "drum_stems")
+WIND_STEMS = ("woodwinds", "no woodwinds")
+"""What the third pass asks its model for, in the labels that model writes them under."""
+
+WIND_KEYS = {"woodwinds": "wind", "no woodwinds": "comp"}
+"""The envelope's names for the two halves of the third pass.
+
+``no woodwinds`` is **not** a piano stem and nothing here may call it one. It is piano plus
+guitar, vibes, percussion and whatever bass leaked through, and on a bass-weak capture it is
+mostly the bass line — #126 measured roughly 60% of its energy below 200 Hz on a source whose
+``bass`` stem came back near-silent. ``comp`` says accompaniment, which is all that can be
+promised about it.
+"""
+
+OTHER_SOURCE = "other"
+"""Which of the four stems the third pass decomposes: everything no model has a stem for."""
+
+SEPARATION = ("model", "drum_model", "wind_model", "stems", "drum_stems", "wind_stems")
 """The params that change what the stems *are*, as opposed to where the audio came from."""
 
 MIX_PASS = "mix"
 DRUM_PASS = "drums"
+OTHER_PASS = "other"
 
 ACQUIRE_FLOOR = 0.02
 ACQUIRE_CEILING = 0.25
 PASS_ONE_CEILING = 0.6
-PASS_TWO_CEILING = 0.9
+PASS_TWO_CEILING = 0.8
+SEPARATED = 0.9
+"""Where the last pass ends, whichever pass that is.
+
+The optional third pass splits the back half rather than extending it: with it off pass two
+runs to ``SEPARATED``, with it on pass two stops at ``PASS_TWO_CEILING`` and pass three
+carries on to ``SEPARATED``. A bar that ended somewhere different depending on a flag would
+have the cheaper job look unfinished at the point the expensive one is done.
+"""
 COLLECTING = 0.95
 
 PERCENT = 100
@@ -85,11 +124,15 @@ def separate_stems(
     clip: str | None = None,
     bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
     refresh: bool = False,
+    split_wind: bool = False,
     runner: separator.Runner | None = None,
     ffmpeg_runner: Runner | None = None,
     config: Config | None = None,
 ) -> dict[str, Any]:
-    """Start a two-pass separation job. Returns the job record, not the stems.
+    """Start a separation job. Returns the job record, not the stems.
+
+    ``split_wind`` adds the third pass over ``other``. It is a job param but not a stems-key
+    param, so asking for it on audio already separated runs that pass alone.
 
     ``runner`` and ``ffmpeg_runner`` are the two subprocess seams: the default shells out
     for real, and a caller can hand in its own to exercise the route without the models or
@@ -106,12 +149,20 @@ def separate_stems(
         runner=ffmpeg_runner,
         config=config,
     )
-    params = {**source.params, **separation_params(config)}
+    params = {**source.params, **separation_params(config), "split_wind": split_wind}
     key = cache.cache_key(KIND, [source.fingerprint], params)
 
     def work(progress: Progress) -> JobOutput:
         audio = acquired(source, progress, config)
-        return two_pass(audio, params, progress, runner=runner, reuse=not refresh, config=config)
+        return multi_pass(
+            audio,
+            params,
+            progress,
+            split_wind=split_wind,
+            runner=runner,
+            reuse=not refresh,
+            config=config,
+        )
 
     return start_job(KIND, params, work, cache_key=key, refresh=refresh, config=config)
 
@@ -150,13 +201,21 @@ def acquired(
 
 
 def separation_params(config: Config | None = None) -> dict[str, Any]:
-    """What is being run, as opposed to what it is being run on. Keys the stems on disk."""
+    """What is being run, as opposed to what it is being run on. Keys the stems on disk.
+
+    The third pass's model is in here whether or not that pass is switched on: the key says
+    which models these stems could have come from, and leaving the name out when the pass is
+    off would let a changed ``wind_model`` be silently ignored by every directory separated
+    before it was turned on.
+    """
     config = config or get_config()
     return {
         "model": config.stem_model,
         "drum_model": config.drum_model,
+        "wind_model": config.wind_model,
         "stems": list(FOUR_STEMS),
         "drum_stems": list(DRUM_STEMS),
+        "wind_stems": list(WIND_STEMS),
     }
 
 
@@ -173,26 +232,30 @@ def stem_key(audio: dict[str, Any], params: dict[str, Any]) -> str:
     return cache.cache_key(KIND, [{"content_sha256": audio["content_sha256"]}], settings)
 
 
-def two_pass(
+def multi_pass(
     audio: dict[str, Any],
     params: dict[str, Any],
     progress: Progress,
+    split_wind: bool = False,
     runner: separator.Runner | None = None,
     reuse: bool = True,
     config: Config | None = None,
 ) -> JobOutput:
-    """The worker: four stems, then the drum stem decomposed into the pieces of the kit."""
+    """The worker: four stems, the drum stem decomposed, and on request the ``other`` stem too."""
     config = config or get_config()
     key = stem_key(audio, params)
     directory = config.stems_dir / f"{slug(Path(str(audio['path'])).stem, 'stems')}-{key[:12]}"
     mix_dir = directory / MIX_PASS
     drums_dir = directory / DRUM_PASS
+    wind_dir = directory / OTHER_PASS
+    drums_ceiling = PASS_TWO_CEILING if split_wind else SEPARATED
 
-    reused = reuse and _already_separated(mix_dir, drums_dir)
+    reused = reuse and _already_separated(mix_dir, drums_dir, wind_dir if split_wind else None)
     if reused:
         log.info("Stems for %s are already on disk at %s", audio["path"], directory)
         stems = separator.collect(mix_dir)
         drums = separator.collect(drums_dir)
+        wind = separator.collect(wind_dir) if split_wind else {}
     else:
         stems = separator.separate(
             audio["path"],
@@ -209,13 +272,25 @@ def two_pass(
             drums_dir,
             config.drum_model,
             DRUM_STEMS,
-            progress=_pass(progress, PASS_ONE_CEILING, PASS_TWO_CEILING, "decomposing the drums"),
+            progress=_pass(progress, PASS_ONE_CEILING, drums_ceiling, "decomposing the drums"),
             runner=runner,
             config=config,
         )
+        wind = {}
+        if split_wind:
+            progress(PASS_TWO_CEILING, "splitting the winds out of the other stem")
+            wind = separator.separate(
+                stems[OTHER_SOURCE],
+                wind_dir,
+                config.wind_model,
+                WIND_STEMS,
+                progress=_pass(progress, PASS_TWO_CEILING, SEPARATED, "splitting the winds"),
+                runner=runner,
+                config=config,
+            )
 
     progress(COLLECTING, "collecting the stems")
-    result = {
+    result: dict[str, Any] = {
         "key": key,
         "directory": str(directory),
         "stems": {name: str(path) for name, path in stems.items()},
@@ -224,16 +299,27 @@ def two_pass(
         "audio": audio,
         "reused": reused,
     }
-    artifacts = tuple([*stems.values(), *drums.values()])
+    if split_wind:
+        # Keyed like ``drums`` is: the name of the stem this pass took apart. Absent rather
+        # than empty when the pass is off, so the envelope never offers a stem nobody made.
+        result[OTHER_PASS] = {WIND_KEYS.get(name, name): str(path) for name, path in wind.items()}
+        result["models"][OTHER_PASS] = config.wind_model
+    artifacts = tuple([*stems.values(), *drums.values(), *wind.values()])
     log.info("Separated %s into %d stems at %s", audio["path"], len(artifacts), directory)
     return JobOutput(result, artifacts)
 
 
-def _already_separated(mix_dir: Path, drums_dir: Path) -> bool:
-    """Both passes are on disk in full — a partial run is worth redoing, not patching."""
-    return not separator.missing_from(mix_dir, FOUR_STEMS) and not separator.missing_from(
-        drums_dir, DRUM_STEMS
-    )
+def _already_separated(mix_dir: Path, drums_dir: Path, wind_dir: Path | None = None) -> bool:
+    """Every pass this run was asked for is on disk in full — a partial run is worth redoing.
+
+    ``wind_dir`` is ``None`` when the third pass is off, and then a two-pass directory is
+    complete rather than partial. The flag is not part of the stems key, so both shapes share
+    a directory: what completeness means has to come from what was asked for, or a job with
+    the pass off would rerun everything to fill a directory it does not want.
+    """
+    if separator.missing_from(mix_dir, FOUR_STEMS) or separator.missing_from(drums_dir, DRUM_STEMS):
+        return False
+    return wind_dir is None or not separator.missing_from(wind_dir, WIND_STEMS)
 
 
 def _pass(progress: Progress, floor: float, ceiling: float, step: str) -> separator.Fraction:

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -22,6 +22,10 @@ DEFAULT_STEM_MODEL = "htdemucs_ft.yaml"
 # The name audio-separator 0.44.5 lists for the six-stem MDX23C drum model; the
 # "MDX23C-DrumSep-6stem-FT.ckpt" spelling is not in its catalog and fails to load.
 DEFAULT_DRUM_MODEL = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
+# The wind split of the "other" stem (#126: settled by ear against a club recording, a DAW
+# render and a bootleg field capture — no measurement picked it, and two proxy metrics picked
+# wrong). Off unless the caller asks for it, so the name only costs a cache key, not a pass.
+DEFAULT_WIND_MODEL = "17_HP-Wind_Inst-UVR.pth"
 # faster-whisper's own defaults, kept as the defaults here: "auto" picks CUDA when there is
 # a card and CPU when there is not, and "default" means the model's stored precision. CUDA
 # buys speed, not accuracy — large-v3 stores float16, which a GPU runs natively and a CPU
@@ -50,6 +54,7 @@ class Config:
     audio_separator: str = DEFAULT_AUDIO_SEPARATOR
     stem_model: str = DEFAULT_STEM_MODEL
     drum_model: str = DEFAULT_DRUM_MODEL
+    wind_model: str = DEFAULT_WIND_MODEL
     default_render_preset: str = DEFAULT_RENDER_PRESET
     whisper_device: str = DEFAULT_WHISPER_DEVICE
     whisper_compute_type: str = DEFAULT_WHISPER_COMPUTE_TYPE
@@ -71,6 +76,7 @@ class Config:
             audio_separator=env.get("RESOLVE_MCP_AUDIO_SEPARATOR") or DEFAULT_AUDIO_SEPARATOR,
             stem_model=env.get("RESOLVE_MCP_STEM_MODEL") or DEFAULT_STEM_MODEL,
             drum_model=env.get("RESOLVE_MCP_DRUM_MODEL") or DEFAULT_DRUM_MODEL,
+            wind_model=env.get("RESOLVE_MCP_WIND_MODEL") or DEFAULT_WIND_MODEL,
             default_render_preset=(
                 env.get("RESOLVE_MCP_DEFAULT_RENDER_PRESET") or DEFAULT_RENDER_PRESET
             ),
@@ -112,7 +118,7 @@ class Config:
 
     @property
     def stems_dir(self) -> Path:
-        """Separated stems, one directory per content hash + params, two passes inside it."""
+        """Separated stems, one directory per content hash + params, a pass each inside it."""
         return self.cache_dir / "stems"
 
     @property

--- a/src/resolve_mcp/tools/stems.py
+++ b/src/resolve_mcp/tools/stems.py
@@ -21,12 +21,21 @@ def separate_stems(
     clip: str | None = None,
     bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
     refresh: bool = False,
+    split_wind: bool = False,
 ) -> dict[str, Any]:
-    """Split audio into stems on the GPU, in two passes, as a background job.
+    """Split audio into stems on the GPU, in two passes or three, as a background job.
 
     Returns a job_id immediately — poll it with get_job. Pass one splits the mix into
     vocals, drums, bass and other; pass two decomposes the drum stem into kick, snare and
     toms, which is what fill detection reads. The result is paths on disk, not audio.
+
+    split_wind=true adds a third pass over the "other" stem, returned under "other" as
+    "wind" (horns and reeds) and "comp" (everything else that landed in "other" — piano,
+    guitar, vibes, percussion, and the bass line itself on a recording whose bass stem came
+    back near-silent; it is not a piano stem). Ask for it when a horn or reed is what you
+    need to hear apart from the piano, and leave it off otherwise: on a band with no piano
+    "other" is already the winds, and the pass costs time to recover nothing. Turning it on
+    for audio already separated re-runs the earlier passes too.
 
     scope=timeline exports and separates the timeline mix (the only route that captures
     Resolve's own summing of the tracks); scope=clip reads one media pool clip's file
@@ -42,6 +51,7 @@ def separate_stems(
             clip=clip,
             bin=bin,
             refresh=refresh,
+            split_wind=split_wind,
         )
     }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,23 +77,26 @@ def test_artifacts_live_under_the_cache_root(tmp_path: Path) -> None:
     assert config.stems_dir == tmp_path / "stems"
 
 
-def test_the_separator_and_its_two_models_are_overridable() -> None:
+def test_the_separator_and_its_three_models_are_overridable() -> None:
     """The models are named, not discovered: a rename must not silently change a cache key."""
     assert Config.from_env({}).audio_separator == "audio-separator"
     assert Config.from_env({}).stem_model.startswith("htdemucs")
     assert "DrumSep" in Config.from_env({}).drum_model
+    assert "Wind" in Config.from_env({}).wind_model
 
     config = Config.from_env(
         {
             "RESOLVE_MCP_AUDIO_SEPARATOR": r"D:\tools\audio-separator.exe",
             "RESOLVE_MCP_STEM_MODEL": "htdemucs_6s.yaml",
             "RESOLVE_MCP_DRUM_MODEL": "drumsep.ckpt",
+            "RESOLVE_MCP_WIND_MODEL": "4_HP-Vocal-UVR.pth",
         }
     )
 
     assert config.audio_separator == r"D:\tools\audio-separator.exe"
     assert config.stem_model == "htdemucs_6s.yaml"
     assert config.drum_model == "drumsep.ckpt"
+    assert config.wind_model == "4_HP-Vocal-UVR.pth"
 
 
 def test_the_default_render_preset_is_a_resolve_built_in_and_overridable() -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -33,7 +33,13 @@ from typing import Any, NamedTuple
 import pytest
 
 from resolve_mcp.audio.acquire import acquire_timeline_audio
-from resolve_mcp.audio.stems import DRUM_STEMS, FOUR_STEMS, separation_params, two_pass
+from resolve_mcp.audio.stems import (
+    DRUM_STEMS,
+    FOUR_STEMS,
+    WIND_KEYS,
+    multi_pass,
+    separation_params,
+)
 from resolve_mcp.config import get_config
 from resolve_mcp.errors import BinNotFoundError, FfmpegUnavailableError
 from resolve_mcp.jobs import cache
@@ -1092,14 +1098,16 @@ def test_the_render_queue_exports_the_real_timeline_mix(a_known_cut: KnownCut) -
     assert again["cached"] is True, "an unchanged timeline must be a cache hit"
 
 
-def test_the_real_separator_produces_the_stems_the_two_passes_expect(tmp_path: Path) -> None:
+def test_the_real_separator_produces_the_stems_the_passes_expect(tmp_path: Path) -> None:
     """The AC no seam can check: that these models exist and label their output that way.
 
-    The fakes prove the two commands, the progress mapping, the caching and every refusal.
-    What they cannot prove is that ``htdemucs_ft.yaml`` and the DrumSep checkpoint are
-    names audio-separator resolves, that the drum model yields kick/snare/toms at all, or
-    that the real CLI writes ``<input>_(Label)_<model>.wav`` — the naming the stem mapping
-    reads back. Slow: the first run downloads both models.
+    The fakes prove the three commands, the progress mapping, the caching and every refusal.
+    What they cannot prove is that ``htdemucs_ft.yaml``, the DrumSep checkpoint and
+    ``17_HP-Wind_Inst-UVR.pth`` are names audio-separator resolves, that the drum model
+    yields kick/snare/toms at all, or that the real CLI writes ``<input>_(Label)_<model>.wav``
+    — the naming the stem mapping reads back. The wind pass is here for the label above all:
+    ``WIND_STEMS`` spells the two halves the way that model writes them, and a fake cannot
+    tell a right guess from a wrong one. Slow: the first run downloads all three models.
 
     The skip asks the *configured* executable, not the default name: a director who pointed
     ``RESOLVE_MCP_AUDIO_SEPARATOR`` at an install off PATH would otherwise silently skip the
@@ -1115,12 +1123,19 @@ def test_the_real_separator_produces_the_stems_the_two_passes_expect(tmp_path: P
         "scope": "live",
     }
 
-    output = two_pass(audio, separation_params(), lambda fraction, step: None)
+    output = multi_pass(
+        audio,
+        separation_params(),
+        lambda fraction, step: None,
+        split_wind=True,
+    )
 
     assert set(output.result["stems"]) >= set(FOUR_STEMS)
     assert set(output.result["drums"]) >= set(DRUM_STEMS)
+    assert set(output.result["other"]) == set(WIND_KEYS.values())
     assert all(Path(one).stat().st_size > 0 for one in output.result["stems"].values())
     assert all(Path(one).stat().st_size > 0 for one in output.result["drums"].values())
+    assert all(Path(one).stat().st_size > 0 for one in output.result["other"].values())
 
 
 @pytest.mark.skipif(

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -30,9 +30,9 @@ from resolve_mcp.audio.stems import (
     KIND,
     MIX_PASS,
     OTHER_PASS,
-    PASS_TWO_CEILING,
     SEPARATED,
     SEPARATION,
+    WIND_FLOOR,
     WIND_KEYS,
     WIND_STEMS,
     acquired,
@@ -257,7 +257,6 @@ def test_the_residual_half_is_never_offered_as_a_piano_stem(
 
     assert record.result is not None
     assert "piano" not in record.result[OTHER_PASS]
-    assert WIND_KEYS["no woodwinds"] == "comp"
     described = stems_tool.separate_stems.__doc__ or ""
     assert "not a piano stem" in described
     assert "bass" in described
@@ -397,10 +396,10 @@ def test_progress_climbs_through_three_passes_without_moving_where_the_last_one_
     assert [fraction for fraction, _ in steps] == sorted(fraction for fraction, _ in steps)
     winds = [fraction for fraction, step in steps if "wind" in step]
     assert winds
-    assert min(winds) >= PASS_TWO_CEILING
+    assert min(winds) >= WIND_FLOOR
     assert max(winds) == pytest.approx(SEPARATED)
     assert max(fraction for fraction, step in steps if "drum" in step) == pytest.approx(
-        PASS_TWO_CEILING
+        WIND_FLOOR
     )
 
 

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -1,11 +1,13 @@
-"""Two-pass stem separation.
+"""Stem separation: two passes always, a third over ``other`` on request.
 
 The separator is a subprocess, so the seam is the same one ffmpeg uses: the call is a
-parameter, and every decision around it — the two commands, which file pass two reads,
-where the stems land, what a refusal looks like, what a rerun costs — is verified with the
-CLI substituted. What no seam here can answer is whether audio-separator on the 4080 Super
-produces those models' stems at all; that is the live tier, and it is why the fake writes
-real WAVs under the real naming convention rather than empty files.
+parameter, and every decision around it — the commands, which file each later pass reads,
+where the stems land, what a refusal looks like, what a rerun costs, and which of the two
+keys the opt-in flag belongs to — is verified with the CLI substituted. What no seam here
+can answer is whether audio-separator on the 4080 Super produces those models' stems at all,
+or that ``17_HP-Wind_Inst-UVR`` labels its halves the way ``WIND_STEMS`` spells them; that is
+the live tier, and it is why the fake writes real WAVs under the real naming convention
+rather than empty files.
 """
 
 from __future__ import annotations
@@ -22,14 +24,21 @@ import pytest
 from resolve_mcp.audio import separator
 from resolve_mcp.audio.acquire import audio_source
 from resolve_mcp.audio.stems import (
+    DRUM_PASS,
     DRUM_STEMS,
     FOUR_STEMS,
     KIND,
+    MIX_PASS,
+    OTHER_PASS,
+    PASS_TWO_CEILING,
+    SEPARATED,
     SEPARATION,
+    WIND_KEYS,
+    WIND_STEMS,
     acquired,
+    multi_pass,
     separate_stems,
     separation_params,
-    two_pass,
 )
 from resolve_mcp.config import Config, get_config, set_config
 from resolve_mcp.errors import InvalidRequestError, StemSeparationError
@@ -38,6 +47,7 @@ from resolve_mcp.ffmpeg import Runner as FfmpegRunner
 from resolve_mcp.jobs import cache
 from resolve_mcp.jobs.runner import Progress, wait_for
 from resolve_mcp.resolve.connection import get_connection
+from resolve_mcp.tools import stems as stems_tool
 
 from .conftest import Attach
 from .fakes import (
@@ -64,6 +74,17 @@ def fixture_audio(tmp_path: Path) -> Path:
 def separating() -> FakeSeparator:
     """A separator that produces four stems on the first pass and six drums on the second."""
     return FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS)
+
+
+@pytest.fixture
+def splitting() -> FakeSeparator:
+    """The same, plus the third pass's two halves — for the runs that ask for the wind split.
+
+    Kept apart from ``separating`` rather than folded into it because the fake hands out its
+    passes by call number: a two-pass run against a three-pass fake would be given the wind
+    labels on its next first pass.
+    """
+    return FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, WIND_STEMS)
 
 
 # --- the two passes ----------------------------------------------------------------------
@@ -155,6 +176,183 @@ def test_the_stems_of_both_passes_are_kept_apart_on_disk(
     assert drum_stem.exists()
 
 
+# --- the opt-in third pass -----------------------------------------------------------------
+
+
+def test_the_wind_pass_does_not_run_unless_it_is_asked_for(
+    attach: Attach,
+    separating: FakeSeparator,
+) -> None:
+    """#126: on a band with no piano the split recovers nothing, so it is not free to run.
+
+    ``other`` is already the wind candidate there, and an unconditional third pass would buy
+    that nothing with minutes of compute on every job.
+    """
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
+
+    record = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    assert record.state == "completed", record.error
+    assert len(separating.calls) == 2
+    assert record.result is not None
+    assert OTHER_PASS not in record.result
+    assert set(record.result["models"]) == {"stems", "drums"}
+
+
+def test_the_other_stem_is_what_the_third_pass_splits(
+    attach: Attach,
+    splitting: FakeSeparator,
+) -> None:
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
+    config = get_config()
+
+    record = wait_for(
+        separate_stems(get_connection(), runner=splitting, split_wind=True)["job_id"]
+    )
+
+    assert record.state == "completed", record.error
+    assert len(splitting.calls) == 3
+    assert record.result is not None
+    assert record.result["stems"]["other"] == splitting.calls[2][1]
+    assert _flag(splitting.calls[2], "--model_filename") == config.wind_model
+    assert record.result["models"]["other"] == config.wind_model
+    assert set(record.result[OTHER_PASS]) == set(WIND_KEYS.values())
+    assert all(Path(one).exists() for one in record.result[OTHER_PASS].values())
+
+
+def test_the_third_pass_writes_beside_the_other_two_not_into_them(
+    attach: Attach,
+    splitting: FakeSeparator,
+) -> None:
+    """The same rule pass two follows: a model that relabels its input must not land on it."""
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
+
+    record = wait_for(
+        separate_stems(get_connection(), runner=splitting, split_wind=True)["job_id"]
+    )
+
+    assert record.result is not None
+    directory = Path(record.result["directory"])
+    wind = Path(record.result[OTHER_PASS]["wind"])
+    assert wind.parent == directory / OTHER_PASS
+    assert wind.parent not in {directory / MIX_PASS, directory / DRUM_PASS}
+    assert Path(record.result["stems"]["other"]).exists()
+
+
+def test_the_residual_half_is_never_offered_as_a_piano_stem(
+    attach: Attach,
+    splitting: FakeSeparator,
+) -> None:
+    """#126: ``No Woodwinds`` is piano *plus* guitar, vibes, percussion and leaked bass.
+
+    On a bass-weak capture it is mostly the bass line, so the one name it must not carry is
+    the one an agent would reach for. The tool's own docstring is where an agent learns that,
+    which makes it part of the envelope rather than a comment.
+    """
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
+
+    record = wait_for(
+        separate_stems(get_connection(), runner=splitting, split_wind=True)["job_id"]
+    )
+
+    assert record.result is not None
+    assert "piano" not in record.result[OTHER_PASS]
+    assert WIND_KEYS["no woodwinds"] == "comp"
+    described = stems_tool.separate_stems.__doc__ or ""
+    assert "not a piano stem" in described
+    assert "bass" in described
+
+
+def test_a_wind_model_that_leaves_a_half_out_fails_naming_it(attach: Attach) -> None:
+    """The drum pass's shape: a model that renames its output is a named failure, not a gap."""
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
+    partial = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, ("woodwinds",))
+
+    record = wait_for(separate_stems(get_connection(), runner=partial, split_wind=True)["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] == "stem_separation_failed"
+    assert "no woodwinds" in record.error["cause"]
+    assert record.error["detail"]["produced"] == ["woodwinds"]
+
+
+def test_the_flag_keys_the_job_while_the_model_keys_the_stems(
+    attach: Attach,
+    separating: FakeSeparator,
+    splitting: FakeSeparator,
+) -> None:
+    """Both halves of where the third pass lives in the two keys.
+
+    The flag is a job param, or the run that asks for the wind pass is handed the cached
+    two-pass answer and never runs anything. It is *not* a stems-key param, or turning it on
+    would separate the same audio into a second directory and orphan the first.
+    """
+    attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
+    two = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+
+    three = separate_stems(get_connection(), runner=splitting, split_wind=True)
+
+    assert three["cached"] is False
+    record = wait_for(three["job_id"])
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    assert two.result is not None
+    assert record.result["directory"] == two.result["directory"]
+    assert separation_params()["wind_model"] == get_config().wind_model
+    assert separation_params()["wind_stems"] == list(WIND_STEMS)
+
+
+def test_a_two_pass_result_on_disk_does_not_read_as_complete_when_the_wind_pass_is_on(
+    tmp_path: Path,
+    separating: FakeSeparator,
+    splitting: FakeSeparator,
+) -> None:
+    """A directory missing the pass this run wants is partial, and partial is redone whole."""
+    audio = _acquired(tmp_path)
+    multi_pass(audio, _params(), _ignored, runner=separating)
+
+    output = multi_pass(audio, _params(), _ignored, runner=splitting, split_wind=True)
+
+    assert output.result["reused"] is False
+    assert len(splitting.calls) == 3
+    assert set(output.result[OTHER_PASS]) == set(WIND_KEYS.values())
+
+
+def test_a_two_pass_result_on_disk_is_complete_when_the_wind_pass_is_off(
+    tmp_path: Path,
+    splitting: FakeSeparator,
+    separating: FakeSeparator,
+) -> None:
+    """The other half: a run that never wanted the third pass must not redo the first two.
+
+    Both directions matter because the two shapes share a directory — the reuse check has to
+    read completeness off what this run asked for, not off what happens to be on disk.
+    """
+    audio = _acquired(tmp_path)
+    multi_pass(audio, _params(), _ignored, runner=splitting, split_wind=True)
+
+    output = multi_pass(audio, _params(), _ignored, runner=separating)
+
+    assert output.result["reused"] is True
+    assert separating.calls == []
+    assert OTHER_PASS not in output.result
+
+
+def test_a_three_pass_result_is_reused_whole(
+    tmp_path: Path,
+    splitting: FakeSeparator,
+) -> None:
+    audio = _acquired(tmp_path)
+    first = multi_pass(audio, _params(), _ignored, runner=splitting, split_wind=True)
+
+    again = multi_pass(audio, _params(), _ignored, runner=splitting, split_wind=True)
+
+    assert len(splitting.calls) == 3
+    assert again.result["reused"] is True
+    assert again.result[OTHER_PASS] == first.result[OTHER_PASS]
+
+
 # --- progress ----------------------------------------------------------------------------
 
 
@@ -168,13 +366,42 @@ def test_progress_climbs_through_both_passes(tmp_path: Path) -> None:
         output=("  0%|          | 0/10", " 50%|#####     | 5/10", "100%|##########| 10/10"),
     )
 
-    two_pass(audio, {"scope": "clip"}, _recording(steps), runner=separating)
+    multi_pass(audio, {"scope": "clip"}, _recording(steps), runner=separating)
 
     assert [fraction for fraction, _ in steps] == sorted(fraction for fraction, _ in steps)
     first = [step for fraction, step in steps if "50%" in step]
     assert any("four stems" in step for step in first)
     assert any("drum" in step for _, step in steps)
     assert steps[-1][0] == pytest.approx(0.95, abs=0.05)
+    assert max(fraction for fraction, step in steps if "drum" in step) == pytest.approx(SEPARATED)
+
+
+def test_progress_climbs_through_three_passes_without_moving_where_the_last_one_ends(
+    tmp_path: Path,
+) -> None:
+    """The third pass splits the back half rather than extending past it.
+
+    Whichever pass is last has to finish where the bar's separation phase always finishes, or
+    the cheaper two-pass job would sit at a number that reads as unfinished while it is done.
+    """
+    steps: list[tuple[float, str]] = []
+    splitting = FakeSeparator(
+        FOUR_STEMS,
+        SIX_DRUM_STEMS,
+        WIND_STEMS,
+        output=("  0%|          | 0/10", " 50%|#####     | 5/10", "100%|##########| 10/10"),
+    )
+
+    multi_pass(_acquired(tmp_path), _params(), _recording(steps), split_wind=True, runner=splitting)
+
+    assert [fraction for fraction, _ in steps] == sorted(fraction for fraction, _ in steps)
+    winds = [fraction for fraction, step in steps if "wind" in step]
+    assert winds
+    assert min(winds) >= PASS_TWO_CEILING
+    assert max(winds) == pytest.approx(SEPARATED)
+    assert max(fraction for fraction, step in steps if "drum" in step) == pytest.approx(
+        PASS_TWO_CEILING
+    )
 
 
 def test_the_model_downloads_own_bar_is_not_this_passs_progress(tmp_path: Path) -> None:
@@ -194,7 +421,7 @@ def test_the_model_downloads_own_bar_is_not_this_passs_progress(tmp_path: Path) 
         ),
     )
 
-    two_pass(_acquired(tmp_path), _params(), _recording(steps), runner=downloading)
+    multi_pass(_acquired(tmp_path), _params(), _recording(steps), runner=downloading)
 
     first = [fraction for fraction, step in steps if "four stems" in step]
     assert first == [pytest.approx(0.32)]  # 20% of the pass one slice, and nothing before it
@@ -248,9 +475,9 @@ def test_the_same_audio_under_a_new_fingerprint_reuses_the_stems_on_disk(
 ) -> None:
     """The directory is keyed by content, so an edit that did not change the mix is free."""
     audio = _acquired(tmp_path)
-    two_pass(audio, {"scope": "timeline"}, _ignored, runner=separating)
+    multi_pass(audio, {"scope": "timeline"}, _ignored, runner=separating)
 
-    output = two_pass(audio, {"scope": "timeline"}, _ignored, runner=separating)
+    output = multi_pass(audio, {"scope": "timeline"}, _ignored, runner=separating)
 
     assert len(separating.calls) == 2
     assert output.result["reused"] is True
@@ -263,9 +490,9 @@ def test_where_the_audio_came_from_is_not_part_of_the_stems_key(
 ) -> None:
     """A renamed timeline is the same audio; separating it again would pay the GPU twice."""
     audio = _acquired(tmp_path)
-    first = two_pass(audio, _params(timeline="sunset-set v3"), _ignored, runner=separating)
+    first = multi_pass(audio, _params(timeline="sunset-set v3"), _ignored, runner=separating)
 
-    renamed = two_pass(audio, _params(timeline="sunset-set v4"), _ignored, runner=separating)
+    renamed = multi_pass(audio, _params(timeline="sunset-set v4"), _ignored, runner=separating)
 
     assert renamed.result["directory"] == first.result["directory"]
     assert renamed.result["reused"] is True
@@ -283,10 +510,10 @@ def test_a_different_model_is_a_different_stems_key(
     than no key at all.
     """
     audio = _acquired(tmp_path)
-    first = two_pass(audio, separation_params(), _ignored, runner=separating)
+    first = multi_pass(audio, separation_params(), _ignored, runner=separating)
 
     set_config(_configured(tmp_path, stem_model="htdemucs_6s.yaml"))
-    other = two_pass(audio, separation_params(), _ignored, runner=separating)
+    other = multi_pass(audio, separation_params(), _ignored, runner=separating)
 
     assert other.result["directory"] != first.result["directory"]
     assert len(separating.calls) == 4


### PR DESCRIPTION
Closes #153.

Adds the third separation pass: `17_HP-Wind_Inst-UVR.pth` over the `other` stem, splitting it
into a wind stem and a residual. Off unless a caller asks for it.

## What changed

- `config.py` — `wind_model`, `DEFAULT_WIND_MODEL`, `RESOLVE_MCP_WIND_MODEL`, mirroring
  `drum_model`.
- `audio/stems.py` — `WIND_STEMS` (the labels the model writes), `WIND_KEYS` (the envelope's
  names for them), `OTHER_SOURCE`, `OTHER_PASS`; a `split_wind` parameter on the worker and the
  starter; a third `separator.separate()` writing into `<directory>/other`.
- `tools/stems.py` — `split_wind` reaches the MCP tool, with a docstring that says what `comp`
  actually contains.
- `CONTEXT.md`, `README.md`, and the two consumer docstrings in `analysis/` that described a
  separation as writing exactly two directories.

## The three constraints from #126

**Opt-in.** `split_wind=False` by default. With it off nothing about the envelope changes: no
`other` key, no third entry in `models`, two separator calls.

**The residual is `comp`, never `piano`.** #153's own proposal. `WIND_KEYS`, the tool docstring
and the CONTEXT.md glossary all state that it is piano *plus* guitar, vibes, percussion and
whatever bass leaked through — mostly the bass line on a bass-weak capture.

**Nothing assumes a populated `bass`.** Nothing new reads that stem.

## The cache key moves — existing stems re-separate once

`separation_params()` gains `wind_model` and `wind_stems` **unconditionally**, so every stems
directory currently on disk has a new key and re-separates on its next run. Deliberate: the key
says which models these stems could have come from, and leaving the name out when the pass is
off would let a changed `wind_model` be silently ignored by every directory separated before it
was turned on.

Where the two keys differ: the *model* keys the stems, the *flag* keys the job. Both shapes land
in one stems directory rather than separating the same audio twice — so completeness depends on
what a run asked for, and a two-pass directory reads as complete with the pass off and partial
with it on. Partial is redone whole, as it already was: turning the flag on for audio already
separated re-runs passes one and two too.

## Seam

Fake tier, `tests/test_stem_separation.py` — the pass wiring and its model, the flag on and off,
reuse in both shapes plus the on-then-off direction, the envelope's key naming, the missing-stem
failure, and which of the two keys the flag belongs to. `tests/test_config.py` covers the env
override. No measurement AC and no quality AC: #126 settled the model by ear, and measurements
went 0-for-3 against them on this pillar.

One thing no fake can check is whether `17_HP-Wind_Inst-UVR.pth` is a name audio-separator
resolves and whether it spells its halves the way `WIND_STEMS` does. Verified directly against
the real CLI on this box (RTX 4080 SUPER, audio-separator 0.44.5, Python 3.12), which downloaded
the model and wrote:

```
probe_(Woodwinds)_17_HP-Wind_Inst-UVR.wav
probe_(No Woodwinds)_17_HP-Wind_Inst-UVR.wav
```

→ labels `woodwinds` / `no woodwinds`, which is what `WIND_STEMS` says. The live smoke test that
asserts this (`test_the_real_separator_produces_the_stems_the_passes_expect`) **skipped**:
Resolve was not running, and the live tier's autouse fixture gates the whole module on it. It is
listed under Needs from you on the ticket.

Fake tier green, mypy strict clean, ruff clean.

## Not in scope

Switching `analysis/solos.py` from the `other` residual to the wind stem — #153 excludes it
explicitly ("analysis work with its own acceptance criteria"), and it is the reason this pass is
worth having. Absent that consumer this ships WAVs nobody reads yet.

## Review

`/code-review` against `main`, two axes in parallel sub-agents.

**Standards — 7 findings, all fixed or answered:**

1. *README's tool row still said "Two-pass"* — fixed.
2. *CONTEXT.md's map half updated, glossary half not; `wind`/`comp` are new domain terms* —
   fixed, glossary entry added with the never-a-piano-stem rule.
3. *`PASS_TWO_CEILING` no longer names where pass two ends (with the flag off it ends at
   `SEPARATED`); it is a hand-over point* — fixed, renamed `WIND_FLOOR`.
4. *`wind`-named locals sitting on `OTHER_PASS`-named directories, both vocabularies on one
   line* — fixed: locals follow the pass they decompose (`other_dir`, `other`), constants keep
   the model's vocabulary (`WIND_STEMS`, `WIND_KEYS`).
5. *`WIND_KEYS.get(name, name)` silently passes an unmapped label through* — fixed. Only the two
   mapped halves reach the envelope; a raw model label leaking out of a reused directory is
   worse than a file left on disk.
6. *Three near-identical `separator.separate()` calls; the per-pass arguments want a record* —
   not taken. Three calls, one of them conditional and none of them looped; a pass record here
   buys indirection over a shape that is still readable top to bottom.
7. *`test_the_residual_half_is_never_offered_as_a_piano_stem` asserted
   `WIND_KEYS["no woodwinds"] == "comp"`, which only restates the constant* — dropped. The
   docstring assertions stay: the tool docstring is where an agent learns what `comp` holds, so
   it is part of the envelope.

**Spec — 4 findings:**

1. *`separate_stems()`'s docstring said asking for the pass on already-separated audio "runs
   that pass alone"; it does not* — fixed. Every other docstring, the commit message and the
   test already said partial is redone whole.
2. *The cache-key AC is unmet until the PR body carries it* — carried above.
3. *`analysis/fills.py` and `analysis/phrases.py` still described a separation as writing
   exactly two directories* — fixed.
4. *The live smoke test now downloads a third model and must be run and recorded, not merged
   unrun* — the label claim it exists to check is verified above; the test itself skipped
   because Resolve was down, and that is on the ticket.

All eight of #153's acceptance criteria are met.

Review: clean
