### PR TITLE
Solo changes: read the wind stem, not the other residual

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,7 +46,9 @@ timelines. The server measures; Claude decides.
   (#153). `wind` is horns and reeds; `comp` is accompaniment — piano,
   guitar, vibes, percussion, and the bass line itself on a capture whose
   `bass` stem came back near-silent (#126). `comp` is **never** a piano
-  stem and nothing may name it one.
+  stem and nothing may name it one. Where both are on disk they replace
+  `other` as voices in `solos` — `other` *is* their sum, and measuring all
+  three counts the residual twice (#157).
 - **phrase** — the cut-placement unit (#46, `styles/concert.md` §1): a
   stretch of the soloist's line between two endings. `analysis/phrases.py`
   reports the **boundaries**, each with two times — `measured_t`, where the
@@ -103,8 +105,11 @@ is a rule layer over, as `drums` is to `fills`), `music` (beats + energy + gist
 job), `phrases` (phrase boundaries: where the soloist stops, which is the
 cut-placement unit #46 named, #143),
 `records` (sliceable record files), `silence` (RMS spans), `solos` (front
-of band changes), `structure` (tunes + solo changes job; both halves read the
-shared beats half), `transcribe`
+of band changes: lead off the stem energy, timbre off one stem's brightness —
+with the third pass on disk the voices are `wind`/`comp` rather than `other`
+and timbre reads `wind`, #157), `structure` (tunes + solo changes job; both
+halves read the shared beats half; its stem loader is what reaches the third
+pass), `transcribe`
 (job), `transcript` (document + Word/Transcription/Transcriber vocabulary),
 `virtual` (a cut file read back as the words it will contain — the P4
 self-review, warnings only, touches no Resolve handle), `whisper`

--- a/src/resolve_mcp/analysis/solos.py
+++ b/src/resolve_mcp/analysis/solos.py
@@ -9,9 +9,16 @@ Two signals, because a jazz set hands the tune over in two different ways:
 
 * **Across the stems.** The vocal takes it, then the horns; the bass takes a chorus. That
   is one stem lifting while the others sit, and it is read off the four energy curves.
-* **Inside the residual.** Tenor out, piano in — both live in ``other``, the energy barely
-  moves, and the only thing that changes is the timbre. That is a step in the residual
-  stem's brightness, and it is the reason this module reads the residual twice.
+* **Inside one stem.** Tenor out, piano in — both live in ``other``, the energy barely
+  moves, and the only thing that changes is the timbre. That is a step in that stem's
+  brightness, and it is the reason this module reads one stem twice.
+
+The optional third separation pass (#153) moves the line between the two. With it, the horns
+live in ``wind`` and the piano in ``comp``, so tenor-out/piano-in is an energy handover like
+any other and the first signal reports it — named at both ends, with a margin in dB, which
+brightness cannot say. The second signal then reads ``wind`` rather than ``other``, where a
+step is one horn giving way to another instead of a horn giving way to a piano. Without the
+pass both stay as they were, and ``other`` is read twice.
 
 The measurement that makes the first signal work is **prominence over a stem's own quiet
 baseline**, not its level. Drums are the loudest stem in almost every mix and are almost
@@ -35,6 +42,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 import numpy as np
 from numpy.typing import NDArray
 
+from ..audio.stems import COMP, WIND
 from . import beats as beats_module
 
 if TYPE_CHECKING:  # pragma: no cover - the worker imports these when it runs
@@ -55,6 +63,9 @@ RANGE_DB = 40.0
 
 RESIDUAL = "other"
 """The stem the horns and the piano land in — everything no model has a stem for."""
+
+SPLIT = (WIND, COMP)
+"""What the residual comes back as when the third pass ran: the two halves it was split into."""
 
 LEAD = "lead"
 TIMBRE = "timbre"
@@ -87,7 +98,7 @@ class Run(NamedTuple):
 
 
 class Step(NamedTuple):
-    """A step in the residual stem's brightness — a handover inside one stem."""
+    """A step in one stem's brightness — a handover inside that stem. See ``timbre_stem``."""
 
     seconds: float
     before: float
@@ -110,6 +121,31 @@ class Change(NamedTuple):
     detail: float
 
 
+def measured(stems: Mapping[str, Path]) -> dict[str, Path]:
+    """Which of the stems on offer are read as voices — every one, bar a residual counted twice.
+
+    ``other`` **is** ``wind`` plus ``comp`` (#153). Measure all three and the residual is in
+    the set twice over: the sum sits above either of its own halves in nearly every window,
+    takes the front off both, and masks the wind↔comp handover the split exists to expose.
+    So when both halves are there the residual leaves, and when they are not it stays.
+
+    Both halves or neither. One half alone is a partial pass, and dropping ``other`` for it
+    would leave the piano in no measured stem at all.
+    """
+    split = all(name in stems for name in SPLIT)
+    return {name: path for name, path in stems.items() if not (split and name == RESIDUAL)}
+
+
+def timbre_stem(stems: Mapping[str, Path]) -> str | None:
+    """Which stem the brightness is read off — ``wind`` if the third pass ran, else ``other``.
+
+    Read off ``wind``, a step is one horn giving way to another, because that stem holds one
+    instrument family. Read off ``other``, it is anything at all that changed in the room.
+    ``None`` when neither stem was separated: there is nothing to read.
+    """
+    return next((name for name in (WIND, RESIDUAL) if name in stems), None)
+
+
 def voices(
     stems: Mapping[str, Path],
     window_seconds: float = DEFAULT_WINDOW_SECONDS,
@@ -121,14 +157,19 @@ def voices(
     of audio and a handover inside it moves both curves from the moment it happens, so the
     window where one stem passes the other is the window straddling the change — dating it
     by its leading edge would report every solo change half a window early, every time.
+
+    Which stems those are is ``measured``'s decision, applied here rather than left to the
+    caller: a stem set that reaches this function unfiltered reads a gigabyte of WAV to
+    produce a curve that then quietly wrecks the answer.
     """
     from . import decode
     from . import energy as energy_module
 
     middle = window_seconds / 2.0
     found: list[Voice] = []
-    for name in sorted(stems):
-        curve = energy_module.curve(decode.read(stems[name]), window_seconds, hop_seconds)
+    reading = measured(stems)
+    for name in sorted(reading):
+        curve = energy_module.curve(decode.read(reading[name]), window_seconds, hop_seconds)
         found.append(
             Voice(
                 name=name,
@@ -348,6 +389,7 @@ def changes(
     stepped: Sequence[Step] = (),
     together_seconds: float = DEFAULT_WINDOW_SECONDS,
     opened: float = 0.0,
+    stem: str = RESIDUAL,
 ) -> tuple[Change, ...]:
     """Every point where the front changed, from both signals, each event reported once.
 
@@ -355,11 +397,17 @@ def changes(
     measurement opened in, and ``opened`` is when that was, so a set that starts mid-solo
     reports its first *change* rather than its first soloist.
 
-    A stem taking the front and the residual's timbre stepping at the same moment is one
-    event seen twice — the horn leaving ``other`` is why the vocal is now clear of it — so
-    the timbre reading is dropped when a lead change is already within ``together_seconds``.
+    ``stem`` is the stem the brightness was read off, and it is what a timbre change names
+    at both ends: the handover is inside that one stem. It defaults to the residual because
+    that is what there is to read without the third pass, but it is never assumed — naming
+    ``other`` on a reading taken off ``wind`` is a record that says the wrong thing.
+
+    A stem taking the front and that stem's timbre stepping at the same moment is one event
+    seen twice — the horn leaving ``other`` is why the vocal is now clear of it — so the
+    timbre reading is dropped when a lead change is already within ``together_seconds``. The
+    lead reading is the one worth keeping: it names both stems and carries a margin in dB.
     Only against the lead changes: two timbre steps close together are two handovers inside
-    the residual, and ``steps`` has already decided how close two of those may be.
+    the one stem, and ``steps`` has already decided how close two of those may be.
     """
     found = [
         Change(
@@ -381,8 +429,8 @@ def changes(
             measured=one.seconds,
             downbeat=False,
             signal=TIMBRE,
-            left=RESIDUAL,
-            entered=RESIDUAL,
+            left=stem,
+            entered=stem,
             detail=one.semitones,
         )
         for one in stepped

--- a/src/resolve_mcp/analysis/solos.py
+++ b/src/resolve_mcp/analysis/solos.py
@@ -56,7 +56,7 @@ DEFAULT_MARGIN_DB = 3.0
 """How far clear of the next stem a stem has to be before it is out front rather than level."""
 DEFAULT_SNAP_SECONDS = 2.0
 DEFAULT_SEMITONES = 4.0
-"""How far the residual's brightness has to step before it is a different instrument."""
+"""How far the read stem's brightness has to step before it is a different instrument."""
 
 QUIET_PERCENTILE = 5.0
 RANGE_DB = 40.0
@@ -271,7 +271,7 @@ def brightness(
     window_seconds: float = DEFAULT_WINDOW_SECONDS,
     hop_seconds: float = DEFAULT_HOP_SECONDS,
 ) -> tuple[tuple[float, ...], tuple[float, ...]]:
-    """The residual stem's spectral centroid per window, in hertz — its brightness curve.
+    """One stem's spectral centroid per window, in hertz — its brightness curve.
 
     Short frames averaged into the analysis window rather than one transform per window: a
     four-second FFT of a concert is both slow and smeared, and what is wanted is the timbre

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -191,7 +191,8 @@ def _stems(stems: str | Path | None, solos: bool) -> dict[str, Path]:
     That job writes each pass into its own directory, so the path it hands back holds the
     four stems one level down; both that path and the pass directory itself are accepted,
     because an agent reading the job record has one and an agent looking at the disk has
-    the other.
+    the other. The opt-in third pass sits beside the first, and comes along when it is
+    there — see ``_wind``.
     """
     if not solos:
         return {}
@@ -206,7 +207,8 @@ def _stems(stems: str | Path | None, solos: bool) -> dict[str, Path]:
         )
     directory = Path(stems)
     inner = directory / stems_module.MIX_PASS
-    found = separator.collect(inner if inner.is_dir() else directory)
+    passes = inner.is_dir()
+    found = separator.collect(inner if passes else directory)
     if not found:
         raise InvalidRequestError(
             cause=f"There are no separated stems in {directory}.",
@@ -216,7 +218,36 @@ def _stems(stems: str | Path | None, solos: bool) -> dict[str, Path]:
             ),
             detail={"requested": str(directory)},
         )
+    found.update(_wind(directory, passes))
     return found
+
+
+def _wind(directory: Path, passes: bool) -> dict[str, Path]:
+    """The third pass's two halves under their envelope names — nothing, if it never ran.
+
+    That pass writes a sibling of the mix pass (#153), so it is reached from whichever of
+    the two accepted directories was given: the job's own directory holds it directly, and
+    the mix pass directory holds it one level up. Anywhere else there is no pass layout to
+    read, and a directory of loose stems gets nothing.
+
+    Both halves or neither, and only the two names the envelope knows. One half alone is a
+    partial pass, and it would join a voice set that still holds ``other`` — the residual
+    measured twice over, which is the one way this change reads worse than no change.
+    """
+    if passes:
+        outer = directory / stems_module.OTHER_PASS
+    elif directory.name == stems_module.MIX_PASS:
+        outer = directory.parent / stems_module.OTHER_PASS
+    else:
+        return {}
+    if not outer.is_dir():
+        return {}
+    halved = {
+        stems_module.WIND_KEYS[name]: path
+        for name, path in separator.collect(outer).items()
+        if name in stems_module.WIND_KEYS
+    }
+    return halved if len(halved) == len(stems_module.WIND_KEYS) else {}
 
 
 def _stem_identity(found: Mapping[str, Path], config: Config) -> dict[str, Any]:
@@ -226,6 +257,11 @@ def _stem_identity(found: Mapping[str, Path], config: Config) -> dict[str, Any]:
     audio they came from and the models that made them, so the name *is* the identity and
     reading a gigabyte of WAV back to learn what it already says would be waste. Stems from
     anywhere else are fingerprinted one by one, because nothing about the name is known.
+
+    The third pass does not change that directory name — the flag keys the stems job, not
+    the stems (#153) — so on the named branch it is ``names`` that separates a wind run
+    from a residual run, and on the other branch the two extra fingerprints. Both branches
+    key the split apart from the unsplit; neither is served the other's cached record.
     """
     if not found:
         return {}
@@ -458,12 +494,17 @@ def _solos(
     hop = float(shape["hop_seconds"])
     minimum = float(shape["solo_seconds"])
 
-    voices = solos_module.voices(stems, window, hop)
+    measured = solos_module.measured(stems)
+    read = solos_module.timbre_stem(stems)
+    voices = solos_module.voices(measured, window, hop)
     runs = solos_module.runs(voices, float(shape["margin_db"]), minimum)
-    stepped = _timbre(stems, window, hop, minimum, float(shape["semitones"]))
+    stepped = _timbre(stems, read, window, hop, minimum, float(shape["semitones"]))
     opened = voices[0].seconds[0] if voices and voices[0].seconds else 0.0
     changes = solos_module.snapped(
-        solos_module.changes(runs, stepped, window, opened),
+        # ``read`` names the stem a timbre change happened inside. It is only ever ``None``
+        # when there was nothing to read the brightness off, and then there are no steps to
+        # name, so the fallback is a label nothing wears rather than a wrong one.
+        solos_module.changes(runs, stepped, window, opened, read or solos_module.RESIDUAL),
         _downbeats(source, described, identity, detector, refresh, config),
         float(shape["snap_seconds"]),
     )
@@ -471,26 +512,36 @@ def _solos(
         **solos_module.gist(runs, changes),
         **shape,
         "stem_count": len(stems),
-        "residual": solos_module.RESIDUAL in stems,
+        # What was measured and where the timbre came from, because neither is inferable
+        # from the count: the same stems directory reads differently depending on whether
+        # the third pass ran, and a record that cannot say which one ran cannot be reviewed.
+        "voices": ", ".join(sorted(measured)),
+        "timbre_stem": read,
     }
-    log.info("Found %d solo changes across %d stems in %s", len(changes), len(stems), source.name)
+    log.info(
+        "Found %d solo changes across %d stems (timbre off %s) in %s",
+        len(changes),
+        len(measured),
+        read or "nothing",
+        source.name,
+    )
     return halves.written(target, SOLOS, described, gist, solos_module.numbered(changes))
 
 
 def _timbre(
     stems: Mapping[str, Path],
+    stem: str | None,
     window: float,
     hop: float,
     minimum: float,
     semitones: float,
 ) -> tuple[solos_module.Step, ...]:
-    """Brightness steps inside the residual stem — nothing, if there is no residual stem."""
+    """Brightness steps inside the stem ``timbre_stem`` picked — nothing, if it picked none."""
     from . import decode
 
-    residual = stems.get(solos_module.RESIDUAL)
-    if residual is None:
+    if stem is None:
         return ()
-    seconds, hertz = solos_module.brightness(decode.read(residual), window, hop)
+    seconds, hertz = solos_module.brightness(decode.read(stems[stem]), window, hop)
     return solos_module.steps(seconds, hertz, semitones, minimum)
 
 

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -207,8 +207,7 @@ def _stems(stems: str | Path | None, solos: bool) -> dict[str, Path]:
         )
     directory = Path(stems)
     inner = directory / stems_module.MIX_PASS
-    passes = inner.is_dir()
-    found = separator.collect(inner if passes else directory)
+    found = separator.collect(inner if inner.is_dir() else directory)
     if not found:
         raise InvalidRequestError(
             cause=f"There are no separated stems in {directory}.",
@@ -218,11 +217,11 @@ def _stems(stems: str | Path | None, solos: bool) -> dict[str, Path]:
             ),
             detail={"requested": str(directory)},
         )
-    found.update(_wind(directory, passes))
+    found.update(_wind(directory))
     return found
 
 
-def _wind(directory: Path, passes: bool) -> dict[str, Path]:
+def _wind(directory: Path) -> dict[str, Path]:
     """The third pass's two halves under their envelope names — nothing, if it never ran.
 
     That pass writes a sibling of the mix pass (#153), so it is reached from whichever of
@@ -234,7 +233,7 @@ def _wind(directory: Path, passes: bool) -> dict[str, Path]:
     partial pass, and it would join a voice set that still holds ``other`` — the residual
     measured twice over, which is the one way this change reads worse than no change.
     """
-    if passes:
+    if (directory / stems_module.MIX_PASS).is_dir():
         outer = directory / stems_module.OTHER_PASS
     elif directory.name == stems_module.MIX_PASS:
         outer = directory.parent / stems_module.OTHER_PASS
@@ -494,35 +493,41 @@ def _solos(
     hop = float(shape["hop_seconds"])
     minimum = float(shape["solo_seconds"])
 
-    measured = solos_module.measured(stems)
-    read = solos_module.timbre_stem(stems)
-    voices = solos_module.voices(measured, window, hop)
+    brightness_stem = solos_module.timbre_stem(stems)
+    voices = solos_module.voices(stems, window, hop)
     runs = solos_module.runs(voices, float(shape["margin_db"]), minimum)
-    stepped = _timbre(stems, read, window, hop, minimum, float(shape["semitones"]))
+    stepped = _timbre(stems, brightness_stem, window, hop, minimum, float(shape["semitones"]))
     opened = voices[0].seconds[0] if voices and voices[0].seconds else 0.0
     changes = solos_module.snapped(
-        # ``read`` names the stem a timbre change happened inside. It is only ever ``None``
-        # when there was nothing to read the brightness off, and then there are no steps to
-        # name, so the fallback is a label nothing wears rather than a wrong one.
-        solos_module.changes(runs, stepped, window, opened, read or solos_module.RESIDUAL),
+        # The stem a timbre change happened inside. It is only ever ``None`` when there was
+        # nothing to read the brightness off, and then there are no steps to name, so the
+        # fallback is a label nothing wears rather than a wrong one.
+        solos_module.changes(
+            runs, stepped, window, opened, brightness_stem or solos_module.RESIDUAL
+        ),
         _downbeats(source, described, identity, detector, refresh, config),
         float(shape["snap_seconds"]),
     )
+    # Off the voices that came back rather than the stems handed in: ``voices`` decides
+    # which stems are read (a residual whose two halves are on disk is not), and a gist
+    # that counted the directory instead would name one set and count another.
+    measured = tuple(one.name for one in voices)
     gist = {
         **solos_module.gist(runs, changes),
         **shape,
-        "stem_count": len(stems),
-        # What was measured and where the timbre came from, because neither is inferable
-        # from the count: the same stems directory reads differently depending on whether
-        # the third pass ran, and a record that cannot say which one ran cannot be reviewed.
-        "voices": ", ".join(sorted(measured)),
-        "timbre_stem": read,
+        "stem_count": len(measured),
+        # What was measured, and which stem the timbre came off, because neither is
+        # inferable from the rest: the same stems directory reads differently depending on
+        # whether the third pass ran, and a record that cannot say which one ran cannot be
+        # reviewed. A joined string, because a gist holds no lists.
+        "voices": ", ".join(measured),
+        "timbre_stem": brightness_stem,
     }
     log.info(
         "Found %d solo changes across %d stems (timbre off %s) in %s",
         len(changes),
         len(measured),
-        read or "nothing",
+        brightness_stem or "nothing",
         source.name,
     )
     return halves.written(target, SOLOS, described, gist, solos_module.numbered(changes))

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -80,7 +80,13 @@ DRUM_SOURCE = "drums"
 WIND_STEMS = ("woodwinds", "no woodwinds")
 """What the third pass asks its model for, in the labels that model writes them under."""
 
-WIND_KEYS = {"woodwinds": "wind", "no woodwinds": "comp"}
+WIND = "wind"
+"""Horns and reeds, once the third pass has taken them out of ``other``."""
+
+COMP = "comp"
+"""What is left of ``other`` after the winds go: accompaniment, and never a piano stem."""
+
+WIND_KEYS = {"woodwinds": WIND, "no woodwinds": COMP}
 """The envelope's names for the two halves of the third pass.
 
 ``no woodwinds`` is **not** a piano stem and nothing here may call it one. It is piano plus

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -95,12 +95,19 @@ def analyze_structure(
 
     solos=true adds the second half and needs stems: pass the directory a separate_stems
     job returned. It measures which stem is out front over its own quiet baseline, and
-    where the residual stem's brightness steps — one horn out, piano in, both inside
-    `other` — and writes one record per change point: where it is called, where it was
+    where one stem's brightness steps — a handover inside that stem, which energy cannot
+    see — and writes one record per change point: where it is called, where it was
     measured, whether it landed on a downbeat, and what handed over to what. Change points
     are snapped to the nearest downbeat within a couple of seconds, so this half reads the
     beat grid — analyze_music's if it exists, or it detects one and leaves it for that tool
     to reuse.
+
+    Which stems those are depends on what separate_stems wrote. With split_wind=true its
+    third pass is on disk, and then the voices are `wind` and `comp` rather than the
+    `other` they add up to, and the brightness is read off `wind`: one horn giving way to
+    another. Without it the voices include `other` and the brightness comes off `other`,
+    where a step is a horn giving way to a piano. The gist says which, in `voices` and
+    `timbre_stem`, so a record can be read back without guessing which run it was.
 
     Nothing here names the soloist: no separator ships a horn stem or a piano stem, so what
     is measured is that the front changed and when. threshold moves how sure the tagger has

--- a/tests/test_music_structure.py
+++ b/tests/test_music_structure.py
@@ -460,7 +460,7 @@ def test_the_solo_gist_says_what_it_measured_once_the_winds_are_their_own_stem(
 
     assert result["solos"]["timbre_stem"] == "wind"
     assert result["solos"]["voices"] == "comp, drums, vocals, wind"
-    assert result["solos"]["stem_count"] == 5
+    assert result["solos"]["stem_count"] == 4
     assert not any(isinstance(value, list) for value in result["solos"].values())
 
 

--- a/tests/test_music_structure.py
+++ b/tests/test_music_structure.py
@@ -23,6 +23,7 @@ from resolve_mcp.analysis import beats as beats_module
 from resolve_mcp.analysis import decode, music, structure
 from resolve_mcp.analysis import solos as solos_module
 from resolve_mcp.analysis.beats import BeatGrid
+from resolve_mcp.audio import stems as stems_module
 from resolve_mcp.config import get_config
 from resolve_mcp.jobs import store
 from resolve_mcp.jobs.runner import wait_for
@@ -145,9 +146,44 @@ def _stems(tmp_path: Path, seconds: float = 24.0) -> Path:
     return directory.parent
 
 
+def _third_pass(directory: Path, seconds: float = 24.0, half: bool = False) -> Path:
+    """The opt-in third pass beside the mix pass: ``other`` taken apart into wind and comp.
+
+    The two halves sum to the residual, which is the whole point of them — the horns take
+    the first chorus of the second half of the set and the piano the next, so the handover
+    that lived entirely inside ``other`` is now one stem falling as another lifts.
+
+    ``half`` writes only the winds: a pass that died between its two files.
+    """
+    outer = directory / stems_module.OTHER_PASS
+    middle = seconds / 2
+    third = middle + seconds / 4
+    write_wav(
+        outer / "concert_(Woodwinds)_model.wav",
+        seconds=seconds,
+        sample_rate=SAMPLE_RATE,
+        frequency=880.0,
+        silence=((0.0, middle), (third, seconds)),
+    )
+    if not half:
+        write_wav(
+            outer / "concert_(No Woodwinds)_model.wav",
+            seconds=seconds,
+            sample_rate=SAMPLE_RATE,
+            frequency=220.0,
+            silence=((0.0, third),),
+        )
+    return directory
+
+
 @pytest.fixture
 def stems(tmp_path: Path) -> Path:
     return _stems(tmp_path)
+
+
+@pytest.fixture
+def split_stems(tmp_path: Path) -> Path:
+    return _third_pass(_stems(tmp_path))
 
 
 @pytest.fixture
@@ -188,6 +224,68 @@ def _solos(audio: Path, stems: Path, **kwargs: Any) -> dict[str, Any]:
     }
     settings.update(kwargs)
     return _started(**settings)
+
+
+# --- which stems the job reads ------------------------------------------------------------
+
+
+def test_the_third_pass_halves_are_read_alongside_the_stems_from_the_first(
+    split_stems: Path,
+) -> None:
+    """The wind pass writes its own directory, so nothing sees it unless this reaches for it."""
+    found = structure._stems(split_stems, solos=True)
+
+    assert sorted(found) == ["comp", "drums", "other", "vocals", "wind"]
+
+
+def test_a_stems_directory_with_no_third_pass_reads_exactly_as_it_did(stems: Path) -> None:
+    found = structure._stems(stems, solos=True)
+
+    assert sorted(found) == ["drums", "other", "vocals"]
+
+
+def test_the_mix_pass_directory_reaches_the_third_pass_beside_it(split_stems: Path) -> None:
+    """An agent looking at the disk has the pass directory; the job record has its parent."""
+    found = structure._stems(split_stems / stems_module.MIX_PASS, solos=True)
+
+    assert sorted(found) == ["comp", "drums", "other", "vocals", "wind"]
+
+
+def test_half_a_third_pass_is_no_third_pass(tmp_path: Path) -> None:
+    """One half alone would join a voice set that still holds ``other`` — the residual twice."""
+    found = structure._stems(_third_pass(_stems(tmp_path), half=True), solos=True)
+
+    assert sorted(found) == ["drums", "other", "vocals"]
+
+
+def test_a_split_stem_set_is_keyed_apart_from_an_unsplit_one() -> None:
+    """The directory name is the same either way — the flag keys the job, not the stems (#153).
+
+    Stems this server separated are keyed by that name, so the names of the stems in it are
+    the only thing between a wind run and a residual run: without them the second run is
+    served the first one's cached record.
+    """
+    inside = _stems(get_config().stems_dir.parent)
+
+    plain = structure._stem_identity(structure._stems(inside, solos=True), get_config())
+    split = structure._stem_identity(
+        structure._stems(_third_pass(inside), solos=True), get_config()
+    )
+
+    assert "stems" in plain
+    assert plain["stems"] == split["stems"]
+    assert plain != split
+
+
+def test_stems_from_outside_this_server_are_keyed_apart_too(tmp_path: Path) -> None:
+    """The other branch of the same function: fingerprints, one per stem, not the name."""
+    loose = structure._stems(_third_pass(_stems(tmp_path / "elsewhere")), solos=True)
+    plain = {name: path for name, path in loose.items() if name not in solos_module.SPLIT}
+
+    split_identity = structure._stem_identity(loose, get_config())
+
+    assert "files" in split_identity
+    assert split_identity != structure._stem_identity(plain, get_config())
 
 
 # --- what lands on disk ----------------------------------------------------------------
@@ -345,7 +443,41 @@ def test_the_solo_gist_says_who_held_the_front_and_how_much_snapped(
     assert result["solos"]["snapped"] == 1
     assert result["solos"]["longest_lead"]["stem"] in {"vocals", "other"}
     assert result["solos"]["stem_count"] == 3
-    assert result["solos"]["residual"] is True
+    assert result["solos"]["timbre_stem"] == "other"
+    assert result["solos"]["voices"] == "drums, other, vocals"
+
+
+def test_the_solo_gist_says_what_it_measured_once_the_winds_are_their_own_stem(
+    solo_audio: Path,
+    split_stems: Path,
+) -> None:
+    """Which stems were voices and which one the brightness came off — a wind run from a not.
+
+    Without this the record cannot be read back: the same directory, the same job settings
+    and two different measurements, with nothing in the gist saying which one ran.
+    """
+    result = _result(_solos(solo_audio, split_stems))
+
+    assert result["solos"]["timbre_stem"] == "wind"
+    assert result["solos"]["voices"] == "comp, drums, vocals, wind"
+    assert result["solos"]["stem_count"] == 5
+    assert not any(isinstance(value, list) for value in result["solos"].values())
+
+
+def test_the_winds_handing_over_to_the_comp_is_a_lead_change_on_disk(
+    solo_audio: Path,
+    split_stems: Path,
+) -> None:
+    """The handover timbre used to be the only witness of, named at both ends and in dB."""
+    result = _result(_solos(solo_audio, split_stems, solo_seconds=4.0))
+
+    written = json.loads(Path(result["solos"]["path"]).read_text(encoding="utf-8"))
+    handover = [one for one in written["solos"] if {one["from"], one["to"]} == {"wind", "comp"}]
+
+    assert handover
+    assert handover[0]["signal"] == "lead"
+    assert handover[0]["detail"] > 0.0
+    assert "other" not in {one["to"] for one in written["solos"]}
 
 
 # --- what a rerun costs -----------------------------------------------------------------

--- a/tests/test_solo_changes.py
+++ b/tests/test_solo_changes.py
@@ -1,16 +1,21 @@
-"""Where the front of the band changes hands, from stem energy and residual timbre.
+"""Where the front of the band changes hands, from stem energy and one stem's timbre.
 
 No model says who is soloing — no separator ships a horn stem or a piano stem (#22). What
-exists is four stems and the arithmetic over them, so that is what is under test: which stem
-is out front over its own norm, when that changes, when the residual stem's brightness steps
-(one horn out, piano in, both inside ``other``), and where those change points land once
-they are snapped to the nearest downbeat.
+exists is the separated stems and the arithmetic over them, so that is what is under test:
+which stems are read as voices at all, which is out front over its own norm, when that
+changes, when the brightness of the stem timbre is read off steps (one horn out, another
+in), and where those change points land once snapped to the nearest downbeat.
+
+The third pass (#153) moves the line between the two signals, so the rules that decide
+which stems are measured and which one the brightness comes off are under test here too.
 
 The fixtures are curves rather than audio: the reading of a WAV is ``energy``'s business and
 is tested there. What can be got wrong here is the rules.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
 
 from resolve_mcp.analysis import solos
 
@@ -93,7 +98,70 @@ def test_stems_of_unequal_length_measure_over_what_they_share() -> None:
     assert found[-1].end == 22.0
 
 
+# --- which stems are measured at all ------------------------------------------------------
+
+
+def _stems(*names: str) -> dict[str, Path]:
+    """A stem set as the loader hands it over: names to files nothing here opens."""
+    return {name: Path(f"{name}.wav") for name in names}
+
+
+def test_the_residual_leaves_the_voice_set_once_both_its_halves_are_there() -> None:
+    """``other`` *is* ``wind`` plus ``comp``, so measuring all three counts it twice.
+
+    The sum sits above either half in nearly every window, takes the front off both, and
+    hides the one handover the split was built to see.
+    """
+    found = solos.measured(_stems("bass", "drums", "vocals", "other", "wind", "comp"))
+
+    assert sorted(found) == ["bass", "comp", "drums", "vocals", "wind"]
+
+
+def test_the_residual_is_measured_when_the_third_pass_never_ran() -> None:
+    found = solos.measured(_stems("bass", "drums", "vocals", "other"))
+
+    assert sorted(found) == ["bass", "drums", "other", "vocals"]
+
+
+def test_one_half_alone_does_not_take_the_residual_out_of_the_voice_set() -> None:
+    """Half a split is not a split: drop ``other`` for it and the other half goes unmeasured."""
+    found = solos.measured(_stems("drums", "other", "wind"))
+
+    assert sorted(found) == ["drums", "other", "wind"]
+
+
+def test_a_handover_between_the_winds_and_the_comp_is_a_lead_change() -> None:
+    """Tenor out, piano in — the change timbre used to be the only witness of.
+
+    With the two in separate stems it is an energy handover like any other: measured
+    against each stem's own quiet baseline, named at both ends, and snapped to the bar.
+    """
+    wind = _voice("wind", (-18.0, 12.0), (-30.0, 12.0))
+    comp = _voice("comp", (-30.0, 12.0), (-18.0, 12.0))
+
+    found = solos.snapped(solos.changes(_runs(wind, comp), ()), (11.6,), tolerance=2.0)
+
+    assert [(one.signal, one.left, one.entered) for one in found] == [
+        (solos.LEAD, "wind", "comp")
+    ]
+    assert found[0].detail > 0.0
+    assert (found[0].seconds, found[0].measured, found[0].downbeat) == (11.6, 12.0, True)
+
+
 # --- the residual stem's timbre ---------------------------------------------------------
+
+
+def test_the_timbre_signal_reads_the_wind_stem_when_the_third_pass_ran() -> None:
+    """A brightness step inside ``wind`` is tenor → trumpet: one family, not two."""
+    assert solos.timbre_stem(_stems("drums", "other", "wind", "comp")) == "wind"
+
+
+def test_the_timbre_signal_falls_back_to_the_residual() -> None:
+    assert solos.timbre_stem(_stems("drums", "vocals", "other")) == "other"
+
+
+def test_with_neither_stem_there_is_nothing_to_read_the_timbre_off() -> None:
+    assert solos.timbre_stem(_stems("drums", "vocals", "bass")) is None
 
 
 def test_a_step_in_brightness_is_a_change_inside_the_residual_stem() -> None:
@@ -182,6 +250,40 @@ def test_two_timbre_steps_close_together_are_both_reported() -> None:
     found = solos.changes((), stepped, together_seconds=4.0)
 
     assert [one.seconds for one in found] == [20.0, 22.0]
+
+
+def test_the_lead_change_is_the_one_kept_when_both_signals_fire_together() -> None:
+    """The winds falling as the comp lifts, and the winds' brightness stepping with it.
+
+    One handover seen twice, and the lead reading is the one worth keeping: it names both
+    stems and carries a margin in dB, neither of which a brightness step can say.
+    """
+    runs = _runs(
+        _voice("wind", (-18.0, 12.0), (-30.0, 12.0)),
+        _voice("comp", (-30.0, 12.0), (-18.0, 12.0)),
+    )
+    stepped = (solos.Step(12.0, 1_800.0, 600.0),)
+
+    found = solos.changes(runs, stepped, together_seconds=4.0, stem="wind")
+
+    assert [(one.signal, one.left, one.entered) for one in found] == [
+        (solos.LEAD, "wind", "comp")
+    ]
+
+
+def test_a_timbre_change_names_the_stem_it_was_measured_on() -> None:
+    """``other`` hardcoded here is a lie the moment the brightness came off ``wind``."""
+    found = solos.changes((), (solos.Step(20.0, 600.0, 1_500.0),), stem="wind")
+
+    assert [(one.left, one.entered) for one in found] == [("wind", "wind")]
+
+
+def test_a_timbre_change_still_names_the_residual_when_that_is_what_was_read() -> None:
+    found = solos.changes((), (solos.Step(20.0, 600.0, 1_500.0),))
+
+    assert [(one.left, one.entered) for one in found] == [
+        (solos.RESIDUAL, solos.RESIDUAL)
+    ]
 
 
 def test_change_records_name_what_left_and_what_took_over() -> None:


### PR DESCRIPTION
Closes #157.

#153 wrote `wind` and `comp` and nothing read them. Both halves of the ticket land here, because they share their plumbing and together they stop the module's two signals overlapping: lead now owns handovers *between* families, timbre owns handovers *within* the winds.

- `_stems()` reaches `<directory>/other` beside the mix pass and keys its two halves under the envelope's names. Both halves or neither — a half-written pass is no pass.
- `other` leaves the voice set when both halves are present. It *is* their sum, so measured beside them it sits above both in nearly every window and masks the wind↔comp handover. That handover is now a `lead` change: named at both ends, with a margin in dB, snapped like any other.
- The timbre signal reads `wind` when it is there and `other` when it is not, and a timbre `Change` names the stem it was measured on instead of hardcoding `other`.
- The gist replaces `"residual"` with `"voices"` and `"timbre_stem"` — which stems were measured, and which one the brightness came off.

**Seam: fake tier.** `tests/test_solo_changes.py` covers the rules (which stems are measured, which is read for timbre, what a timbre change names, which signal survives a collision — the lead reading, pinned). `tests/test_music_structure.py` covers the loader, both accepted directories, the half-pass case, the gist, the wind→comp change on disk, and that a split stem set keys apart from an unsplit one on **both** branches of `_stem_identity()`. Fake tier, mypy strict and ruff are green.

No measurement AC and no quality AC, per the ticket: whether `comp` earns its place as a voice or just shadows `bass` is a listening question, and #126 is the standing evidence that a metric asked to settle it settles it wrongly.

## Review

Two-axis review (Standards and Spec) run on the branch before this PR existed. Findings and what they got:

**Standards**
1. *Stale agent-facing prose* — `tools/analysis.py` still told a calling agent the timbre signal reads the residual, and said nothing about which stems become voices. **Fixed**: it now describes both runs and names the two new gist keys.
2. *Stale docstrings in the edited module* — `brightness()` and `DEFAULT_SEMITONES` still said "residual". **Fixed**.
3. *Duplicated "both halves or neither" across two modules* — `_wind` (loader) and `measured` (measurement). **Kept, deliberately**: they guard different failures. Without the loader gate a half pass yields `wind` alongside `other`, and `measured` would then measure the winds twice; without `measured` the sum is measured beside its own halves. Neither subsumes the other.
4. *The voice filter ran twice* — in `_solos` and again inside `voices()`, whose docstring says the decision is applied there rather than left to the caller. **Fixed**: one owner, `voices()`; `_solos` reads the names off what came back.
5. *`stem_count` contradicted `voices`* — 5 beside a set of 4. **Fixed**: both come off the voices.
6. *Names* — `read` for a stem name two lines from `decode.read`, and `_wind(directory, passes)` taking a flag its caller had already derived. **Fixed**: `brightness_stem`, and `_wind` reads the layout itself.
7. *`voices` as a comma-joined string* (primitive obsession) — **kept**: a gist holds no lists, which its own test asserts.
8. *`phrases.py` still pins `DEFAULT_STEM = solos.RESIDUAL`* — **out of scope by the ticket's own words**: "Phrase boundaries are a different question about the same stem and deserve their own ticket."

**Spec**
1. *"A stems directory with no third pass behaves exactly as it does today — no change to any existing record"* vs the ticket's own instruction to replace `"residual"`. The replacement is what the ticket asks for in "Where it lands in code", so the record does change shape on unsplit runs too. **Consequence worth knowing**: job records cached before this branch still carry `residual` and no `timbre_stem`/`voices`, because the cache key hashes inputs and settings, not the gist's shape. `refresh=true` re-runs them.
2. *`stem_count` did not match `voices`* — same as Standards 5. **Fixed**.
3. *Tool docstring* — same as Standards 1. **Fixed**.
4. *Filtering inside `voices()` as well as at the call site was more than the ticket located* — **resolved by consolidating**: the filter lives in `voices()` alone, so a stem set can no longer reach the measurement unfiltered.

Fix diff re-checked on its own; no new findings.

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
