### PR TITLE
fix(correlate): refuse a cut the beat grid does not reach (#160)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -91,10 +91,13 @@ Top level:
 `applause` (bursts → tune boundaries, then a beat-density floor drops the calls
 with no pulse under them, #133), `beats` (grid + downbeats, model
 injected per ADR 0002; `trust` says which beats the grid describes well enough
-to count, #112), `correlate` (measure a cut against its music — by default the *visible* edit,
+to count, #112; `spacing` says how wide a beat is at each beat), `correlate`
+(measure a cut against its music — by default the *visible* edit,
 every frame resolved to the topmost enabled video item with uncovered stretches
 as black shots, #142; `track=` measures one video track alone. Gates the beat
-statistics on `trust` and leaves the transient ones ungated), `cuda` (preloads
+statistics on `trust`, refuses as `stranded` a cut further from its beat than a
+beat is wide — the grid does not reach it, #160 — and leaves the transient ones
+ungated), `cuda` (preloads
 the CUDA runtime the `analysis` extra ships, so CTranslate2 finds it on Windows;
 pure decisions, #128),
 `decode` (WAV → numpy, no third-party decoder), `drums` (hits per stem), `energy`

--- a/src/resolve_mcp/analysis/beats.py
+++ b/src/resolve_mcp/analysis/beats.py
@@ -295,6 +295,25 @@ def _steady_flags(times: Sequence[float]) -> tuple[bool, ...]:
     )
 
 
+def spacing(times: Sequence[float]) -> tuple[float | None, ...]:
+    """How wide a beat is at each beat, in seconds — the local tempo, parallel to ``times``.
+
+    Public for the reason ``nearest`` is: more than one reading has to ask how far a beat is
+    around here, and two answers to that would be two grids. The steadiness check above judges
+    an interval against it; the cut side asks whether a cut sits further from its beat than a
+    beat is wide, which is how a cut the grid does not reach is told from one it does (#160).
+
+    Local rather than set-wide for the same reason the steadiness window is: a two-hour set
+    has tunes at different tempos, and a beat in the fast one is not half a beat of the slow
+    one. ``None`` where the grid cannot say — a lone beat has no interval, and inventing a
+    width for it would be a verdict rather than a reading.
+    """
+    intervals = [later - earlier for earlier, later in zip(times, times[1:], strict=False)]
+    if not intervals:
+        return tuple(None for _ in times)
+    return tuple(_local(intervals, min(index, len(intervals) - 1)) for index in range(len(times)))
+
+
 def _local(intervals: Sequence[float], index: int) -> float:
     """The tempo around one interval, as the median of the window it sits in."""
     start = max(0, index - STEADINESS_WINDOW // 2)

--- a/src/resolve_mcp/analysis/beats.py
+++ b/src/resolve_mcp/analysis/beats.py
@@ -211,12 +211,7 @@ def bar_line_strength(row: Mapping[str, Any] | None) -> float:
 
 def gist(grid: BeatGrid, records: Sequence[dict[str, Any]]) -> dict[str, Any]:
     """The stats worth returning inline: how many, how fast, and in what meter."""
-    intervals = [
-        later - earlier
-        for earlier, later in zip(grid.beats, grid.beats[1:], strict=False)
-        if later > earlier
-    ]
-    tempos = sorted(60.0 / interval for interval in intervals)
+    tempos = sorted(60.0 / one for one in _intervals(grid.beats) if one > 0)
     return {
         "count": len(grid.beats),
         "downbeat_count": sum(1 for record in records if record["downbeat"]),
@@ -275,13 +270,42 @@ def meter(records: Sequence[Mapping[str, Any]]) -> int | None:
     return statistics.mode(lengths) if lengths else None
 
 
+def spacing(times: Sequence[float]) -> tuple[float | None, ...]:
+    """How wide a beat is at each beat, in seconds — the local tempo, parallel to ``times``.
+
+    Public for the reason ``nearest`` is: more than one reading has to ask how far a beat is
+    around here, and two answers to that would be two grids. It reads the same window the
+    steadiness check judges an interval against; the cut side asks whether a cut sits further
+    from its beat than a beat is wide, which is how a cut the grid does not reach is told from
+    one it does (#160).
+
+    Local rather than set-wide for the same reason the steadiness window is: a two-hour set
+    has tunes at different tempos, and a beat in the fast one is not half a beat of the slow
+    one. A beat is read from the window of the interval that *follows* it, and the last beat
+    borrows the one before it — an asymmetry the steadiness check does not have, because that
+    check is looking for the interval that does not belong and needs both sides to convict,
+    while this one is only asking how fast the music runs around here and both sides answer
+    the same. ``None`` where the grid cannot say: a lone beat has no interval, and inventing a
+    width for it would be a verdict rather than a reading.
+    """
+    intervals = _intervals(times)
+    if not intervals:
+        return tuple(None for _ in times)
+    return tuple(_local(intervals, min(index, len(intervals) - 1)) for index in range(len(times)))
+
+
+def _intervals(times: Sequence[float]) -> list[float]:
+    """The grid as the gaps between its beats — the one form every reading here is taken over."""
+    return [later - earlier for earlier, later in zip(times, times[1:], strict=False)]
+
+
 def _steady_flags(times: Sequence[float]) -> tuple[bool, ...]:
     """Whether each beat sits between intervals that match the tempo around them.
 
     A beat is judged by the intervals either side of it, so an interval that does not belong
     discredits both of the beats it joins rather than one arbitrary end of it.
     """
-    intervals = [later - earlier for earlier, later in zip(times, times[1:], strict=False)]
+    intervals = _intervals(times)
     if len(intervals) < 2:
         # One interval has no neighbours to be judged against; refusing it would be inventing
         # a verdict rather than reaching one.
@@ -293,25 +317,6 @@ def _steady_flags(times: Sequence[float]) -> tuple[bool, ...]:
         not any(unsteady[near] for near in (position - 1, position) if 0 <= near < len(unsteady))
         for position in range(len(times))
     )
-
-
-def spacing(times: Sequence[float]) -> tuple[float | None, ...]:
-    """How wide a beat is at each beat, in seconds — the local tempo, parallel to ``times``.
-
-    Public for the reason ``nearest`` is: more than one reading has to ask how far a beat is
-    around here, and two answers to that would be two grids. The steadiness check above judges
-    an interval against it; the cut side asks whether a cut sits further from its beat than a
-    beat is wide, which is how a cut the grid does not reach is told from one it does (#160).
-
-    Local rather than set-wide for the same reason the steadiness window is: a two-hour set
-    has tunes at different tempos, and a beat in the fast one is not half a beat of the slow
-    one. ``None`` where the grid cannot say — a lone beat has no interval, and inventing a
-    width for it would be a verdict rather than a reading.
-    """
-    intervals = [later - earlier for earlier, later in zip(times, times[1:], strict=False)]
-    if not intervals:
-        return tuple(None for _ in times)
-    return tuple(_local(intervals, min(index, len(intervals) - 1)) for index in range(len(times)))
 
 
 def _local(intervals: Sequence[float], index: int) -> float:

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -62,7 +62,7 @@ from ..resolve.timeline import (
 )
 from ..timing import SECONDS_PRECISION, dual_time, to_frames
 from . import decode, energy, records
-from .beats import GridTrust, nearest, trust
+from .beats import GridTrust, nearest, spacing, trust
 
 log = get_logger("analysis")
 
@@ -73,6 +73,19 @@ INLINE_CUTS = 12
 
 UNLABELLED = "unlabelled"
 """Where shots from a clip the angle sidecar does not name are counted."""
+
+BEAT_REACH = 1.0
+"""How far from a beat a cut may sit and still be described by it, in local beat intervals.
+
+Inside a grid that reaches the cut, the nearest beat is at most *half* a beat away by
+construction, so a whole beat is slack rather than a threshold to tune. What it catches is
+the cut the grid does not reach at all — past its ends, or in a hole it left — where the
+nearest *surviving* beat can be seconds away and the offset against it describes nothing
+(#160: one cut 6.08 s from its beat in a grid of 0.39 s beats, because the detector stopped
+six seconds before the cut). Drawing the line at the width of a beat rather than at the edge
+of the grid keeps the honest near miss: a cut 20 ms before the first beat is a real
+measurement, and refusing it would be trading one wrong answer for another.
+"""
 
 BLACK = "black"
 """Where the stretches nothing covers are counted — a known absence, not a missing label."""
@@ -736,12 +749,14 @@ def measure(
     solo_times = [float(row["t"]) for row in (music.solos or ())]
     roles = music.roles or {}
     trusted = (grid if grid is not None else trust(music.beats)).trusted
+    widths = spacing(times)
 
     rows: list[dict[str, Any]] = []
     for index, shot in enumerate(shots, start=1):
         seconds = clock.seconds(shot.record_in)
         found = nearest(times, seconds)
         beat = None if found is None else music.beats[found]
+        stranded = _stranded(seconds, times, widths, found, trusted)
         rows.append(
             {
                 "cut": index,
@@ -760,16 +775,46 @@ def measure(
                 "beat": None if beat is None else beat.get("beat"),
                 "bar": None if beat is None else beat.get("bar"),
                 "in_bar": None if beat is None else beat.get("in_bar"),
-                # Whether the grid describes the music here at all (#112). The measurement
-                # itself is kept either way — a marked cut is a fact about the detector, and
-                # dropping the row would hide the very thing the gate exists to report.
-                "in_grid": found is not None and trusted[found],
+                # Whether the grid describes the music here at all (#112, #160). The
+                # measurement itself is kept either way — a marked cut is a fact about the
+                # detector, and dropping the row would hide the very thing the gate exists to
+                # report.
+                "in_grid": found is not None and trusted[found] and not stranded,
+                "stranded": stranded,
                 "transient_offset": _offset(transients, seconds),
                 "tune": _tune_at(music.tunes, tune_times, seconds),
                 "front": _front_at(music.solos, solo_times, seconds),
             }
         )
     return rows
+
+
+def _stranded(
+    seconds: float,
+    times: Sequence[float],
+    widths: Sequence[float | None],
+    found: int | None,
+    trusted: Sequence[bool],
+) -> bool:
+    """Whether the grid reaches this cut, or only has a beat somewhere in the distance (#160).
+
+    The #112 gate refuses *beats*, so it catches a cut whose nearest beat is one it refused.
+    It cannot catch the other shape: where the grid stops — or leaves a hole — the nearest
+    *surviving* beat is trusted and far away, and the row goes into the trusted columns
+    carrying an offset measured across the silence. One such cut in 504 moved no histogram
+    and dragged a mean to 3.6× its own median, which is the reading a style profile is
+    written from.
+
+    Only rows the beat gate let through are claimed here, so ``gated`` keeps meaning exactly
+    what it meant: beats the grid describes badly, counted the same way across passes. A grid
+    that cannot say how wide a beat is — one lone beat, or two beats at the same time — is not
+    a grid this can judge against, and inventing a verdict there would be the same mistake in
+    the other direction.
+    """
+    if found is None or not trusted[found]:
+        return False
+    width = widths[found]
+    return width is not None and width > 0 and abs(seconds - times[found]) > BEAT_REACH * width
 
 
 def _opens(index: int, shot: Shot, shots: Sequence[Shot]) -> bool:
@@ -851,6 +896,7 @@ def _summary(
     # measured over every cut; the beat and bar statistics are taken over the cuts the grid
     # can actually describe, and the count of the rest is reported rather than swallowed.
     in_grid = [row for row in cut_to_music if row["in_grid"]]
+    stranded = sum(1 for row in cut_to_music if row["stranded"])
     transient_offsets = (
         None if transients is None else _offsets([row["transient_offset"] for row in cut_to_music])
     )
@@ -860,12 +906,15 @@ def _summary(
         "visible": visible,
         "cuts": len(rows),
         "openings": sum(1 for row in rows if row["opening"]),
-        # ``outside_grid`` and ``gated`` are different refusals and neither implies the other:
-        # the first is a cut beyond the ends of the analysed span, which means the times and
-        # the audio are not the same recording; the second is a cut inside the span that the
-        # grid describes badly. A misaligned clock shows in the first, rubato in the second.
+        # Three refusals, and none of them implies the others. ``outside_grid`` is a cut
+        # beyond the ends of the analysed span, which means the times and the audio are not
+        # the same recording; ``gated`` is a cut whose nearest beat the grid describes badly;
+        # ``stranded`` is a cut with no beat near it at all, scored against a trusted one too
+        # far away to be describing the music there (#160). A misaligned clock shows in the
+        # first, rubato in the second, a detector that stopped early in the third.
         "outside_grid": _outside(rows, grid),
-        "gated": len(cut_to_music) - len(in_grid),
+        "gated": len(cut_to_music) - len(in_grid) - stranded,
+        "stranded": stranded,
         "grid_meter": trusted.meter,
         "grid_refused": trusted.reasons,
         "beat_offsets": _offsets([row["beat_offset"] for row in in_grid]),

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -756,7 +756,14 @@ def measure(
         seconds = clock.seconds(shot.record_in)
         found = nearest(times, seconds)
         beat = None if found is None else music.beats[found]
-        stranded = _stranded(seconds, times, widths, found, trusted)
+        # Only rows the beat gate let through are claimed by the reach rule, so ``gated`` keeps
+        # meaning exactly what it meant: beats the grid describes badly, counted the same way
+        # across passes.
+        stranded = (
+            found is not None
+            and trusted[found]
+            and _out_of_reach(seconds, times[found], widths[found])
+        )
         rows.append(
             {
                 "cut": index,
@@ -789,13 +796,7 @@ def measure(
     return rows
 
 
-def _stranded(
-    seconds: float,
-    times: Sequence[float],
-    widths: Sequence[float | None],
-    found: int | None,
-    trusted: Sequence[bool],
-) -> bool:
+def _out_of_reach(seconds: float, beat: float, width: float | None) -> bool:
     """Whether the grid reaches this cut, or only has a beat somewhere in the distance (#160).
 
     The #112 gate refuses *beats*, so it catches a cut whose nearest beat is one it refused.
@@ -805,16 +806,12 @@ def _stranded(
     and dragged a mean to 3.6× its own median, which is the reading a style profile is
     written from.
 
-    Only rows the beat gate let through are claimed here, so ``gated`` keeps meaning exactly
-    what it meant: beats the grid describes badly, counted the same way across passes. A grid
-    that cannot say how wide a beat is — one lone beat, or two beats at the same time — is not
-    a grid this can judge against, and inventing a verdict there would be the same mistake in
-    the other direction.
+    A grid that cannot say how wide a beat is — one lone beat, or two beats at the same time —
+    is not a grid this can judge against, and inventing a verdict there would be the same
+    mistake in the other direction. Such a grid answers to the #112 gate instead: a single
+    beat is a meter of one, which that gate refuses whole.
     """
-    if found is None or not trusted[found]:
-        return False
-    width = widths[found]
-    return width is not None and width > 0 and abs(seconds - times[found]) > BEAT_REACH * width
+    return width is not None and width > 0 and abs(seconds - beat) > BEAT_REACH * width
 
 
 def _opens(index: int, shot: Shot, shots: Sequence[Shot]) -> bool:
@@ -911,7 +908,10 @@ def _summary(
         # the same recording; ``gated`` is a cut whose nearest beat the grid describes badly;
         # ``stranded`` is a cut with no beat near it at all, scored against a trusted one too
         # far away to be describing the music there (#160). A misaligned clock shows in the
-        # first, rubato in the second, a detector that stopped early in the third.
+        # first, rubato in the second, a detector that stopped early in the third. The first
+        # and third overlap on a cut beyond the ends far enough to be out of reach, and that
+        # is two facts about one cut rather than one counted twice: only ``stranded`` keeps it
+        # out of the beat statistics, and only ``outside_grid`` says the clock is suspect.
         "outside_grid": _outside(rows, grid),
         "gated": len(cut_to_music) - len(in_grid) - stranded,
         "stranded": stranded,

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -441,12 +441,17 @@ hole *inside* the grid: Freefall's grid ends at 670.72 s and the cut is at
 mostly gates itself — the steadiness check refuses both beats of an aberrant
 interval, so the nearest beat to a cut in the hole is usually a refused one.)
 The gate now refuses a cut further from its beat than a beat is wide and counts
-it as `stranded`, apart from `gated`. Every Freefall beat figure in this
-document predates that refusal, so a re-run would move exactly this much: one
-cut leaves `beat_offsets` and `bars` (35 measured → 34 in the gated pass, 50 →
-49 in the visible-edit one, and one off the beat-1 column in each), the `max_abs`
-of 6.08 s goes with it, and the medians — 69 ms and 80 ms — are untouched,
-because a median never noticed the cut in the first place.
+it as `stranded`, apart from `gated`. Every beat figure in this document
+predates that refusal, and no pass has been re-run against it, so what follows
+is a prediction and not a measurement. This cut at least leaves `beat_offsets`
+and `bars` — Freefall 35 measured → 34 in the gated pass and 50 → 49 in the
+visible-edit one, one off the beat-1 column in each, and the `max_abs` of 6.08 s
+with it — while the medians (69 ms, 80 ms) are untouched, a median never having
+noticed the cut. The refusal is corpus-wide, though, so any other cut sitting
+more than a beat from a trusted beat — at a grid's *start* as well as its end —
+would go too, and only a re-run settles how many that is. Note also that this
+cut is past the end of its grid and so was already counted in `outside_grid`;
+the two counts overlap on it, as they may on any stranded cut beyond the ends.
 
 ### Two bookkeeping consequences of re-running
 

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -434,6 +434,20 @@ to this corpus, and one instance across 455 cuts is thin justification for
 making it. Recorded here so the next mean that looks wrong has an explanation
 waiting.
 
+**Fixed in #160**, and the diagnosis above was half right. The cut is not in a
+hole *inside* the grid: Freefall's grid ends at 670.72 s and the cut is at
+676.80 s, so the nearest surviving beat is the last one the detector emitted,
+6.08 s earlier, in a stretch whose beats are 0.39 s apart. (An interior hole
+mostly gates itself — the steadiness check refuses both beats of an aberrant
+interval, so the nearest beat to a cut in the hole is usually a refused one.)
+The gate now refuses a cut further from its beat than a beat is wide and counts
+it as `stranded`, apart from `gated`. Every Freefall beat figure in this
+document predates that refusal, so a re-run would move exactly this much: one
+cut leaves `beat_offsets` and `bars` (35 measured → 34 in the gated pass, 50 →
+49 in the visible-edit one, and one off the beat-1 column in each), the `max_abs`
+of 6.08 s goes with it, and the medians — 69 ms and 80 ms — are untouched,
+because a median never noticed the cut in the first place.
+
 ### Two bookkeeping consequences of re-running
 
 - **The anchor's clock moved one frame, and the gate did not do it.** Zinc's

--- a/tests/test_beat_grid.py
+++ b/tests/test_beat_grid.py
@@ -237,3 +237,31 @@ def test_an_empty_grid_has_nothing_to_trust_and_no_meter() -> None:
 
     assert found.trusted == ()
     assert found.meter is None
+
+
+# --- how wide a beat is here (#160) -----------------------------------------------------------
+
+
+def test_the_width_of_a_beat_is_the_local_interval_and_is_given_for_every_beat() -> None:
+    """One reading per beat, so a caller can ask about the beat it already found."""
+    widths = beats.spacing(_steady(13).beats)
+
+    assert len(widths) == 13
+    assert widths == (0.5,) * 13
+
+
+def test_a_beat_is_as_wide_as_the_tempo_around_it_rather_than_the_tempo_of_the_set() -> None:
+    """A set has tunes at different tempos, and a beat in the fast one is not half a slow one."""
+    slow = [round(index * 0.5, 6) for index in range(12)]
+    fast = [round(slow[-1] + (index + 1) * 0.2, 6) for index in range(12)]
+
+    widths = beats.spacing(tuple(slow + fast))
+
+    assert widths[2] == pytest.approx(0.5)
+    assert widths[-2] == pytest.approx(0.2)
+
+
+def test_one_lone_beat_has_no_width_the_grid_can_vouch_for() -> None:
+    """No interval means no answer: inventing a width would be a verdict rather than a reading."""
+    assert beats.spacing((4.0,)) == (None,)
+    assert beats.spacing(()) == ()

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -236,6 +236,7 @@ def test_every_shot_lands_on_disk_with_its_offsets_bar_and_section(
         "bar": 1,
         "in_bar": 3,
         "in_grid": True,
+        "stranded": False,
         "transient_offset": -0.017,
         "tune": 1,
         "front": "drums",
@@ -1117,3 +1118,96 @@ def test_every_cut_carries_the_marker_even_when_the_grid_is_sound(
 
     assert [one["in_grid"] for one in _rows(result)] == [True, True, True]
     assert result["gated"] == 0
+
+
+# --- the grid that does not reach the cut (#160) -----------------------------------------------
+
+
+def _short_grid(tmp_path: Path, last: float = 1.5) -> str:
+    """A grid that stops before the concert does, leaving the last cut with no beat near it.
+
+    This is the observed shape, not an invented one: the Freefall pass keeps a cut 6.08 s
+    from its nearest beat because the detector's grid ends at 670.72 s and the cut is at
+    676.80 s. The nearest *surviving* beat is trusted and far away, which is exactly the row
+    the gate was supposed to keep out of the trusted columns.
+    """
+    seconds = tuple(round(index * 0.5, 6) for index in range(int(last / 0.5) + 1))
+    return str(beats_file(tmp_path, seconds=seconds, name=f"short-grid-{last}-beats.json"))
+
+
+def test_a_cut_the_grid_does_not_reach_is_refused_rather_than_scored_against_a_distant_beat(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """#160: a beat a second away in a grid of half-second beats describes nothing at the cut."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, beats=_short_grid(tmp_path))
+
+    cuts = _rows(result)
+    assert cuts[1]["in_grid"] is True  # 33 ms from its beat, well inside the grid
+    assert cuts[1]["stranded"] is False
+    # Two beats past the end of a grid whose beats are half a second apart.
+    assert cuts[2]["beat_offset"] == 0.983
+    assert cuts[2]["stranded"] is True
+    assert cuts[2]["in_grid"] is False
+
+
+def test_a_stranded_cut_is_counted_apart_from_the_beats_the_gate_refused(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A third refusal beside ``outside_grid`` and ``gated``, so neither count changes meaning.
+
+    ``gated`` is beats the grid describes badly; this is a cut the grid does not describe at
+    all. Folding the two together would make a hole in the detector's output read as rubato.
+    """
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, beats=_short_grid(tmp_path))
+
+    assert result["stranded"] == 1
+    assert result["gated"] == 0
+    assert result["grid_refused"] == {}
+
+
+def test_a_stranded_cut_is_kept_out_of_the_bar_and_beat_statistics(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The whole point of the refusal: the mean it would drag is the one style is read from."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, beats=_short_grid(tmp_path))
+
+    assert result["beat_offsets"]["measured"] == 1
+    assert result["beat_offsets"]["max_abs"] == 0.033
+    assert result["bars"] == {"3": 1}
+
+
+def test_the_reach_refusal_leaves_the_transient_measurement_exactly_as_it_was(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Transients need no grid, so a grid that stops early may not shrink their n by a cut."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, beats=_short_grid(tmp_path))
+
+    assert result["transient_offsets"]["measured"] == 2
+
+
+def test_a_cut_that_misses_the_last_beat_by_less_than_a_beat_is_still_measured(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The refusal is about reach, not about the ends: a near miss at the edge is a real cut.
+
+    Refusing everything past the last beat would throw away the cut that lands 20 ms before
+    the grid starts or after it stops — an honest measurement — so the line is drawn at the
+    width of a beat rather than at the edge of the grid.
+    """
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, beats=_short_grid(tmp_path, last=2.0))
+
+    cuts = _rows(result)
+    assert cuts[2]["beat_offset"] == 0.483  # inside the half-second beat it is measured against
+    assert cuts[2]["stranded"] is False
+    assert cuts[2]["in_grid"] is True
+    assert result["stranded"] == 0

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -1193,6 +1193,52 @@ def test_the_reach_refusal_leaves_the_transient_measurement_exactly_as_it_was(
     assert result["transient_offsets"]["measured"] == 2
 
 
+def test_a_cut_in_a_hole_inside_the_grid_is_refused_by_the_beat_gate_rather_than_the_reach_rule(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Why #160 needed no "a refused beat lies between" rule: an interior hole gates itself.
+
+    ``nearest`` looks over every beat, so no beat can sit between a cut and the beat it was
+    scored against — a nearer one would be the one it was scored against. And the steadiness
+    check refuses *both* beats of an interval that does not belong, so the beat on the near
+    side of a hole is refused already. The reach rule is therefore about the ends of the grid
+    and the two counts stay apart here, which is the claim this pins.
+    """
+    attach(studio(timeline=a_cut()))
+
+    # Half-second beats with the third cut's second missing from the middle of them.
+    holed = (0.0, 0.5, 1.0, 1.5, 4.0, 4.5, 5.0, 5.5, 6.0)
+    result = _measured(
+        tmp_path, beats=str(beats_file(tmp_path, seconds=holed, name="holed-beats.json"))
+    )
+
+    cuts = _rows(result)
+    assert cuts[2]["in_grid"] is False
+    assert cuts[2]["stranded"] is False
+    assert result["gated"] == 1
+    assert result["stranded"] == 0
+
+
+def test_a_grid_that_calls_the_whole_span_one_beat_reaches_the_cuts_inside_it(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The rule is a beat wide, not a number of seconds: a slow grid reaches further.
+
+    Two beats six seconds apart is a grid saying the music runs at 10bpm. That is a bad grid,
+    but it is bad in the way #112 judges — nothing about a cut three seconds in contradicts
+    it, and refusing that cut for distance would be this rule inventing a tempo of its own.
+    """
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(
+        tmp_path,
+        beats=str(beats_file(tmp_path, seconds=(0.0, 6.0), name="coarse-beats.json")),
+    )
+
+    assert [one["stranded"] for one in _rows(result)] == [False, False, False]
+    assert result["stranded"] == 0
+
+
 def test_a_cut_that_misses_the_last_beat_by_less_than_a_beat_is_still_measured(
     attach: Attach, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Closes #160.

## What was wrong

The #112 gate refuses *beats*, so it catches a cut whose nearest beat is one it refused. It cannot catch the other shape: where the grid stops, or leaves a hole, the nearest **surviving** beat is trusted and far away, and the row goes into the trusted columns carrying an offset measured across the silence.

The ticket guessed the observed row sat beside a refused stretch. It does not — I read the row out of the on-disk corpus result rather than trusting the guess. Freefall's detector emits its last beat at **670.72 s** and the cut is at **676.80 s**: the nearest beat is the last one there is, trusted, 6.08 s away, in a stretch whose beats are 0.39 s apart. (An interior hole mostly gates itself: `nearest` looks over every beat, so no beat can lie between a cut and the beat it was scored against, and the steadiness check refuses *both* beats of an aberrant interval. The ticket's alternative "a refused beat lies between" criterion is therefore unreachable as written, and is not implemented.)

## The fix

- `beats.spacing(times)` — how wide a beat is at each beat, from the same local window the steadiness check uses, so the grid has one answer to "how far is a beat around here" rather than two.
- `correlate` refuses a cut further from its beat than a beat is wide (`BEAT_REACH = 1.0` local intervals) and marks the row `stranded: true`. Inside a grid that reaches the cut the nearest beat is at most *half* a beat away by construction, so a whole beat is slack rather than a threshold to tune — and drawing the line at the width of a beat rather than at the edge of the grid keeps the honest near miss (a cut 20 ms past the last beat is a real measurement).
- `stranded` is a third summary count beside `outside_grid` and `gated`. Only rows the beat gate let through are claimed by it, so **`gated` keeps its exact old meaning** and counts stay comparable across passes. The measurement is still written to the row — dropping it would hide the thing the gate exists to report.
- `styles/corpus.md`: the open note "What the gate does not fix" now records the real diagnosis and what a re-run would move. `CONTEXT.md` map updated.

**Seam** (as the ticket named): fake tier, `tests/test_correlate_timeline.py` and `tests/test_beat_grid.py`. No live AC. Fake tier 1570 passed, mypy strict clean, ruff clean.

## Review

`/code-review` since `origin/main`, two axes in parallel sub-agents.

**Standards — no hard violations.** Three judgement calls and two style notes, all addressed in `7e3b30b`:

1. *Duplicated Code* — `spacing` opened with a line byte-identical to `_steady_flags`, with a third filtered variant in `gist`. → `beats._intervals` is now the module's one definition of "the grid as its gaps"; all three share it.
2. *Data Clumps* — `_stranded(seconds, times, widths, found, trusted)` took three parallel sequences and an index into all of them, when `GridTrust` already exists as the bundle. → replaced by `_out_of_reach(seconds, beat, width)`, which takes scalars; the caller keeps the arrays aligned where it already had them.
3. *Speculative Generality (mild)* — `BEAT_REACH` as a multiplier the docstring itself says is not a knob to tune. → kept: the repo's named-constant habit is the stronger standard here, and the constant is what names the rule.
4. *Style* — public `spacing` was sitting among the privates. → moved up beside `meter`.
5. *Style* — the docstring did not name the asymmetry `spacing` has and `_steady_flags` does not (a beat is read from the window of the interval that **follows** it; the last beat borrows the one before). → it does now.

**Spec — faithful.** The ticket delegated the criterion ("builder's call on the exact criterion") and named this one as its second option; `stranded` is a third count, `in_grid` excludes it, `beat_offsets`/`bars` read `in_grid` only. The axis independently confirmed the "between" criterion is unreachable given `nearest()`. Two gaps, both closed in `7e3b30b`:

1. Every new test used a grid that *ends early*; the reasoning that justified dropping the second criterion was asserted in prose and locked by no test. → added a fixture with a hole inside the grid, asserting the cut lands in `gated` and not `stranded`.
2. The edge of the criterion (a grid too coarse to be judged against) had no correlate-seam test. → added one: a grid calling the whole span one beat reaches the cuts inside it, because refusing them for distance would be this rule inventing a tempo of its own.
3. Caveat, not a defect: `corpus.md` predicted exact re-run deltas without a re-run, and the refusal is corpus-wide. → the section now says it is a prediction, names the grid *start* as another place a cut could strand, and notes that `outside_grid` and `stranded` overlap on this cut.

Review: clean — both axes; Standards found no hard violations and its five judgement calls are applied, Spec found the change faithful and its two coverage gaps are closed.
