### PR TITLE
Retrofit from claude-principles: hardened context-guard, promoted session-memory facts

### DIFF
--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -13,7 +13,8 @@ Measured motivation (2026-08 transcript audit): 233 piped harness runs with
 zero scratch-file adoption, and one 237k-token session that pulled 162KB via
 `cat` loops without a single Read call.
 
-starter-version: 2026-08-10 (claude-principles; locally tuned: LAUNCHERS)
+starter-version: 2026-08-10 (claude-principles; locally tuned: LAUNCHERS,
+block messages use this repo's scratch-log names)
 """
 import json
 import re
@@ -34,49 +35,55 @@ if data.get("tool_name") != "Bash":
 
 cmd = data.get("tool_input", {}).get("command", "") or ""
 
-# Match against a copy with heredoc bodies and quoted strings blanked out:
-# quoted text and heredoc content are data, not commands — a commit message
-# or issue body merely mentioning pytest/cat false-positived here
-# (session note: context-guard-blocks-some-heredocs, 2026-08).
-scan = re.sub(r"<<-?\s*(['\"]?)(\w+)\1[\s\S]*?\n\2\b", "<<HEREDOC", cmd)
-scan = re.sub(r"'[^']*'", "''", scan)
+# Heredoc bodies are data, not commands; `<<-` terminators may be indented
+# (session note context-guard-blocks-some-heredocs, 2026-08 — now fixed).
+HEREDOC = r"<<-?\s*(['\"]?)(\w+)\1[\s\S]*?\n[ \t]*\2\b"
+blanked = re.sub(HEREDOC, "<<HEREDOC", cmd)
+# The noisy/gh rules also blank quoted strings: a commit message merely
+# mentioning pytest is prose. The cat rules instead use a quote-STRIPPED
+# copy (quotes removed, content kept): `cat "notes.md"` is still a cat, and
+# command-position anchoring is what protects those rules from prose.
+scan = re.sub(r"'[^']*'", "''", blanked)
 scan = re.sub(r'"[^"]*"', '""', scan)
+scan_cat = re.sub(r"[\"']", "", blanked)
 
-# Anchored at command position (line start, `;`, `&`, `|`, `(`, or a backtick/
-# $( substitution), allowing env-var assignments (`CI=1 pytest …`) and an
-# optional launcher before the tool name.
-CMD_POS = r"(?:^\s*|[;&|(`\n]\s*|\$\(\s*)"
+# Command position: line start, a separator (`;`, `&`, `|`, `(`, `)`, `{`,
+# backtick, newline), a $( substitution, or a then/do/else keyword — with
+# env-var assignments (`CI=1 pytest …`) and any chain of launchers
+# (`uv run python -m pytest`) allowed before the tool name.
+CMD_POS = r"(?:^\s*|[;&|(){`\n]\s*|\$\(\s*|\b(?:then|do|else)\s+)"
 NOISY = (
     CMD_POS
     + r"(?:\w+=\S+\s+)*"
-    + r"(?:" + LAUNCHERS + r")?"
+    + r"(?:" + LAUNCHERS + r")*"
     + r"(?:" + NOISY_TOOLS + r")\b"
 )
 if re.search(NOISY + r"[^|]*\|\s*(tail|head|less|more|cat)\b", scan):
     sys.stderr.write(
         "Blocked (context discipline): noisy runs never pipe to tail/head — a tail caps one run, runs repeat.\n"
-        "Use: <cmd> > run.scratch.log 2>&1; then grep the log for the decisive line (FAIL|passed|error).\n"
-        "On failure, grep the log for the failing case by name; never cat the log.\n"
+        "Use one bare command: <cmd> > pytest.scratch.log 2>&1. Then Grep the log for the decisive line (FAILED|passed|error).\n"
+        "On failure, Grep the log for the failing case by name; never cat the log.\n"
     )
     sys.exit(2)
 
 # gh comment pulls: the full thread is 5-7KB per call and repeats (measured
 # 2026-08-05). Piping to tail caps nothing that matters, and dropping the pipe
 # is worse — so the rule is: comments land in a file (or a --json filter),
-# never straight in context.
-if re.search(r"\bgh\s+(issue|pr)\s+view\b[^>|]*--comments", scan) and not re.search(
-    r"--comments[^|>]*>\s*\S", scan
-):
-    sys.stderr.write(
-        "Blocked (context discipline): a comment pull lands in a file, never straight in context.\n"
-        "Use: gh issue view <n> --comments > comments.scratch.log; then grep the log — or --json comments with a jq filter.\n"
-    )
-    sys.exit(2)
+# never straight in context. Checked per pull, within that pull's own command
+# segment; a digit before `>` is an fd redirect (2>), not a landing.
+for m in re.finditer(r"\bgh\s+(issue|pr)\s+view\b[^|;&]*--comments", scan):
+    seg = re.split(r"[|;&]", scan[m.end():], 1)[0]
+    if not re.search(r"(?<!\d)>\s*\S", seg):
+        sys.stderr.write(
+            "Blocked (context discipline): a comment pull lands in a file, never straight in context.\n"
+            "Use one bare command: gh issue view <n> --comments > comments.scratch.log. Then Grep the log — or --json comments with a jq filter.\n"
+        )
+        sys.exit(2)
 
 SRC_EXT = r"\.(md|sh|py|js|ts|json|yml|yaml|txt|log|conf|ini)\b"
 
 # for-loop cat sweep: `for f in src/*.py; do cat $f; done`
-if re.search(r"\bfor\b[^;]*" + SRC_EXT + r".*\bcat\b", scan):
+if re.search(r"\bfor\b[^;]*" + SRC_EXT + r".*\bcat\b", scan_cat):
     sys.stderr.write(
         "Blocked (context discipline): a cat loop over source files is a mass whole-file Read.\n"
         "Use the Read tool per file you will edit, or grep for the lines you actually need.\n"
@@ -85,9 +92,9 @@ if re.search(r"\bfor\b[^;]*" + SRC_EXT + r".*\bcat\b", scan):
 
 # bare cat of a source file, not piped onward and not a redirect/heredoc —
 # anchored at command position so prose mentioning "cat" never matches
-for m in re.finditer(CMD_POS + r"cat\b(?:\s+-[\w]+)*((?:\s+[\w$./*-]+)+)", scan):
+for m in re.finditer(CMD_POS + r"cat\b(?:\s+-[\w]+)*((?:\s+[\w$./*-]+)+)", scan_cat):
     args = m.group(1)
-    rest = scan[m.end():]
+    rest = scan_cat[m.end():]
     if re.search(SRC_EXT, args) and not re.match(r"\s*[|>]", rest):
         sys.stderr.write(
             "Blocked (context discipline): don't cat files into context — the rules govern content entering "

--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -2,18 +2,27 @@
 """PreToolUse hook enforcing CLAUDE.md's context-discipline rules on Bash.
 
 Blocks (exit 2, message to the model):
-  1. Noisy runs (pytest, mypy, ruff) piped to tail/head/cat — the mktemp+grep
-     rule.
-  2. `cat` of source/config files straight into context — that is a whole-file
+  1. Noisy runs (NOISY_TOOLS below) piped to tail/head/cat — the
+     scratch-log+grep rule.
+  2. `gh` comment pulls that don't land in a file — the full thread is the
+     largest tool-result class measured.
+  3. `cat` of source/config files straight into context — that is a whole-file
      Read with a worse interface; use the Read tool or pipe to grep.
 
 Measured motivation (2026-08 transcript audit): 233 piped harness runs with
-zero mktemp adoption, and one 237k-token session that pulled 162KB via `cat`
-loops without a single Read call.
+zero scratch-file adoption, and one 237k-token session that pulled 162KB via
+`cat` loops without a single Read call.
+
+starter-version: 2026-08-10 (claude-principles; locally tuned: LAUNCHERS)
 """
 import json
 import re
 import sys
+
+# The commands whose full output belongs in a scratch log, never in context.
+NOISY_TOOLS = r"pytest|mypy|ruff"
+# Launcher prefixes those commands may hide behind in this repo.
+LAUNCHERS = r"(?:uv\s+run\s+(?:-\S+\s+)*|python3?\s+-m\s+)"
 
 try:
     data = json.load(sys.stdin)
@@ -25,46 +34,60 @@ if data.get("tool_name") != "Bash":
 
 cmd = data.get("tool_input", {}).get("command", "") or ""
 
+# Match against a copy with heredoc bodies and quoted strings blanked out:
+# quoted text and heredoc content are data, not commands — a commit message
+# or issue body merely mentioning pytest/cat false-positived here
+# (session note: context-guard-blocks-some-heredocs, 2026-08).
+scan = re.sub(r"<<-?\s*(['\"]?)(\w+)\1[\s\S]*?\n\2\b", "<<HEREDOC", cmd)
+scan = re.sub(r"'[^']*'", "''", scan)
+scan = re.sub(r'"[^"]*"', '""', scan)
+
 # Anchored at command position (line start, `;`, `&`, `|`, `(`, or a backtick/
-# $( substitution), optionally behind a `uv run` / `python -m` launcher — a bare
-# word match false-positived on commit messages and PR bodies that merely
-# mention pytest/mypy/ruff in quoted text.
+# $( substitution), allowing env-var assignments (`CI=1 pytest …`) and an
+# optional launcher before the tool name.
+CMD_POS = r"(?:^\s*|[;&|(`\n]\s*|\$\(\s*)"
 NOISY = (
-    r"(?:^|[;&|(`\n]\s*|\$\(\s*)"
-    r"(?:uv\s+run\s+(?:-\S+\s+)*|python3?\s+-m\s+)?"
-    r"(?:pytest|mypy|ruff)\b"
+    CMD_POS
+    + r"(?:\w+=\S+\s+)*"
+    + r"(?:" + LAUNCHERS + r")?"
+    + r"(?:" + NOISY_TOOLS + r")\b"
 )
-if re.search(NOISY + r"[^|]*\|\s*(tail|head|less|more|cat)\b", cmd):
+if re.search(NOISY + r"[^|]*\|\s*(tail|head|less|more|cat)\b", scan):
     sys.stderr.write(
         "Blocked (context discipline): noisy runs never pipe to tail/head — a tail caps one run, runs repeat.\n"
-        'Use: log=$(mktemp); <cmd> >"$log" 2>&1; grep -E \'FAIL|Totals\' "$log"\n'
+        "Use: <cmd> > run.scratch.log 2>&1; then grep the log for the decisive line (FAIL|passed|error).\n"
         "On failure, grep the log for the failing case by name; never cat the log.\n"
     )
     sys.exit(2)
 
-# unbounded gh comment pulls: `gh issue view N --comments | tail -80` drags 5-7KB
-# per call and repeats (measured 2026-08-05); the tail caps nothing that matters.
-if re.search(r"\bgh (issue|pr) view\b[^|]*--comments[^|]*\|\s*(tail|head)\b", cmd):
+# gh comment pulls: the full thread is 5-7KB per call and repeats (measured
+# 2026-08-05). Piping to tail caps nothing that matters, and dropping the pipe
+# is worse — so the rule is: comments land in a file (or a --json filter),
+# never straight in context.
+if re.search(r"\bgh\s+(issue|pr)\s+view\b[^>|]*--comments", scan) and not re.search(
+    r"--comments[^|>]*>\s*\S", scan
+):
     sys.stderr.write(
-        "Blocked (context discipline): an unbounded comment pull piped to tail repeats its full cost every call.\n"
-        "Use --json comments with a jq filter for the fields you need, or write to $(mktemp) and grep.\n"
+        "Blocked (context discipline): a comment pull lands in a file, never straight in context.\n"
+        "Use: gh issue view <n> --comments > comments.scratch.log; then grep the log — or --json comments with a jq filter.\n"
     )
     sys.exit(2)
 
 SRC_EXT = r"\.(md|sh|py|js|ts|json|yml|yaml|txt|log|conf|ini)\b"
 
 # for-loop cat sweep: `for f in src/*.py; do cat $f; done`
-if re.search(r"\bfor\b[^;]*" + SRC_EXT + r".*\bcat\b", cmd):
+if re.search(r"\bfor\b[^;]*" + SRC_EXT + r".*\bcat\b", scan):
     sys.stderr.write(
         "Blocked (context discipline): a cat loop over source files is a mass whole-file Read.\n"
         "Use the Read tool per file you will edit, or grep for the lines you actually need.\n"
     )
     sys.exit(2)
 
-# bare cat of a source file, not piped onward and not a redirect/heredoc
-for m in re.finditer(r"\bcat\b(?:\s+-[\w]+)*((?:\s+[\w$./*\"'-]+)+)", cmd):
+# bare cat of a source file, not piped onward and not a redirect/heredoc —
+# anchored at command position so prose mentioning "cat" never matches
+for m in re.finditer(CMD_POS + r"cat\b(?:\s+-[\w]+)*((?:\s+[\w$./*-]+)+)", scan):
     args = m.group(1)
-    rest = cmd[m.end():]
+    rest = scan[m.end():]
     if re.search(SRC_EXT, args) and not re.match(r"\s*[|>]", rest):
         sys.stderr.write(
             "Blocked (context discipline): don't cat files into context — the rules govern content entering "

--- a/.claude/hooks/read-guard.py
+++ b/.claude/hooks/read-guard.py
@@ -17,6 +17,9 @@ Measured motivation (2026-08-05 transcript audit): read-after-edit ran ~46% of
 sessions pre-rules and ~39% after prose alone — the one axis prose never moved;
 and one session full-read a 656-line module three times under the grep-first
 prose rule.
+
+starter-version: 2026-08-10 (claude-principles; matches the starter — only
+this docstring's framing is local)
 """
 import json
 import os

--- a/.claude/hooks/read-guard.py
+++ b/.claude/hooks/read-guard.py
@@ -18,8 +18,9 @@ sessions pre-rules and ~39% after prose alone — the one axis prose never moved
 and one session full-read a 656-line module three times under the grep-first
 prose rule.
 
-starter-version: 2026-08-10 (claude-principles; matches the starter — only
-this docstring's framing is local)
+starter-version: 2026-08-10 (claude-principles; matches the starter — this
+docstring's framing is local, and the formatter-hook hint was added to the
+re-read message in the same sync)
 """
 import json
 import os
@@ -110,6 +111,8 @@ if event == "PreToolUse" and tool == "Read":
                 "Blocked (context discipline): this session already edited that file — its content is in your "
                 "context, and Edit/Write fail loudly on a miss, so a whole-file re-read buys nothing.\n"
                 "If you need a specific section, grep -n for it and Read with offset/limit.\n"
+                "(If Edit just failed with 'modified since read' — a formatter hook rewrote it — re-read the "
+                "changed region with offset/limit.)\n"
             )
             sys.exit(2)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,8 @@
 {
   "permissions": {
     "allow": [
+      "Bash(git worktree add:*)",
+      "Bash(git worktree list:*)",
       "Bash(git worktree remove:*)",
       "Bash(git worktree prune:*)",
       "Bash(gh api --method PUT repos/danielbaldwin47/resolve-mcp/pulls/:*)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # resolve-mcp
 
+An MCP server that lets an agent edit concert footage in DaVinci Resolve
+Studio: analyse audio, author cut and titles files as validated JSON, and
+materialise them as Resolve timelines. The server measures; Claude decides.
+Map and vocabulary: `CONTEXT.md`.
+
 ## Test seams
 
 Before building a ticket, decide **which seam verifies it** and say so in the
@@ -84,12 +89,22 @@ produced no work; relaunch rather than assume.)
    lines stay above it as the record.
 5. **Merge through the PR** — everything reaches `main` through a PR, never
    a direct commit.
-6. **After a stacked PR merges, verify its head is an ancestor of
-   `origin/main`** — one plain `git merge-base --is-ancestor <head-sha>
-   origin/main` per branch (no loops or `$(...)`; the worktree guard
-   refuses compound commands). A PR that merges into a just-consumed parent
-   branch reads MERGED while its commits never reach main.
-7. **Close the ticket with the PR link**; name any unrun live ACs in the
+6. **After a stacked PR merges, verify its commits reached main by
+   content.** PRs here land both ways — merge commits and squashes — so
+   check `git log origin/main` for either the `Merge pull request #<n>`
+   commit or a squashed subject ending `(#<n>)`, and confirm the files
+   landed. `git merge-base --is-ancestor <head-sha> origin/main` proves a
+   merge-commit PR, but exits 1 for every squashed one — a failing check
+   alone proves nothing (#45: squashed PR #109 read as unlanded). The risk
+   the check exists for is real either way: a PR that merges into a
+   just-consumed parent branch reads MERGED while its commits never reach
+   main (#109's work needed re-landing as #111).
+7. **If the PR was squashed, continue its ticket on a fresh branch.** The
+   old branch then sits on history main no longer shares; a second PR from
+   it drags the already-merged commits back in. Branch from `origin/main`
+   and cherry-pick only the new commits — never force-push. (After a
+   merge-commit PR, continuing on the same branch is safe.)
+8. **Close the ticket with the PR link**; name any unrun live ACs in the
    close comment.
 
 When resolving merge conflicts, grep every conflicted file for `<<<<<<<`
@@ -141,6 +156,29 @@ adds, moves, or deletes a module updates the map in the same PR.
 Long multi-PR sweeps (merge trains, cross-PR audits) shard per-PR into
 subagents; the orchestrating session keeps receipts, not diffs — past
 sweeps that inlined everything ended at 2× the usable context budget.
+
+## Gotchas
+
+Facts rediscovered across sessions, promoted from session memory. Each one
+cost a session real time at least twice before landing here.
+
+- **Worktree sessions: pin every review and diff to `origin/main`.** The
+  local `main` checkout lags while other worktrees merge; a diff against
+  local `main` sweeps in commits that are not yours.
+- **Worktree pytest runs the main checkout's source.** The editable install
+  points at the main working copy, so a new test in a worktree fails
+  against old code with no import error to warn you. Reinstall in the
+  worktree (`uv sync`) before trusting a red run.
+- **`ruff format` is not a gate.** CI runs `ruff check` only;
+  `ruff format --check` fails repo-wide by design. Don't "fix" formatting
+  the repo never enforced.
+
+## Doc maintenance
+
+A dated `/writing-for-agents` pass over CLAUDE.md, CONTEXT.md and `docs/`
+runs periodically (last: 2026-08-10); session-memory facts that prove
+repo-general over multiple sessions graduate into this file and the memory
+note becomes history. Verified against mattpocock-skills 1.2.3.
 
 ## Agent skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,8 @@
 # resolve-mcp
 
 An MCP server that lets an agent edit concert footage in DaVinci Resolve
-Studio: analyse audio, author cut and titles files as validated JSON, and
-materialise them as Resolve timelines. The server measures; Claude decides.
-Map and vocabulary: `CONTEXT.md`.
+Studio — the server measures; Claude decides. Map and vocabulary:
+`CONTEXT.md`.
 
 ## Test seams
 
@@ -98,12 +97,14 @@ produced no work; relaunch rather than assume.)
    alone proves nothing (#45: squashed PR #109 read as unlanded). The risk
    the check exists for is real either way: a PR that merges into a
    just-consumed parent branch reads MERGED while its commits never reach
-   main (#109's work needed re-landing as #111).
+   main.
 7. **If the PR was squashed, continue its ticket on a fresh branch.** The
    old branch then sits on history main no longer shares; a second PR from
    it drags the already-merged commits back in. Branch from `origin/main`
-   and cherry-pick only the new commits — never force-push. (After a
-   merge-commit PR, continuing on the same branch is safe.)
+   and cherry-pick only the new commits — never force-push. (#45: after
+   #109's squash, the continuation landed cleanly from the fresh branch
+   `issue-45-entries-2-3` as PR #111. After a merge-commit PR, continuing
+   on the same branch is safe.)
 8. **Close the ticket with the PR link**; name any unrun live ACs in the
    close comment.
 
@@ -160,25 +161,30 @@ sweeps that inlined everything ended at 2× the usable context budget.
 ## Gotchas
 
 Facts rediscovered across sessions, promoted from session memory. Each one
-cost a session real time at least twice before landing here.
+cost a session real time at least twice before landing here; a gotcha that
+later gets a real fix gets its line removed.
 
-- **Worktree sessions: pin every review and diff to `origin/main`.** The
-  local `main` checkout lags while other worktrees merge; a diff against
-  local `main` sweeps in commits that are not yours.
-- **Worktree pytest runs the main checkout's source.** The editable install
-  points at the main working copy, so a new test in a worktree fails
-  against old code with no import error to warn you. Reinstall in the
-  worktree (`uv sync`) before trusting a red run.
-- **`ruff format` is not a gate.** CI runs `ruff check` only;
-  `ruff format --check` fails repo-wide by design. Don't "fix" formatting
-  the repo never enforced.
+- **R1 — Worktree sessions: pin every review and diff to `origin/main`.**
+  The local `main` checkout lags while other worktrees merge; a diff
+  against local `main` sweeps in commits that are not yours. (Session
+  memory `worktree-main-is-stale`, 2026-08.)
+- **R2 — Worktree pytest runs the main checkout's source.** The editable
+  install points at the main working copy, so a new test in a worktree
+  fails against old code with no import error to warn you. Reinstall in
+  the worktree (`uv sync`) before trusting a red run. (Session memory
+  `worktree-tests-hit-main-checkout`, 2026-08.)
+- **R3 — `ruff format` is not a gate.** CI (`ci.yml`) runs `ruff check`
+  only; `ruff format --check` fails repo-wide by design. Don't "fix"
+  formatting the repo never enforced. (Session memory
+  `ruff-format-is-not-a-gate`, 2026-08.)
 
 ## Doc maintenance
 
 A dated `/writing-for-agents` pass over CLAUDE.md, CONTEXT.md and `docs/`
-runs periodically (last: 2026-08-10); session-memory facts that prove
-repo-general over multiple sessions graduate into this file and the memory
-note becomes history. Verified against mattpocock-skills 1.2.3.
+runs periodically (last: 2026-08-10, CLAUDE.md and CONTEXT.md only);
+session-memory facts that prove repo-general over multiple sessions
+graduate into this file and the memory note becomes history. Verified
+against mattpocock-skills 1.2.3.
 
 ## Agent skills
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,9 +29,8 @@ timelines. The server measures; Claude decides.
   tool addressing one clip by name: omitted is the whole pool, a name is
   that bin and everything nested inside it, `""` is the root folder alone
   — the value `list_media` reports for a root clip, so a listing reads
-  back verbatim (#122).
-  _Avoid_: reading `""` as the whole pool — that is the omitted form; `""`
-  is the root folder alone. Each media tool taking a bin — `list_media`,
+  back verbatim (#122); `""` is never the whole pool — that is the
+  omitted form. Each media tool taking a bin — `list_media`,
   `inspect_clip`, `relink_media`, and per item on `set_clip_metadata` and
   `organize_media`'s `move_clips` — also takes `recursive`, false meaning
   that bin's own clips alone: the address of a copy a subfolder shadows
@@ -54,8 +53,7 @@ timelines. The server measures; Claude decides.
   stretch of the soloist's line between two endings. `analysis/phrases.py`
   reports the **boundaries**, each with two times — `measured_t`, where the
   line actually stopped, and `t`, the beat inside the rest that a cut is
-  placed on.
-  _Avoid_: the `phrase` factor inside `fills` — that one is only "how far
+  placed on. Not the `phrase` factor inside `fills`, which is only "how far
   into a four-bar group does this land".
 - **style layer** — `styles/` at the repo root: layered Markdown style
   profiles (`base.md` + `concert.md`), the corpus record (`corpus.md`) and
@@ -247,8 +245,9 @@ and the variable is for a project that does have an edit to scan.
   also home of the `projects/<project>/` convention and the songs file's
   ownership, #132).
 - Landing places for artifacts that today live only in issue and PR
-  threads: research reports → `docs/research/`, adversarial and other
-  standalone reviews → `reviews/` (dated filenames). Both merge to `main`
-  in the PR that produced them — a finding on an unmerged branch or in a
-  thread is unreadable from here.
+  threads: research reports → `docs/research/`, spike reports and design
+  bibles → `docs/reference/`, adversarial and other standalone reviews →
+  `reviews/` (dated filenames). All merge to `main` in the PR that
+  produced them — a finding on an unmerged branch or in a thread is
+  unreadable from here.
 - Wayfinder: map = issue #1, scope = #2, spec = #22, build tickets #23–#47.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,7 +29,9 @@ timelines. The server measures; Claude decides.
   tool addressing one clip by name: omitted is the whole pool, a name is
   that bin and everything nested inside it, `""` is the root folder alone
   — the value `list_media` reports for a root clip, so a listing reads
-  back verbatim (#122). Each media tool taking a bin — `list_media`,
+  back verbatim (#122).
+  _Avoid_: reading `""` as the whole pool — that is the omitted form; `""`
+  is the root folder alone. Each media tool taking a bin — `list_media`,
   `inspect_clip`, `relink_media`, and per item on `set_clip_metadata` and
   `organize_media`'s `move_clips` — also takes `recursive`, false meaning
   that bin's own clips alone: the address of a copy a subfolder shadows
@@ -45,13 +47,15 @@ timelines. The server measures; Claude decides.
 - **wind / comp** — the two halves of the opt-in third pass over `other`
   (#153). `wind` is horns and reeds; `comp` is accompaniment — piano,
   guitar, vibes, percussion, and the bass line itself on a capture whose
-  `bass` stem came back near-silent (#126). `comp` is **never** a piano
-  stem and nothing may name it one.
+  `bass` stem came back near-silent (#126).
+  _Avoid_: "piano stem" as a name for `comp` — it is accompaniment, and
+  nothing may name it otherwise (#126).
 - **phrase** — the cut-placement unit (#46, `styles/concert.md` §1): a
   stretch of the soloist's line between two endings. `analysis/phrases.py`
   reports the **boundaries**, each with two times — `measured_t`, where the
   line actually stopped, and `t`, the beat inside the rest that a cut is
-  placed on. Not the `phrase` factor inside `fills`, which is only "how far
+  placed on.
+  _Avoid_: the `phrase` factor inside `fills` — that one is only "how far
   into a four-bar group does this land".
 - **style layer** — `styles/` at the repo root: layered Markdown style
   profiles (`base.md` + `concert.md`), the corpus record (`corpus.md`) and
@@ -65,6 +69,8 @@ timelines. The server measures; Claude decides.
 - **angle sidecar** — one JSON file per Resolve project labelling each camera
   by subject × character; `role` is the only key `correlate_timeline` reads,
   and it arrives as a mapping the agent lifted, never as a path.
+  _Avoid_: `camera_sidecar` for this — that module reads a camera model off
+  the card's own XML (#94) and is not an angle sidecar.
 
 ## Module map — `src/resolve_mcp/`
 
@@ -240,4 +246,9 @@ and the variable is for a project that does have an edit to scan.
   assembly loop, the `virtual_transcript` self-review and the cut report;
   also home of the `projects/<project>/` convention and the songs file's
   ownership, #132).
+- Landing places for artifacts that today live only in issue and PR
+  threads: research reports → `docs/research/`, adversarial and other
+  standalone reviews → `reviews/` (dated filenames). Both merge to `main`
+  in the PR that produced them — a finding on an unmerged branch or in a
+  thread is unreadable from here.
 - Wayfinder: map = issue #1, scope = #2, spec = #22, build tickets #23–#47.


### PR DESCRIPTION
Back-ports from the claude-principles template into its main source repo, all surgical deltas: the hardened context-guard (fixes the documented heredoc false-positive and the env-prefix bypass), worktree add/list permissions, the seed sentence, merge-verification steps 6/7 rewritten for this repo's mixed merge/squash reality, a tagged Gotchas section promoting three multi-session memory facts, the stated doc-maintenance ritual, _Avoid_ lines and landing places in CONTEXT.md.

Review record (executable diff → full review, two rounds):
1. Fable adversarial pass over the whole retrofit — its finding here (steps 6/7 overgeneralized squash-merging; recent PRs are merge commits) fixed: verification is now by content, accepting either merge form.
2. Opus two-axis /code-review, 15 findings, all addressed in the second commit: five hook regex gaps closed (indented heredoc terminators, quoted-path cat bypass, brace/keyword command positions, chained launchers, per-pull gh redirect check), read-guard formatter hint restored to match its stamp, the false #109 re-landing citation moved to step 7 where the history supports it, Gotchas tagged R1–R3 with sources, maintenance claim scoped, seed deduplicated against CONTEXT.md, _Avoid_ lines returned to strict synonym form, docs/reference/ added to landing places.
Hook verified by a 28-case adversarial battery (all green) — the five regex fixes also flowed upstream into the template starter and its other four consumer repos.

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Merged origin/main (the branch had been cut from a stale local main — the RETROFIT fetch-first lesson, re-learned; no force-push). One conflict in CONTEXT.md (wind/comp entry) resolved by keeping upstream's #157 solos sentence alongside the _Avoid_ line.

Review: clean
