### PR TITLE
Write the concert-pillar process doc (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,13 @@ The five canonical triage roles, each label string equal to its role name. See `
 Single-context — `CONTEXT.md` (repo map + vocabulary) and `docs/adr/` at
 the repo root. See `docs/agents/domain.md`.
 
+### The concert pillar
+
+P3: the style-driven concert cut. The director's three inputs, session-start
+analysis prep, song-by-song planning, the mandatory `correlate_timeline`
+self-review, the cut report and review-round conventions:
+`docs/agents/concert.md`.
+
 ### The rough-cut pillar
 
 P4: transcript-driven A-roll assembly. The per-project brief and b-roll

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -247,7 +247,10 @@ and the variable is for a project that does have an edit to scan.
   source start.
 - `docs/agents/` — issue-tracker conventions (wayfinder map ops), triage
   labels, domain-docs usage, the style layer (sidecar + profile formats,
-  provenance tags, how a corpus pass is run), the rough-cut pillar
+  provenance tags, how a corpus pass is run), the concert pillar
+  (`concert.md`: the director's three inputs, session-start analysis prep,
+  song-by-song planning, the mandatory `correlate_timeline` self-review,
+  the cut report and review-round conventions, #16), the rough-cut pillar
   (`rough-cut.md`: the brief and b-roll catalog the agent owns, the
   assembly loop, the `virtual_transcript` self-review and the cut report;
   also home of the `projects/<project>/` convention and the songs file's

--- a/docs/agents/concert.md
+++ b/docs/agents/concert.md
@@ -1,0 +1,131 @@
+# The concert pillar
+
+How a style-driven concert cut runs end to end: what the director hands over, the
+analysis prep you kick off before planning, the song-by-song loop, the self-review that
+has to pass before the director sees anything, and the review rounds that follow.
+
+This is P3 of spec #22 (stories 40–50), settled in #16. It is the other shape from the
+rough-cut pillar: the substrate is one continuous master mix under stacked synced
+angles, the evidence is the analysis suite, and the taste you cut with is
+`styles/concert.md` — that profile holds the numbers (transient offsets, shot rhythm,
+angle roles, event moves); this doc holds the process. Neither repeats the other.
+
+## What the director hands you
+
+Three inputs, all theirs to make. Session preconditions — ask, never derive:
+
+- **The sync-reference timeline.** Angles waveform-synced by hand in the GUI, stacked
+  on one timeline. Read each angle's offset off it with `inspect_timeline` and record
+  it as `sync_offset` on the cut file's source aliases — informational only, the server
+  never computes or validates with it. You plan in the common clock; sync math stays
+  the director's.
+- **The master-mix file.** An explicit audio file that *is* the mix — every analysis
+  runs on it directly, and it is the continuous audio clip your cut file names in its
+  `audio` block. Its record position on the sync-reference timeline is the
+  audio→timeline mapping.
+- **The angle sidecar.** `styles/angles/<project>.json`, subject×character labels per
+  angle. If it does not exist yet, build it by the labelling flow in
+  `docs/agents/style-layer.md` — grab, propose, director confirms once — and it is
+  never re-asked.
+
+## Session-start prep
+
+Kick off the fixed suite first and label angles while it runs — jobs are background,
+and the cache makes a rerun free, so there is no per-session picking:
+
+1. `analyze_music` on the master-mix file path — beats, downbeats, energy — and
+   `separate_stems` two-pass, together. Stems feed `detect_fills` and the solo half of
+   structure. `separate_stems` takes `scope`, not a path — the mix must sit in the
+   media pool, so `import_media` it first if the director handed a bare file. One
+   extra call, deliberate: stems are keyed to pool media.
+2. `analyze_structure` on the mix path when the stems land, `solos=true` with the
+   stems directory — tunes from applause, solo changes from the stems. Keep the file
+   paths every job returns: the self-review consumes them verbatim.
+3. **`songs.json`** is shared prep, not titling-owned: applause analysis proposes the
+   song starts, the director confirms the blue markers (one per song key, T7), you
+   author the file. Whichever pillar runs first writes it; format and ownership live
+   in `docs/agents/rough-cut.md` §songs.json.
+
+Rubato regions are excluded from cut-placement evidence by beat-confidence gating — a
+grid fitted to free time measures nothing (`styles/concert.md` §1).
+
+## Planning
+
+One cut file per concert, planned **song by song** — analysis slices stay digestible,
+the file grows a song at a time, and `build_timeline` materializes the whole set as one
+versioned timeline. Per-song deliverables are range renders of the final version, not
+separate timelines.
+
+- Candidate angles you genuinely weighed go on the segment as `alternates[]` — that is
+  what makes a review-round angle note a `swap_take` instead of a rebuild.
+- Visual evidence is **targeted frame grabs at event-nominated moments**: the audio
+  analysis nominates (fills, solo changes, builds, candidate holds), `grab_frames`
+  answers only the visual questions the profile actually asks. Band interaction is
+  primarily an audio signal — read it from stem activity and onsets; frames verify,
+  they do not discover.
+- Every taste call — where the cut lands relative to the transient, how long shots
+  run, who deserves the frame — comes from `styles/concert.md`. When the profile is
+  silent, that is an observation to add, not a licence to improvise silently.
+
+## The self-review
+
+**Mandatory, per song, before the director sees anything**: run `correlate_timeline`
+on the cut you just built — beats, tunes, solos files from prep, the master-mix path as
+`audio` (that is what makes the transient column real), and the sidecar's labels passed
+as `angles`. This is the concert counterpart to the rough-cut pillar's
+`virtual_transcript`, and the same tool the corpus was measured with, so your cut is
+measured on exactly the axes the profile's `[measured]` claims stand on.
+
+The tool reports and never judges — the bar is the profile. Compare the inline gist
+against `styles/concert.md`'s measured claims: the transient-offset distribution
+(fourth-wall risk, §1), shot-duration runs (§3), role shares and transitions (§4),
+event responses (§5). **Every outlier is either fixed — edit the cut JSON, rebuild —
+or justified by name in the cut report** ("spectacle earns the hold"). Nothing lands
+off-style silently. Check `alignment.mode` before trusting a run, per
+`docs/agents/style-layer.md`.
+
+## The cut report
+
+What the director gets is the built timeline, markers on it, and a per-song report:
+the key moves, the event responses taken, and every self-review deviation you kept,
+with its justification. Markers are **uncertainties only** — `set_markers` on the
+frames you want eyes on, nothing else; the GUI is not wallpaper. Reviewing a song
+should take minutes.
+
+The report is a teaching surface: the director critiques the reasoning
+editor-to-editor, and that critique feeds the style profile, not just this cut.
+
+Markers survive rebuilds here: `build_timeline` carries the previous version's markers
+onto the new one by the frame of the master mix under them (ADR 0006) — the mix is the
+shared axis a rough cut lacks.
+
+## The review round
+
+Five conventions (#16, and they are the general feedback-loop conventions, not
+concert-only):
+
+1. **Two note channels, equal weight**: GUI markers left while watching
+   (`list_markers` is your queue) and chat critique of the cut report.
+2. **The revision unit is the round, not the note.** A batch of notes → cut-JSON
+   edits → one rebuild → the next `<name> v<N>`. The next report answers each note:
+   what changed, or pushback with reasoning — editor-talk goes both ways.
+3. **The in-place exception**: an angle-swap-only note is `swap_take` immediately,
+   with the cut JSON updated in the same breath (`sync` on the tool call) — the file
+   stays authoritative, no drift. Structural notes wait for the round's rebuild.
+4. **Every note is sorted two ways.** Cut-level ("this cut is late") → cut JSON edit.
+   Style-level ("too choppy in ballads") → a `[review feedback, YYYY-MM]` entry in
+   `styles/concert.md` **now**, in the same round, and the cut fix — the profile
+   learns the moment the note lands, not at the next corpus pass. You propose the
+   sort; the director can override.
+5. **Done is when the director says done.** The final version renders the per-song
+   deliverables as range renders.
+
+## Titling on a concert cut
+
+Titles ride the same timeline but never the cut file: author `titles.json` from
+`songs.json` and re-apply with `apply_titles` after any rebuild — it owns its track,
+so rebuild-then-reapply is the whole recovery. Placement and fade timing are yours,
+phrase-aware and energy-scaled — the test is "would a phone going off be rude here?":
+land titles where the music has room, scale fades to the energy around them. The
+schema deliberately ships ranges, not defaults (`titles/schema.py` §3) — a title
+placed mechanically reads mechanical.

--- a/docs/agents/rough-cut.md
+++ b/docs/agents/rough-cut.md
@@ -140,7 +140,7 @@ subject rather than the shot.
 `virtual_transcript` reads the cut file back as the words the built timeline will contain.
 Pass it the cut file and a mapping of source alias to the transcript document for that
 source. Run it before the director sees the cut, every version. It is the P4 counterpart to
-the mandatory `correlate_timeline` pass on a concert cut.
+the mandatory `correlate_timeline` pass on a concert cut (`docs/agents/concert.md`).
 
 Read `text` first — that is the piece, as prose. If it does not read as something a person
 said, nothing else matters yet.


### PR DESCRIPTION
Closes #164. The one blocker-grade finding from the #22 close-out spec review (2026-08-11): the concert pillar had no process document — stories 42/47/48/49's process half lived only in #16's close comment and session memory, and `rough-cut.md`'s self-review section forward-referenced a doc that didn't exist.

**What lands**: `docs/agents/concert.md` — the director's three inputs (sync-reference timeline, master-mix file, angle sidecar), session-start analysis prep with the stems-before-structure ordering, song-by-song planning, the mandatory per-song `correlate_timeline` self-review (fix or justify every outlier), the uncertainty-only cut report with ADR 0006 marker carry, the five review-round conventions (including style-level notes landing in `styles/concert.md` in the same round), and titling judgment (story 38's doc home). Content collected from #16, spec #22, and `styles/concert.md` — the profile keeps the numbers, this doc keeps the process, neither repeats the other. Companion edits: the `rough-cut.md` cross-reference, the CLAUDE.md agent-skills pointer, the CONTEXT.md map entry (same PR, per the map rule).

**Seam**: pure prose — no code touched; fake tier on `main` at 1570 passed pre-branch.

**Review findings (inline single pass), both fixed pre-PR**:
- Fade-guidance pointer cited `titles/schema.py` §4; the fades section is §3. Corrected.
- Prep sequence initially ran `analyze_structure` before `separate_stems`, but the solo half needs the stems directory (`tools/analysis.py` `analyze_structure(solos=True, stems=...)`). Reordered: music + stems together, then structure.

Review: clean — prose only, single-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)