### PR TITLE
Gauntlet G6: correct A7IV record zero in the Zinc angle sidecar (#185)

### DIFF
--- a/gauntlet/GAPS.md
+++ b/gauntlet/GAPS.md
@@ -70,10 +70,15 @@ Round 1 critic, verbatim needs; each is server measurement work:
 9. Head/tail treatment: fade-in vs dropped frames, audio floor handling.
 10. Audio feel across cuts (balance/room-tone jumps) beyond RMS level.
 
-## G6 — angle sidecar A7IV zero off by one (open, trivial)
+## G6 — angle sidecar A7IV zero off by one (closed)
 
-Builder measured A7IV record zero 86306 live; sidecar says 86307.
-Correct the sidecar datum.
+Builder measured A7IV record zero 86306 live; sidecar said 86307.
+Fixed 2026-08-14 (#185): the second A7IV item in
+`styles/angles/mcp-tests-zinc.json` carried source in 31269 against record
+117576; it is 31270, and the entry now records why (live `GetLeftOffset`,
+frame proof, and the entry's own duration arithmetic). No test fixture
+encoded the old datum, and the cut files under `projects/mcp-tests-zinc/`
+were already on 86306.
 
 ## G8 — song-opening title card convention absent from our workflow (open)
 

--- a/gauntlet/HANDOFF.md
+++ b/gauntlet/HANDOFF.md
@@ -97,7 +97,8 @@ filed via `/to-tickets` (user skill; if absent post-compact, ask or use
    in/out + straddle check; per-cut visual delta + 30°-rule; stability
    score. (Motion classes, boundary strips, audio classing, beat offsets
    are done — scope tickets to the remainder.)
-4. G6: angle sidecar A7IV zero off-by-one (86306 measured vs 86307) — trivial.
+4. ~~G6: angle sidecar A7IV zero off-by-one (86306 measured vs 86307)~~ —
+   done, #185 (sidecar item source in 31269 → 31270).
 5. G7: four dormant build-path risks (startFrame rebase; fail-open E5 on
    bounds-less clips; _append length unchecked; _verify no readback).
 6. G13: built timelines inherit project 4K default; every round manually

--- a/styles/angles/mcp-tests-zinc.json
+++ b/styles/angles/mcp-tests-zinc.json
@@ -35,7 +35,8 @@
         "track": "Video 2",
         "clip": "20260617_D_A7IV_0006.MP4",
         "record": [117576, 184982],
-        "source": [31269, 98675]
+        "source": [31270, 98675],
+        "source_in_basis": "Source in is 31270, giving an A7IV record zero of record - source = 86306 - the same zero the first A7IV item carries (87304 - 998). It was written as 31269 until 2026-08-14 (#185, gauntlet gap G6), which implied a zero of 86307 and put every frame mapped through this item one frame late. 31270 is what the item's GetLeftOffset returns live (gauntlet/recon/angle_probe.json, Video 2 item at record 117576), it is what a frame proof against the source clip confirmed (gauntlet/recon/mid_p3r2_frameproof.py), and it is the only value consistent with this entry's own arithmetic: 31270 + 67406 - 1 = 98675 = source out, where 31269 would overlap the preceding item's last frame and make the durations disagree by one. GetSourceStartFrame reports 31269 on this item and is the quirk, not the datum - prefer GetLeftOffset for a zero."
       }
     ]
   },


### PR DESCRIPTION
Closes #185.

## What changed

`styles/angles/mcp-tests-zinc.json`, second A7IV timeline item (record
117576–184982): source in `31269` → `31270`. That item implied a record zero of
86307 while the first A7IV item (87304 − 998) and the gauntlet's live
measurement both say 86306, so any frame mapped through it landed one frame
late.

`31270` is what the item's `GetLeftOffset` returns live
(`gauntlet/recon/angle_probe.json`, Video 2 item at record 117576), what the
frame proof confirmed (`gauntlet/recon/mid_p3r2_frameproof.py`), and the only
value consistent with the entry's own arithmetic: 31270 + 67406 − 1 = 98675 =
source out. `31269` would also overlap the preceding item's last frame.
`GetSourceStartFrame` reports 31269 on this item — recorded in the entry as the
quirk, not the datum.

The new `source_in_basis` key on the entry carries that provenance (AC 1).

Ledger G6 marked closed in `gauntlet/GAPS.md` and `gauntlet/HANDOFF.md`.

## AC 2 — fixtures encoding the old datum

None exist. `31269` appeared only in this sidecar; the cut files under
`projects/mcp-tests-zinc/` already carry `sync_offset: 86306`, and no fixture in
`tests/` encodes either value. Nothing to update.

## Test seam

Fake tier, and only as a regression guard: `styles/` is never read by server
code (`tests/test_style_layer.py` is what enforces that), so this data change
has no assertion to add. `uv run pytest -m 'not live'` → 1776 passed, 38
deselected. No `.py` changed, so mypy/ruff see nothing new; CI runs them anyway.
JSON re-parsed and both A7IV items verified at zero 86306.

## Review

Two files, both non-executable data/prose (angle sidecar JSON, gauntlet ledger
markdown) — CLAUDE.md's lightweight single-pass class, not `/code-review`.
Pass checked: sidecar parses; both A7IV zeros now 86306 and the FX6 zeros
unchanged; every file the provenance note cites exists; no other file in the
repo carried the old datum; no `<<<<<<<` markers; scratch log gitignored and
uncommitted. No findings.

Review: clean — prose only, single-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
