### PR TITLE
Beats cache: identity is audio content, not source path (#193)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,11 +149,11 @@ and the build). A `segments` entry is a shot or a **gap**
 (`{"id", "gap": <frames>}`, literal black); `is_gap`/`entry_duration`/
 `overlay_track` are the accessors every walker of that array shares.
 
-`jobs/` — `cache` (hash-keyed results; `identity` is audio's content hash
-wherever the file sits, `known_hash` reads those bytes once per file state
-and remembers it against a stat, `fingerprint` is path+size+mtime and stays
-the identity for video sources and stems — ADR 0007, ADR 0003), `runner`
-(start heavy work without
+`jobs/` — `cache` (hash-keyed results; `audio_identity` is the content hash
+wherever the file sits, read off a `known_hash` note remembered against a
+stat, except under `audio_dir` where it is always read for real;
+`fingerprint` is path+size+mtime and stays the identity for video sources
+and stems — ADR 0007, ADR 0003), `runner` (start heavy work without
 stalling stdio), `store` (one JSON record per job on disk), `detached` (hand
 a job to a process that outlives this one — flags, command, environment),
 `worker` (that process's entry point: `python -m resolve_mcp.jobs.worker

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,7 +149,11 @@ and the build). A `segments` entry is a shot or a **gap**
 (`{"id", "gap": <frames>}`, literal black); `is_gap`/`entry_duration`/
 `overlay_track` are the accessors every walker of that array shares.
 
-`jobs/` — `cache` (hash-keyed results), `runner` (start heavy work without
+`jobs/` — `cache` (hash-keyed results; `identity` is audio's content hash
+wherever the file sits, `known_hash` reads those bytes once per file state
+and remembers it against a stat, `fingerprint` is path+size+mtime and stays
+the identity for video sources and stems — ADR 0007, ADR 0003), `runner`
+(start heavy work without
 stalling stdio), `store` (one JSON record per job on disk), `detached` (hand
 a job to a process that outlives this one — flags, command, environment),
 `worker` (that process's entry point: `python -m resolve_mcp.jobs.worker
@@ -301,7 +305,8 @@ template; `titles/schema.py` §6).
   analysis models are injected; 0003 stems fingerprinted (path is a
   content hash); 0004 editor-state getters answer only for the current
   timeline; 0005 source frames are read off the left offset, not the
-  source start.
+  source start; 0006 markers ride the mix across a rebuild; 0007 audio is
+  identified by content, the hash remembered against a stat.
 - `docs/agents/` — issue-tracker conventions (wayfinder map ops), triage
   labels, domain-docs usage, the style layer (sidecar + profile formats,
   provenance tags, how a corpus pass is run), the concert pillar

--- a/docs/adr/0003-stems-are-fingerprinted-because-their-path-is-a-content-hash.md
+++ b/docs/adr/0003-stems-are-fingerprinted-because-their-path-is-a-content-hash.md
@@ -37,9 +37,15 @@ everything upstream of it, and size and mtime catch a rewrite in place. Fingerpr
 these files is not a weaker identity than hashing them — it is the same identity, read off
 a name instead of off two gigabytes.
 
-`cache.identity(path, written_under)` holds the general rule, so two jobs keying off the
+`cache.identity(path, config)` holds the general rule, so two jobs keying off the
 same master agree about what it is; `analysis/fills.py:_key` is the one caller that departs
 from it, and says so.
+
+> **Amended by [ADR 0007](0007-audio-is-identified-by-content-with-the-hash-remembered.md)
+> (2026-08-14).** The rule's fingerprint half no longer covers audio: an audio master is
+> hashed too, with the hash remembered against a stat so the starter still returns at once.
+> This decision is unchanged — stems keep fingerprint identity, on the reasoning below, and
+> so do video sources.
 
 ## Consequences
 

--- a/docs/adr/0007-audio-is-identified-by-content-with-the-hash-remembered.md
+++ b/docs/adr/0007-audio-is-identified-by-content-with-the-hash-remembered.md
@@ -27,13 +27,23 @@ I/O.
 The starter is protected by a **memo instead of a weaker identity**: `cache.known_hash`
 writes one note per file state into `config.identity_dir`, keyed on the fingerprint that
 was already cheap to take. The first sight of a given path/size/mtime costs one read; every
-later call for that unchanged file costs a `stat`. `audio/acquire.py` takes its
-`content_sha256` through the same call, so a WAV this server just wrote arrives at the next
-analysis already remembered.
+later call for that unchanged file costs a `stat`.
 
-A note is a shortcut and never an authority. One that cannot be read, cannot be written, or
-whose recorded size and mtime no longer match the file is ignored and the bytes are read
-again — a memo can cost a reread, never a wrong answer.
+A note that cannot be read, cannot be written, or whose recorded size and mtime no longer
+match the file is ignored and the bytes are read again. What a note **cannot** do is be more
+trusting than the fingerprint guarding it, and that bounds where it is allowed to apply. A
+same-size rewrite in place, on a filesystem whose mtime is granular to two seconds — exFAT
+and SMB, which is what external concert drives are formatted as — is one file state by a
+fingerprint's reading and different audio in fact.
+
+For the director's master that is not a new risk: it is precisely the risk the old rule ran,
+since a master's whole identity used to be that same fingerprint with no hash behind it at
+all. Under `audio_dir` it *would* be new, on the substrate every later job keys off, where a
+false hit attributes one concert's beats to another. So **audio this server wrote is hashed
+for real on every call and never read off a note** — `cache.audio_identity` branches there,
+and these are files the server sized itself and can afford to read. The branch is about how
+the same answer is reached, never about what the answer is: identity is the content hash on
+both sides of it, which is what makes a copy hit its original.
 
 `fingerprint` stays, and stays the identity for **video** sources (`video/scenes.py`,
 `video/frames.py`, `video/occlusion.py`) and for stems (ADR 0003). Those are the files the
@@ -49,6 +59,9 @@ master the job keying off it never reads it end to end anyway.
   beat, structure and phrase work it is about to save — and no run after it pays anything.
   If a route ever needs audio identity for a file it will *not* then analyse, that trade
   stops holding and the route should say so.
+- Audio under `audio_dir` costs a full read on every starter that keys off it. That is
+  unchanged — it is what the old rule already did to acquired audio — so nothing regresses,
+  but it is also the reason the memo is not simply applied everywhere.
 - Entries already on disk need no migration pass. Identity was a `{"sha256"}` dict for
   hashed audio and a `{"path", "size", "mtime_ns"}` dict for everything else, and the dict
   goes into the key verbatim: acquired-audio entries keep hitting under exactly the same

--- a/docs/adr/0007-audio-is-identified-by-content-with-the-hash-remembered.md
+++ b/docs/adr/0007-audio-is-identified-by-content-with-the-hash-remembered.md
@@ -1,0 +1,59 @@
+# ADR 0007 — Audio is identified by content, with the hash remembered against a stat
+
+- **Status**: accepted
+- **Date**: 2026-08-14
+- **Context**: [#193](https://github.com/danielbaldwin47/resolve-mcp/issues/193) — a staged copy of the director's master missed the beats cache during the gauntlet
+
+## Context
+
+`jobs/cache.py` originally split identity two ways: audio this server wrote under
+`audio_dir` was hashed, and everything else — the director's master included — was
+*fingerprinted* by path, size and mtime. The reason was the starter contract (#22, story
+25): a starter returns a job id at once, and reading tens of gigabytes before the first
+byte of the response is exactly the stall a fingerprint avoids.
+
+The cost of that split showed up the moment the same audio existed twice. During the
+gauntlet an acquisition staged a copy of the director's master into the cache directory;
+the copy hashed, the original fingerprinted, so the two identities could not agree and the
+beat model ran a second time over byte-identical audio. The same happens for every
+workflow that stages or copies audio — renders, per-song excerpts, a delivered mix — and
+each copy repays the full analysis cost, which is minutes of model time, not seconds of
+I/O.
+
+## Decision
+
+`cache.identity` is the content hash of the file, wherever the file sits.
+
+The starter is protected by a **memo instead of a weaker identity**: `cache.known_hash`
+writes one note per file state into `config.identity_dir`, keyed on the fingerprint that
+was already cheap to take. The first sight of a given path/size/mtime costs one read; every
+later call for that unchanged file costs a `stat`. `audio/acquire.py` takes its
+`content_sha256` through the same call, so a WAV this server just wrote arrives at the next
+analysis already remembered.
+
+A note is a shortcut and never an authority. One that cannot be read, cannot be written, or
+whose recorded size and mtime no longer match the file is ignored and the bytes are read
+again — a memo can cost a reread, never a wrong answer.
+
+`fingerprint` stays, and stays the identity for **video** sources (`video/scenes.py`,
+`video/frames.py`, `video/occlusion.py`) and for stems (ADR 0003). Those are the files the
+old reasoning was really about: a camera master is tens of gigabytes, and unlike an audio
+master the job keying off it never reads it end to end anyway.
+
+## Consequences
+
+- A copy of already-analysed audio hits the cache of its original, which is the whole point
+  of #193.
+- An audio master is read once per file state. The first analysis of a fresh master pays a
+  full sequential read in the starter — seconds for a concert WAV, against the minutes of
+  beat, structure and phrase work it is about to save — and no run after it pays anything.
+  If a route ever needs audio identity for a file it will *not* then analyse, that trade
+  stops holding and the route should say so.
+- Entries already on disk need no migration pass. Identity was a `{"sha256"}` dict for
+  hashed audio and a `{"path", "size", "mtime_ns"}` dict for everything else, and the dict
+  goes into the key verbatim: acquired-audio entries keep hitting under exactly the same
+  key, and every path-keyed entry now produces a key nothing asks for. A stale hit is not
+  reachable — the two shapes cannot collide — so the dead entries are left to be swept with
+  the rest of the cache directory rather than hunted down.
+- The identity notes are cache, in the cache directory, and a user who deletes them gets
+  rereads rather than errors.

--- a/src/resolve_mcp/analysis/fills.py
+++ b/src/resolve_mcp/analysis/fills.py
@@ -442,7 +442,7 @@ def detect_drum_fills(
     halves.sane_floor(minimum_confidence, DEFAULT_MINIMUM_CONFIDENCE)
 
     settings = {"minimum_confidence": float(minimum_confidence)}
-    identity = cache.identity(source, config)
+    identity = halves.identity(source, config)
     key = _key(identity, found, settings)
 
     def work(progress: Progress) -> JobOutput:
@@ -593,7 +593,7 @@ def detect(
     config = config or get_config()
     config.analysis_dir.mkdir(parents=True, exist_ok=True)
     described = wav.describe(source)
-    known = dict(identity) if identity is not None else cache.identity(source, config)
+    known = dict(identity) if identity is not None else halves.identity(source, config)
     key = key or _key(known, stems, settings)
 
     progress(0.05, "reading the beat grid")

--- a/src/resolve_mcp/analysis/fills.py
+++ b/src/resolve_mcp/analysis/fills.py
@@ -442,7 +442,7 @@ def detect_drum_fills(
     halves.sane_floor(minimum_confidence, DEFAULT_MINIMUM_CONFIDENCE)
 
     settings = {"minimum_confidence": float(minimum_confidence)}
-    identity = cache.identity(source, config.audio_dir)
+    identity = cache.identity(source, config)
     key = _key(identity, found, settings)
 
     def work(progress: Progress) -> JobOutput:
@@ -593,7 +593,7 @@ def detect(
     config = config or get_config()
     config.analysis_dir.mkdir(parents=True, exist_ok=True)
     described = wav.describe(source)
-    known = dict(identity) if identity is not None else cache.identity(source, config.audio_dir)
+    known = dict(identity) if identity is not None else cache.identity(source, config)
     key = key or _key(known, stems, settings)
 
     progress(0.05, "reading the beat grid")

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -63,16 +63,17 @@ def sane_floor(minimum_confidence: float, default: float, writes: str = "candida
 
 
 def identity(source: Path, config: Config) -> dict[str, Any]:
-    """Hash what this server wrote; fingerprint what the director handed over.
+    """What this audio is: its bytes, whoever wrote the file and wherever it sits.
 
-    Audio this server wrote is hashed, because it is the substrate later analysis keys off
-    and a false hit there would attribute one concert's beats to another; a master the
-    director handed over is fingerprinted, because it is tens of gigabytes that sit
-    unchanged for months and reading all of it would stall the starter that is supposed to
-    return a job id at once. The rule itself lives in ``jobs.cache``, so jobs that key off
-    an audio path without going through a half agree with the ones that do.
+    Content rather than path, because the same concert arrives under several names — the
+    director's master, the copy an acquisition staged into the cache directory, an excerpt
+    rendered for one song — and a half keyed on the name is a beat model run again over
+    identical audio (#193). The hash is read once per file state and remembered against a
+    stat, so the starter this runs in still returns a job id at once. The rule itself lives
+    in ``jobs.cache``, so jobs that key off an audio path without going through a half agree
+    with the ones that do.
     """
-    return cache.identity(source, config.audio_dir)
+    return cache.identity(source, config)
 
 
 def inside(source: Path, directory: Path) -> bool:

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -70,10 +70,11 @@ def identity(source: Path, config: Config) -> dict[str, Any]:
     rendered for one song — and a half keyed on the name is a beat model run again over
     identical audio (#193). The hash is read once per file state and remembered against a
     stat, so the starter this runs in still returns a job id at once. The rule itself lives
-    in ``jobs.cache``, so jobs that key off an audio path without going through a half agree
-    with the ones that do.
+    in ``jobs.cache``; this is the door every analysis module goes through to reach it, so a
+    job that keys off an audio path without writing a half of its own still agrees with the
+    ones that do.
     """
-    return cache.identity(source, config)
+    return cache.audio_identity(source, config)
 
 
 def inside(source: Path, directory: Path) -> bool:

--- a/src/resolve_mcp/analysis/phrases.py
+++ b/src/resolve_mcp/analysis/phrases.py
@@ -409,7 +409,7 @@ def detect_phrases(
     halves.sane_floor(minimum_confidence, DEFAULT_MINIMUM_CONFIDENCE, writes="boundary")
 
     settings = {"stem": stem, "minimum_confidence": float(minimum_confidence)}
-    identity = cache.identity(source, config)
+    identity = halves.identity(source, config)
     key = _key(identity, stem, found, settings)
 
     def work(progress: Progress) -> JobOutput:
@@ -545,7 +545,7 @@ def detect(
     config = config or get_config()
     config.analysis_dir.mkdir(parents=True, exist_ok=True)
     described = wav.describe(source)
-    known = dict(identity) if identity is not None else cache.identity(source, config)
+    known = dict(identity) if identity is not None else halves.identity(source, config)
     label = str(settings["stem"])
     key = key or _key(known, label, stem, settings)
 

--- a/src/resolve_mcp/analysis/phrases.py
+++ b/src/resolve_mcp/analysis/phrases.py
@@ -409,7 +409,7 @@ def detect_phrases(
     halves.sane_floor(minimum_confidence, DEFAULT_MINIMUM_CONFIDENCE, writes="boundary")
 
     settings = {"stem": stem, "minimum_confidence": float(minimum_confidence)}
-    identity = cache.identity(source, config.audio_dir)
+    identity = cache.identity(source, config)
     key = _key(identity, stem, found, settings)
 
     def work(progress: Progress) -> JobOutput:
@@ -545,7 +545,7 @@ def detect(
     config = config or get_config()
     config.analysis_dir.mkdir(parents=True, exist_ok=True)
     described = wav.describe(source)
-    known = dict(identity) if identity is not None else cache.identity(source, config.audio_dir)
+    known = dict(identity) if identity is not None else cache.identity(source, config)
     label = str(settings["stem"])
     key = key or _key(known, label, stem, settings)
 

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -13,8 +13,10 @@ Which route is chosen is not a preference, it is a correctness question:
   is checked first and a linked or offset source is refused with a pointer at the timeline
   route rather than quietly extracting the wrong thing.
 
-Caching follows the same split (see ``jobs.cache``): the source clip is fingerprinted
-cheaply, the acquired WAV is hashed for real, and that hash is what analysis jobs key off.
+Caching splits along the same line (see ``jobs.cache``): the clip's media file on disk is
+fingerprinted cheaply, because an acquisition is cheap to redo if that guess is ever wrong,
+while the acquired WAV is hashed for real — and that hash is what analysis jobs key off,
+wherever a copy of it turns up later (#193).
 A timeline has no bytes to fingerprint, so its identity is name, unique id, bounds, track
 counts and a digest of the shots on it — still a heuristic, because a clip's audio level is
 not readable through the scripting API at all, which is why every starter takes ``refresh``
@@ -535,9 +537,7 @@ def _clip_params(clip: str, bin_path: str, sample_rate: int, bit_depth: int) -> 
 def _result(target: Path, params: dict[str, Any]) -> dict[str, Any]:
     """What the agent — and every analysis job after it — reads off a finished acquisition."""
     reading = wav.describe(target)
-    # Through the memo rather than straight to the hash: the WAV was just written, so this is
-    # where its identity gets remembered, and the analysis job the agent starts next stats it.
-    reading["content_sha256"] = cache.known_hash(target)
+    reading["content_sha256"] = cache.content_hash(target)
     reading["scope"] = params["scope"]
     log.info(
         "Acquired %.1fs of audio for %s scope at %s",

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -535,7 +535,9 @@ def _clip_params(clip: str, bin_path: str, sample_rate: int, bit_depth: int) -> 
 def _result(target: Path, params: dict[str, Any]) -> dict[str, Any]:
     """What the agent — and every analysis job after it — reads off a finished acquisition."""
     reading = wav.describe(target)
-    reading["content_sha256"] = cache.content_hash(target)
+    # Through the memo rather than straight to the hash: the WAV was just written, so this is
+    # where its identity gets remembered, and the analysis job the agent starts next stats it.
+    reading["content_sha256"] = cache.known_hash(target)
     reading["scope"] = params["scope"]
     log.info(
         "Acquired %.1fs of audio for %s scope at %s",

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -138,6 +138,11 @@ class Config:
         return self.cache_dir / "results"
 
     @property
+    def identity_dir(self) -> Path:
+        """One note per file state, remembering the content hash a stat stands in for."""
+        return self.cache_dir / "identity"
+
+    @property
     def audio_dir(self) -> Path:
         """Acquired WAVs. Analysis workers key off the content hash of what lands here."""
         return self.cache_dir / "audio"

--- a/src/resolve_mcp/jobs/cache.py
+++ b/src/resolve_mcp/jobs/cache.py
@@ -2,15 +2,26 @@
 
 Two kinds of identity live here, and the difference is the whole design:
 
-* **Source media is fingerprinted, not hashed.** A concert master is tens of gigabytes and
-  sits on the director's disk unchanged for months; reading all of it to prove that takes
-  minutes, every run. Path, size and mtime answer "is this the same file" well enough to
-  key an acquisition, and the acquisition is cheap to redo if the guess is ever wrong.
+* **Audio is identified by its bytes** (``identity``). The same concert reaches this server
+  under several names — the director's master, the copy an acquisition staged into the cache
+  directory, an excerpt rendered for one song — and keying on the name made each of those pay
+  for its own beat model over identical audio (#193). ``sha256`` of the file is the identity,
+  wherever the file sits, which is also what #22 asked for ("workers key off content hash of
+  cached audio + params hash") and what keeps one concert's beats off another's cut.
 
-* **Acquired audio is hashed for real.** The WAV this server wrote is the substrate every
-  analysis job keys off (#22: "workers key off content hash of cached audio + params
-  hash"), it is a manageable size, and a false cache hit there would silently attribute
-  one concert's beats to another.
+* **Video sources are fingerprinted, not hashed** (``fingerprint``). A camera master is tens
+  of gigabytes that sit unchanged for months; reading all of it to prove that takes minutes,
+  and the jobs that key off it — scene cuts, grabbed frames, occlusion — never read it end to
+  end themselves. Path, size and mtime answer "is this the same file" well enough there, and
+  the cost of being wrong is one redundant rerun rather than a wrong answer.
+
+Reading the bytes is not free, so **a hash is remembered against a fingerprint**
+(``known_hash``): the first sight of a file state costs one read, and every later call for
+that same path, size and mtime costs a ``stat``. That memo is what lets a starter whose whole
+contract is to return a job id at once (#22, story 25) key on content — an audio master gets
+read end to end by the analysis it is about to start anyway. The note is only ever a shortcut:
+one that cannot be read, written, or that no longer describes the file costs a reread, never a
+wrong answer.
 
 A hit is only a hit if the artifacts are still on disk. The cache directory is a user's
 local app data — they are allowed to delete things in it, and the agent must get a rerun
@@ -54,16 +65,64 @@ def content_hash(path: Path | str) -> str:
     return digest.hexdigest()
 
 
-def identity(path: Path | str, written_under: Path) -> dict[str, Any]:
-    """Hash what this server wrote under ``written_under``; fingerprint anything else.
+def known_hash(path: Path | str, config: Config | None = None) -> str:
+    """The file's content hash, read once per file state and remembered against a stat.
+
+    The memo is what makes content identity affordable where it is asked for — in a starter,
+    before a job id goes back. It is a shortcut and nothing else: a note that cannot be read,
+    cannot be written, or no longer describes the file on disk costs a reread.
+    """
+    config = config or get_config()
+    seen = fingerprint(path)
+    note = _note_path(seen, config)
+    remembered = _remembered(note, seen)
+    if remembered is not None:
+        return remembered
+    log.info("Hashing %s (%d bytes): first sight of this file state", seen["path"], seen["size"])
+    digest = content_hash(path)
+    _note(note, {**seen, "sha256": digest})
+    return digest
+
+
+def identity(path: Path | str, config: Config | None = None) -> dict[str, Any]:
+    """What audio is, for cache purposes: its bytes, wherever the file happens to sit.
 
     The rule at the top of this module, as one call — so two jobs keying off the same
     master agree about what it is, rather than each deciding for itself.
     """
-    resolved = Path(path)
-    if resolved.resolve().is_relative_to(written_under.resolve()):
-        return {"sha256": content_hash(resolved)}
-    return fingerprint(resolved)
+    return {"sha256": known_hash(path, config)}
+
+
+def _note_path(seen: Mapping[str, Any], config: Config) -> Path:
+    token = hashlib.sha256(
+        json.dumps([seen["path"], seen["size"], seen["mtime_ns"]]).encode("utf-8")
+    ).hexdigest()
+    return config.identity_dir / f"{token}.json"
+
+
+def _remembered(note: Path, seen: Mapping[str, Any]) -> str | None:
+    """The hash this note carries, if it still describes the file that was just stat'd."""
+    try:
+        noted = json.loads(note.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError):
+        log.warning("Discarding an unreadable identity note: %s", note)
+        _discard(note)
+        return None
+    if not isinstance(noted, dict) or not isinstance(noted.get("sha256"), str):
+        return None
+    describes = all(noted.get(field) == seen[field] for field in ("path", "size", "mtime_ns"))
+    return str(noted["sha256"]) if describes else None
+
+
+def _note(note: Path, remembering: Mapping[str, Any]) -> None:
+    """Write down what this file state hashed to. A memo that cannot be kept is not an error."""
+    try:
+        note.parent.mkdir(parents=True, exist_ok=True)
+        note.write_text(json.dumps(remembering, indent=2), encoding="utf-8")
+    except OSError:
+        log.warning("Could not remember the identity of %s", remembering["path"], exc_info=True)
 
 
 def cache_key(

--- a/src/resolve_mcp/jobs/cache.py
+++ b/src/resolve_mcp/jobs/cache.py
@@ -19,9 +19,10 @@ Reading the bytes is not free, so **a hash is remembered against a fingerprint**
 (``known_hash``): the first sight of a file state costs one read, and every later call for
 that same path, size and mtime costs a ``stat``. That memo is what lets a starter whose whole
 contract is to return a job id at once (#22, story 25) key on content — an audio master gets
-read end to end by the analysis it is about to start anyway. The note is only ever a shortcut:
-one that cannot be read, written, or that no longer describes the file costs a reread, never a
-wrong answer.
+read end to end by the analysis it is about to start anyway. A note that cannot be read,
+cannot be written, or no longer describes the file costs a reread. What it cannot do is be
+*more* trusting than the fingerprint it is guarded by, which is why audio under ``audio_dir``
+is hashed for real every time and never read off a note: see ``audio_identity``.
 
 A hit is only a hit if the artifacts are still on disk. The cache directory is a user's
 local app data — they are allowed to delete things in it, and the agent must get a rerun
@@ -80,20 +81,38 @@ def known_hash(path: Path | str, config: Config | None = None) -> str:
         return remembered
     log.info("Hashing %s (%d bytes): first sight of this file state", seen["path"], seen["size"])
     digest = content_hash(path)
-    _note(note, {**seen, "sha256": digest})
+    _write_note(note, {**seen, "sha256": digest})
     return digest
 
 
-def identity(path: Path | str, config: Config | None = None) -> dict[str, Any]:
+def audio_identity(path: Path | str, config: Config | None = None) -> dict[str, Any]:
     """What audio is, for cache purposes: its bytes, wherever the file happens to sit.
 
-    The rule at the top of this module, as one call — so two jobs keying off the same
-    master agree about what it is, rather than each deciding for itself.
+    The audio half of the rule at the top of this module, as one call — so two jobs keying
+    off the same master agree about what it is, rather than each deciding for itself. Named
+    for what it covers, because the other half of the rule is a different call: pointing this
+    one at a camera master would read tens of gigabytes to answer a question ``fingerprint``
+    answers with a stat.
+
+    Audio this server wrote is hashed for real every time, never off a note. The note's own
+    guard is a fingerprint, and a fingerprint can be fooled — a same-size rewrite in place, on
+    a filesystem whose mtime is granular to two seconds, is the same file state by that
+    reading and different audio in fact. Everywhere else that risk is the one this cache
+    already ran (the master used to be fingerprinted outright, with no hash behind it), so the
+    note leaves it exactly where it was. Under ``audio_dir`` it would be a new risk on the
+    substrate every later job keys off, where a false hit attributes one concert's beats to
+    another — and it buys nothing worth that, because these are the files this server sized
+    itself and can afford to read.
     """
-    return {"sha256": known_hash(path, config)}
+    config = config or get_config()
+    resolved = Path(path)
+    if resolved.resolve().is_relative_to(config.audio_dir.resolve()):
+        return {"sha256": content_hash(resolved)}
+    return {"sha256": known_hash(resolved, config)}
 
 
 def _note_path(seen: Mapping[str, Any], config: Config) -> Path:
+    """One file per file state, named after the fingerprint it remembers a hash for."""
     token = hashlib.sha256(
         json.dumps([seen["path"], seen["size"], seen["mtime_ns"]]).encode("utf-8")
     ).hexdigest()
@@ -111,12 +130,16 @@ def _remembered(note: Path, seen: Mapping[str, Any]) -> str | None:
         _discard(note)
         return None
     if not isinstance(noted, dict) or not isinstance(noted.get("sha256"), str):
+        log.warning("Discarding an identity note that is not one: %s", note)
+        _discard(note)
         return None
     describes = all(noted.get(field) == seen[field] for field in ("path", "size", "mtime_ns"))
+    # A note that no longer describes the file is not discarded: it is named after the file
+    # state it belongs to, so it can only be reached again by a file that went back to it.
     return str(noted["sha256"]) if describes else None
 
 
-def _note(note: Path, remembering: Mapping[str, Any]) -> None:
+def _write_note(note: Path, remembering: Mapping[str, Any]) -> None:
     """Write down what this file state hashed to. A memo that cannot be kept is not an error."""
     try:
         note.parent.mkdir(parents=True, exist_ok=True)

--- a/src/resolve_mcp/jobs/cache.py
+++ b/src/resolve_mcp/jobs/cache.py
@@ -134,8 +134,8 @@ def _remembered(note: Path, seen: Mapping[str, Any]) -> str | None:
         _discard(note)
         return None
     describes = all(noted.get(field) == seen[field] for field in ("path", "size", "mtime_ns"))
-    # A note that no longer describes the file is not discarded: it is named after the file
-    # state it belongs to, so it can only be reached again by a file that went back to it.
+    # A note that no longer describes the file needs no discarding of its own: it is named
+    # after the file state it answers for, so the reread it just forced overwrites it.
     return str(noted["sha256"]) if describes else None
 
 

--- a/tests/test_job_cache.py
+++ b/tests/test_job_cache.py
@@ -7,8 +7,13 @@ someone deleted from the cache directory all have to miss.
 
 from __future__ import annotations
 
+import json
 import os
+import shutil
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 from resolve_mcp.config import get_config
 from resolve_mcp.jobs import cache
@@ -52,6 +57,114 @@ def test_acquired_audio_is_identified_by_its_bytes(tmp_path: Path) -> None:
 
     two.write_bytes(b"RIFF....WAVEx")
     assert cache.content_hash(one) != cache.content_hash(two)
+
+
+# --- identity: the bytes, not the name (#193) -------------------------------------------
+
+
+def _wav(path: Path, body: bytes = b"RIFF....WAVE") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(body)
+    return path
+
+
+def _refuse(path: Any) -> str:
+    raise AssertionError("the hash was already remembered against this file state")
+
+
+def test_a_copy_of_analysed_audio_shares_the_identity_of_its_original(tmp_path: Path) -> None:
+    """The staged copy of a master is the same audio under another name, and pays nothing."""
+    master = _wav(tmp_path / "director" / "master.wav")
+    staged = get_config().audio_dir / "mix-abc123.wav"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(master, staged)
+
+    assert cache.identity(master) == cache.identity(staged)
+    assert cache.identity(master) == {"sha256": cache.content_hash(master)}
+
+
+def test_different_audio_is_a_different_identity_however_it_is_named(tmp_path: Path) -> None:
+    one = _wav(tmp_path / "a.wav")
+    two = _wav(tmp_path / "b.wav", b"RIFF....WAVEx")
+
+    assert cache.identity(one) != cache.identity(two)
+
+
+def test_a_rewritten_file_is_hashed_again_rather_than_read_off_the_old_note(
+    tmp_path: Path,
+) -> None:
+    media = _wav(tmp_path / "master.wav")
+    before = cache.identity(media)
+
+    media.write_bytes(b"RIFF....WAVEx")
+
+    assert cache.identity(media) != before
+
+
+def test_the_bytes_are_read_once_per_file_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The memo is what keeps content identity affordable in a starter that must return at once."""
+    media = _wav(tmp_path / "master.wav")
+    first = cache.identity(media)
+
+    monkeypatch.setattr(cache, "content_hash", _refuse)
+
+    assert cache.identity(media) == first
+
+
+def test_a_note_that_disagrees_with_the_file_is_ignored(tmp_path: Path) -> None:
+    """A note is a shortcut, never an authority: it is only used if it still describes the file."""
+    media = _wav(tmp_path / "master.wav")
+    cache.identity(media)
+    for note in get_config().identity_dir.iterdir():
+        note.write_text(
+            json.dumps({"path": str(media), "size": 999, "mtime_ns": 0, "sha256": "deadbeef"}),
+            encoding="utf-8",
+        )
+
+    assert cache.identity(media) == {"sha256": cache.content_hash(media)}
+
+
+def test_an_unreadable_note_is_a_reread_not_a_crash(tmp_path: Path) -> None:
+    media = _wav(tmp_path / "master.wav")
+    cache.identity(media)
+    for note in get_config().identity_dir.iterdir():
+        note.write_text("{ truncated", encoding="utf-8")
+
+    assert cache.identity(media) == {"sha256": cache.content_hash(media)}
+
+
+def test_a_note_that_cannot_be_written_costs_a_reread_not_an_answer(tmp_path: Path) -> None:
+    """The cache root is the user's own; a directory they replaced with a file must not raise."""
+    get_config().identity_dir.parent.mkdir(parents=True, exist_ok=True)
+    get_config().identity_dir.write_text("someone put a file here", encoding="utf-8")
+    media = _wav(tmp_path / "master.wav")
+
+    assert cache.identity(media) == {"sha256": cache.content_hash(media)}
+
+
+# --- what the change to content identity does to entries already on disk ------------------
+
+
+def test_an_entry_keyed_the_old_way_misses_rather_than_hitting_stale(tmp_path: Path) -> None:
+    """Path-keyed identity and content-keyed identity are different shapes, so no key survives."""
+    media = _wav(tmp_path / "master.wav")
+
+    was = cache.cache_key("analyze_music:beats", [cache.fingerprint(media)], {})
+    now = cache.cache_key("analyze_music:beats", [cache.identity(media)], {})
+
+    assert was != now
+
+
+def test_an_entry_keyed_on_a_hashed_wav_carries_over_unchanged(tmp_path: Path) -> None:
+    """Acquired audio was hashed before this change, so its entries migrate rather than re-run."""
+    acquired = _wav(get_config().audio_dir / "mix.wav")
+
+    was = cache.cache_key("analyze_music:beats", [{"sha256": cache.content_hash(acquired)}], {})
+    now = cache.cache_key("analyze_music:beats", [cache.identity(acquired)], {})
+
+    assert was == now
 
 
 def test_a_remembered_result_comes_straight_back(tmp_path: Path) -> None:

--- a/tests/test_job_cache.py
+++ b/tests/test_job_cache.py
@@ -79,26 +79,26 @@ def test_a_copy_of_analysed_audio_shares_the_identity_of_its_original(tmp_path: 
     staged.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(master, staged)
 
-    assert cache.identity(master) == cache.identity(staged)
-    assert cache.identity(master) == {"sha256": cache.content_hash(master)}
+    assert cache.audio_identity(master) == cache.audio_identity(staged)
+    assert cache.audio_identity(master) == {"sha256": cache.content_hash(master)}
 
 
 def test_different_audio_is_a_different_identity_however_it_is_named(tmp_path: Path) -> None:
     one = _wav(tmp_path / "a.wav")
     two = _wav(tmp_path / "b.wav", b"RIFF....WAVEx")
 
-    assert cache.identity(one) != cache.identity(two)
+    assert cache.audio_identity(one) != cache.audio_identity(two)
 
 
 def test_a_rewritten_file_is_hashed_again_rather_than_read_off_the_old_note(
     tmp_path: Path,
 ) -> None:
     media = _wav(tmp_path / "master.wav")
-    before = cache.identity(media)
+    before = cache.audio_identity(media)
 
     media.write_bytes(b"RIFF....WAVEx")
 
-    assert cache.identity(media) != before
+    assert cache.audio_identity(media) != before
 
 
 def test_the_bytes_are_read_once_per_file_state(
@@ -106,33 +106,33 @@ def test_the_bytes_are_read_once_per_file_state(
 ) -> None:
     """The memo is what keeps content identity affordable in a starter that must return at once."""
     media = _wav(tmp_path / "master.wav")
-    first = cache.identity(media)
+    first = cache.audio_identity(media)
 
     monkeypatch.setattr(cache, "content_hash", _refuse)
 
-    assert cache.identity(media) == first
+    assert cache.audio_identity(media) == first
 
 
 def test_a_note_that_disagrees_with_the_file_is_ignored(tmp_path: Path) -> None:
     """A note is a shortcut, never an authority: it is only used if it still describes the file."""
     media = _wav(tmp_path / "master.wav")
-    cache.identity(media)
+    cache.audio_identity(media)
     for note in get_config().identity_dir.iterdir():
         note.write_text(
             json.dumps({"path": str(media), "size": 999, "mtime_ns": 0, "sha256": "deadbeef"}),
             encoding="utf-8",
         )
 
-    assert cache.identity(media) == {"sha256": cache.content_hash(media)}
+    assert cache.audio_identity(media) == {"sha256": cache.content_hash(media)}
 
 
 def test_an_unreadable_note_is_a_reread_not_a_crash(tmp_path: Path) -> None:
     media = _wav(tmp_path / "master.wav")
-    cache.identity(media)
+    cache.audio_identity(media)
     for note in get_config().identity_dir.iterdir():
         note.write_text("{ truncated", encoding="utf-8")
 
-    assert cache.identity(media) == {"sha256": cache.content_hash(media)}
+    assert cache.audio_identity(media) == {"sha256": cache.content_hash(media)}
 
 
 def test_a_note_that_cannot_be_written_costs_a_reread_not_an_answer(tmp_path: Path) -> None:
@@ -141,10 +141,37 @@ def test_a_note_that_cannot_be_written_costs_a_reread_not_an_answer(tmp_path: Pa
     get_config().identity_dir.write_text("someone put a file here", encoding="utf-8")
     media = _wav(tmp_path / "master.wav")
 
-    assert cache.identity(media) == {"sha256": cache.content_hash(media)}
+    assert cache.audio_identity(media) == {"sha256": cache.content_hash(media)}
+
+
+def test_audio_the_server_wrote_is_hashed_rather_than_read_off_a_note() -> None:
+    """A note is guarded by a fingerprint, and this is the one substrate that cannot risk one.
+
+    A same-size rewrite in place, on a filesystem whose mtime is granular to two seconds, is
+    one file state by a fingerprint's reading and different audio in fact. Elsewhere that is
+    the risk this cache already ran; under ``audio_dir`` it would be a new one, on the files
+    every later job keys off — and these are files the server sized itself, so it can read them.
+    """
+    acquired = _wav(get_config().audio_dir / "mix.wav")
+
+    assert cache.audio_identity(acquired) == {"sha256": cache.content_hash(acquired)}
+    assert not get_config().identity_dir.exists()
 
 
 # --- what the change to content identity does to entries already on disk ------------------
+
+
+def test_an_entry_remembered_under_the_old_identity_is_not_hit(tmp_path: Path) -> None:
+    """End to end: an entry a previous release wrote for this file cannot come back."""
+    media = _wav(tmp_path / "master.wav")
+    artifact = _wav(get_config().analysis_dir / "concert-beats.json", b"{}")
+    was = cache.cache_key("analyze_music:beats", [cache.fingerprint(media)], {})
+    cache.remember(was, "analyze_music:beats", {"path": str(artifact)}, [artifact])
+
+    now = cache.cache_key("analyze_music:beats", [cache.audio_identity(media)], {})
+
+    assert cache.lookup(was) is not None
+    assert cache.lookup(now) is None
 
 
 def test_an_entry_keyed_the_old_way_misses_rather_than_hitting_stale(tmp_path: Path) -> None:
@@ -152,7 +179,7 @@ def test_an_entry_keyed_the_old_way_misses_rather_than_hitting_stale(tmp_path: P
     media = _wav(tmp_path / "master.wav")
 
     was = cache.cache_key("analyze_music:beats", [cache.fingerprint(media)], {})
-    now = cache.cache_key("analyze_music:beats", [cache.identity(media)], {})
+    now = cache.cache_key("analyze_music:beats", [cache.audio_identity(media)], {})
 
     assert was != now
 
@@ -162,7 +189,7 @@ def test_an_entry_keyed_on_a_hashed_wav_carries_over_unchanged(tmp_path: Path) -
     acquired = _wav(get_config().audio_dir / "mix.wav")
 
     was = cache.cache_key("analyze_music:beats", [{"sha256": cache.content_hash(acquired)}], {})
-    now = cache.cache_key("analyze_music:beats", [cache.identity(acquired)], {})
+    now = cache.cache_key("analyze_music:beats", [cache.audio_identity(acquired)], {})
 
     assert was == now
 

--- a/tests/test_music_analysis.py
+++ b/tests/test_music_analysis.py
@@ -227,17 +227,33 @@ def test_audio_the_server_wrote_is_identified_by_its_content(fixture_audio: Path
     assert again["cached"] is True
 
 
-def test_a_master_the_director_handed_over_is_not_read_end_to_end(
+def test_a_staged_copy_of_the_master_hits_the_analysis_of_the_original(
+    fixture_audio: Path,
+) -> None:
+    """#193: an acquired copy of the director's master is the same audio, and pays nothing."""
+    staged = get_config().audio_dir / "mix-abc123.wav"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(fixture_audio, staged)
+
+    _result(music.analyze_music(fixture_audio, energy=False, detector=_detector()))
+    again = music.analyze_music(staged, energy=False, detector=_detector_that_must_not_run())
+
+    assert again["cached"] is True
+
+
+def test_a_master_is_read_once_rather_than_on_every_run(
     fixture_audio: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A concert master is tens of gigabytes; hashing it would stall the starter (jobs.cache)."""
+    """A concert master is gigabytes; re-reading it per run would stall the starter (jobs.cache)."""
+    _result(music.analyze_music(fixture_audio, energy=False, detector=_detector()))
 
     def refuse(path: Any) -> str:
-        raise AssertionError("source media the server did not write is fingerprinted, not hashed")
+        raise AssertionError("the master's hash was remembered against its file state")
 
     monkeypatch.setattr(cache, "content_hash", refuse)
+    again = music.analyze_music(fixture_audio, energy=False, detector=_detector_that_must_not_run())
 
-    assert _result(music.analyze_music(fixture_audio, energy=False, detector=_detector()))
+    assert again["cached"] is True
 
 
 def test_a_deleted_curve_file_is_not_a_cache_hit(fixture_audio: Path) -> None:

--- a/tests/test_style_layer.py
+++ b/tests/test_style_layer.py
@@ -55,6 +55,7 @@ DIRECTORIES = (
     "listing_dir",
     "job_dir",
     "result_dir",
+    "identity_dir",
     "audio_dir",
     "stems_dir",
     "frame_dir",


### PR DESCRIPTION
Closes #193.

## What changed

Beats-cache identity keyed to the source path, so an acquired copy of the director's master could not agree with the master about what it was, and the beat model ran twice over byte-identical audio. `cache.audio_identity` is now the content hash wherever the file sits.

The starter contract (#22, story 25 — return a job id at once) is kept by a **memo rather than a weaker identity**: `cache.known_hash` writes one note per file state under the new `config.identity_dir`, so the first sight of a file costs one read and every later call costs a `stat`. Audio under `audio_dir` is exempt and hashed for real every time — the note's guard is a fingerprint, and a fingerprint must not become the only thing standing between one concert's beats and another's cut. The exemption changes how the answer is reached, never what it is, so a copy still hits its original either way.

`fingerprint` stays, and stays the identity for video sources and stems (ADR 0003 unchanged). ADR 0007 records the reversal; ADR 0003 carries a dated amendment.

**Seam: fake tier** (`uv run pytest -m 'not live'`). Every AC is a decision about identity and keys, which is exactly what the fakes verify; no live AC.

## Review

Two-axis `/code-review` against `origin/main`, run on the branch before this PR existed.

### Standards axis — 5 findings, all addressed

1. **Stale docstring, `audio/acquire.py`** (documented-standard, soft) — its module prose still described the retired source-vs-acquired split. *Fixed*: reworded to the audio-vs-video line the rule actually draws now.
2. **Possible Mysterious Name, `cache.identity`** — it hashes unconditionally, so the bare name invited a caller to point it at a camera master and read 40 GB. *Fixed*: renamed `audio_identity`, with the docstring saying what the other half of the rule is.
3. **Possible Middle Man + inconsistent layering, `halves.identity`** — the wrapper used to earn its keep translating `config → config.audio_dir` and became a pass-through, while `fills` and `phrases` reached past it to `jobs.cache` directly. *Fixed by unifying the door*: `halves.identity` is the one entry every analysis module uses, `fills` and `phrases` included; the seam is kept and documented rather than deleted.
4. **Inconsistent note disposal, `_remembered`** — an unreadable note was discarded, a note that parsed but was not a note was left on disk. *Fixed*: both discard. A note that parses and simply no longer matches is left deliberately — it is named after the file state it answers for, so the reread it forces overwrites it — and now says so.
5. **Nits** — `_note_path` missing a docstring, `_note` overloading the word as verb and variable, a ragged CONTEXT.md wrap. *Fixed* (`_note` → `_write_note`). The one nit not taken: `_refuse` in `test_job_cache.py` duplicates `refuse` in `test_music_analysis.py` — two lines with different messages, and a cross-file test helper for that would cost more than it saves.

### Spec axis — 5 findings, 3 addressed, 2 accepted with reasons

1. **AC2, dead entries** — the axis traced all four key shapes that could exist on disk (`{sha256}` audio, `{path,size,mtime_ns}` masters, direct `fingerprint` callers in `video/`, `{content_sha256}` in stems/transcribe) and **confirmed the "cannot collide" claim holds**: no stale hit is reachable. What it flagged is that the *invalidated* master entries are left in `result_dir` with no sweep. **Accepted as decided**: this repo has no cache-sweep facility at all, and adding one is a different ticket. ADR 0007 records it as a decision rather than an oversight.
2. **AC2 test depth** — both migration tests compared key strings only; nothing wrote an old-shape entry and proved the new call misses it. *Fixed*: `test_an_entry_remembered_under_the_old_identity_is_not_hit` does it end to end through `remember`/`lookup`.
3. **The memo weakened a guarantee the module made out loud** — the deleted docstring promised acquired audio was "hashed for real" because "a false cache hit there would silently attribute one concert's beats to another", and a memo validated by `path + size + mtime_ns` does not keep that promise: on exFAT or SMB (what external concert drives are formatted as) mtime is granular to 10 ms–2 s, so a same-size rewrite in place inside that window returns a stale hash. **This was the most valuable finding in either axis.** *Fixed*: `audio_dir` audio is hashed on every call and never read off a note, with a test asserting no note is even written for it. For the director's master the memo leaves the risk exactly where the old fingerprint rule already had it — which ADR 0007 now says, instead of overclaiming "never a wrong answer".
4. **Scope creep, `acquire._result`** — routing `content_sha256` through the memo was not asked for and changed the provenance of a reported field feeding two unrelated cache families. *Fixed*: reverted to `content_hash`, and moot once `audio_dir` is never memoised.
5. **Scope creep, CONTEXT.md ADR line** — backfilling ADR 0006 is unrelated to #193. **Accepted**: the list was wrong, the fix is four words, and it sat in a line this PR was editing anyway.

### Verification

`uv run pytest -m 'not live'` → **1788 passed, 38 deselected**. `uv run mypy src tests` → clean, 178 source files. `uv run ruff check .` → clean. Re-checked the fix diff only after the findings landed (one comment sharpened), then re-ran the six touched test files → 205 passed.

Review: clean — both axes' findings resolved or accepted with reasons above; fake tier, mypy and ruff green.
