### PR TITLE
Gauntlet G5a: per-shot subject labeling x who-is-soloing (#181)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,8 +67,10 @@ timelines. The server measures; Claude decides.
   `[measured — N projects, n=…, context]`, `[review feedback, YYYY-MM]`,
   `[believed, unverified]`.
 - **angle sidecar** — one JSON file per Resolve project labelling each camera
-  by subject × character; `role` is the only key `correlate_timeline` reads,
-  and it arrives as a mapping the agent lifted, never as a path.
+  by subject × character; `correlate_timeline` reads `role` and `subject`
+  (falling back to the subject half of a `subject-character` role) plus the
+  optional `voice`, which says what the solo map calls that subject, and it
+  arrives as a mapping the agent lifted, never as a path.
   _Avoid_: `camera_sidecar` for this — that module reads a camera model off
   the card's own XML (#94) and is not an angle sidecar.
 
@@ -120,7 +122,11 @@ monophonic pitch + gating, model injected per ADR 0002; the reading `phrases`
 is a rule layer over, as `drums` is to `fills`), `music` (beats + energy + gist
 job), `phrases` (phrase boundaries: where the soloist stops, which is the
 cut-placement unit #46 named, #143),
-`records` (sliceable record files), `silence` (RMS spans), `solos` (front
+`records` (sliceable record files), `silence` (RMS spans), `subject` (what a
+shot is framed on crossed with who is out front: the sidecar's subject read as
+player/ensemble/other, joined to the solo windows in seconds so a shot that
+outlives its solo is split where the front changed — pure, no I/O, read by
+`correlate` #181), `solos` (front
 of band changes: lead off the stem energy, timbre off one stem's brightness —
 with the third pass on disk the voices are `wind`/`comp` rather than `other`
 and timbre reads `wind`, #157), `structure` (tunes + solo changes job; both
@@ -282,7 +288,10 @@ per critic loss or prep finding, open/in-work/fixed), `HANDOFF.md`.
 cut-boundary filmstrips and a measured `cuts.json`, with the label→source
 mapping quarantined in `assignment.json` so a critic reads the pack without
 knowing whose cut is whose; it refuses to seal when its scene scan finds far
-fewer cuts than the timeline holds (G3). `recon/` is one-off instruments —
+fewer cuts than the timeline holds (G3). Given each label's own
+`correlate_timeline` cuts file (`--a-subjects`/`--b-subjects`, both or
+neither) it also carries the on-soloist track, stripped to four columns so no
+timeline or clip name reaches the pack (#181). `recon/` is one-off instruments —
 one script plus its JSON receipt per question (plans, builds, pixel checks,
 occlusion scans). Renders, packs, frame dirs and the per-frame ffmpeg dumps
 under `recon/` are regenerable and gitignored; only scripts and receipts are

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -122,16 +122,15 @@ monophonic pitch + gating, model injected per ADR 0002; the reading `phrases`
 is a rule layer over, as `drums` is to `fills`), `music` (beats + energy + gist
 job), `phrases` (phrase boundaries: where the soloist stops, which is the
 cut-placement unit #46 named, #143),
-`records` (sliceable record files), `silence` (RMS spans), `subject` (what a
-shot is framed on crossed with who is out front: the sidecar's subject read as
-player/ensemble/other, joined to the solo windows in seconds so a shot that
-outlives its solo is split where the front changed — pure, no I/O, read by
-`correlate` #181), `solos` (front
+`records` (sliceable record files), `silence` (RMS spans), `solos` (front
 of band changes: lead off the stem energy, timbre off one stem's brightness —
 with the third pass on disk the voices are `wind`/`comp` rather than `other`
 and timbre reads `wind`, #157), `structure` (tunes + solo changes job; both
 halves read the shared beats half; its stem loader is what reaches the third
-pass), `transcribe`
+pass), `subject` (what a shot is framed on crossed with who is out front: the
+angle sidecar's subject read as player/ensemble/other, joined to the solo
+windows in seconds so a shot that outlives its solo is split where the front
+changed — pure, no I/O, read by `correlate`, #181), `transcribe`
 (job), `transcript` (document + Word/Transcription/Transcriber vocabulary),
 `virtual` (a cut file read back as the words it will contain — the P4
 self-review, warnings only, touches no Resolve handle), `whisper`

--- a/docs/agents/concert.md
+++ b/docs/agents/concert.md
@@ -90,10 +90,13 @@ The tool reports and never judges — the bar is the profile. Compare the inline
 against `styles/concert.md`'s measured claims: the transient-offset distribution
 (fourth-wall risk, §1), shot-duration runs (§3), role shares and transitions (§4),
 event responses (§5). With a solo map and a sidecar that names subjects, the
-`on_soloist` block is the one that answers the core concert question — what share of
-the solo-window screen time went to the player out front, to the ensemble, and to
-somebody who was not soloing. Read `unlabelled_seconds` next to it: a high share on
-the soloist over a quarter of the cut is a claim about a quarter of the cut. **Every outlier is either fixed — edit the cut JSON, rebuild —
+`on_soloist` block answers the core concert question — what share of the
+solo-window screen time went to the player out front, to the ensemble, and to a
+player who was not soloing. Read three of its lines next to the share:
+`unlabelled_seconds` (a high share measured over a quarter of the cut is a claim
+about a quarter of the cut), `black_seconds`, and
+`soloist_seconds_by_follow_camera`, which is the part of the soloist line a
+camera's label asserted rather than the solo map measured. **Every outlier is either fixed — edit the cut JSON, rebuild —
 or justified by name in the cut report** ("spectacle earns the hold"). Nothing lands
 off-style silently. Check `alignment.mode` before trusting a run, per
 `docs/agents/style-layer.md`.

--- a/docs/agents/concert.md
+++ b/docs/agents/concert.md
@@ -89,7 +89,11 @@ measured on exactly the axes the profile's `[measured]` claims stand on.
 The tool reports and never judges — the bar is the profile. Compare the inline gist
 against `styles/concert.md`'s measured claims: the transient-offset distribution
 (fourth-wall risk, §1), shot-duration runs (§3), role shares and transitions (§4),
-event responses (§5). **Every outlier is either fixed — edit the cut JSON, rebuild —
+event responses (§5). With a solo map and a sidecar that names subjects, the
+`on_soloist` block is the one that answers the core concert question — what share of
+the solo-window screen time went to the player out front, to the ensemble, and to
+somebody who was not soloing. Read `unlabelled_seconds` next to it: a high share on
+the soloist over a quarter of the cut is a claim about a quarter of the cut. **Every outlier is either fixed — edit the cut JSON, rebuild —
 or justified by name in the cut report** ("spectacle earns the hold"). Nothing lands
 off-style silently. Check `alignment.mode` before trusting a run, per
 `docs/agents/style-layer.md`.

--- a/docs/agents/style-layer.md
+++ b/docs/agents/style-layer.md
@@ -104,14 +104,16 @@ director confirmed this reading on 2026-08-07** — sidecars stay in the repo.
   shape.
 - **`subject`** and **`character`** are the two axes kept apart, because
   "the drummer" and "a moving shot" are different facts about the same camera
-  and the profile makes claims about each.
-- **`subject`** is the second key `correlate_timeline` consumes (#181): with a
-  solo map it answers whether a shot is on the player out front, on the
-  ensemble, or on somebody who was not soloing. It is read from `subject` where
-  an entry names one and otherwise from the subject half of a
+  and the profile makes claims about each. `subject` is also the second key
+  `correlate_timeline` consumes (#181): with a solo map it answers whether a
+  shot is on the player out front, on the ensemble, on a player who was not
+  soloing, or on neither (an audience camera, a room shot). It is read from
+  `subject` where an entry names one and otherwise from the subject half of a
   `<subject>-<character>` role — a one-word role is a *character* and labels no
   subject. `ensemble` is the whole band; `soloist` is a camera pointed at
-  whoever is out front, and its shots are on the soloist by construction.
+  whoever is out front, whose shots are on the soloist by construction rather
+  than by measurement — the reading says which of the two it was, and how many
+  of a cut's soloist seconds came from a camera taken at its word.
 - **`voice`** — optional, and only where this sidecar's subjects and the solo
   map's stems are different words for the same player: `{"subject": "mike",
   "voice": "wind"}`. The join uses it; a subject the solo map never names reads

--- a/docs/agents/style-layer.md
+++ b/docs/agents/style-layer.md
@@ -99,12 +99,24 @@ director confirmed this reading on 2026-08-07** — sidecars stay in the repo.
 }
 ```
 
-- **`role`** is the only key `correlate_timeline` consumes, and it is what
-  cross-project claims group on — so keep the vocabulary small and reuse it
-  across projects. `<subject>-<character>` is the default shape.
+- **`role`** is what cross-project claims group on — so keep the vocabulary
+  small and reuse it across projects. `<subject>-<character>` is the default
+  shape.
 - **`subject`** and **`character`** are the two axes kept apart, because
   "the drummer" and "a moving shot" are different facts about the same camera
   and the profile makes claims about each.
+- **`subject`** is the second key `correlate_timeline` consumes (#181): with a
+  solo map it answers whether a shot is on the player out front, on the
+  ensemble, or on somebody who was not soloing. It is read from `subject` where
+  an entry names one and otherwise from the subject half of a
+  `<subject>-<character>` role — a one-word role is a *character* and labels no
+  subject. `ensemble` is the whole band; `soloist` is a camera pointed at
+  whoever is out front, and its shots are on the soloist by construction.
+- **`voice`** — optional, and only where this sidecar's subjects and the solo
+  map's stems are different words for the same player: `{"subject": "mike",
+  "voice": "wind"}`. The join uses it; a subject the solo map never names reads
+  as neither a player nor the band, which is right for an audience camera and
+  wrong for a horn player nobody aliased.
 - **`confidence`** and **`evidence`** are why a claim resting on this angle is
   thin or not: a `low` here is a reason a corpus claim downgrades.
 - **`confirmed_by_director`** — `false` until confirmed, then the date it was
@@ -169,7 +181,9 @@ one project: on the Judson's show `Angle 10` is the drummer on one tune and the
 roaming camera on another. Label every timeline separately.
 
 An entry with no `role` is dropped by `correlate_timeline` rather than refused,
-so a half-labelled project still measures — its shots land under `unlabelled`.
+so a half-labelled project still measures — its shots land under `unlabelled`,
+in the role shares and in the on-soloist track alike, and the track counts that
+screen time apart from its shares rather than in them.
 
 Pass a sidecar by lifting its `angles` object straight through; the tool takes
 labels, never a path:

--- a/gauntlet/GAPS.md
+++ b/gauntlet/GAPS.md
@@ -81,7 +81,15 @@ Round 1 critic, verbatim needs; each is server measurement work:
    check against frames of both cameras: the FX6 wide holds the whole band
    (`ensemble`) and the A7IV holds the drummer (`drums`, a player), the two
    labels 15 of the opening's 17 shots carry; the other two are title cards,
-   which is what `unlabelled_seconds` counts.
+   which is what `unlabelled_seconds` counts. Two things the reading refuses to
+   round off: a camera on neither a player nor the band (audience, room) has its
+   own `elsewhere` line rather than counting as a player nobody was watching,
+   and `soloist_seconds_by_follow_camera` says how much of the soloist share
+   came from a camera whose sidecar label asserts it follows the front rather
+   than from a subject the solo map matched. Pack side verified on the same two
+   cuts (`recon/subject_pack.py`): the pack's share equals correlate's exactly,
+   nothing but the four subject columns crosses into the pack, and a span that
+   cuts through shots counts the part inside where the front held through it.
 7. Per-shot sharpness, clipped-highlight %, exposure variance.
 8. Super/graphic presence detection with in/out timecodes + straddle check.
 9. Head/tail treatment: fade-in vs dropped frames, audio floor handling.

--- a/gauntlet/GAPS.md
+++ b/gauntlet/GAPS.md
@@ -64,7 +64,15 @@ Round 1 critic, verbatim needs; each is server measurement work:
    cannot resolve musicality).
 5. Audio class track (applause/speech/music/silence at 1 s resolution).
 6. Per-shot subject labeling × who-is-soloing track — the core concert
-   question.
+   question. **Fixed in #181** (`analysis/subject.py`): the sidecar's subject
+   read as player/ensemble/other and joined to the solo windows in seconds, so
+   `correlate_timeline` carries `subject`/`subject_kind`/`on_soloist` per shot
+   and an `on_soloist` share inline, and `ab_pack.py` carries the same track
+   into a pack (`--a-subjects`/`--b-subjects`, both or neither). Authored, not
+   detected: no pixel here knows a drummer from a horn player, so the answer is
+   only as good as the sidecar — a camera that roams the band is labelled by
+   habit rather than by shot, and `unlabelled_seconds` is what says how much of
+   the cut no label reached.
 7. Per-shot sharpness, clipped-highlight %, exposure variance.
 8. Super/graphic presence detection with in/out timecodes + straddle check.
 9. Head/tail treatment: fade-in vs dropped frames, audio floor handling.

--- a/gauntlet/GAPS.md
+++ b/gauntlet/GAPS.md
@@ -72,7 +72,16 @@ Round 1 critic, verbatim needs; each is server measurement work:
    detected: no pixel here knows a drummer from a horn player, so the answer is
    only as good as the sidecar — a camera that roams the band is labelled by
    habit rather than by shot, and `unlabelled_seconds` is what says how much of
-   the cut no label reached.
+   the cut no label reached. Measured live on the two closed Taurus pieces
+   (`recon/subject_track.py`, receipt beside it): the R3 opening is 52% on the
+   ensemble, 48% on a non-soloing player, 0% on the soloist over 81.5 s of
+   labelled screen time; the P4 R2 capstone is 53% / 42% / 5% over 489 s. The
+   0% is real rather than a hole — this rig's only player camera is the drum
+   cam, and the solo map has nobody drumming out front in the opening. Spot
+   check against frames of both cameras: the FX6 wide holds the whole band
+   (`ensemble`) and the A7IV holds the drummer (`drums`, a player), the two
+   labels 15 of the opening's 17 shots carry; the other two are title cards,
+   which is what `unlabelled_seconds` counts.
 7. Per-shot sharpness, clipped-highlight %, exposure variance.
 8. Super/graphic presence detection with in/out timecodes + straddle check.
 9. Head/tail treatment: fade-in vs dropped frames, audio floor handling.

--- a/gauntlet/recon/subject_pack.json
+++ b/gauntlet/recon/subject_pack.json
@@ -1,0 +1,246 @@
+{
+  "source_receipt": "C:\\Users\\Daniel\\repos\\resolve-mcp\\.claude\\worktrees\\issue-181\\gauntlet\\recon\\subject_track.json",
+  "checks": [
+    {
+      "timeline": "Taurus People Opening R3 v3",
+      "cuts_file": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\analysis\\Taurus-People-Opening-R3-v3-b27ee8a933e2.correlate.json",
+      "shots_in_track": 17,
+      "fields_beyond_the_four": [],
+      "whole_span": {
+        "summary": {
+          "solo_window_seconds": 90.007,
+          "labelled_seconds": 81.54,
+          "unlabelled_seconds": 8.467,
+          "black_seconds": 0.0,
+          "seconds": {
+            "ensemble": 42.459,
+            "other_player": 39.081
+          },
+          "fraction_on_soloist": 0.0,
+          "fraction_on_ensemble": 0.521,
+          "fraction_on_other_player": 0.479,
+          "fraction_elsewhere": 0.0,
+          "soloist_seconds_by_follow_camera": 0.0,
+          "shots": {
+            "ensemble": 8,
+            "other_player": 7,
+            "unlabelled": 2
+          }
+        },
+        "matches_correlate": true,
+        "correlate_said": {
+          "solo_window_seconds": 90.007,
+          "labelled_seconds": 81.54,
+          "unlabelled_seconds": 8.467,
+          "black_seconds": 0.0,
+          "seconds": {
+            "ensemble": 42.459,
+            "other_player": 39.081
+          },
+          "fraction_on_soloist": 0.0,
+          "fraction_on_ensemble": 0.521,
+          "fraction_on_other_player": 0.479,
+          "fraction_elsewhere": 0.0,
+          "soloist_seconds_by_follow_camera": 0.0,
+          "shots": {
+            "ensemble": 8,
+            "other_player": 7,
+            "unlabelled": 2
+          }
+        },
+        "detected_shots_labelled": 16,
+        "detected_shots": 16,
+        "first_three_detected": [
+          {
+            "index": 1,
+            "start": 0.4,
+            "end": 2.736,
+            "subject": {
+              "subject": null,
+              "subject_kind": null,
+              "on_soloist": null,
+              "on_soloist_by": null,
+              "overlap_sec": 1.936
+            }
+          },
+          {
+            "index": 2,
+            "start": 2.736,
+            "end": 20.879,
+            "subject": {
+              "subject": "drums",
+              "subject_kind": "player",
+              "on_soloist": false,
+              "on_soloist_by": null,
+              "overlap_sec": 9.843
+            }
+          },
+          {
+            "index": 3,
+            "start": 20.879,
+            "end": 21.046,
+            "subject": {
+              "subject": null,
+              "subject_kind": null,
+              "on_soloist": null,
+              "on_soloist_by": null,
+              "overlap_sec": 0.167
+            }
+          }
+        ]
+      },
+      "cut_span": {
+        "span_sec": [
+          3590.987,
+          3635.99
+        ],
+        "shots_outside_clip": 8,
+        "shots_cut_by_the_span": 2,
+        "shots_left_out_of_the_share": 0,
+        "summary": {
+          "solo_window_seconds": 45.003,
+          "labelled_seconds": 40.728,
+          "unlabelled_seconds": 4.275,
+          "black_seconds": 0.0,
+          "seconds": {
+            "ensemble": 18.414,
+            "other_player": 22.314
+          },
+          "fraction_on_soloist": 0.0,
+          "fraction_on_ensemble": 0.452,
+          "fraction_on_other_player": 0.548,
+          "fraction_elsewhere": 0.0,
+          "soloist_seconds_by_follow_camera": 0.0,
+          "shots": {
+            "ensemble": 4,
+            "other_player": 4,
+            "unlabelled": 1
+          }
+        }
+      }
+    },
+    {
+      "timeline": "Taurus People Full P4 R2 v3",
+      "cuts_file": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\analysis\\Taurus-People-Full-P4-R2-v3-d4bd89e16d84.correlate.json",
+      "shots_in_track": 85,
+      "fields_beyond_the_four": [],
+      "whole_span": {
+        "summary": {
+          "solo_window_seconds": 497.496,
+          "labelled_seconds": 489.029,
+          "unlabelled_seconds": 8.467,
+          "black_seconds": 0.0,
+          "seconds": {
+            "soloist": 24.312,
+            "ensemble": 259.089,
+            "other_player": 205.628
+          },
+          "fraction_on_soloist": 0.05,
+          "fraction_on_ensemble": 0.53,
+          "fraction_on_other_player": 0.42,
+          "fraction_elsewhere": 0.0,
+          "soloist_seconds_by_follow_camera": 0.0,
+          "shots": {
+            "soloist": 4,
+            "ensemble": 42,
+            "other_player": 37,
+            "unlabelled": 2
+          }
+        },
+        "matches_correlate": true,
+        "correlate_said": {
+          "solo_window_seconds": 497.496,
+          "labelled_seconds": 489.029,
+          "unlabelled_seconds": 8.467,
+          "black_seconds": 0.0,
+          "seconds": {
+            "soloist": 24.312,
+            "ensemble": 259.089,
+            "other_player": 205.628
+          },
+          "fraction_on_soloist": 0.05,
+          "fraction_on_ensemble": 0.53,
+          "fraction_on_other_player": 0.42,
+          "fraction_elsewhere": 0.0,
+          "soloist_seconds_by_follow_camera": 0.0,
+          "shots": {
+            "soloist": 4,
+            "ensemble": 42,
+            "other_player": 37,
+            "unlabelled": 2
+          }
+        },
+        "detected_shots_labelled": 84,
+        "detected_shots": 84,
+        "first_three_detected": [
+          {
+            "index": 1,
+            "start": 0.4,
+            "end": 2.736,
+            "subject": {
+              "subject": null,
+              "subject_kind": null,
+              "on_soloist": null,
+              "on_soloist_by": null,
+              "overlap_sec": 1.936
+            }
+          },
+          {
+            "index": 2,
+            "start": 2.736,
+            "end": 20.879,
+            "subject": {
+              "subject": "drums",
+              "subject_kind": "player",
+              "on_soloist": false,
+              "on_soloist_by": null,
+              "overlap_sec": 9.843
+            }
+          },
+          {
+            "index": 3,
+            "start": 20.879,
+            "end": 21.046,
+            "subject": {
+              "subject": null,
+              "subject_kind": null,
+              "on_soloist": null,
+              "on_soloist_by": null,
+              "overlap_sec": 0.167
+            }
+          }
+        ]
+      },
+      "cut_span": {
+        "span_sec": [
+          3692.86,
+          3941.609
+        ],
+        "shots_outside_clip": 43,
+        "shots_cut_by_the_span": 2,
+        "shots_left_out_of_the_share": 0,
+        "summary": {
+          "solo_window_seconds": 248.75,
+          "labelled_seconds": 248.75,
+          "unlabelled_seconds": 0.0,
+          "black_seconds": 0.0,
+          "seconds": {
+            "soloist": 24.312,
+            "ensemble": 143.559,
+            "other_player": 80.879
+          },
+          "fraction_on_soloist": 0.098,
+          "fraction_on_ensemble": 0.577,
+          "fraction_on_other_player": 0.325,
+          "fraction_elsewhere": 0.0,
+          "soloist_seconds_by_follow_camera": 0.0,
+          "shots": {
+            "soloist": 4,
+            "ensemble": 21,
+            "other_player": 17
+          }
+        }
+      }
+    }
+  ]
+}

--- a/gauntlet/recon/subject_pack.py
+++ b/gauntlet/recon/subject_pack.py
@@ -1,0 +1,128 @@
+"""Does a blind pack carry the on-soloist track intact? (#181, AC3)
+
+No Resolve, no ffmpeg, no render: this runs `ab_pack`'s subject-track path over the
+two real `correlate_timeline` cuts files `subject_track.py` produced and checks the
+three things a pack could get wrong.
+
+1. **Stripped.** Only the columns SUBJECT_FIELDS names come through -- a pack that
+   carries a timeline name or a camera roll's file name is not a blind pack.
+2. **Whole span.** With the pack covering the whole cut, the pack's share must equal
+   the share correlate already reported. A pack that quietly recomputes it differently
+   is worse than a pack without one.
+3. **Cut span.** With the pack covering the middle of the cut, a shot the span cuts
+   through counts the part inside where the front held through it, and is left out of
+   the share where it did not -- and the shots left out are counted, not swallowed.
+
+The detected-shot join is exercised against boundaries deliberately out of step with
+the authored ones (offset, and two shots merged into one), because that disagreement
+is exactly what a scene scan does to a real pack.
+
+    uv run python gauntlet/recon/subject_pack.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+OUT = HERE / "subject_pack.json"
+TRACK_RECEIPT = HERE / "subject_track.json"
+AB_PACK = HERE.parents[1] / "gauntlet" / "tools" / "ab_pack.py"
+
+
+def load_ab_pack() -> Any:
+    """Load the pack builder by path: `gauntlet/tools` is not a package."""
+    spec = importlib.util.spec_from_file_location("ab_pack", AB_PACK)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {AB_PACK}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def detected(shots: list[dict[str, Any]], offset: float) -> list[dict[str, Any]]:
+    """The pack's own shot list, as a scene scan would hand it back: out of step.
+
+    Every boundary moved by `offset`, and the second and third shots run together as
+    one -- the missed cut that overlap matching exists to survive.
+    """
+    edges = [(float(one["start"]), float(one["end"])) for one in shots]
+    if len(edges) > 3:
+        edges = [edges[0], (edges[1][0], edges[2][1]), *edges[3:]]
+    return [
+        {"index": index, "start": round(start + offset, 3), "end": round(end + offset, 3)}
+        for index, (start, end) in enumerate(edges, start=1)
+    ]
+
+
+def check(ab_pack: Any, name: str, cuts_file: Path, reported: dict[str, Any]) -> dict[str, Any]:
+    track = ab_pack.load_subject_track(cuts_file)
+    leaked = sorted({key for row in track for key in row} - {"t", "seconds", *ab_pack.SUBJECT_FIELDS})
+    # The cut's own span, not the concert's: these times count from the master mix's zero, so
+    # a render of this cut starts at the first shot rather than at t=0.
+    opens = min(row["t"] for row in track)
+    closes = max(row["t"] + row["seconds"] for row in track)
+
+    whole = ab_pack.place_subject_track(track, (opens, closes), closes - opens)
+    whole_shots = detected(whole["shots"], offset=0.4)
+    ab_pack.attach_subjects(whole_shots, whole["shots"])
+
+    middle = (opens + (closes - opens) * 0.25, opens + (closes - opens) * 0.75)
+    cut = ab_pack.place_subject_track(track, middle, middle[1] - middle[0])
+
+    return {
+        "timeline": name,
+        "cuts_file": str(cuts_file),
+        "shots_in_track": len(track),
+        "fields_beyond_the_four": leaked,
+        "whole_span": {
+            "summary": whole["summary"],
+            "matches_correlate": whole["summary"] == reported,
+            "correlate_said": reported,
+            "detected_shots_labelled": sum(
+                1 for shot in whole_shots if shot.get("subject") is not None
+            ),
+            "detected_shots": len(whole_shots),
+            "first_three_detected": whole_shots[:3],
+        },
+        "cut_span": {
+            "span_sec": [round(one, 3) for one in middle],
+            "shots_outside_clip": cut["shots_outside_clip"],
+            "shots_cut_by_the_span": cut["shots_cut_by_the_span"],
+            "shots_left_out_of_the_share": cut["shots_left_out_of_the_share"],
+            "summary": cut["summary"],
+        },
+    }
+
+
+def main() -> None:
+    ab_pack = load_ab_pack()
+    receipt = json.loads(TRACK_RECEIPT.read_text(encoding="utf-8"))
+    checks = [
+        check(
+            ab_pack,
+            one["timeline"],
+            Path(one["cuts_file"]),
+            one["reading"]["on_soloist"],
+        )
+        for one in receipt["measured"]
+        if one.get("cuts_file")
+    ]
+    OUT.write_text(
+        json.dumps({"source_receipt": str(TRACK_RECEIPT), "checks": checks}, indent=2),
+        encoding="utf-8",
+    )
+    for one in checks:
+        print(
+            f"{one['timeline']}: whole-span share matches correlate = "
+            f"{one['whole_span']['matches_correlate']}, "
+            f"leaked fields = {one['fields_beyond_the_four'] or 'none'}"
+        )
+    print("wrote", OUT)
+
+
+if __name__ == "__main__":
+    main()

--- a/gauntlet/recon/subject_track.json
+++ b/gauntlet/recon/subject_track.json
@@ -1,0 +1,1936 @@
+{
+  "errors": [],
+  "timelines": [
+    "Zinc - Set 2 Main",
+    "Mailand clip",
+    "Monkfish Main",
+    "Zinc SYNC",
+    "Taurus People Opening v1",
+    "Taurus People Opening v2",
+    "Taurus People Opening v3",
+    "Taurus People Opening R2 v1",
+    "Taurus People Opening R2 v2",
+    "Taurus People Opening R2 v3",
+    "Taurus People Opening R3 v1",
+    "Taurus People Opening R3 v2",
+    "Taurus People Opening R3 v3",
+    "Taurus People Ending P2 v1",
+    "Taurus People Ending P2 v2",
+    "Taurus People Ending P2 R3 v1",
+    "Taurus People Mid P3 R1 v1",
+    "Taurus People Mid P3 R2 v1",
+    "Taurus People Full P4 R1 v1",
+    "Taurus People Full P4 R1 v2",
+    "Taurus People Full P4 R2 v3",
+    "resolve-mcp-smoke v1",
+    "resolve-mcp smoke round-trip 122233",
+    "resolve-mcp-smoke v2",
+    "resolve-mcp smoke dissolve 122238",
+    "resolve-mcp-smoke v3",
+    "resolve-mcp-smoke v4",
+    "resolve-mcp-smoke v5",
+    "resolve-mcp-smoke v6",
+    "resolve-mcp-smoke v7",
+    "resolve-mcp-smoke v8",
+    "resolve-mcp-smoke v9",
+    "resolve-mcp-smoke v10",
+    "resolve-mcp-smoke v11"
+  ],
+  "inputs": {
+    "timelines": [
+      "Taurus People Opening R3 v3",
+      "Taurus People Full P4 R2 v3"
+    ],
+    "sidecar": "C:\\Users\\Daniel\\repos\\resolve-mcp\\.claude\\worktrees\\issue-181\\styles\\angles\\mcp-tests-zinc.json",
+    "beats": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\analysis\\Zinc-Set-2-Reaper-v4-62537c590a14-beats.json",
+    "solos": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\analysis\\Zinc-Set-2-Reaper-v4-0f3a70a16e52-solos.json",
+    "subjects": {
+      "A014C002_2606170Z.MXF": "ensemble",
+      "A015C001_2606170J.MXF": "ensemble",
+      "20260617_D_A7IV_0006.MP4": "drums"
+    }
+  },
+  "measured": [
+    {
+      "timeline": "Taurus People Opening R3 v3",
+      "job": {
+        "state": "completed",
+        "error": null
+      },
+      "reading": {
+        "alignment": {
+          "mode": "audio_clip",
+          "audio": "Zinc Set 2 Reaper v4.wav",
+          "matched": false,
+          "zero_frame": 842
+        },
+        "cuts": 17,
+        "openings": 1,
+        "on_soloist": {
+          "solo_window_seconds": 90.007,
+          "labelled_seconds": 81.54,
+          "unlabelled_seconds": 8.467,
+          "black_seconds": 0.0,
+          "seconds": {
+            "ensemble": 42.459,
+            "other_player": 39.081
+          },
+          "fraction_on_soloist": 0.0,
+          "fraction_on_ensemble": 0.521,
+          "fraction_on_other_player": 0.479,
+          "shots": {
+            "ensemble": 8,
+            "other_player": 7,
+            "unlabelled": 2
+          }
+        },
+        "subjects": {
+          "unlabelled": {
+            "cuts": 2,
+            "seconds": 8.467,
+            "share": 0.094
+          },
+          "ensemble": {
+            "cuts": 8,
+            "seconds": 42.459,
+            "share": 0.472
+          },
+          "drums": {
+            "cuts": 7,
+            "seconds": 39.081,
+            "share": 0.434
+          }
+        },
+        "roles": {
+          "unlabelled": {
+            "cuts": 2,
+            "seconds": 8.467,
+            "share": 0.094
+          },
+          "ensemble-wide": {
+            "cuts": 8,
+            "seconds": 42.459,
+            "share": 0.472
+          },
+          "drums-tight": {
+            "cuts": 7,
+            "seconds": 39.081,
+            "share": 0.434
+          }
+        },
+        "solos": {
+          "covered": 2,
+          "outside": 0,
+          "cuts": {
+            "bass": 8,
+            "other": 8
+          }
+        }
+      },
+      "cuts_file": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\analysis\\Taurus-People-Opening-R3-v3-b27ee8a933e2.correlate.json",
+      "shots": [
+        {
+          "cut": 1,
+          "clip": "title_[0000-0055].png",
+          "t": 3568.485,
+          "seconds": 2.336,
+          "role": null,
+          "subject": null,
+          "subject_kind": null,
+          "front": "other",
+          "on_soloist": null,
+          "on_soloist_seconds": {
+            "unlabelled": 2.336
+          }
+        },
+        {
+          "cut": 2,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3570.821,
+          "seconds": 8.3,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 8.3
+          }
+        },
+        {
+          "cut": 3,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3579.121,
+          "seconds": 9.843,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 9.843
+          }
+        },
+        {
+          "cut": 4,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3588.964,
+          "seconds": 0.167,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 0.167
+          }
+        },
+        {
+          "cut": 5,
+          "clip": "personnel2_[0000-0146].png",
+          "t": 3589.131,
+          "seconds": 6.131,
+          "role": null,
+          "subject": null,
+          "subject_kind": null,
+          "front": "other",
+          "on_soloist": null,
+          "on_soloist_seconds": {
+            "unlabelled": 6.131
+          }
+        },
+        {
+          "cut": 6,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3595.262,
+          "seconds": 4.838,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 4.838
+          }
+        },
+        {
+          "cut": 7,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3600.1,
+          "seconds": 2.211,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 2.211
+          }
+        },
+        {
+          "cut": 8,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3602.311,
+          "seconds": 2.252,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 2.252
+          }
+        },
+        {
+          "cut": 9,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3604.563,
+          "seconds": 8.258,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 8.258
+          }
+        },
+        {
+          "cut": 10,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3612.821,
+          "seconds": 9.927,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 9.927
+          }
+        },
+        {
+          "cut": 11,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3622.748,
+          "seconds": 7.257,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 7.257
+          }
+        },
+        {
+          "cut": 12,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3630.005,
+          "seconds": 5.297,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 5.297
+          }
+        },
+        {
+          "cut": 13,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3635.302,
+          "seconds": 4.963,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 4.963
+          }
+        },
+        {
+          "cut": 14,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3640.265,
+          "seconds": 4.046,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 4.046
+          }
+        },
+        {
+          "cut": 15,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3644.311,
+          "seconds": 3.837,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 3.837
+          }
+        },
+        {
+          "cut": 16,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3648.148,
+          "seconds": 2.878,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 2.878
+          }
+        },
+        {
+          "cut": 17,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3651.026,
+          "seconds": 7.466,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 7.466
+          }
+        }
+      ],
+      "spot_check": [
+        {
+          "clip": "title_[0000-0055].png",
+          "shots": [
+            1
+          ],
+          "shot_count": 1,
+          "claimed_subject": null,
+          "claimed_kind": null,
+          "bin": null,
+          "grabbed_at_sec": [
+            0.58,
+            1.75
+          ],
+          "frames": null,
+          "ok": false,
+          "error": {
+            "code": "internal_error",
+            "cause": "FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\\\Users\\\\Daniel\\\\repos\\\\resolve-mcp\\\\.claude\\\\worktrees\\\\gauntlet-loop-1\\\\projects\\\\mcp-tests-zinc\\\\cards\\\\taurus-people\\\\title\\\\title_[0000-0055].png'",
+            "fix": "This is a bug in resolve-mcp rather than a Resolve state problem. Retry once; if it persists, work around it with run_python and report it.",
+            "detail": {}
+          }
+        },
+        {
+          "clip": "A015C001_2606170J.MXF",
+          "shots": [
+            2,
+            4,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17
+          ],
+          "shot_count": 8,
+          "claimed_subject": "ensemble",
+          "claimed_kind": "ensemble",
+          "bin": "Zinc Bar/Footage",
+          "grabbed_at_sec": [
+            739.03,
+            2217.09
+          ],
+          "frames": [
+            {
+              "time": {
+                "frames": 17718,
+                "seconds": 738.989,
+                "timecode": "00:12:18:06",
+                "fps": 23.976
+              },
+              "path": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\frames\\A015C001_2606170J.MXF-17407860bcbb.jpg",
+              "width": 1568,
+              "height": 882,
+              "bytes": 139708
+            },
+            {
+              "time": {
+                "frames": 53156,
+                "seconds": 2217.05,
+                "timecode": "00:36:54:20",
+                "fps": 23.976
+              },
+              "path": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\frames\\A015C001_2606170J.MXF-26db4dd00ea5.jpg",
+              "width": 1568,
+              "height": 882,
+              "bytes": 143111
+            }
+          ],
+          "ok": true,
+          "error": null
+        },
+        {
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "shots": [
+            3,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16
+          ],
+          "shot_count": 7,
+          "claimed_subject": "drums",
+          "claimed_kind": "player",
+          "bin": "Zinc Bar/Footage",
+          "grabbed_at_sec": [
+            1028.9,
+            3086.71
+          ],
+          "frames": [
+            {
+              "time": {
+                "frames": 24668,
+                "seconds": 1028.862,
+                "timecode": "00:17:07:20",
+                "fps": 23.976
+              },
+              "path": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\frames\\20260617_D_A7IV_0006.MP4-2feb6711d864.jpg",
+              "width": 1568,
+              "height": 882,
+              "bytes": 98598
+            },
+            {
+              "time": {
+                "frames": 74006,
+                "seconds": 3086.67,
+                "timecode": "00:51:23:14",
+                "fps": 23.976
+              },
+              "path": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\frames\\20260617_D_A7IV_0006.MP4-75ba8d2d4762.jpg",
+              "width": 1568,
+              "height": 882,
+              "bytes": 99979
+            }
+          ],
+          "ok": true,
+          "error": null
+        },
+        {
+          "clip": "personnel2_[0000-0146].png",
+          "shots": [
+            5
+          ],
+          "shot_count": 1,
+          "claimed_subject": null,
+          "claimed_kind": null,
+          "bin": null,
+          "grabbed_at_sec": [
+            1.53,
+            4.6
+          ],
+          "frames": null,
+          "ok": false,
+          "error": {
+            "code": "internal_error",
+            "cause": "FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\\\Users\\\\Daniel\\\\repos\\\\resolve-mcp\\\\.claude\\\\worktrees\\\\gauntlet-loop-1\\\\projects\\\\mcp-tests-zinc\\\\cards\\\\taurus-people\\\\personnel2\\\\personnel2_[0000-0146].png'",
+            "fix": "This is a bug in resolve-mcp rather than a Resolve state problem. Retry once; if it persists, work around it with run_python and report it.",
+            "detail": {}
+          }
+        }
+      ]
+    },
+    {
+      "timeline": "Taurus People Full P4 R2 v3",
+      "job": {
+        "state": "completed",
+        "error": null
+      },
+      "reading": {
+        "alignment": {
+          "mode": "audio_clip",
+          "audio": "Zinc Set 2 Reaper v4.wav",
+          "matched": false,
+          "zero_frame": 842
+        },
+        "cuts": 85,
+        "openings": 1,
+        "on_soloist": {
+          "solo_window_seconds": 497.496,
+          "labelled_seconds": 489.029,
+          "unlabelled_seconds": 8.467,
+          "black_seconds": 0.0,
+          "seconds": {
+            "soloist": 24.312,
+            "ensemble": 259.089,
+            "other_player": 205.628
+          },
+          "fraction_on_soloist": 0.05,
+          "fraction_on_ensemble": 0.53,
+          "fraction_on_other_player": 0.42,
+          "shots": {
+            "soloist": 4,
+            "ensemble": 42,
+            "other_player": 37,
+            "unlabelled": 2
+          }
+        },
+        "subjects": {
+          "unlabelled": {
+            "cuts": 2,
+            "seconds": 8.467,
+            "share": 0.017
+          },
+          "ensemble": {
+            "cuts": 42,
+            "seconds": 259.091,
+            "share": 0.521
+          },
+          "drums": {
+            "cuts": 41,
+            "seconds": 229.939,
+            "share": 0.462
+          }
+        },
+        "roles": {
+          "unlabelled": {
+            "cuts": 2,
+            "seconds": 8.467,
+            "share": 0.017
+          },
+          "ensemble-wide": {
+            "cuts": 42,
+            "seconds": 259.091,
+            "share": 0.521
+          },
+          "drums-tight": {
+            "cuts": 41,
+            "seconds": 229.939,
+            "share": 0.462
+          }
+        },
+        "solos": {
+          "covered": 3,
+          "outside": 0,
+          "cuts": {
+            "bass": 13,
+            "drums": 9,
+            "other": 62
+          }
+        }
+      },
+      "cuts_file": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\analysis\\Taurus-People-Full-P4-R2-v3-d4bd89e16d84.correlate.json",
+      "shots": [
+        {
+          "cut": 1,
+          "clip": "title_[0000-0055].png",
+          "t": 3568.485,
+          "seconds": 2.336,
+          "role": null,
+          "subject": null,
+          "subject_kind": null,
+          "front": "other",
+          "on_soloist": null,
+          "on_soloist_seconds": {
+            "unlabelled": 2.336
+          }
+        },
+        {
+          "cut": 2,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3570.821,
+          "seconds": 8.3,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 8.3
+          }
+        },
+        {
+          "cut": 3,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3579.121,
+          "seconds": 9.843,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 9.843
+          }
+        },
+        {
+          "cut": 4,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3588.964,
+          "seconds": 0.167,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 0.167
+          }
+        },
+        {
+          "cut": 5,
+          "clip": "personnel2_[0000-0146].png",
+          "t": 3589.131,
+          "seconds": 6.131,
+          "role": null,
+          "subject": null,
+          "subject_kind": null,
+          "front": "other",
+          "on_soloist": null,
+          "on_soloist_seconds": {
+            "unlabelled": 6.131
+          }
+        },
+        {
+          "cut": 6,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3595.262,
+          "seconds": 4.838,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 4.838
+          }
+        },
+        {
+          "cut": 7,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3600.1,
+          "seconds": 2.211,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 2.211
+          }
+        },
+        {
+          "cut": 8,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3602.311,
+          "seconds": 2.252,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 2.252
+          }
+        },
+        {
+          "cut": 9,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3604.563,
+          "seconds": 8.258,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 8.258
+          }
+        },
+        {
+          "cut": 10,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3612.821,
+          "seconds": 9.927,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 9.927
+          }
+        },
+        {
+          "cut": 11,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3622.748,
+          "seconds": 7.257,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 7.257
+          }
+        },
+        {
+          "cut": 12,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3630.005,
+          "seconds": 5.297,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 5.297
+          }
+        },
+        {
+          "cut": 13,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3635.302,
+          "seconds": 4.963,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 4.963
+          }
+        },
+        {
+          "cut": 14,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3640.265,
+          "seconds": 7.132,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 7.132
+          }
+        },
+        {
+          "cut": 15,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3647.397,
+          "seconds": 17.142,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 17.142
+          }
+        },
+        {
+          "cut": 16,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3664.54,
+          "seconds": 12.93,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 12.93
+          }
+        },
+        {
+          "cut": 17,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3677.469,
+          "seconds": 2.503,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 2.503
+          }
+        },
+        {
+          "cut": 18,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3679.972,
+          "seconds": 10.26,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 10.26
+          }
+        },
+        {
+          "cut": 19,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3690.232,
+          "seconds": 20.729,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 20.729
+          }
+        },
+        {
+          "cut": 20,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3710.961,
+          "seconds": 14.348,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 11.039,
+            "soloist": 3.309
+          }
+        },
+        {
+          "cut": 21,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3725.309,
+          "seconds": 7.633,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "drums",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 7.633
+          }
+        },
+        {
+          "cut": 22,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3732.941,
+          "seconds": 4.254,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "drums",
+          "on_soloist": true,
+          "on_soloist_seconds": {
+            "soloist": 4.239,
+            "other_player": 0.016
+          }
+        },
+        {
+          "cut": 23,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3737.196,
+          "seconds": 10.802,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 10.802
+          }
+        },
+        {
+          "cut": 24,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3747.998,
+          "seconds": 2.419,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "bass",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 1.962,
+            "soloist": 0.457
+          }
+        },
+        {
+          "cut": 25,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3750.417,
+          "seconds": 3.67,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "drums",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 3.67
+          }
+        },
+        {
+          "cut": 26,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3754.087,
+          "seconds": 3.086,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "drums",
+          "on_soloist": true,
+          "on_soloist_seconds": {
+            "soloist": 3.086
+          }
+        },
+        {
+          "cut": 27,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3757.174,
+          "seconds": 15.557,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "drums",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 15.557
+          }
+        },
+        {
+          "cut": 28,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3772.731,
+          "seconds": 9.259,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "drums",
+          "on_soloist": true,
+          "on_soloist_seconds": {
+            "soloist": 9.259
+          }
+        },
+        {
+          "cut": 29,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3781.99,
+          "seconds": 10.135,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "drums",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 10.135
+          }
+        },
+        {
+          "cut": 30,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3792.125,
+          "seconds": 3.962,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "drums",
+          "on_soloist": true,
+          "on_soloist_seconds": {
+            "soloist": 3.962
+          }
+        },
+        {
+          "cut": 31,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3796.088,
+          "seconds": 10.344,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "drums",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 10.343
+          }
+        },
+        {
+          "cut": 32,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3806.431,
+          "seconds": 3.295,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 3.295
+          }
+        },
+        {
+          "cut": 33,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3809.726,
+          "seconds": 6.173,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 6.173
+          }
+        },
+        {
+          "cut": 34,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3815.899,
+          "seconds": 3.629,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 3.629
+          }
+        },
+        {
+          "cut": 35,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3819.528,
+          "seconds": 10.052,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 10.052
+          }
+        },
+        {
+          "cut": 36,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3829.58,
+          "seconds": 5.339,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 5.339
+          }
+        },
+        {
+          "cut": 37,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3834.918,
+          "seconds": 2.503,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 2.503
+          }
+        },
+        {
+          "cut": 38,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3837.421,
+          "seconds": 9.927,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 9.927
+          }
+        },
+        {
+          "cut": 39,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3847.347,
+          "seconds": 8.592,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 8.592
+          }
+        },
+        {
+          "cut": 40,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3855.939,
+          "seconds": 4.463,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 4.463
+          }
+        },
+        {
+          "cut": 41,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3860.402,
+          "seconds": 10.093,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 10.093
+          }
+        },
+        {
+          "cut": 42,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3870.495,
+          "seconds": 4.963,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 4.963
+          }
+        },
+        {
+          "cut": 43,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3875.459,
+          "seconds": 9.009,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 9.009
+          }
+        },
+        {
+          "cut": 44,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3884.468,
+          "seconds": 4.505,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 4.505
+          }
+        },
+        {
+          "cut": 45,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3888.972,
+          "seconds": 1.96,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 1.96
+          }
+        },
+        {
+          "cut": 46,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3890.933,
+          "seconds": 1.752,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 1.752
+          }
+        },
+        {
+          "cut": 47,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3892.684,
+          "seconds": 3.754,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 3.754
+          }
+        },
+        {
+          "cut": 48,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3896.438,
+          "seconds": 7.174,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 7.174
+          }
+        },
+        {
+          "cut": 49,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3903.612,
+          "seconds": 2.002,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 2.002
+          }
+        },
+        {
+          "cut": 50,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3905.614,
+          "seconds": 3.545,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 3.545
+          }
+        },
+        {
+          "cut": 51,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3909.159,
+          "seconds": 3.795,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 3.795
+          }
+        },
+        {
+          "cut": 52,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3912.955,
+          "seconds": 3.17,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 3.17
+          }
+        },
+        {
+          "cut": 53,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3916.124,
+          "seconds": 2.503,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 2.503
+          }
+        },
+        {
+          "cut": 54,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3918.627,
+          "seconds": 4.338,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 4.338
+          }
+        },
+        {
+          "cut": 55,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3922.965,
+          "seconds": 1.627,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 1.627
+          }
+        },
+        {
+          "cut": 56,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3924.591,
+          "seconds": 3.837,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 3.837
+          }
+        },
+        {
+          "cut": 57,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3928.428,
+          "seconds": 1.585,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 1.585
+          }
+        },
+        {
+          "cut": 58,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3930.013,
+          "seconds": 7.841,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 7.841
+          }
+        },
+        {
+          "cut": 59,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3937.855,
+          "seconds": 3.67,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 3.67
+          }
+        },
+        {
+          "cut": 60,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3941.525,
+          "seconds": 4.671,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 4.671
+          }
+        },
+        {
+          "cut": 61,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3946.196,
+          "seconds": 3.253,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 3.253
+          }
+        },
+        {
+          "cut": 62,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3949.449,
+          "seconds": 6.757,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 6.757
+          }
+        },
+        {
+          "cut": 63,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3956.206,
+          "seconds": 3.378,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 3.378
+          }
+        },
+        {
+          "cut": 64,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3959.585,
+          "seconds": 6.798,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 6.798
+          }
+        },
+        {
+          "cut": 65,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3966.383,
+          "seconds": 2.044,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 2.044
+          }
+        },
+        {
+          "cut": 66,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3968.427,
+          "seconds": 3.67,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 3.67
+          }
+        },
+        {
+          "cut": 67,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3972.097,
+          "seconds": 3.837,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 3.837
+          }
+        },
+        {
+          "cut": 68,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3975.934,
+          "seconds": 6.924,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 6.924
+          }
+        },
+        {
+          "cut": 69,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3982.858,
+          "seconds": 4.254,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 4.254
+          }
+        },
+        {
+          "cut": 70,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 3987.112,
+          "seconds": 8.967,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 8.967
+          }
+        },
+        {
+          "cut": 71,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 3996.079,
+          "seconds": 4.004,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 4.004
+          }
+        },
+        {
+          "cut": 72,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 4000.083,
+          "seconds": 1.627,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 1.627
+          }
+        },
+        {
+          "cut": 73,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 4001.71,
+          "seconds": 4.421,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 4.421
+          }
+        },
+        {
+          "cut": 74,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 4006.131,
+          "seconds": 3.879,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 3.879
+          }
+        },
+        {
+          "cut": 75,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 4010.01,
+          "seconds": 3.378,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 3.378
+          }
+        },
+        {
+          "cut": 76,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 4013.388,
+          "seconds": 5.756,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 5.756
+          }
+        },
+        {
+          "cut": 77,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 4019.144,
+          "seconds": 6.256,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 6.256
+          }
+        },
+        {
+          "cut": 78,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 4025.4,
+          "seconds": 2.753,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 2.753
+          }
+        },
+        {
+          "cut": 79,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 4028.153,
+          "seconds": 1.418,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 1.418
+          }
+        },
+        {
+          "cut": 80,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 4029.571,
+          "seconds": 2.336,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 2.336
+          }
+        },
+        {
+          "cut": 81,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 4031.907,
+          "seconds": 6.089,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 6.089
+          }
+        },
+        {
+          "cut": 82,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 4037.996,
+          "seconds": 4.963,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 4.963
+          }
+        },
+        {
+          "cut": 83,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 4042.96,
+          "seconds": 6.048,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 6.047
+          }
+        },
+        {
+          "cut": 84,
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "t": 4049.007,
+          "seconds": 3.253,
+          "role": "drums-tight",
+          "subject": "drums",
+          "subject_kind": "player",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "other_player": 3.253
+          }
+        },
+        {
+          "cut": 85,
+          "clip": "A015C001_2606170J.MXF",
+          "t": 4052.261,
+          "seconds": 13.722,
+          "role": "ensemble-wide",
+          "subject": "ensemble",
+          "subject_kind": "ensemble",
+          "front": "other",
+          "on_soloist": false,
+          "on_soloist_seconds": {
+            "ensemble": 13.722
+          }
+        }
+      ],
+      "spot_check": [
+        {
+          "clip": "title_[0000-0055].png",
+          "shots": [
+            1
+          ],
+          "shot_count": 1,
+          "claimed_subject": null,
+          "claimed_kind": null,
+          "bin": null,
+          "grabbed_at_sec": [
+            0.58,
+            1.75
+          ],
+          "frames": null,
+          "ok": false,
+          "error": {
+            "code": "internal_error",
+            "cause": "FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\\\Users\\\\Daniel\\\\repos\\\\resolve-mcp\\\\.claude\\\\worktrees\\\\gauntlet-loop-1\\\\projects\\\\mcp-tests-zinc\\\\cards\\\\taurus-people\\\\title\\\\title_[0000-0055].png'",
+            "fix": "This is a bug in resolve-mcp rather than a Resolve state problem. Retry once; if it persists, work around it with run_python and report it.",
+            "detail": {}
+          }
+        },
+        {
+          "clip": "A015C001_2606170J.MXF",
+          "shots": [
+            2,
+            4,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17
+          ],
+          "shot_count": 42,
+          "claimed_subject": "ensemble",
+          "claimed_kind": "ensemble",
+          "bin": "Zinc Bar/Footage",
+          "grabbed_at_sec": [
+            739.03,
+            2217.09
+          ],
+          "frames": [
+            {
+              "time": {
+                "frames": 17718,
+                "seconds": 738.989,
+                "timecode": "00:12:18:06",
+                "fps": 23.976
+              },
+              "path": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\frames\\A015C001_2606170J.MXF-17407860bcbb.jpg",
+              "width": 1568,
+              "height": 882,
+              "bytes": 139708
+            },
+            {
+              "time": {
+                "frames": 53156,
+                "seconds": 2217.05,
+                "timecode": "00:36:54:20",
+                "fps": 23.976
+              },
+              "path": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\frames\\A015C001_2606170J.MXF-26db4dd00ea5.jpg",
+              "width": 1568,
+              "height": 882,
+              "bytes": 143111
+            }
+          ],
+          "ok": true,
+          "error": null
+        },
+        {
+          "clip": "20260617_D_A7IV_0006.MP4",
+          "shots": [
+            3,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18
+          ],
+          "shot_count": 41,
+          "claimed_subject": "drums",
+          "claimed_kind": "player",
+          "bin": "Zinc Bar/Footage",
+          "grabbed_at_sec": [
+            1028.9,
+            3086.71
+          ],
+          "frames": [
+            {
+              "time": {
+                "frames": 24668,
+                "seconds": 1028.862,
+                "timecode": "00:17:07:20",
+                "fps": 23.976
+              },
+              "path": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\frames\\20260617_D_A7IV_0006.MP4-2feb6711d864.jpg",
+              "width": 1568,
+              "height": 882,
+              "bytes": 98598
+            },
+            {
+              "time": {
+                "frames": 74006,
+                "seconds": 3086.67,
+                "timecode": "00:51:23:14",
+                "fps": 23.976
+              },
+              "path": "C:\\Users\\Daniel\\AppData\\Local\\resolve-mcp\\frames\\20260617_D_A7IV_0006.MP4-75ba8d2d4762.jpg",
+              "width": 1568,
+              "height": 882,
+              "bytes": 99979
+            }
+          ],
+          "ok": true,
+          "error": null
+        },
+        {
+          "clip": "personnel2_[0000-0146].png",
+          "shots": [
+            5
+          ],
+          "shot_count": 1,
+          "claimed_subject": null,
+          "claimed_kind": null,
+          "bin": null,
+          "grabbed_at_sec": [
+            1.53,
+            4.6
+          ],
+          "frames": null,
+          "ok": false,
+          "error": {
+            "code": "internal_error",
+            "cause": "FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\\\Users\\\\Daniel\\\\repos\\\\resolve-mcp\\\\.claude\\\\worktrees\\\\gauntlet-loop-1\\\\projects\\\\mcp-tests-zinc\\\\cards\\\\taurus-people\\\\personnel2\\\\personnel2_[0000-0146].png'",
+            "fix": "This is a bug in resolve-mcp rather than a Resolve state problem. Retry once; if it persists, work around it with run_python and report it.",
+            "detail": {}
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/gauntlet/recon/subject_track.json
+++ b/gauntlet/recon/subject_track.json
@@ -23,9 +23,9 @@
     "Taurus People Full P4 R1 v2",
     "Taurus People Full P4 R2 v3",
     "resolve-mcp-smoke v1",
-    "resolve-mcp smoke round-trip 122233",
+    "resolve-mcp smoke round-trip 125402",
     "resolve-mcp-smoke v2",
-    "resolve-mcp smoke dissolve 122238",
+    "resolve-mcp smoke dissolve 125405",
     "resolve-mcp-smoke v3",
     "resolve-mcp-smoke v4",
     "resolve-mcp-smoke v5",
@@ -78,6 +78,8 @@
           "fraction_on_soloist": 0.0,
           "fraction_on_ensemble": 0.521,
           "fraction_on_other_player": 0.479,
+          "fraction_elsewhere": 0.0,
+          "soloist_seconds_by_follow_camera": 0.0,
           "shots": {
             "ensemble": 8,
             "other_player": 7,
@@ -510,6 +512,16 @@
             "detail": {}
           }
         }
+      ],
+      "spot_check_failed": [
+        {
+          "clip": "title_[0000-0055].png",
+          "cause": "FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\\\Users\\\\Daniel\\\\repos\\\\resolve-mcp\\\\.claude\\\\worktrees\\\\gauntlet-loop-1\\\\projects\\\\mcp-tests-zinc\\\\cards\\\\taurus-people\\\\title\\\\title_[0000-0055].png'"
+        },
+        {
+          "clip": "personnel2_[0000-0146].png",
+          "cause": "FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\\\Users\\\\Daniel\\\\repos\\\\resolve-mcp\\\\.claude\\\\worktrees\\\\gauntlet-loop-1\\\\projects\\\\mcp-tests-zinc\\\\cards\\\\taurus-people\\\\personnel2\\\\personnel2_[0000-0146].png'"
+        }
       ]
     },
     {
@@ -540,6 +552,8 @@
           "fraction_on_soloist": 0.05,
           "fraction_on_ensemble": 0.53,
           "fraction_on_other_player": 0.42,
+          "fraction_elsewhere": 0.0,
+          "soloist_seconds_by_follow_camera": 0.0,
           "shots": {
             "soloist": 4,
             "ensemble": 42,
@@ -1929,6 +1943,16 @@
             "fix": "This is a bug in resolve-mcp rather than a Resolve state problem. Retry once; if it persists, work around it with run_python and report it.",
             "detail": {}
           }
+        }
+      ],
+      "spot_check_failed": [
+        {
+          "clip": "title_[0000-0055].png",
+          "cause": "FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\\\Users\\\\Daniel\\\\repos\\\\resolve-mcp\\\\.claude\\\\worktrees\\\\gauntlet-loop-1\\\\projects\\\\mcp-tests-zinc\\\\cards\\\\taurus-people\\\\title\\\\title_[0000-0055].png'"
+        },
+        {
+          "clip": "personnel2_[0000-0146].png",
+          "cause": "FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\\\Users\\\\Daniel\\\\repos\\\\resolve-mcp\\\\.claude\\\\worktrees\\\\gauntlet-loop-1\\\\projects\\\\mcp-tests-zinc\\\\cards\\\\taurus-people\\\\personnel2\\\\personnel2_[0000-0146].png'"
         }
       ]
     }

--- a/gauntlet/recon/subject_track.py
+++ b/gauntlet/recon/subject_track.py
@@ -1,0 +1,188 @@
+"""LIVE check of the on-soloist track (#181) against a Taurus People cut.
+
+READ-ONLY as far as Resolve is concerned: it lists timelines and measures one.
+Everything it writes goes to subject_track.json next to this file; the frame
+grabs for the spot check land in the media cache grab_frames already owns, and
+the receipt names their paths.
+
+    uv run python gauntlet/recon/subject_track.py [--timeline NAME]
+
+Ground truth for the spot check is a frame of the shot itself: the sidecar's
+labels were read off frames of each source clip, so a shot the track calls
+"drums" should be a frame of the drum kit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import traceback
+from pathlib import Path
+from typing import Any
+
+OUT = Path(__file__).with_name("subject_track.json")
+SIDECAR = Path(__file__).resolve().parents[2] / "styles" / "angles" / "mcp-tests-zinc.json"
+ANALYSIS = Path.home() / "AppData" / "Local" / "resolve-mcp" / "analysis"
+BEATS = ANALYSIS / "Zinc-Set-2-Reaper-v4-62537c590a14-beats.json"
+SOLOS = ANALYSIS / "Zinc-Set-2-Reaper-v4-0f3a70a16e52-solos.json"
+SAMPLE = 8  # how many shots to grab a frame for
+FOOTAGE_BIN = "Zinc Bar/Footage"
+"""Where this night's cameras live, for the clip names the whole pool holds more than once."""
+
+DEFAULT_TIMELINES = ("Taurus People Opening R3 v3", "Taurus People Full P4 R2 v3")
+"""The two cuts the gauntlet closed pieces on: the R3 opening and the full-song capstone."""
+
+report: dict[str, Any] = {"errors": [], "timelines": [], "inputs": {}}
+
+
+def note(where: str, exc: BaseException) -> None:
+    report["errors"].append(
+        {"where": where, "type": type(exc).__name__, "message": str(exc),
+         "traceback": traceback.format_exc(limit=6)}
+    )
+
+
+def timelines() -> list[str]:
+    from resolve_mcp.resolve.connection import get_connection
+
+    project = get_connection().handle().GetProjectManager().GetCurrentProject()
+    found = []
+    for index in range(1, int(project.GetTimelineCount()) + 1):
+        timeline = project.GetTimelineByIndex(index)
+        if timeline is not None:
+            found.append(str(timeline.GetName()))
+    return found
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--timeline", action="append", default=None, help="timeline to measure")
+    args = parser.parse_args()
+
+    from resolve_mcp import interpreter as interp
+
+    interp.ensure_supported()
+
+    report["timelines"] = timelines()
+    names = args.timeline or [one for one in DEFAULT_TIMELINES if one in report["timelines"]]
+    if not names:
+        OUT.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print("none of the default timelines are in this project; wrote the list to", OUT)
+        return
+
+    angles = json.loads(SIDECAR.read_text(encoding="utf-8"))["angles"]
+    report["inputs"] = {
+        "timelines": names,
+        "sidecar": str(SIDECAR),
+        "beats": str(BEATS),
+        "solos": str(SOLOS),
+        "subjects": {clip: entry.get("subject") for clip, entry in angles.items()},
+    }
+    report["measured"] = [measure(name, angles) for name in names]
+    OUT.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print("wrote", OUT)
+
+
+def measure(name: str, angles: dict[str, Any]) -> dict[str, Any]:
+    """One timeline: the reading, every shot's subject columns, and the spot-check grabs."""
+    from resolve_mcp.analysis import correlate
+    from resolve_mcp.jobs.runner import wait_for
+    from resolve_mcp.resolve.connection import get_connection
+
+    measured: dict[str, Any] = {"timeline": name}
+    started = correlate.correlate_timeline(
+        get_connection(),
+        beats=str(BEATS),
+        timeline=name,
+        solos=str(SOLOS),
+        angles=angles,
+        refresh=True,
+    )
+    record = wait_for(started["job_id"])
+    result = record.result or {}
+    measured["job"] = {"state": record.state, "error": record.error}
+    measured["reading"] = {
+        key: result.get(key)
+        for key in ("alignment", "cuts", "openings", "on_soloist", "subjects", "roles", "solos")
+    }
+
+    path = result.get("path")
+    measured["cuts_file"] = path
+    if not path:
+        return measured
+
+    cuts = json.loads(Path(path).read_text(encoding="utf-8"))["cuts"]
+    measured["shots"] = [
+        {
+            key: shot.get(key)
+            for key in ("cut", "clip", "t", "seconds", "role", "subject", "subject_kind",
+                        "front", "on_soloist", "on_soloist_seconds")
+        }
+        for shot in cuts
+    ]
+
+    # The spot check. Every camera on this rig is locked -- the sidecar's own labels were read
+    # off frames of these clips -- so what a shot is framed on is a fact about the camera it
+    # came from, and a frame of that clip is the ground truth for every shot that used it.
+    # Grabs are taken inside the clip's own bounds rather than at the shot's time: the shot's
+    # time counts from the master mix's zero and a clip's frames count from its own, and the
+    # rebase between them (G6) is the thing this check must not depend on.
+    from resolve_mcp.tools import media as media_tools
+    from resolve_mcp.tools import video as video_tools
+
+    held: dict[str, list[int]] = {}
+    for shot in cuts:
+        clip = shot.get("clip")
+        if clip is not None:
+            held.setdefault(str(clip), []).append(int(shot["cut"]))
+
+    grabs = []
+    for clip, used in held.items():
+        first = next(one for one in cuts if one.get("clip") == clip)
+        try:
+            # The pool holds several copies of some of these names -- the same camera roll
+            # under two projects' bins, the same card imported twice -- so a bare name is
+            # ambiguous and the footage bin is what disambiguates it.
+            info = media_tools.inspect_clip(clip=clip)
+            bin_path = None
+            if not info.get("ok", True):
+                bin_path = FOOTAGE_BIN
+                info = media_tools.inspect_clip(clip=clip, bin=bin_path)
+            bounds = info.get("bounds") or (info.get("clip") or {}).get("bounds") or {}
+            media_bounds = bounds.get("media") or bounds
+            span = (
+                float(media_bounds["in"]["seconds"]),
+                float(media_bounds["out"]["seconds"]),
+            )
+            at = [round(span[0] + (span[1] - span[0]) * where, 2) for where in (0.25, 0.75)]
+            grabbed = video_tools.grab_frames(
+                clip=clip, bin=bin_path, times=[{"seconds": one, "snap": "floor"} for one in at]
+            )
+        except Exception as exc:  # noqa: BLE001 - a receipt of the failure is the point
+            note(f"grab {clip}", exc)
+            continue
+        grabs.append(
+            {
+                "clip": clip,
+                "shots": used[:SAMPLE],
+                "shot_count": len(used),
+                "claimed_subject": first.get("subject"),
+                "claimed_kind": first.get("subject_kind"),
+                "bin": bin_path,
+                "grabbed_at_sec": at,
+                "frames": grabbed.get("frames"),
+                "ok": grabbed.get("ok"),
+                "error": grabbed.get("error"),
+            }
+        )
+    measured["spot_check"] = grabs
+    return measured
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except BaseException as exc:  # noqa: BLE001 - the receipt is the point
+        note("main", exc)
+        OUT.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        raise

--- a/gauntlet/recon/subject_track.py
+++ b/gauntlet/recon/subject_track.py
@@ -176,6 +176,14 @@ def measure(name: str, angles: dict[str, Any]) -> dict[str, Any]:
             }
         )
     measured["spot_check"] = grabs
+    # A refusal comes back in the envelope rather than as an exception, so it never reaches
+    # the errors list: a receipt whose errors are empty while half its grabs failed reads as
+    # a clean check. Name the failures at the top of the check instead.
+    measured["spot_check_failed"] = [
+        {"clip": one["clip"], "cause": (one.get("error") or {}).get("cause")}
+        for one in grabs
+        if not one.get("ok")
+    ]
     return measured
 
 

--- a/gauntlet/tools/ab_pack.py
+++ b/gauntlet/tools/ab_pack.py
@@ -8,7 +8,8 @@ assigns them to labels A and B, and builds a scrubbed evidence pack:
     out/<label>/clip.mp4         the extracted span, 540p
     out/<label>/cuts.json        cut times + transition type, shots + motion,
                                  stats, loudness, the 1-s audio class track,
-                                 the ending type and slow-transition events
+                                 the ending type, slow-transition events and
+                                 the on-soloist track where one was given
     out/<label>/sheet_N.jpg      contact sheets, 6 per row, timestamp burned in
     out/<label>/cutstrip_N.jpg   cut-boundary filmstrips, one cut per row:
                                  3 outgoing frames then 3 incoming frames
@@ -28,9 +29,17 @@ visible 5.9 s tail dissolve as "hard", so the ending and every weak boundary
 are refitted against a multi-second luma ramp, and mid-shot double images are
 reported as ghosting events.
 
+Pack v4 answers the core concert question (gap G5 item 6, #181): given each
+label's own correlate_timeline reading, the pack carries an on-soloist track --
+per shot, what it is framed on and whether that is the player out front, and per
+label, what share of the solo-window screen time went to the soloist. It is
+authored rather than detected: no pixel here knows a drummer from a horn player.
+Both labels carry one or neither does.
+
 Usage:
     uv run python gauntlet/tools/ab_pack.py \
-        --a <video> --b <video> [--a-span S,E] [--b-span S,E] --out <dir>
+        --a <video> --b <video> [--a-span S,E] [--b-span S,E] --out <dir> \
+        [--a-subjects <cuts.json> --b-subjects <cuts.json>]
 
 Dependencies: stdlib + numpy + ffmpeg/ffprobe on PATH, and the repo's own
 resolve_mcp package for the shot-length bin labels -- run it with `uv run` so
@@ -62,6 +71,7 @@ from typing import Any, NamedTuple
 
 import numpy as np
 
+from resolve_mcp.analysis import subject as subject_module
 from resolve_mcp.analysis.correlate import RHYTHM_BINS
 
 # --------------------------------------------------------------------------
@@ -1168,6 +1178,117 @@ def audio_class_summary(track: list[dict[str, Any]], spans: list[dict[str, Any]]
 
 
 # --------------------------------------------------------------------------
+# subject track (who the shot is on, crossed with who is soloing)
+
+
+SUBJECT_FIELDS = ("subject", "subject_kind", "on_soloist", "on_soloist_seconds")
+"""The only fields carried over from a correlate reading.
+
+Everything else in that file names the cut -- the timeline, the camera clips, the angle
+roles -- and a blind pack that carries a timeline name is not a blind pack. Copying the
+four columns by name is the guard: a field added to correlate later cannot leak through
+this without someone adding it here.
+"""
+
+
+def load_subject_track(path: Path) -> list[dict[str, Any]]:
+    """The on-soloist track out of a correlate_timeline cuts file, stripped to four columns."""
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    rows = doc.get("cuts", []) if isinstance(doc, dict) else doc
+    if not isinstance(rows, list):
+        sys.exit(f"error: {path} is neither a correlate cuts file nor a list of shots")
+    track = []
+    for row in rows:
+        if not isinstance(row, dict) or "t" not in row or "seconds" not in row:
+            sys.exit(f"error: {path} has a shot with no t/seconds -- not a correlate cuts file")
+        track.append(
+            {
+                "t": float(row["t"]),
+                "seconds": float(row["seconds"]),
+                **{name: row.get(name) for name in SUBJECT_FIELDS},
+            }
+        )
+    return track
+
+
+def place_subject_track(
+    track: list[dict[str, Any]], span: tuple[float, float] | None, duration: float
+) -> dict[str, Any]:
+    """The track in the extracted clip's own time: shifted, and cut to what the clip holds.
+
+    A shot the span cuts through keeps its place so a judge can still read what shot 7 is on.
+    Its seconds still count where the front held all the way through it -- the line is the
+    same either side of the cut, so the part inside the clip is exact arithmetic rather than
+    a guess. Where the front changed inside that shot they are dropped: scaling a split
+    across a boundary nobody measured would overstate whichever line the shot opened on.
+    """
+    start = span[0] if span else 0.0
+    placed: list[dict[str, Any]] = []
+    partial = 0
+    for row in track:
+        head, tail = row["t"] - start, row["t"] - start + row["seconds"]
+        if tail <= 0 or head >= duration:
+            continue
+        whole = head >= 0 and tail <= duration
+        partial += 0 if whole else 1
+        inside = round(min(tail, duration) - max(head, 0.0), 3)
+        placed.append(
+            {
+                "start": round(max(head, 0.0), 3),
+                "end": round(min(tail, duration), 3),
+                "whole": whole,
+                "counted_seconds": _counted(row.get("on_soloist_seconds"), whole, inside),
+                **{name: row.get(name) for name in SUBJECT_FIELDS},
+            }
+        )
+    counted = [{"on_soloist_seconds": row["counted_seconds"]} for row in placed]
+    return {
+        "shots": placed,
+        "shots_outside_clip": len(track) - len(placed),
+        "shots_cut_by_the_span": partial,
+        "shots_left_out_of_the_share": sum(1 for row in placed if row["counted_seconds"] is None),
+        "summary": subject_module.summary(counted),
+    }
+
+
+def _counted(split: Any, whole: bool, inside: float) -> dict[str, float] | None:
+    """What a placed shot contributes to the share: all of it, the part inside, or nothing."""
+    if not isinstance(split, dict) or not split:
+        return None
+    if whole:
+        return {str(line): float(held) for line, held in split.items()}
+    if len(split) > 1:
+        return None
+    return {str(next(iter(split))): inside}
+
+
+def attach_subjects(shot_docs: list[dict[str, Any]], placed: list[dict[str, Any]]) -> None:
+    """Label each *detected* shot with the authored shot that holds most of it.
+
+    The pack's own shots come from a scene scan and the track comes from the timeline, so the
+    two boundary lists agree only as well as the detector does. Matching by overlap rather
+    than by index means a missed cut reads as one shot carrying the subject it mostly is,
+    instead of a track silently sliding one shot out of step for the rest of the film.
+    """
+    for shot in shot_docs:
+        best, held = None, 0.0
+        for row in placed:
+            overlap = min(shot["end"], row["end"]) - max(shot["start"], row["start"])
+            if overlap > held:
+                best, held = row, overlap
+        shot["subject"] = (
+            None
+            if best is None
+            else {
+                "subject": best["subject"],
+                "subject_kind": best["subject_kind"],
+                "on_soloist": best["on_soloist"],
+                "overlap_sec": round(held, 3),
+            }
+        )
+
+
+# --------------------------------------------------------------------------
 # contact sheets
 
 
@@ -1429,6 +1550,7 @@ def build_label(
     span: tuple[float, float] | None,
     out: Path,
     keep_work: bool,
+    subjects: Path | None = None,
 ) -> dict[str, Any]:
     label_dir = out / label
     label_dir.mkdir(parents=True, exist_ok=True)
@@ -1472,6 +1594,14 @@ def build_label(
             }
         )
 
+    subject_track = (
+        None
+        if subjects is None
+        else place_subject_track(load_subject_track(subjects), span, duration)
+    )
+    if subject_track is not None:
+        attach_subjects(shot_docs, subject_track["shots"])
+
     cuts_doc: dict[str, Any] = {
         "label": label,
         "clip_duration_sec": round(duration, 3),
@@ -1500,6 +1630,9 @@ def build_label(
         "slow_transitions": slow_events,
         "ghosting": ghosts,
     }
+    if subject_track is not None:
+        cuts_doc["subject_track"] = subject_track
+
     samples = decode_mono(clip)
     features = audio_features(samples)
     audio_track, audio_thresholds = classify_audio(features)
@@ -1546,6 +1679,7 @@ def build_label(
         "slow_transitions": len(slow_events),
         "ghost_events": len(ghosts),
         "audio_classes": cuts_doc.get("audio_class_summary", {}).get("seconds_by_class"),
+        "on_soloist": None if subject_track is None else subject_track["summary"],
         "files": ["clip.mp4", "cuts.json", *sheets, *strips],
     }
 
@@ -1577,6 +1711,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out", required=True, help="output pack directory")
     parser.add_argument("--keep-work", action="store_true", help="keep intermediate frames")
     parser.add_argument(
+        "--a-subjects",
+        default=None,
+        help="correlate_timeline cuts file for --a: carries its on-soloist track into the pack",
+    )
+    parser.add_argument(
+        "--b-subjects",
+        default=None,
+        help="correlate_timeline cuts file for --b",
+    )
+    parser.add_argument(
         "--expect-a",
         type=int,
         default=None,
@@ -1602,6 +1746,25 @@ def main(argv: list[str] | None = None) -> int:
     a_span = parse_span(args.a_span)
     b_span = parse_span(args.b_span)
 
+    # Both or neither. One side carrying a subject track and the other not is a difference
+    # between the labels that has nothing to do with the cuts, and a critic reading one
+    # annotated version against one bare one is no longer comparing the two edits.
+    subject_files = {"--a-subjects": args.a_subjects, "--b-subjects": args.b_subjects}
+    if any(subject_files.values()) and not all(subject_files.values()):
+        missing = [flag for flag, given in subject_files.items() if not given]
+        sys.exit(
+            f"error: {', '.join(missing)} missing. A subject track on one label only is an "
+            "asymmetry between the labels, not a measurement -- pass both or neither."
+        )
+    # Keyed by input flag rather than by source path: two spans of one video are two labels
+    # sharing a path, and keying on the path would hand both of them the same track.
+    track_of_flag: dict[str, Path | None] = {}
+    for flag, given in (("--a", args.a_subjects), ("--b", args.b_subjects)):
+        track = None if given is None else Path(given).resolve()
+        if track is not None and not track.is_file():
+            sys.exit(f"error: subject track not found: {track}")
+        track_of_flag[flag] = track
+
     out = Path(args.out).resolve()
     out.mkdir(parents=True, exist_ok=True)
 
@@ -1618,11 +1781,20 @@ def main(argv: list[str] | None = None) -> int:
                 unclaimed.pop(i)
                 break
 
+    # A label that never matched back to its flag would silently build without its track,
+    # which is the asymmetry the both-or-neither check above exists to refuse.
+    if all(subject_files.values()) and set(flag_of) != {"A", "B"}:
+        sys.exit(
+            "error: subject tracks were given, but a label could not be matched back to the "
+            "flag it came from, so one label would build without its track. Refusing to build."
+        )
+
     label_entries = []
     for label in ("A", "B"):
         src, span = labels[label]
         print(f"[{label}] building...", file=sys.stderr)
-        label_entries.append(build_label(label, src, span, out, args.keep_work))
+        subjects = track_of_flag.get(flag_of.get(label, ""))
+        label_entries.append(build_label(label, src, span, out, args.keep_work, subjects))
 
     # Refuse to seal a pack whose detector couldn't see the cuts it was told
     # to expect -- a confident manifest built on a blind detector is worse
@@ -1676,7 +1848,7 @@ def main(argv: list[str] | None = None) -> int:
     (out / "assignment.json").write_text(json.dumps(assignment, indent=2), encoding="utf-8")
 
     manifest = {
-        "pack_version": 3,
+        "pack_version": 4,
         "kind": "blind_ab_comparison",
         "scene_threshold": SCENE_THRESHOLD,
         "contact_sheet": {
@@ -1768,6 +1940,29 @@ def main(argv: list[str] | None = None) -> int:
             "onsets": "each run carries start_refined -- the loudness edge inside the "
             "window that moved the class",
             "written_to": "cuts.json: audio_class_1s, audio_class_spans, audio_class_summary",
+        },
+        "subject_track": {
+            "carried": all(subject_files.values()),
+            "method": "authored, not detected: each label's own correlate_timeline reading of "
+            "what its shots are framed on (the angle sidecar's subject) crossed with who was "
+            "out front (the solo changes), shifted into the extracted clip's own time",
+            "lines": {
+                "soloist": "framed on the player out front",
+                "ensemble": "framed on the band rather than one player",
+                "other": "framed on somebody who was not soloing",
+                "unlabelled": "screen time no sidecar label reaches -- counted apart from the "
+                "shares, never in them",
+            },
+            "per_detected_shot": "shots[].subject -- the authored shot holding most of it, with "
+            "the overlap in seconds, because the pack's boundaries are a scene scan's and the "
+            "track's are the timeline's",
+            "seconds": "a shot the span cuts through counts the part inside the clip where "
+            "the front held through it, and is left out of the share where it did not "
+            "(subject_track.shots_left_out_of_the_share counts those); every shot carries its "
+            "own counted_seconds",
+            "both_or_neither": "one label annotated and the other bare would be a difference "
+            "between the labels that is not a difference between the cuts",
+            "written_to": "cuts.json: subject_track, and shots[].subject",
         },
         "labels": label_entries,
         "sealed_envelope": "assignment.json",

--- a/gauntlet/tools/ab_pack.py
+++ b/gauntlet/tools/ab_pack.py
@@ -1181,7 +1181,7 @@ def audio_class_summary(track: list[dict[str, Any]], spans: list[dict[str, Any]]
 # subject track (who the shot is on, crossed with who is soloing)
 
 
-SUBJECT_FIELDS = ("subject", "subject_kind", "on_soloist", "on_soloist_seconds")
+SUBJECT_FIELDS = ("subject", "subject_kind", "on_soloist", "on_soloist_by", "on_soloist_seconds")
 """The only fields carried over from a correlate reading.
 
 Everything else in that file names the cut -- the timeline, the camera clips, the angle
@@ -1283,6 +1283,7 @@ def attach_subjects(shot_docs: list[dict[str, Any]], placed: list[dict[str, Any]
                 "subject": best["subject"],
                 "subject_kind": best["subject_kind"],
                 "on_soloist": best["on_soloist"],
+                "on_soloist_by": best["on_soloist_by"],
                 "overlap_sec": round(held, 3),
             }
         )
@@ -1949,13 +1950,20 @@ def main(argv: list[str] | None = None) -> int:
             "lines": {
                 "soloist": "framed on the player out front",
                 "ensemble": "framed on the band rather than one player",
-                "other_player": "framed on somebody who was not soloing -- not `other`, which "
+                "other_player": "framed on a player who was not soloing -- not `other`, which "
                 "is the name of a stem",
+                "elsewhere": "framed on something that is neither a player nor the band (an "
+                "audience camera, a room shot)",
                 "unlabelled": "screen time no sidecar label reaches -- counted apart from the "
                 "shares, never in them",
                 "black": "a stretch nothing covers -- a fact about the edit rather than about "
                 "the labelling, so counted apart from unlabelled as well",
             },
+            "how_a_shot_reaches_the_soloist_line": "shots[].subject.on_soloist_by -- "
+            "`front_match` where the subject matched the front the solo map measured, "
+            "`follow_camera` where the sidecar says that camera follows whoever is out front "
+            "and the shot was taken at its word; the summary's "
+            "soloist_seconds_by_follow_camera is how much of the share is the second kind",
             "per_detected_shot": "shots[].subject -- the authored shot holding most of it, with "
             "the overlap in seconds, because the pack's boundaries are a scene scan's and the "
             "track's are the timeline's",

--- a/gauntlet/tools/ab_pack.py
+++ b/gauntlet/tools/ab_pack.py
@@ -1949,9 +1949,12 @@ def main(argv: list[str] | None = None) -> int:
             "lines": {
                 "soloist": "framed on the player out front",
                 "ensemble": "framed on the band rather than one player",
-                "other": "framed on somebody who was not soloing",
+                "other_player": "framed on somebody who was not soloing -- not `other`, which "
+                "is the name of a stem",
                 "unlabelled": "screen time no sidecar label reaches -- counted apart from the "
                 "shares, never in them",
+                "black": "a stretch nothing covers -- a fact about the edit rather than about "
+                "the labelling, so counted apart from unlabelled as well",
             },
             "per_detected_shot": "shots[].subject -- the authored shot holding most of it, with "
             "the overlap in seconds, because the pack's boundaries are a scene scan's and the "

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -925,7 +925,6 @@ def measure(
     for index, shot in enumerate(shots, start=1):
         seconds = clock.seconds(shot.record_in)
         framed = None if shot.clip is None else subjects.get(shot.clip)
-        framed_kind = subject.kind(framed, voices)
         found = nearest(times, seconds)
         beat = None if found is None else music.beats[found]
         # Only rows the beat gate let through are claimed by the reach rule, so ``gated`` keeps
@@ -947,10 +946,9 @@ def measure(
                 # whole length, because a shot that outlives the solo it opened in is two
                 # facts and reading the front at the cut alone records only the first.
                 "subject": None if framed is None else framed.name,
-                "subject_kind": framed_kind,
                 **subject.reading(
                     framed,
-                    framed_kind,
+                    voices,
                     seconds,
                     seconds + shot.duration / clock.fps,
                     spans,

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -3,7 +3,9 @@
 This is the instrument style is learned with (#22, story 32) and the one a build is reviewed
 with (story 47). Both directions need the same numbers: for every shot, how far its start
 sits from the nearest beat and from the nearest transient, where in the bar that is, which
-tune it happens in, who was out front, how long the shot runs and which angle it came from.
+tune it happens in, who was out front, how long the shot runs, which angle it came from and
+— where the sidecar labels its subject — whether the shot is on the player out front
+(`subject.py`, #181).
 
 Two rules shape everything here.
 
@@ -62,7 +64,7 @@ from ..resolve.timeline import (
     track_enabled,
 )
 from ..timing import SECONDS_PRECISION, dual_time, to_frames
-from . import decode, energy, records
+from . import decode, energy, records, subject
 from .beats import GridTrust, nearest, spacing, trust
 
 log = get_logger("analysis")
@@ -254,6 +256,7 @@ class Music(NamedTuple):
     tunes: tuple[dict[str, Any], ...] | None
     solos: tuple[dict[str, Any], ...] | None
     roles: dict[str, str] | None
+    subjects: dict[str, subject.Subject] | None
     audio: Path | None
 
 
@@ -296,7 +299,8 @@ def correlate_timeline(
     """
     config = config or get_config()
     roles = _roles(angles)
-    music = _music(beats, audio, tunes, solos, roles)
+    subjects = _subjects(angles)
+    music = _music(beats, audio, tunes, solos, roles, subjects)
     cut = _read_cut(connection, timeline, track, music.audio, audio_at)
 
     params: dict[str, Any] = {
@@ -308,6 +312,10 @@ def correlate_timeline(
         "tunes": _named(tunes),
         "solos": _named(solos),
         "angles": dict(sorted(roles.items())) if roles is not None else None,
+        # Carried apart from the roles so that relabelling a camera's subject — the one edit
+        # that moves the on-soloist track and nothing else — is a different job rather than a
+        # cache hit on the reading it replaces.
+        "subjects": None if subjects is None else _labelling(subjects),
     }
     watched = [{"reading": READING}, cut.fingerprint, *_fingerprints(beats, audio, tunes, solos)]
     key = cache.cache_key(KIND, watched, params)
@@ -705,6 +713,7 @@ def _music(
     tunes: str | None,
     solos: str | None,
     roles: dict[str, str] | None,
+    subjects: dict[str, subject.Subject] | None,
 ) -> Music:
     """Every file the measurement joins — or a refusal naming the one that is not there."""
     return Music(
@@ -712,6 +721,7 @@ def _music(
         tunes=_optional_rows(tunes, "tune list", "tunes"),
         solos=_optional_rows(solos, "solo changes", "solos"),
         roles=roles,
+        subjects=subjects,
         audio=_path(audio, "master mix", "it is the file the analysis ran on") if audio else None,
     )
 
@@ -802,6 +812,29 @@ def _role(entry: Any) -> str | None:
     return None
 
 
+def _subjects(angles: Mapping[str, Any] | None) -> dict[str, subject.Subject] | None:
+    """Clip name to what that camera is framed on — the other half of the same sidecar.
+
+    Separate from the roles because the two answer different questions and a sidecar can hold
+    either alone: the role is how a cut spends its angles, the subject is who the shot is on.
+    ``angles`` is validated by ``_roles``, which runs first on the same mapping.
+    """
+    if angles is None:
+        return None
+    return {
+        str(clip): found
+        for clip, entry in angles.items()
+        if (found := subject.subject_of(entry)) is not None
+    }
+
+
+def _labelling(subjects: Mapping[str, subject.Subject]) -> dict[str, dict[str, str]]:
+    """The subject labels as the job records them — plain JSON, in clip order."""
+    return {
+        clip: {"subject": one.name, "voice": one.voice} for clip, one in sorted(subjects.items())
+    }
+
+
 def _transients(audio: Path | None, onsets: Onsets | None) -> tuple[float, ...] | None:
     """Onset times for the mix, or ``None`` when no mix was named.
 
@@ -882,12 +915,17 @@ def measure(
     tune_times = [float(row["t"]) for row in (music.tunes or ())]
     solo_times = [float(row["t"]) for row in (music.solos or ())]
     roles = music.roles or {}
+    subjects = music.subjects or {}
+    voices = subject.voices(music.solos)
+    spans = subject.windows(music.solos)
     trusted = (grid if grid is not None else trust(music.beats)).trusted
     widths = spacing(times)
 
     rows: list[dict[str, Any]] = []
     for index, shot in enumerate(shots, start=1):
         seconds = clock.seconds(shot.record_in)
+        framed = None if shot.clip is None else subjects.get(shot.clip)
+        framed_kind = subject.kind(framed, voices)
         found = nearest(times, seconds)
         beat = None if found is None else music.beats[found]
         # Only rows the beat gate let through are claimed by the reach rule, so ``gated`` keeps
@@ -904,6 +942,15 @@ def measure(
                 "clip": shot.clip,
                 "track": shot.track,
                 "role": None if shot.clip is None else roles.get(shot.clip),
+                # What the shot is on, and who was playing while it held (#181). The subject
+                # is the sidecar's; the join against the solo map is measured over the shot's
+                # whole length, because a shot that outlives the solo it opened in is two
+                # facts and reading the front at the cut alone records only the first.
+                "subject": None if framed is None else framed.name,
+                "subject_kind": framed_kind,
+                **subject.reading(
+                    framed, framed_kind, seconds, seconds + shot.duration / clock.fps, spans
+                ),
                 "opening": _opens(index, shot, shots),
                 "t": _rounded(seconds),
                 # Dual time for the two timeline positions, because an outlier the agent
@@ -1065,6 +1112,10 @@ def _summary(
         "shot_rhythm": _rhythm(rows, levels),
         "clips": _usage(rows, "clip"),
         "roles": _usage(rows, "role") if _measured("role", rows) else None,
+        "subjects": _usage(rows, "subject") if _measured("subject", rows) else None,
+        # Taken over every shot, openings included: the question is where the screen time
+        # went, and a shot that starts the film is screen time like any other (#181).
+        "on_soloist": subject.summary(rows),
     }
 
 

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -949,7 +949,12 @@ def measure(
                 "subject": None if framed is None else framed.name,
                 "subject_kind": framed_kind,
                 **subject.reading(
-                    framed, framed_kind, seconds, seconds + shot.duration / clock.fps, spans
+                    framed,
+                    framed_kind,
+                    seconds,
+                    seconds + shot.duration / clock.fps,
+                    spans,
+                    black=shot.clip is None,
                 ),
                 "opening": _opens(index, shot, shots),
                 "t": _rounded(seconds),

--- a/src/resolve_mcp/analysis/subject.py
+++ b/src/resolve_mcp/analysis/subject.py
@@ -159,6 +159,11 @@ def kind(subject: Subject | None, known: frozenset[str]) -> str | None:
     as a player away from the front would make a cut look like it was watching the wrong
     person. With no solo map there is no roster to contradict the sidecar, so a named subject
     is taken at its word.
+
+    Where that rule is wrong it is wrong in one direction, and the sidecar is what fixes it: a
+    player who never took the front all night is on no roster either, and reads as neither.
+    Naming that camera's ``voice`` — the stem the solo map would have called them — is the
+    escape hatch, and a solo map that covers the whole night is what makes it unnecessary.
     """
     if subject is None:
         return None

--- a/src/resolve_mcp/analysis/subject.py
+++ b/src/resolve_mcp/analysis/subject.py
@@ -29,36 +29,58 @@ from typing import Any, NamedTuple
 
 from ..timing import SECONDS_PRECISION
 
+SHARE_PRECISION = 3
+"""Decimals a share is reported to. Not seconds — a fraction of a cut, rounded on its own."""
+
+# --- the sidecar's vocabulary: what a camera can be framed on ---------------------------------
+#
+# ENSEMBLE is the whole band rather than one of its players. FOLLOWS_FRONT is a camera pointed
+# at whoever is out front rather than at a fixed player: its shots are on the soloist by
+# construction — that is the camera's job — and the solo map is what says who that was. A rig
+# with one operated camera and one locked one has exactly one of these, and reading it as a
+# player named "soloist" would look for a stem nobody separated.
+
 ENSEMBLE = "ensemble"
-"""The subject that is the whole band rather than one of its players."""
-
 FOLLOWS_FRONT = "soloist"
-"""The subject of a camera pointed at whoever is out front, rather than at a fixed player.
 
-Its shots are on the soloist by construction — that is the camera's job — and the solo map
-is what says who that was. A rig with one operated camera and one locked one has exactly one
-of these, and reading it as a player named "soloist" would look for a stem nobody separated.
-"""
+# --- what kind of subject that is -------------------------------------------------------------
+#
+# One of the band, the band itself (spelled ENSEMBLE, as the subject is), or neither — an
+# audience camera, a room shot.
 
 PLAYER = "player"
 OTHER = "other"
-"""What a subject can be: one of the band, the band itself, or neither (audience, room)."""
+
+# --- the lines a shot's screen time is counted on ----------------------------------------------
+#
+# On the player out front, on the band, on a player who was not soloing, on something that is
+# neither (an audience camera, a room shot), on nobody the sidecar has named, or on nothing at
+# all. Three of these names were chosen carefully.
+# ON_OTHER is not ``other``: the residual stem is *called* ``other``, so a line by that name
+# sitting beside a solo map whose front reads ``other`` would be two things spelled the same.
+# ON_ELSEWHERE exists because a room shot is not a player: folded into ON_OTHER it would read
+# as a cut watching the wrong musician, which is a different fact about a cut than a cut
+# watching the room, and the aggregate is where that difference would otherwise be lost.
+# ON_SOLOIST *is* spelled like FOLLOWS_FRONT, and that one is a real coincidence rather than an
+# accident: a shot from the camera that follows the front is on the soloist by definition, so
+# the subject and the line it lands on are the same word about the same fact.
+# BLACK is kept apart from UNLABELLED for the reason the angle shares keep them apart: how much
+# of a cut is empty is a fact about the edit, and how much of it the sidecar has not named is a
+# fact about the sidecar. Added together neither is readable.
 
 ON_SOLOIST = "soloist"
 ON_ENSEMBLE = "ensemble"
 ON_OTHER = "other_player"
-"""Not ``other``: the residual stem is *called* ``other``, so a line by that name sitting next
-to a solo map whose front reads ``other`` is two different things spelled the same."""
+ON_ELSEWHERE = "elsewhere"
 UNLABELLED = "unlabelled"
 BLACK = "black"
-"""Where a shot's screen time is counted: on the player out front, on the band, on somebody
-else, on nobody the sidecar has named, or on nothing at all.
 
-Black is kept apart from unlabelled for the reason the angle shares keep them apart: how much
-of a cut is empty is a fact about the edit, and how much of it the sidecar has not named is a
-fact about the sidecar. Added together neither is readable."""
+FRONT_MATCH = "front_match"
+FOLLOW_CAMERA = "follow_camera"
+"""How a shot came to be on the soloist: the subject matched the front the solo map measured,
+or the sidecar says this camera follows the front and the shot was taken at its word."""
 
-ORDER = (ON_SOLOIST, ON_ENSEMBLE, ON_OTHER, UNLABELLED, BLACK)
+ORDER = (ON_SOLOIST, ON_ENSEMBLE, ON_OTHER, ON_ELSEWHERE, UNLABELLED, BLACK)
 """The order the readings are reported in, so two runs of the same cut compare line by line."""
 
 
@@ -176,13 +198,18 @@ def windows(rows: Sequence[Mapping[str, Any]] | None) -> tuple[Window, ...]:
 
 def reading(
     subject: Subject | None,
-    subject_kind: str | None,
+    known: frozenset[str],
     start: float,
     end: float,
     spans: Sequence[Window],
     black: bool = False,
 ) -> dict[str, Any]:
-    """One shot against the solo windows: where its screen time went, and the one-word verdict.
+    """One shot against the solo windows: what it is on, where its screen time went, and the
+    one-word verdict.
+
+    The kind is worked out here rather than passed in, because it is a fact about the subject
+    and the solo map's roster and about nothing else — the caller that had to compute it first
+    could only ever have computed it this way.
 
     ``on_soloist`` is the reading a critic quotes and the seconds are what it was taken from:
     the verdict is whichever line holds the most of the shot, and a shot split evenly takes
@@ -192,14 +219,37 @@ def reading(
     ``black`` is a stretch nothing covers, which is not a shot with no label on it: it is
     counted on its own line and its verdict is nothing rather than false.
     """
+    subject_kind = kind(subject, known)
     seconds = _split(subject, subject_kind, start, end, spans, black)
-    if not seconds:
-        return {"on_soloist": None, "on_soloist_seconds": None}
-    verdict = max(seconds, key=lambda line: seconds[line])
+    verdict = None if not seconds else _verdict(seconds)
+    on_soloist = None if verdict in (None, UNLABELLED, BLACK) else verdict == ON_SOLOIST
     return {
-        "on_soloist": None if verdict in (UNLABELLED, BLACK) else verdict == ON_SOLOIST,
-        "on_soloist_seconds": seconds,
+        "subject_kind": subject_kind,
+        "on_soloist": on_soloist,
+        # How the shot got onto that line, because the two ways are not equally well known: a
+        # subject that *matches* the front was joined against the solo map, while a camera
+        # whose whole job is the front was taken at the sidecar's word. Both are real readings
+        # and only one of them is a measurement — a rig with a follow camera can otherwise post
+        # a high share on the soloist without anything ever having been measured.
+        "on_soloist_by": _by(subject, subject_kind, on_soloist),
+        "on_soloist_seconds": seconds or None,
     }
+
+
+def _by(subject: Subject | None, subject_kind: str | None, on_soloist: bool | None) -> str | None:
+    """``follow_camera`` where the sidecar asserted it, ``front_match`` where the join found it."""
+    if not on_soloist or subject is None or subject_kind != PLAYER:
+        return None
+    return FOLLOW_CAMERA if subject.voice == FOLLOWS_FRONT else FRONT_MATCH
+
+
+def _verdict(seconds: Mapping[str, float]) -> str:
+    """The line a shot is called by: whichever holds most of it, ties to the one it opened on.
+
+    The dict is built in the order the windows were played, so ``max`` returning the first of
+    equal values *is* the tie-break — it does not need one of its own.
+    """
+    return max(seconds, key=lambda line: float(seconds[line]))
 
 
 def _split(
@@ -230,7 +280,9 @@ def _line(subject: Subject | None, subject_kind: str | None, front: str, black: 
         return UNLABELLED
     if subject_kind == ENSEMBLE:
         return ON_ENSEMBLE
-    if subject_kind == PLAYER and (subject.voice == FOLLOWS_FRONT or subject.voice == front):
+    if subject_kind != PLAYER:
+        return ON_ELSEWHERE
+    if subject.voice == FOLLOWS_FRONT or subject.voice == front:
         return ON_SOLOIST
     return ON_OTHER
 
@@ -244,18 +296,23 @@ def summary(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any] | None:
     """
     seconds: dict[str, float] = {}
     shots: dict[str, int] = {}
+    asserted = 0.0
     for row in rows:
         split = row.get("on_soloist_seconds")
         if not isinstance(split, Mapping) or not split:
             continue
         for line, held in split.items():
             seconds[str(line)] = round(seconds.get(str(line), 0.0) + float(held), SECONDS_PRECISION)
-        verdict = max(split, key=lambda line: float(split[line]))
-        shots[str(verdict)] = shots.get(str(verdict), 0) + 1
+        if row.get("on_soloist_by") == FOLLOW_CAMERA:
+            asserted = round(asserted + float(split.get(ON_SOLOIST, 0.0)), SECONDS_PRECISION)
+        verdict = _verdict({str(line): float(held) for line, held in split.items()})
+        shots[verdict] = shots.get(verdict, 0) + 1
     if not seconds:
         return None
     apart = (UNLABELLED, BLACK)
-    labelled = round(sum(held for line, held in seconds.items() if line not in apart), 3)
+    labelled = round(
+        sum(held for line, held in seconds.items() if line not in apart), SECONDS_PRECISION
+    )
     return {
         "solo_window_seconds": round(sum(seconds.values()), SECONDS_PRECISION),
         "labelled_seconds": labelled,
@@ -267,9 +324,14 @@ def summary(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any] | None:
         "fraction_on_soloist": _share(seconds.get(ON_SOLOIST, 0.0), labelled),
         "fraction_on_ensemble": _share(seconds.get(ON_ENSEMBLE, 0.0), labelled),
         "fraction_on_other_player": _share(seconds.get(ON_OTHER, 0.0), labelled),
+        "fraction_elsewhere": _share(seconds.get(ON_ELSEWHERE, 0.0), labelled),
+        # How much of the soloist line was asserted by a follow camera's label rather than
+        # joined against the solo map. Zero is the usual answer and the reason to print it:
+        # a share that is mostly this is a share of the sidecar's word, not of the music.
+        "soloist_seconds_by_follow_camera": asserted,
         "shots": {line: shots[line] for line in ORDER if line in shots},
     }
 
 
 def _share(held: float, total: float) -> float | None:
-    return None if total <= 0 else round(held / total, 3)
+    return None if total <= 0 else round(held / total, SHARE_PRECISION)

--- a/src/resolve_mcp/analysis/subject.py
+++ b/src/resolve_mcp/analysis/subject.py
@@ -46,12 +46,19 @@ OTHER = "other"
 
 ON_SOLOIST = "soloist"
 ON_ENSEMBLE = "ensemble"
-ON_OTHER = "other"
+ON_OTHER = "other_player"
+"""Not ``other``: the residual stem is *called* ``other``, so a line by that name sitting next
+to a solo map whose front reads ``other`` is two different things spelled the same."""
 UNLABELLED = "unlabelled"
+BLACK = "black"
 """Where a shot's screen time is counted: on the player out front, on the band, on somebody
-else, or nowhere anyone can attribute."""
+else, on nobody the sidecar has named, or on nothing at all.
 
-ORDER = (ON_SOLOIST, ON_ENSEMBLE, ON_OTHER, UNLABELLED)
+Black is kept apart from unlabelled for the reason the angle shares keep them apart: how much
+of a cut is empty is a fact about the edit, and how much of it the sidecar has not named is a
+fact about the sidecar. Added together neither is readable."""
+
+ORDER = (ON_SOLOIST, ON_ENSEMBLE, ON_OTHER, UNLABELLED, BLACK)
 """The order the readings are reported in, so two runs of the same cut compare line by line."""
 
 
@@ -173,6 +180,7 @@ def reading(
     start: float,
     end: float,
     spans: Sequence[Window],
+    black: bool = False,
 ) -> dict[str, Any]:
     """One shot against the solo windows: where its screen time went, and the one-word verdict.
 
@@ -180,13 +188,16 @@ def reading(
     the verdict is whichever line holds the most of the shot, and a shot split evenly takes
     the one it opened on — the tie is broken by time rather than by name, so renaming a
     player cannot move a verdict.
+
+    ``black`` is a stretch nothing covers, which is not a shot with no label on it: it is
+    counted on its own line and its verdict is nothing rather than false.
     """
-    seconds = _split(subject, subject_kind, start, end, spans)
+    seconds = _split(subject, subject_kind, start, end, spans, black)
     if not seconds:
         return {"on_soloist": None, "on_soloist_seconds": None}
     verdict = max(seconds, key=lambda line: seconds[line])
     return {
-        "on_soloist": None if verdict == UNLABELLED else verdict == ON_SOLOIST,
+        "on_soloist": None if verdict in (UNLABELLED, BLACK) else verdict == ON_SOLOIST,
         "on_soloist_seconds": seconds,
     }
 
@@ -197,6 +208,7 @@ def _split(
     start: float,
     end: float,
     spans: Sequence[Window],
+    black: bool,
 ) -> dict[str, float]:
     """How many seconds of this shot fall on each line, in the order they were played."""
     seconds: dict[str, float] = {}
@@ -206,12 +218,14 @@ def _split(
         overlap = min(end, span.end) - max(start, span.start)
         if overlap <= 0:
             continue
-        line = _line(subject, subject_kind, span.front)
+        line = _line(subject, subject_kind, span.front, black)
         seconds[line] = round(seconds.get(line, 0.0) + overlap, SECONDS_PRECISION)
     return seconds
 
 
-def _line(subject: Subject | None, subject_kind: str | None, front: str) -> str:
+def _line(subject: Subject | None, subject_kind: str | None, front: str, black: bool) -> str:
+    if black:
+        return BLACK
     if subject is None or subject_kind is None:
         return UNLABELLED
     if subject_kind == ENSEMBLE:
@@ -240,17 +254,19 @@ def summary(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any] | None:
         shots[str(verdict)] = shots.get(str(verdict), 0) + 1
     if not seconds:
         return None
-    labelled = round(sum(held for line, held in seconds.items() if line != UNLABELLED), 3)
+    apart = (UNLABELLED, BLACK)
+    labelled = round(sum(held for line, held in seconds.items() if line not in apart), 3)
     return {
         "solo_window_seconds": round(sum(seconds.values()), SECONDS_PRECISION),
         "labelled_seconds": labelled,
         "unlabelled_seconds": seconds.get(UNLABELLED, 0.0),
+        "black_seconds": seconds.get(BLACK, 0.0),
         "seconds": {
-            line: seconds[line] for line in ORDER if line in seconds and line != UNLABELLED
+            line: seconds[line] for line in ORDER if line in seconds and line not in apart
         },
         "fraction_on_soloist": _share(seconds.get(ON_SOLOIST, 0.0), labelled),
         "fraction_on_ensemble": _share(seconds.get(ON_ENSEMBLE, 0.0), labelled),
-        "fraction_on_other": _share(seconds.get(ON_OTHER, 0.0), labelled),
+        "fraction_on_other_player": _share(seconds.get(ON_OTHER, 0.0), labelled),
         "shots": {line: shots[line] for line in ORDER if line in shots},
     }
 

--- a/src/resolve_mcp/analysis/subject.py
+++ b/src/resolve_mcp/analysis/subject.py
@@ -1,0 +1,259 @@
+"""Which player a shot is framed on, crossed with who is out front.
+
+The core concert question, and the one a blind viewer-judge kept asking for: not "how long
+is the shot" but "is it on the person playing". Two documents already answer half of it each
+— the angle sidecar says what a camera is framed on, the solo changes say who was out front
+— and neither is useful alone. This joins them.
+
+*Nothing here decides.* A cut that spends its solos on the drummer is reported as a cut that
+spends its solos on the drummer; whether that is wrong is the style profile's business (#21).
+
+Two rules keep the numbers honest.
+
+*Seconds, not verdicts at the cut.* A shot that opens on a drum solo and runs four seconds
+past the horn's entrance is two facts, and reading the front at the cut alone would record
+only the first. Every reading here is screen time inside solo windows, split where the front
+changes, so "62% of the solo-window screen time is on the soloist" is arithmetic over the
+records rather than an impression.
+
+*Unattributable screen time is counted apart.* A shot from a camera the sidecar has not
+labelled is not a shot away from the soloist. Folded into the denominator it reads as a cut
+ignoring the player; dropped silently it reads as a cut with nothing to answer for. It gets
+its own line, so a fraction is always read next to how much of the cut it could not see.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, NamedTuple
+
+from ..timing import SECONDS_PRECISION
+
+ENSEMBLE = "ensemble"
+"""The subject that is the whole band rather than one of its players."""
+
+FOLLOWS_FRONT = "soloist"
+"""The subject of a camera pointed at whoever is out front, rather than at a fixed player.
+
+Its shots are on the soloist by construction — that is the camera's job — and the solo map
+is what says who that was. A rig with one operated camera and one locked one has exactly one
+of these, and reading it as a player named "soloist" would look for a stem nobody separated.
+"""
+
+PLAYER = "player"
+OTHER = "other"
+"""What a subject can be: one of the band, the band itself, or neither (audience, room)."""
+
+ON_SOLOIST = "soloist"
+ON_ENSEMBLE = "ensemble"
+ON_OTHER = "other"
+UNLABELLED = "unlabelled"
+"""Where a shot's screen time is counted: on the player out front, on the band, on somebody
+else, or nowhere anyone can attribute."""
+
+ORDER = (ON_SOLOIST, ON_ENSEMBLE, ON_OTHER, UNLABELLED)
+"""The order the readings are reported in, so two runs of the same cut compare line by line."""
+
+
+class Subject(NamedTuple):
+    """What a camera is framed on, and what the solo map calls that.
+
+    Two fields because the two documents need not share a vocabulary: a sidecar may name the
+    player ("mike") where the solo map names the stem he is heard on ("wind"). Where the
+    sidecar says nothing else, the two are the same string.
+    """
+
+    name: str
+    voice: str
+
+
+class Window(NamedTuple):
+    """A stretch of the concert with one voice out front. ``front`` unknown is not a window
+    anything can be measured against — it is the part of the concert the solo map does not
+    describe."""
+
+    start: float
+    end: float
+    front: str | None
+
+
+def subject_of(entry: Any) -> Subject | None:
+    """What one angle-sidecar entry says its camera is framed on, or nothing.
+
+    Read from ``subject`` where the entry names one. Otherwise from ``role``, which the
+    corpus writes as ``<subject>-<character>`` ("drums-tight", "ensemble-wide") — its head is
+    a subject. A one-word role is a *character* ("wide", "moving"): it says how the camera
+    frames, not what it is framed on, and turning that into a subject would invent a fact the
+    sidecar did not state.
+
+    ``voice`` is the escape hatch for the sidecar whose subjects are people rather than
+    stems: it is what the solo map calls this subject, and the join uses it.
+    """
+    if isinstance(entry, str):
+        return _named(_head(entry), None)
+    if not isinstance(entry, Mapping):
+        return None
+    named = entry.get("subject")
+    role = entry.get("role")
+    name = named if isinstance(named, str) else _head(role) if isinstance(role, str) else None
+    voice = entry.get("voice")
+    return _named(name, voice if isinstance(voice, str) else None)
+
+
+def _named(name: str | None, voice: str | None) -> Subject | None:
+    if name is None or not name.strip():
+        return None
+    return Subject(name, (voice or name))
+
+
+def _head(role: str) -> str | None:
+    """The subject half of a ``<subject>-<character>`` role, or nothing for a bare one."""
+    subject, dash, character = role.partition("-")
+    return subject if dash and subject and character else None
+
+
+def voices(rows: Sequence[Mapping[str, Any]] | None) -> frozenset[str]:
+    """Every voice the solo map names — the only roster of players that was measured."""
+    if not rows:
+        return frozenset()
+    found = {
+        str(row[key]) for row in rows for key in ("from", "to") if isinstance(row.get(key), str)
+    }
+    return frozenset(found)
+
+
+def kind(subject: Subject | None, known: frozenset[str]) -> str | None:
+    """Whether this subject is a player, the ensemble, or neither.
+
+    The roster is the solo map's own, not a list this file keeps: a subject it never names is
+    an audience camera or a room shot as far as anything measurable goes, and counting that
+    as a player away from the front would make a cut look like it was watching the wrong
+    person. With no solo map there is no roster to contradict the sidecar, so a named subject
+    is taken at its word.
+    """
+    if subject is None:
+        return None
+    if subject.name == ENSEMBLE:
+        return ENSEMBLE
+    if subject.voice == FOLLOWS_FRONT:
+        return PLAYER
+    if known and subject.voice not in known:
+        return OTHER
+    return PLAYER
+
+
+def windows(rows: Sequence[Mapping[str, Any]] | None) -> tuple[Window, ...]:
+    """The solo changes read as stretches: who was out front, from when to when.
+
+    Before the first change there is still someone out front — the change records who it was
+    taken over *from* — and after the last one the front holds to the end of the concert. The
+    ends are unbounded on purpose: this measures shots, and a shot past the last change is
+    still on whoever the map left out front.
+    """
+    if not rows:
+        return ()
+    ordered = sorted(rows, key=lambda row: float(row["t"]))
+    first = ordered[0].get("from")
+    held: str | None = str(first) if isinstance(first, str) else None
+    built: list[Window] = []
+    start = float("-inf")
+    for row in ordered:
+        moment = float(row["t"])
+        built.append(Window(start, moment, held))
+        entered = row.get("to")
+        held = str(entered) if isinstance(entered, str) else held
+        start = moment
+    built.append(Window(start, float("inf"), held))
+    return tuple(built)
+
+
+def reading(
+    subject: Subject | None,
+    subject_kind: str | None,
+    start: float,
+    end: float,
+    spans: Sequence[Window],
+) -> dict[str, Any]:
+    """One shot against the solo windows: where its screen time went, and the one-word verdict.
+
+    ``on_soloist`` is the reading a critic quotes and the seconds are what it was taken from:
+    the verdict is whichever line holds the most of the shot, and a shot split evenly takes
+    the one it opened on — the tie is broken by time rather than by name, so renaming a
+    player cannot move a verdict.
+    """
+    seconds = _split(subject, subject_kind, start, end, spans)
+    if not seconds:
+        return {"on_soloist": None, "on_soloist_seconds": None}
+    verdict = max(seconds, key=lambda line: seconds[line])
+    return {
+        "on_soloist": None if verdict == UNLABELLED else verdict == ON_SOLOIST,
+        "on_soloist_seconds": seconds,
+    }
+
+
+def _split(
+    subject: Subject | None,
+    subject_kind: str | None,
+    start: float,
+    end: float,
+    spans: Sequence[Window],
+) -> dict[str, float]:
+    """How many seconds of this shot fall on each line, in the order they were played."""
+    seconds: dict[str, float] = {}
+    for span in spans:
+        if span.front is None:
+            continue
+        overlap = min(end, span.end) - max(start, span.start)
+        if overlap <= 0:
+            continue
+        line = _line(subject, subject_kind, span.front)
+        seconds[line] = round(seconds.get(line, 0.0) + overlap, SECONDS_PRECISION)
+    return seconds
+
+
+def _line(subject: Subject | None, subject_kind: str | None, front: str) -> str:
+    if subject is None or subject_kind is None:
+        return UNLABELLED
+    if subject_kind == ENSEMBLE:
+        return ON_ENSEMBLE
+    if subject_kind == PLAYER and (subject.voice == FOLLOWS_FRONT or subject.voice == front):
+        return ON_SOLOIST
+    return ON_OTHER
+
+
+def summary(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any] | None:
+    """The list-free reading: what share of the measured screen time is on the player playing.
+
+    ``None`` when nothing was measured at all — no solo map, or no angle labels — because a
+    cut that was never asked the question and a cut that never went near the soloist are
+    opposite facts and a zero would read as the second.
+    """
+    seconds: dict[str, float] = {}
+    shots: dict[str, int] = {}
+    for row in rows:
+        split = row.get("on_soloist_seconds")
+        if not isinstance(split, Mapping) or not split:
+            continue
+        for line, held in split.items():
+            seconds[str(line)] = round(seconds.get(str(line), 0.0) + float(held), SECONDS_PRECISION)
+        verdict = max(split, key=lambda line: float(split[line]))
+        shots[str(verdict)] = shots.get(str(verdict), 0) + 1
+    if not seconds:
+        return None
+    labelled = round(sum(held for line, held in seconds.items() if line != UNLABELLED), 3)
+    return {
+        "solo_window_seconds": round(sum(seconds.values()), SECONDS_PRECISION),
+        "labelled_seconds": labelled,
+        "unlabelled_seconds": seconds.get(UNLABELLED, 0.0),
+        "seconds": {
+            line: seconds[line] for line in ORDER if line in seconds and line != UNLABELLED
+        },
+        "fraction_on_soloist": _share(seconds.get(ON_SOLOIST, 0.0), labelled),
+        "fraction_on_ensemble": _share(seconds.get(ON_ENSEMBLE, 0.0), labelled),
+        "fraction_on_other": _share(seconds.get(ON_OTHER, 0.0), labelled),
+        "shots": {line: shots[line] for line in ORDER if line in shots},
+    }
+
+
+def _share(held: float, total: float) -> float | None:
+    return None if total <= 0 else round(held / total, 3)

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -205,6 +205,10 @@ def correlate_timeline(
     other job, so they are measured here. tunes and solos are the structure job's files.
     angles is the angle labels themselves, not a path: {"C0012.mp4": {"role": "drums"}}, or
     just {"C0012.mp4": "drums"} — you keep the sidecar, you read it, you pass what it says.
+    An entry's subject — what that camera is framed on — is read from "subject", or from a
+    role written the way the corpus writes them, "drums-tight" or "ensemble-wide"; a one-word
+    role names a character rather than a subject and labels nothing. Add "voice" where your
+    sidecar names people and the solo map names stems: {"subject": "mike", "voice": "wind"}.
     Each of these is optional, and each one absent means that column reads null rather than
     a guess.
 
@@ -228,6 +232,12 @@ def correlate_timeline(
     histogram of where in the bar the cuts land, shot-duration stats, and how much of the
     cut each angle and role holds (black counted on its own line, apart from the angles the
     sidecar has not named).
+
+    With both a solo map and subject labels it also carries the on-soloist track: per shot,
+    what it is framed on and whether that is the player out front, split in seconds where the
+    front changes mid-shot; and inline, what share of the solo-window screen time went to the
+    soloist, to the ensemble and to a player who was not soloing. Screen time no label reaches
+    is counted apart rather than folded into the share.
 
     Nothing here judges the edit. Two frames late is reported as two frames late; what
     counts as musical belongs in your style profile, not in this server.

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -236,8 +236,11 @@ def correlate_timeline(
     With both a solo map and subject labels it also carries the on-soloist track: per shot,
     what it is framed on and whether that is the player out front, split in seconds where the
     front changes mid-shot; and inline, what share of the solo-window screen time went to the
-    soloist, to the ensemble and to a player who was not soloing. Screen time no label reaches
-    is counted apart rather than folded into the share.
+    soloist, to the ensemble, to a player who was not soloing and to neither (an audience
+    camera, a room shot). Screen time no label reaches, and black, are counted apart rather
+    than folded into the shares. on_soloist_by says how a shot reached the soloist line —
+    joined against the solo map, or asserted by a camera the sidecar says follows the front —
+    and soloist_seconds_by_follow_camera is how much of the share is the second kind.
 
     Nothing here judges the edit. Two frames late is reported as two frames late; what
     counts as musical belongs in your style profile, not in this server.

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -261,6 +261,10 @@ def test_every_shot_lands_on_disk_with_its_offsets_bar_and_section(
         "clip": "C0031.mp4",
         "track": 1,
         "role": None,
+        "subject": None,
+        "subject_kind": None,
+        "on_soloist": None,
+        "on_soloist_seconds": {"unlabelled": 1.45},
         "opening": False,
         "t": 1.033,
         "in": {"frames": 162, "seconds": 2.7, "timecode": "00:00:02:42", "fps": 60.0},
@@ -368,6 +372,89 @@ def test_an_entry_with_no_role_in_it_is_dropped_rather_than_refused(
     result = _measured(tmp_path, angles={"C0012.mp4": {"subject": "the room"}})
 
     assert result["roles"] is None
+
+
+ANGLES: dict[str, Any] = {
+    "C0012.mp4": {"role": "ensemble-wide"},
+    "C0031.mp4": {"role": "drums-tight", "subject": "drums"},
+}
+"""The fixture rig: a wide on the band and a tight one on the drummer, as a sidecar labels them.
+
+The solo fixture puts drums out front from the top and hands over at 2.0 s, so the drum cam's
+shot — 1.033 s to 2.483 s — straddles the change and is the case the seconds exist for.
+"""
+
+
+def test_each_shot_says_what_it_is_framed_on_and_whether_that_is_the_soloist(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timeline=a_cut()))
+
+    cuts = _rows(_measured(tmp_path, angles=ANGLES, solos=str(solos_file(tmp_path))))
+
+    assert [one["subject"] for one in cuts] == ["ensemble", "drums", "ensemble"]
+    assert [one["subject_kind"] for one in cuts] == ["ensemble", "player", "ensemble"]
+    assert [one["on_soloist"] for one in cuts] == [False, True, False]
+
+
+def test_a_shot_that_outlives_the_solo_it_opened_in_is_split_where_the_front_changed(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Reading the front at the cut alone would call this shot 1.45 s on the soloist."""
+    attach(studio(timeline=a_cut()))
+
+    cuts = _rows(_measured(tmp_path, angles=ANGLES, solos=str(solos_file(tmp_path))))
+
+    assert cuts[1]["front"] == "drums"
+    assert cuts[1]["on_soloist_seconds"] == {"soloist": 0.967, "other": 0.483}
+
+
+def test_the_reading_says_what_share_of_the_solo_windows_is_on_the_soloist(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, angles=ANGLES, solos=str(solos_file(tmp_path)))
+
+    assert result["subjects"]["drums"]["cuts"] == 1
+    assert result["on_soloist"]["seconds"] == {
+        "soloist": 0.967,
+        "ensemble": 1.866,
+        "other": 0.483,
+    }
+    assert result["on_soloist"]["fraction_on_soloist"] == 0.292
+    assert result["on_soloist"]["unlabelled_seconds"] == 0.0
+    assert result["on_soloist"]["shots"] == {"soloist": 1, "ensemble": 2}
+
+
+def test_without_a_solo_map_a_shot_is_labelled_but_nothing_is_on_the_soloist(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Who is out front is the other document's answer; absent it, the join reads nothing."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(tmp_path, angles=ANGLES)
+
+    assert [one["subject"] for one in _rows(result)] == ["ensemble", "drums", "ensemble"]
+    assert [one["on_soloist"] for one in _rows(result)] == [None, None, None]
+    assert result["on_soloist"] is None
+
+
+def test_screen_time_no_sidecar_label_reaches_is_counted_apart_from_the_fractions(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Folded into the denominator it reads as a cut ignoring the soloist; it is not that."""
+    attach(studio(timeline=a_cut()))
+
+    result = _measured(
+        tmp_path,
+        angles={"C0031.mp4": {"role": "drums-tight"}},
+        solos=str(solos_file(tmp_path)),
+    )
+
+    assert result["on_soloist"]["unlabelled_seconds"] == 1.866
+    assert result["on_soloist"]["labelled_seconds"] == 1.45
+    assert result["on_soloist"]["shots"]["unlabelled"] == 2
 
 
 def test_a_dissolve_is_not_a_shot(attach: Attach, tmp_path: Path) -> None:

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -406,7 +406,7 @@ def test_a_shot_that_outlives_the_solo_it_opened_in_is_split_where_the_front_cha
     cuts = _rows(_measured(tmp_path, angles=ANGLES, solos=str(solos_file(tmp_path))))
 
     assert cuts[1]["front"] == "drums"
-    assert cuts[1]["on_soloist_seconds"] == {"soloist": 0.967, "other": 0.483}
+    assert cuts[1]["on_soloist_seconds"] == {"soloist": 0.967, "other_player": 0.483}
 
 
 def test_the_reading_says_what_share_of_the_solo_windows_is_on_the_soloist(
@@ -420,7 +420,7 @@ def test_the_reading_says_what_share_of_the_solo_windows_is_on_the_soloist(
     assert result["on_soloist"]["seconds"] == {
         "soloist": 0.967,
         "ensemble": 1.866,
-        "other": 0.483,
+        "other_player": 0.483,
     }
     assert result["on_soloist"]["fraction_on_soloist"] == 0.292
     assert result["on_soloist"]["unlabelled_seconds"] == 0.0
@@ -642,6 +642,22 @@ def test_black_is_counted_apart_from_the_clips_nobody_labelled(
     assert result["roles"]["black"]["cuts"] == 1
     assert result["roles"]["unlabelled"]["cuts"] == 1
     assert result["roles"]["wide"]["cuts"] == 1
+
+
+def test_black_is_counted_apart_in_the_on_soloist_track_too(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The same distinction, one reading down: a cut to black is not a camera nobody named."""
+    gapped = (SHOTS[0], ("C0031.mp4", 200, 87, 4200))
+    attach(studio(timeline=a_cut(shots=gapped)))
+
+    result = _measured(tmp_path, angles=ANGLES, solos=str(solos_file(tmp_path)))
+
+    assert result["on_soloist"]["black_seconds"] == 0.633
+    assert result["on_soloist"]["unlabelled_seconds"] == 0.0
+    assert result["on_soloist"]["shots"]["black"] == 1
+    assert [one["on_soloist"] for one in _rows(result)] == [False, None, False]
+    assert _rows(result)[1]["on_soloist_seconds"] == {"black": 0.633}
 
 
 def test_a_cut_out_of_black_is_a_cut_rather_than_an_opening(

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -264,6 +264,7 @@ def test_every_shot_lands_on_disk_with_its_offsets_bar_and_section(
         "subject": None,
         "subject_kind": None,
         "on_soloist": None,
+        "on_soloist_by": None,
         "on_soloist_seconds": {"unlabelled": 1.45},
         "opening": False,
         "t": 1.033,

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -134,7 +134,7 @@ def test_a_shot_on_the_player_out_front_is_on_the_soloist() -> None:
 def test_a_shot_on_a_player_who_is_not_soloing_is_on_a_non_soloing_player() -> None:
     reading = subject_module.reading(Subject("drums", "drums"), "player", 12.0, 15.0, _windows())
     assert reading["on_soloist"] is False
-    assert reading["on_soloist_seconds"] == {"other": 3.0}
+    assert reading["on_soloist_seconds"] == {"other_player": 3.0}
 
 
 def test_a_shot_on_the_ensemble_is_counted_apart_from_both() -> None:
@@ -154,13 +154,13 @@ def test_a_camera_that_follows_the_front_is_on_the_soloist_whoever_that_is() -> 
 def test_a_shot_that_outlives_its_solo_is_split_across_the_change() -> None:
     """The whole point of measuring seconds rather than reading the front at the cut."""
     reading = subject_module.reading(Subject("drums", "drums"), "player", 8.0, 14.0, _windows())
-    assert reading["on_soloist_seconds"] == {"soloist": 2.0, "other": 4.0}
+    assert reading["on_soloist_seconds"] == {"soloist": 2.0, "other_player": 4.0}
     assert reading["on_soloist"] is False
 
 
 def test_a_shot_split_evenly_takes_the_verdict_it_opened_on() -> None:
     reading = subject_module.reading(Subject("drums", "drums"), "player", 8.0, 12.0, _windows())
-    assert reading["on_soloist_seconds"] == {"soloist": 2.0, "other": 2.0}
+    assert reading["on_soloist_seconds"] == {"soloist": 2.0, "other_player": 2.0}
     assert reading["on_soloist"] is True
 
 
@@ -173,7 +173,7 @@ def test_a_shot_with_no_subject_label_is_screen_time_nobody_can_attribute() -> N
 def test_a_subject_that_is_neither_player_nor_band_is_not_on_the_soloist() -> None:
     reading = subject_module.reading(Subject("audience", "audience"), "other", 2.0, 6.0, _windows())
     assert reading["on_soloist"] is False
-    assert reading["on_soloist_seconds"] == {"other": 4.0}
+    assert reading["on_soloist_seconds"] == {"other_player": 4.0}
 
 
 def test_a_stretch_with_nobody_measured_out_front_is_left_out_of_the_seconds() -> None:
@@ -183,6 +183,13 @@ def test_a_stretch_with_nobody_measured_out_front_is_left_out_of_the_seconds() -
         Subject("drums", "drums"), "player", 0.0, 6.0, subject_module.windows(rows)
     )
     assert reading["on_soloist_seconds"] == {"soloist": 2.0}
+
+
+def test_a_stretch_nothing_covers_is_counted_as_black_rather_than_as_unlabelled() -> None:
+    """How much of a cut is empty is a fact about the edit, not about the sidecar."""
+    reading = subject_module.reading(None, None, 2.0, 6.0, _windows(), black=True)
+    assert reading["on_soloist"] is None
+    assert reading["on_soloist_seconds"] == {"black": 4.0}
 
 
 def test_a_shot_measured_against_no_solo_map_at_all_says_nothing() -> None:
@@ -220,10 +227,10 @@ def _rows() -> list[dict[str, Any]]:
 def test_the_summary_says_what_share_of_the_measured_screen_time_is_on_the_soloist() -> None:
     found = subject_module.summary(_rows())
     assert found is not None
-    assert found["seconds"] == {"soloist": 6.0, "ensemble": 4.0, "other": 2.0}
+    assert found["seconds"] == {"soloist": 6.0, "ensemble": 4.0, "other_player": 2.0}
     assert found["fraction_on_soloist"] == 0.5
     assert found["fraction_on_ensemble"] == pytest.approx(0.333)
-    assert found["fraction_on_other"] == pytest.approx(0.167)
+    assert found["fraction_on_other_player"] == pytest.approx(0.167)
 
 
 def test_the_summary_counts_the_screen_time_no_label_reaches_apart() -> None:
@@ -235,10 +242,20 @@ def test_the_summary_counts_the_screen_time_no_label_reaches_apart() -> None:
     assert found["solo_window_seconds"] == 14.0
 
 
+def test_the_summary_counts_black_apart_from_both() -> None:
+    black = subject_module.reading(None, None, 14.0, 15.0, _windows(), black=True)
+    found = subject_module.summary([*_rows(), {"subject": None, **black}])
+    assert found is not None
+    assert found["black_seconds"] == 1.0
+    assert found["unlabelled_seconds"] == 2.0
+    assert found["labelled_seconds"] == 12.0
+    assert found["shots"]["black"] == 1
+
+
 def test_the_summary_counts_shots_as_well_as_seconds() -> None:
     found = subject_module.summary(_rows())
     assert found is not None
-    assert found["shots"] == {"soloist": 1, "ensemble": 1, "other": 1, "unlabelled": 1}
+    assert found["shots"] == {"soloist": 1, "ensemble": 1, "other_player": 1, "unlabelled": 1}
 
 
 def test_nothing_measured_is_no_reading_rather_than_a_reading_of_zero() -> None:

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -1,0 +1,246 @@
+"""Which player a shot is framed on, crossed with who is out front.
+
+Pure arithmetic over two documents the agent already owns — the angle sidecar's labels and
+the solo changes another job wrote — so every case here is a fake-tier one. The interesting
+failures are all about the join: a shot that outlives the solo it opened in, a subject the
+solo map never names, and the difference between "nobody was measured" and "nobody was out
+front".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from resolve_mcp.analysis import subject as subject_module
+from resolve_mcp.analysis.subject import Subject
+
+SOLOS: tuple[dict[str, Any], ...] = (
+    {"change": 1, "t": 0.0, "from": "bass", "to": "drums"},
+    {"change": 2, "t": 10.0, "from": "drums", "to": "wind"},
+)
+"""Bass out front until the top, drums to 10 s, wind after — the shape solos.py writes."""
+
+
+def _windows() -> tuple[subject_module.Window, ...]:
+    return subject_module.windows(SOLOS)
+
+
+# --- reading the sidecar ----------------------------------------------------------------------
+
+
+def test_a_subject_is_read_off_the_entry_that_names_one() -> None:
+    assert subject_module.subject_of({"role": "drums-tight", "subject": "drums"}) == Subject(
+        "drums", "drums"
+    )
+
+
+def test_a_role_in_the_corpus_form_yields_its_subject() -> None:
+    assert subject_module.subject_of({"role": "ensemble-wide"}) == Subject("ensemble", "ensemble")
+
+
+def test_a_bare_role_names_a_character_and_yields_no_subject() -> None:
+    """``wide`` says how the camera frames, not what it is framed on — inventing one would lie."""
+    assert subject_module.subject_of("wide") is None
+    assert subject_module.subject_of({"role": "wide"}) is None
+
+
+def test_a_bare_role_in_the_corpus_form_still_yields_its_subject() -> None:
+    assert subject_module.subject_of("drums-tight") == Subject("drums", "drums")
+
+
+def test_a_voice_key_is_what_the_solo_map_calls_this_subject() -> None:
+    """The sidecar names the player; the solo map names stems. The escape hatch joins them."""
+    entry = {"role": "sax-tight", "subject": "mike", "voice": "wind"}
+    assert subject_module.subject_of(entry) == Subject("mike", "wind")
+
+
+def test_an_entry_with_neither_subject_nor_usable_role_is_dropped() -> None:
+    assert subject_module.subject_of({"note": "the room"}) is None
+    assert subject_module.subject_of(None) is None
+
+
+# --- what kind of subject it is ---------------------------------------------------------------
+
+
+def test_the_ensemble_is_its_own_kind() -> None:
+    assert subject_module.kind(Subject("ensemble", "ensemble"), frozenset()) == "ensemble"
+
+
+def test_a_camera_on_whoever_is_out_front_is_a_player() -> None:
+    """One player at a time — which one is the solo map's answer, not the sidecar's."""
+    assert subject_module.kind(Subject("soloist", "soloist"), frozenset()) == "player"
+
+
+def test_a_subject_the_solo_map_names_is_a_player() -> None:
+    assert subject_module.kind(Subject("drums", "drums"), subject_module.voices(SOLOS)) == "player"
+
+
+def test_a_subject_the_solo_map_never_names_reads_as_other() -> None:
+    """An audience camera is neither a player nor the band, and counting it as one would skew."""
+    assert subject_module.kind(Subject("audience", "audience"), subject_module.voices(SOLOS)) == (
+        "other"
+    )
+
+
+def test_without_a_solo_map_there_is_no_roster_to_contradict_a_subject() -> None:
+    assert subject_module.kind(Subject("piano", "piano"), frozenset()) == "player"
+
+
+def test_no_subject_is_no_kind() -> None:
+    assert subject_module.kind(None, subject_module.voices(SOLOS)) is None
+
+
+# --- the solo windows -------------------------------------------------------------------------
+
+
+def test_the_front_before_the_first_change_is_who_it_was_taken_over_from() -> None:
+    first = _windows()[0]
+    assert first.front == "bass"
+    assert first.end == 0.0
+
+
+def test_each_change_opens_a_window_that_runs_to_the_next_one() -> None:
+    middle = _windows()[1]
+    assert (middle.start, middle.end, middle.front) == (0.0, 10.0, "drums")
+
+
+def test_the_last_change_holds_to_the_end_of_the_concert() -> None:
+    last = _windows()[-1]
+    assert last.front == "wind"
+    assert last.end == float("inf")
+
+
+def test_a_first_change_that_took_over_from_nobody_leaves_the_front_unknown() -> None:
+    rows = [{"change": 1, "t": 4.0, "from": None, "to": "drums"}]
+    assert subject_module.windows(rows)[0].front is None
+
+
+def test_no_solo_map_is_no_windows() -> None:
+    assert subject_module.windows(None) == ()
+    assert subject_module.windows(()) == ()
+
+
+# --- the join ---------------------------------------------------------------------------------
+
+
+def test_a_shot_on_the_player_out_front_is_on_the_soloist() -> None:
+    reading = subject_module.reading(Subject("drums", "drums"), "player", 2.0, 6.0, _windows())
+    assert reading["on_soloist"] is True
+    assert reading["on_soloist_seconds"] == {"soloist": 4.0}
+
+
+def test_a_shot_on_a_player_who_is_not_soloing_is_on_a_non_soloing_player() -> None:
+    reading = subject_module.reading(Subject("drums", "drums"), "player", 12.0, 15.0, _windows())
+    assert reading["on_soloist"] is False
+    assert reading["on_soloist_seconds"] == {"other": 3.0}
+
+
+def test_a_shot_on_the_ensemble_is_counted_apart_from_both() -> None:
+    reading = subject_module.reading(
+        Subject("ensemble", "ensemble"), "ensemble", 2.0, 6.0, _windows()
+    )
+    assert reading["on_soloist"] is False
+    assert reading["on_soloist_seconds"] == {"ensemble": 4.0}
+
+
+def test_a_camera_that_follows_the_front_is_on_the_soloist_whoever_that_is() -> None:
+    follower = Subject("soloist", "soloist")
+    reading = subject_module.reading(follower, "player", 12.0, 15.0, _windows())
+    assert reading["on_soloist"] is True
+
+
+def test_a_shot_that_outlives_its_solo_is_split_across_the_change() -> None:
+    """The whole point of measuring seconds rather than reading the front at the cut."""
+    reading = subject_module.reading(Subject("drums", "drums"), "player", 8.0, 14.0, _windows())
+    assert reading["on_soloist_seconds"] == {"soloist": 2.0, "other": 4.0}
+    assert reading["on_soloist"] is False
+
+
+def test_a_shot_split_evenly_takes_the_verdict_it_opened_on() -> None:
+    reading = subject_module.reading(Subject("drums", "drums"), "player", 8.0, 12.0, _windows())
+    assert reading["on_soloist_seconds"] == {"soloist": 2.0, "other": 2.0}
+    assert reading["on_soloist"] is True
+
+
+def test_a_shot_with_no_subject_label_is_screen_time_nobody_can_attribute() -> None:
+    reading = subject_module.reading(None, None, 2.0, 6.0, _windows())
+    assert reading["on_soloist"] is None
+    assert reading["on_soloist_seconds"] == {"unlabelled": 4.0}
+
+
+def test_a_subject_that_is_neither_player_nor_band_is_not_on_the_soloist() -> None:
+    reading = subject_module.reading(Subject("audience", "audience"), "other", 2.0, 6.0, _windows())
+    assert reading["on_soloist"] is False
+    assert reading["on_soloist_seconds"] == {"other": 4.0}
+
+
+def test_a_stretch_with_nobody_measured_out_front_is_left_out_of_the_seconds() -> None:
+    """A window whose front is unknown is not solo-window screen time — it is no measurement."""
+    rows = [{"change": 1, "t": 4.0, "from": None, "to": "drums"}]
+    reading = subject_module.reading(
+        Subject("drums", "drums"), "player", 0.0, 6.0, subject_module.windows(rows)
+    )
+    assert reading["on_soloist_seconds"] == {"soloist": 2.0}
+
+
+def test_a_shot_measured_against_no_solo_map_at_all_says_nothing() -> None:
+    reading = subject_module.reading(Subject("drums", "drums"), "player", 0.0, 6.0, ())
+    assert reading["on_soloist"] is None
+    assert reading["on_soloist_seconds"] is None
+
+
+def test_a_shot_of_no_length_is_no_measurement() -> None:
+    reading = subject_module.reading(Subject("drums", "drums"), "player", 4.0, 4.0, _windows())
+    assert reading["on_soloist_seconds"] is None
+
+
+# --- the reading a critic quotes ---------------------------------------------------------------
+
+
+def _rows() -> list[dict[str, Any]]:
+    windows = _windows()
+    return [
+        {
+            "subject": name,
+            **subject_module.reading(
+                None if name is None else Subject(name, name), kind, start, end, windows
+            ),
+        }
+        for name, kind, start, end in (
+            ("drums", "player", 0.0, 6.0),
+            ("ensemble", "ensemble", 6.0, 10.0),
+            ("drums", "player", 10.0, 12.0),
+            (None, None, 12.0, 14.0),
+        )
+    ]
+
+
+def test_the_summary_says_what_share_of_the_measured_screen_time_is_on_the_soloist() -> None:
+    found = subject_module.summary(_rows())
+    assert found is not None
+    assert found["seconds"] == {"soloist": 6.0, "ensemble": 4.0, "other": 2.0}
+    assert found["fraction_on_soloist"] == 0.5
+    assert found["fraction_on_ensemble"] == pytest.approx(0.333)
+    assert found["fraction_on_other"] == pytest.approx(0.167)
+
+
+def test_the_summary_counts_the_screen_time_no_label_reaches_apart() -> None:
+    """In the denominator it would read as a cut that ignores the soloist; hidden, as none."""
+    found = subject_module.summary(_rows())
+    assert found is not None
+    assert found["unlabelled_seconds"] == 2.0
+    assert found["labelled_seconds"] == 12.0
+    assert found["solo_window_seconds"] == 14.0
+
+
+def test_the_summary_counts_shots_as_well_as_seconds() -> None:
+    found = subject_module.summary(_rows())
+    assert found is not None
+    assert found["shots"] == {"soloist": 1, "ensemble": 1, "other": 1, "unlabelled": 1}
+
+
+def test_nothing_measured_is_no_reading_rather_than_a_reading_of_zero() -> None:
+    assert subject_module.summary([{"subject": None, "on_soloist_seconds": None}]) is None
+    assert subject_module.summary([]) is None

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -125,101 +125,115 @@ def test_no_solo_map_is_no_windows() -> None:
 # --- the join ---------------------------------------------------------------------------------
 
 
+def _read(name: str | None, start: float, end: float, **rest: Any) -> dict[str, Any]:
+    """One shot, named by its subject — the roster is the fixture solo map's own."""
+    subject = None if name is None else Subject(name, name)
+    spans = rest.pop("spans", None)
+    return subject_module.reading(
+        subject,
+        subject_module.voices(SOLOS),
+        start,
+        end,
+        _windows() if spans is None else spans,
+        **rest,
+    )
+
+
 def test_a_shot_on_the_player_out_front_is_on_the_soloist() -> None:
-    reading = subject_module.reading(Subject("drums", "drums"), "player", 2.0, 6.0, _windows())
+    reading = _read("drums", 2.0, 6.0)
+    assert reading["subject_kind"] == "player"
     assert reading["on_soloist"] is True
     assert reading["on_soloist_seconds"] == {"soloist": 4.0}
 
 
 def test_a_shot_on_a_player_who_is_not_soloing_is_on_a_non_soloing_player() -> None:
-    reading = subject_module.reading(Subject("drums", "drums"), "player", 12.0, 15.0, _windows())
+    reading = _read("drums", 12.0, 15.0)
     assert reading["on_soloist"] is False
     assert reading["on_soloist_seconds"] == {"other_player": 3.0}
 
 
 def test_a_shot_on_the_ensemble_is_counted_apart_from_both() -> None:
-    reading = subject_module.reading(
-        Subject("ensemble", "ensemble"), "ensemble", 2.0, 6.0, _windows()
-    )
+    reading = _read("ensemble", 2.0, 6.0)
+    assert reading["subject_kind"] == "ensemble"
     assert reading["on_soloist"] is False
     assert reading["on_soloist_seconds"] == {"ensemble": 4.0}
 
 
 def test_a_camera_that_follows_the_front_is_on_the_soloist_whoever_that_is() -> None:
-    follower = Subject("soloist", "soloist")
-    reading = subject_module.reading(follower, "player", 12.0, 15.0, _windows())
-    assert reading["on_soloist"] is True
+    assert _read("soloist", 12.0, 15.0)["on_soloist"] is True
+
+
+def test_the_two_ways_onto_the_soloist_line_are_told_apart() -> None:
+    """One was joined against the solo map; the other is the sidecar's word about a camera."""
+    assert _read("drums", 2.0, 6.0)["on_soloist_by"] == "front_match"
+    assert _read("soloist", 12.0, 15.0)["on_soloist_by"] == "follow_camera"
+    assert _read("ensemble", 2.0, 6.0)["on_soloist_by"] is None
 
 
 def test_a_shot_that_outlives_its_solo_is_split_across_the_change() -> None:
     """The whole point of measuring seconds rather than reading the front at the cut."""
-    reading = subject_module.reading(Subject("drums", "drums"), "player", 8.0, 14.0, _windows())
+    reading = _read("drums", 8.0, 14.0)
     assert reading["on_soloist_seconds"] == {"soloist": 2.0, "other_player": 4.0}
     assert reading["on_soloist"] is False
 
 
 def test_a_shot_split_evenly_takes_the_verdict_it_opened_on() -> None:
-    reading = subject_module.reading(Subject("drums", "drums"), "player", 8.0, 12.0, _windows())
+    reading = _read("drums", 8.0, 12.0)
     assert reading["on_soloist_seconds"] == {"soloist": 2.0, "other_player": 2.0}
     assert reading["on_soloist"] is True
 
 
 def test_a_shot_with_no_subject_label_is_screen_time_nobody_can_attribute() -> None:
-    reading = subject_module.reading(None, None, 2.0, 6.0, _windows())
+    reading = _read(None, 2.0, 6.0)
+    assert reading["subject_kind"] is None
     assert reading["on_soloist"] is None
     assert reading["on_soloist_seconds"] == {"unlabelled": 4.0}
 
 
-def test_a_subject_that_is_neither_player_nor_band_is_not_on_the_soloist() -> None:
-    reading = subject_module.reading(Subject("audience", "audience"), "other", 2.0, 6.0, _windows())
+def test_a_subject_that_is_neither_player_nor_band_is_counted_as_neither() -> None:
+    """An audience camera on the ``other_player`` line would read as watching the wrong
+    musician, which is a different fact about a cut than watching the room."""
+    reading = _read("audience", 2.0, 6.0)
+    assert reading["subject_kind"] == "other"
     assert reading["on_soloist"] is False
-    assert reading["on_soloist_seconds"] == {"other_player": 4.0}
+    assert reading["on_soloist_seconds"] == {"elsewhere": 4.0}
 
 
 def test_a_stretch_with_nobody_measured_out_front_is_left_out_of_the_seconds() -> None:
     """A window whose front is unknown is not solo-window screen time — it is no measurement."""
     rows = [{"change": 1, "t": 4.0, "from": None, "to": "drums"}]
-    reading = subject_module.reading(
-        Subject("drums", "drums"), "player", 0.0, 6.0, subject_module.windows(rows)
-    )
+    reading = _read("drums", 0.0, 6.0, spans=subject_module.windows(rows))
     assert reading["on_soloist_seconds"] == {"soloist": 2.0}
 
 
 def test_a_stretch_nothing_covers_is_counted_as_black_rather_than_as_unlabelled() -> None:
     """How much of a cut is empty is a fact about the edit, not about the sidecar."""
-    reading = subject_module.reading(None, None, 2.0, 6.0, _windows(), black=True)
+    reading = _read(None, 2.0, 6.0, black=True)
     assert reading["on_soloist"] is None
     assert reading["on_soloist_seconds"] == {"black": 4.0}
 
 
 def test_a_shot_measured_against_no_solo_map_at_all_says_nothing() -> None:
-    reading = subject_module.reading(Subject("drums", "drums"), "player", 0.0, 6.0, ())
+    reading = _read("drums", 0.0, 6.0, spans=())
     assert reading["on_soloist"] is None
     assert reading["on_soloist_seconds"] is None
 
 
 def test_a_shot_of_no_length_is_no_measurement() -> None:
-    reading = subject_module.reading(Subject("drums", "drums"), "player", 4.0, 4.0, _windows())
-    assert reading["on_soloist_seconds"] is None
+    assert _read("drums", 4.0, 4.0)["on_soloist_seconds"] is None
 
 
 # --- the reading a critic quotes ---------------------------------------------------------------
 
 
 def _rows() -> list[dict[str, Any]]:
-    windows = _windows()
     return [
-        {
-            "subject": name,
-            **subject_module.reading(
-                None if name is None else Subject(name, name), kind, start, end, windows
-            ),
-        }
-        for name, kind, start, end in (
-            ("drums", "player", 0.0, 6.0),
-            ("ensemble", "ensemble", 6.0, 10.0),
-            ("drums", "player", 10.0, 12.0),
-            (None, None, 12.0, 14.0),
+        {"subject": name, **_read(name, start, end)}
+        for name, start, end in (
+            ("drums", 0.0, 6.0),
+            ("ensemble", 6.0, 10.0),
+            ("drums", 10.0, 12.0),
+            (None, 12.0, 14.0),
         )
     ]
 
@@ -243,7 +257,7 @@ def test_the_summary_counts_the_screen_time_no_label_reaches_apart() -> None:
 
 
 def test_the_summary_counts_black_apart_from_both() -> None:
-    black = subject_module.reading(None, None, 14.0, 15.0, _windows(), black=True)
+    black = _read(None, 14.0, 15.0, black=True)
     found = subject_module.summary([*_rows(), {"subject": None, **black}])
     assert found is not None
     assert found["black_seconds"] == 1.0
@@ -256,6 +270,21 @@ def test_the_summary_counts_shots_as_well_as_seconds() -> None:
     found = subject_module.summary(_rows())
     assert found is not None
     assert found["shots"] == {"soloist": 1, "ensemble": 1, "other_player": 1, "unlabelled": 1}
+
+
+def test_the_summary_says_how_much_of_the_soloist_line_nobody_measured() -> None:
+    """A rig whose camera follows the front can post a high share without a join ever running."""
+    rows = [*_rows(), {"subject": "soloist", **_read("soloist", 14.0, 18.0)}]
+
+    found = subject_module.summary(rows)
+
+    assert found is not None
+    assert found["seconds"]["soloist"] == 10.0
+    assert found["soloist_seconds_by_follow_camera"] == 4.0
+
+    joined = subject_module.summary(_rows())
+    assert joined is not None
+    assert joined["soloist_seconds_by_follow_camera"] == 0.0
 
 
 def test_nothing_measured_is_no_reading_rather_than_a_reading_of_zero() -> None:


### PR DESCRIPTION
Closes #181.

## What this is

The core concert question, measured: for every shot, what it is framed on, crossed with who was out front. Two documents each answer half of it — the angle sidecar's subject and the solo changes — and `analysis/subject.py` is the join, as pure arithmetic over both.

The join is in **seconds**, not a verdict at the cut: a shot that opens on a drum solo and runs four seconds past the horn's entrance is two facts, and reading the front at the cut alone would record only the first.

- **`correlate_timeline`** — per shot `subject`, `subject_kind` (player / ensemble / other), `on_soloist`, `on_soloist_by` and `on_soloist_seconds`; inline, a `subjects` usage table and an `on_soloist` block with the shares.
- **`ab_pack.py` (pack v4)** — `--a-subjects` / `--b-subjects` carry each label's own correlate reading into a blind pack, stripped to four columns so no timeline or clip name crosses the line, matched to the pack's *detected* shots by overlap rather than by index, and both-or-neither: one label annotated and the other bare is a difference between the labels that is not a difference between the cuts.
- **Sidecar** — `subject` is now read alongside `role` (or taken from the subject half of a `subject-character` role; a one-word role is a *character* and labels nothing), plus an optional `voice` for a sidecar that names people where the solo map names stems.

Four things it refuses to round off, each because folding them together hides both facts: **unlabelled** screen time (no sidecar label reaches it), **black** (a fact about the edit, not about the labelling), **elsewhere** (an audience camera is not a player nobody was watching), and `soloist_seconds_by_follow_camera` (how much of the soloist share a camera's label asserted rather than the solo map measured).

## Test seams

Fake tier for every decision — the join is pure functions over two documents (`tests/test_subject.py`, 36 cases), its wiring is the correlate seam already used for roles (`tests/test_correlate_timeline.py`). `gauntlet/` is agent-owned and outside the tested tree (it imports numpy, which CI does not install), so both gauntlet paths are verified by receipt instead.

Live smoke (AC1) — **run, on the live Windows box, Resolve Studio 21.0.3.7, project `mcp-tests-zinc`**, receipt at `gauntlet/recon/subject_track.json`:

| cut | cuts | ensemble | other player | soloist | labelled |
| --- | --- | --- | --- | --- | --- |
| Taurus People Opening R3 v3 | 17 | 52.1% | 47.9% | 0.0% | 81.5 s |
| Taurus People Full P4 R2 v3 | 85 | 53.0% | 42.0% | 5.0% | 489.0 s |

The 0% is real rather than a hole: this rig's only player camera is the drum cam, and the solo map has nobody drumming out front during the opening. Spot check against frames of both cameras — the FX6 wide holds the whole band (`ensemble`), the A7IV holds the drummer (`drums`, a player) — which is 15 of the opening's 17 shots; the other two are title cards, which is exactly what `unlabelled_seconds` counts.

AC3 receipt at `gauntlet/recon/subject_pack.json`: both real cuts files run through the pack's track path — whole-span share equals correlate's exactly, no field beyond the four subject columns crosses into the pack, and a span cutting through shots keeps the part inside where the front held through it (8 shots outside the clip, 2 clipped, 0 dropped from the share).

Gates: fake tier green, mypy strict clean (180 files), ruff clean. Live tier ran green before the change (32 passed, 8 skipped); it covers no subject path.

## Review

Two-axis review (`/code-review`) on the branch against `origin/main`, both axes as parallel sub-agents.

**Spec axis — 3 findings, all fixed.**

1. *An audience or room camera was reported as "on a non-soloing player".* `subject_kind` kept the distinction but the aggregate lost it, and the shot sat in the denominator of every fraction wearing a player's label. Now `elsewhere` is its own line with its own share.
2. *A camera whose subject is `soloist` asserted the answer instead of joining against the solo map* — inflating the exact critic-visible number the ticket names. It still counts (that is what the camera is for), but every shot carries `on_soloist_by` (`front_match` vs `follow_camera`) and the summary carries `soloist_seconds_by_follow_camera`, so the share always says how much of it nobody measured.
3. *AC3 was unexercised* — no test and no receipt had ever run a cuts file through the pack's track path. `gauntlet/recon/subject_pack.py` now does, on both real readings, against deliberately out-of-step detected boundaries.

Also raised and answered: the roster is the solo map's own, so a player who never takes the front all night reads as neither player nor band. That is the rule's one wrong direction; the `voice` alias is the escape hatch and both the module and `docs/agents/style-layer.md` now name it. The occlusion discriminant the ticket mentions as motivation is a follow-up, not an AC — nothing here joins subject to occlusion.

**Standards axis — 3 hard violations, 4 judgement calls, all fixed.** `subject` filed under S in the CONTEXT map instead of between `silence` and `solos`; `SHARE_PRECISION`/`SECONDS_PRECISION` instead of bare `3`s; the doubled `**subject**` bullet in `style-layer.md` merged. Judgement calls taken: the verdict rule written once as `_verdict` instead of twice; `kind` worked out inside `reading` rather than passed alongside the subject it is a function of; constants documented in one comment block each rather than by attribute docstrings that described their siblings; and the `soloist` collision noted for what it is — unlike `other`/`other`, that one is the same word about the same fact.

Fix diff re-checked on its own; no fresh full pass.

Review: clean — both axes' findings fixed on the branch before this PR was opened.
