### PR TITLE
docs: name the cd+redirect approval guard in Context discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,14 @@ One rule: nothing enters the session unless the session is about to act on
 it. Noisy commands (`pytest`, `mypy`, `ruff`) redirect to a scratch file and
 the decisive line comes back via the Grep tool. Two plain calls — the
 worktree guard refuses compound commands (`;`-chains, `$(...)`, env-var
-paths), so the redirect is one bare command to a gitignored repo-local log:
+paths), and Claude Code (≥2.1.232) forces a manual approval prompt on any
+compound that pairs a directory change with output redirection — `cd`
+under Git Bash, `Set-Location` under PowerShell, so switching shells is no
+way out. The guard fires before it reads the target: an absolute log path
+does not clear it, an allow-rule does not either, and auto mode is
+explicitly barred from deciding. So the redirect is one bare command, run
+from the session's own cwd — a worktree session already starts in its
+worktree — to a gitignored repo-local log:
 
     uv run pytest -m 'not live' > pytest.scratch.log 2>&1
 


### PR DESCRIPTION
## What

One paragraph in CLAUDE.md's **Context discipline** section. The two-plain-calls rule previously cited only the worktree guard as its reason; it now also names the Claude Code guard that has been prompting for manual approval on every noisy command since 2026-08-13.

## Why

Claude Code 2.1.232 (installed 2026-08-13 20:07) added a Windows path-validation branch that returns `behavior: "ask"` for any compound command pairing a directory change with output redirection, and states outright that the request "cannot be delegated to the auto-approval classifier" — so `defaultMode: auto` cannot clear it.

Verified by string presence across the retained binaries:

| version | `Cygwin-emulated symlinks` | `delegated to the auto-approval classifier` |
|---|---|---|
| 2.1.229 | 0 | 0 |
| 2.1.231 | 0 | 0 |
| 2.1.232 | 2 | 2 |

Decompiled control flow confirms the guard returns before it inspects the redirect target (only `/dev/null` is exempt), so an absolute log path does not clear it. It is a safety-layer `ask`, not a rule miss, so an `allow` entry does not clear it either. Nothing in `.claude/hooks/` or any installed plugin produces the message — a repo-wide search over `~/.claude/` found no source but this session's own transcript.

The shape is manufactured by this repo's own conventions: Context discipline mandates `> *.scratch.log` redirects, and worktree sessions plus subagents prefix `cd "<worktree>" &&`.

## Review

Lightweight inline pass (prose only, no executable files touched).

- **Finding — incomplete scope, fixed before commit.** The first draft scoped the guard to "Windows Git Bash". The PowerShell tool carries the same branch (`Set-Location`/`Push-Location`/`Pop-Location`/`New-PSDrive` in a compound → `ask`), so the wording left an escape hatch an agent would plausibly try. Reworded to name both shells and close it explicitly.
- Checked against writing-for-agents: single source of truth (the reason lives with the rule it explains — no duplicate Gotchas entry), positive target stated (bare command from the session's own cwd) rather than a bare prohibition, and each of the three dead-ends listed is a turn an agent would otherwise waste. Version-stamped so the line is prunable if the guard is relaxed.

Review: clean — prose only, single-pass
