### PR TITLE
CUDA everywhere: NVDEC decode config, loud CPU fallbacks, separator torch report (#202)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -140,7 +140,10 @@ the grids that gate refuses whole, #180),
 `cuda` (preloads
 the CUDA runtime the `analysis` extra ships, so CTranslate2 finds it on Windows;
 pure decisions, #128),
-`decode` (WAV → numpy, no third-party decoder), `drums` (hits per stem), `energy`
+`decode` (WAV → numpy, no third-party decoder), `device` (which device the
+torch models infer on, announced once per process and carried in job records —
+no silent CPU fallback, #202; the inventory and the stays-on-CPU corpus policy:
+`docs/reference/compute-device-inventory.md`), `drums` (hits per stem), `energy`
 (loudness curves; `rms_curve` is the cheap level-only pass, no K-weighting and
 no onsets), `fills` (drum-fill candidates), `halves` (shared
 identify/cache/write pattern, plus `collected`/`stem_named` — where a
@@ -296,7 +299,10 @@ same reason: gaps and overlay tracks are one device each across `cut/validate`,
 failures are the disagreements between them. `test_cut_tail.py` is the third: the
 tail is one device across `cut/tail`, `cut/validate`, `resolve/tail` and
 `resolve/build`, and a dissolve that did not land looks exactly like a cut that
-never asked for one. Live tier: `test_live_smoke.py` (module-level
+never asked for one. `test_hardware_decode.py` (#202) is the fourth: NVDEC is
+one decision across `ffmpeg` (the probe), `video/ffmpeg` (flags, fallback,
+report) and the three video routes that carry the report, and the failure worth
+testing is a decode that ran one way and reported another. Live tier: `test_live_smoke.py` (module-level
 `pytest.mark.live`) and two `@pytest.mark.live` tests in
 `test_live_analysis.py`; everything else is fake-tier. The live tier assumes no
 project state it can build itself (#135): a session-scoped sweep clears the last

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -265,7 +265,9 @@ module, not the package, and never the whole package at once:
 - `fixtures.py` — `write_wav`/`write_clicks`/`write_hits`/`write_tones`
   (a melodic stem: pitched notes of a known length with known gaps)/
   `write_sections`/
-  `write_jpeg`, `ffmpeg_absent`, `ffmpeg_refusing`; and the headers stdlib
+  `write_jpeg`, `ffmpeg_absent`, `ffmpeg_refusing`, `hwaccel_probe_reply`
+  (answers the `-hwaccels` capability probe so fake runners survive it);
+  and the headers stdlib
   `wave` cannot write, built by hand — `write_float_wav`,
   `write_extensible_pcm_wav`, `write_tagged_wav`
 - `builders.py` — `studio()`, `sync_reference()`, `with_a_mix()`

--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -10,9 +10,9 @@ says so in the log and the job record.**
 
 | Path | Module(s) | Device after #202 | GPU path | Fallback reporting |
 | --- | --- | --- | --- | --- |
-| Video decode: scene scan | `video/ffmpeg.scan` → `video/scenes` | **NVDEC** via `ffmpeg_hwaccel=auto` | yes — `-hwaccel cuda` | probe logged once; `decode` block in catalog + gist; software retry is a WARNING + `reason` |
-| Video decode: occlusion sampling | `video/ffmpeg.sample` → `video/occlusion` | **NVDEC** (same setting) | yes | same `decode` block in catalog + gist |
-| Video decode: frame grabs | `video/ffmpeg.grab` → `video/frames` | **NVDEC** (same setting) | yes | `decode` in the tool payload (`null` when every frame came off the cache) |
+| Video decode: scene scan | `video/ffmpeg.scan` → `video/scenes` | **NVDEC where the profile allows** via `ffmpeg_hwaccel=auto` — this box's 4:2:2 sources decode in software, recorded (see the measurements below) | yes — `-hwaccel cuda` | probe logged once; `decode` block in catalog + gist; software retry and ffmpeg's internal fallback are each a WARNING + `reason` |
+| Video decode: occlusion sampling | `video/ffmpeg.sample` → `video/occlusion` | same as the scene scan | yes | same `decode` block in catalog + gist |
+| Video decode: frame grabs | `video/ffmpeg.grab` → `video/frames` | same as the scene scan | yes | `decode` in the tool payload (`null` when every frame came off the cache) |
 | Video post-decode filters (scale, select, JPEG encode) | same commands | CPU (ffmpeg filters) | not worth it | n/a — decode dominates; the scale runs on frames already in RAM, which is the shape the numpy consumers need |
 | Audio extraction | `audio/ffmpeg`, `analysis/decode` | CPU | none applicable | n/a — audio demux/PCM decode, no video stream decoded |
 | Occlusion arithmetic | `video/blocking` (numpy/scipy) | CPU | none wired | n/a — milliseconds per scan; decode dominates |
@@ -40,6 +40,33 @@ says so in the log and the job record.**
   refuses codecs it does not know) and the retry is a WARNING plus a
   `reason` in the record. Forcing `cuda` disables the retry: forcing is a
   claim about the box, and a wrong claim should fail loudly.
+- **ffmpeg's own internal fallback is detected off stderr.** When NVDEC
+  lacks the stream's codec profile, ffmpeg prints
+  `Failed setup for format cuda`, decodes in software and exits 0 — so the
+  exit-code retry never fires and the record would have claimed a decode
+  the card never did. `_decoded` scans stderr for that line and rewrites
+  the record to `cpu` with the reason, at a WARNING; the decode commands
+  hold their log level at `warning` or louder so the line stays visible.
+  This fires on a forced `cuda` too — the frames arrived, so failing would
+  discard good work; there, the loudness *is* the record.
+
+### Measured on the live box, 2026-08-14 (AC 3)
+
+Full-file decode to a null sink (no encode, no scale), second-of-two runs
+so the OS file cache is warm both ways. RTX 4080 SUPER (Ada), ffmpeg 8.1.2:
+
+| Stream | Software | `-hwaccel cuda` | Verdict |
+| --- | --- | --- | --- |
+| 4K HEVC 4:2:2 10-bit — real A7IV concert clip, 1.1 GB / 85 s | 17.1 s | 17.3 s | **NVDEC cannot engage**: Ada has no 4:2:2 decode (Blackwell adds it). ffmpeg fell back internally; wall clock identical; the record now says `cpu` with the reason |
+| 1080p H.264 4:2:0 High — real screen recording, 8.5 min | 10.4 s | 28.6 s | NVDEC engages and **loses 2.8×**: one decode engine (~530 fps) against a many-core software decode (~1460 fps), plus the PCIe download |
+| 4K HEVC 4:2:0 — generated, 60 s @ 60 Mbps | 13.0 s | 5.5 s | NVDEC wins 2.35× — the profile the card is built for |
+
+Why `auto` stays the default despite the mixed table: the box's real
+concert footage is all 4:2:2 (FX6 XAVC Intra H.264 4:2:2, A7IV H.265
+4:2:2 10-bit), where the flag costs nothing and the fallback is recorded;
+4K 4:2:0 — phone footage, most delivered renders — is the win case. The
+losing case is long 1080p H.264, rare in a 4K pipeline — a box that works
+mostly on those should set `RESOLVE_MCP_FFMPEG_HWACCEL=off`.
 
 ## The torch decision: beats and applause stay on the CPU
 

--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -16,12 +16,18 @@ says so in the log and the job record.**
 | Video post-decode filters (scale, select, JPEG encode) | same commands | CPU (ffmpeg filters) | not worth it | n/a — decode dominates; the scale runs on frames already in RAM, which is the shape the numpy consumers need |
 | Audio extraction | `audio/ffmpeg`, `analysis/decode` | CPU | none applicable | n/a — audio demux/PCM decode, no video stream decoded |
 | Occlusion arithmetic | `video/blocking` (numpy/scipy) | CPU | none wired | n/a — milliseconds per scan; decode dominates |
-| DSP analysis (energy, silence, drums, fills, melody, phrases, solos) | `analysis/*` (numpy) | CPU | none wired | n/a — pure numpy, no torch involved |
+| DSP analysis (energy, silence, drums, fills, melody, phrases, solos, correlate) | `analysis/*` (numpy) | CPU | none wired | n/a — pure numpy, no torch involved |
 | Beat grid | `analysis/beats` (beat_this, torch) | **CPU by policy** — see below | exists upstream (CUDA torch) | `device.announce("beat_this")` at inference; `torch` note in the music/structure job results |
 | Applause curve | `analysis/applause` (PANNs, torch) | **CPU by policy** — same decision | exists upstream | `device.announce("PANNs")`; same `torch` note |
 | Transcription | `analysis/whisper` (faster-whisper/CTranslate2) | **CUDA** (`whisper_device=auto`, runtime shipped by the analysis extra, #128) | yes — already wired | resolved device logged after model load; `auto`→CPU resolve is a WARNING |
 | Stem separation | `audio/separator` (external CLI, its own torch) | whatever the PATH install has — **found `2.13.0+cpu` on the live box, 2026-08-14** | yes — CUDA torch in the separator's env | `--env_info` probed before every fresh separation; build in the log + job record; `+cpu` build is a WARNING |
 | Rendering | `resolve/render`, `deliver` | Resolve's own GPU pipeline | Resolve's business | out of scope — Resolve manages its own devices |
+
+Deliberately out of scope: the gauntlet A/B pack's decodes
+(`gauntlet/tools/ab_pack.py`) run bare software ffmpeg — a dev-only
+evaluation tool, not a server compute path, and its runs are attended.
+`video/framing.py` (#184) is not on this branch; when it lands it takes
+its own row here.
 
 ## ffmpeg hardware decode (`ffmpeg_hwaccel`)
 

--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -1,0 +1,77 @@
+# Compute device inventory (#202)
+
+Surveyed 2026-08-14 on the live box (Windows 11, RTX 4080 SUPER, ffmpeg
+8.1.2 gyan.dev full build). One row per compute path in `src/`, with the
+device it runs on and whether a GPU path exists. The rule this inventory
+serves: **if it can use CUDA, it should use CUDA — and any CPU fallback
+says so in the log and the job record.**
+
+## The table
+
+| Path | Module(s) | Device after #202 | GPU path | Fallback reporting |
+| --- | --- | --- | --- | --- |
+| Video decode: scene scan | `video/ffmpeg.scan` → `video/scenes` | **NVDEC** via `ffmpeg_hwaccel=auto` | yes — `-hwaccel cuda` | probe logged once; `decode` block in catalog + gist; software retry is a WARNING + `reason` |
+| Video decode: occlusion sampling | `video/ffmpeg.sample` → `video/occlusion` | **NVDEC** (same setting) | yes | same `decode` block in catalog + gist |
+| Video decode: frame grabs | `video/ffmpeg.grab` → `video/frames` | **NVDEC** (same setting) | yes | `decode` in the tool payload (`null` when every frame came off the cache) |
+| Video post-decode filters (scale, select, JPEG encode) | same commands | CPU (ffmpeg filters) | not worth it | n/a — decode dominates; the scale runs on frames already in RAM, which is the shape the numpy consumers need |
+| Audio extraction | `audio/ffmpeg`, `analysis/decode` | CPU | none applicable | n/a — audio demux/PCM decode, no video stream decoded |
+| Occlusion arithmetic | `video/blocking` (numpy/scipy) | CPU | none wired | n/a — milliseconds per scan; decode dominates |
+| DSP analysis (energy, silence, drums, fills, melody, phrases, solos) | `analysis/*` (numpy) | CPU | none wired | n/a — pure numpy, no torch involved |
+| Beat grid | `analysis/beats` (beat_this, torch) | **CPU by policy** — see below | exists upstream (CUDA torch) | `device.announce("beat_this")` at inference; `torch` note in the music/structure job results |
+| Applause curve | `analysis/applause` (PANNs, torch) | **CPU by policy** — same decision | exists upstream | `device.announce("PANNs")`; same `torch` note |
+| Transcription | `analysis/whisper` (faster-whisper/CTranslate2) | **CUDA** (`whisper_device=auto`, runtime shipped by the analysis extra, #128) | yes — already wired | resolved device logged after model load; `auto`→CPU resolve is a WARNING |
+| Stem separation | `audio/separator` (external CLI, its own torch) | whatever the PATH install has — **found `2.13.0+cpu` on the live box, 2026-08-14** | yes — CUDA torch in the separator's env | `--env_info` probed before every fresh separation; build in the log + job record; `+cpu` build is a WARNING |
+| Rendering | `resolve/render`, `deliver` | Resolve's own GPU pipeline | Resolve's business | out of scope — Resolve manages its own devices |
+
+## ffmpeg hardware decode (`ffmpeg_hwaccel`)
+
+`RESOLVE_MCP_FFMPEG_HWACCEL` = `auto` (default) / `cuda` / `off`.
+
+- `auto` probes `ffmpeg -hwaccels` once per process and passes
+  `-hwaccel cuda` when the binary lists it; a box without a card degrades
+  to software decode with the reason recorded. The live box lists `cuda`,
+  so the default gets NVDEC there.
+- `-hwaccel_output_format cuda` is deliberately **not** passed: every
+  consumer (scene select, occlusion numpy, JPEG grabs) needs frames in
+  system memory, so decoded frames download either way and keeping the
+  filters on the CPU side keeps the transfer identical while the decode —
+  the dominant term — moves to the card.
+- A hardware decode that exits non-zero retries once in software (NVDEC
+  refuses codecs it does not know) and the retry is a WARNING plus a
+  `reason` in the record. Forcing `cuda` disables the retry: forcing is a
+  claim about the box, and a wrong claim should fail loudly.
+
+## The torch decision: beats and applause stay on the CPU
+
+The analysis extra pins the PyPI torch wheel, which on Windows is the CPU
+build (`pyproject.toml`), and beat_this is pinned to the commit the corpus
+was measured with. This is a **policy, not an accident**: the corpus —
+every `[measured — N projects]` claim in `styles/` — was measured on the
+CPU build, and a GPU build that produced even slightly different beat
+times would change what the style profiles were learned from without
+anyone deciding that. Re-measuring the corpus is a human decision
+(director's call), not an agent's; until it is made, the CPU build is the
+reference implementation and both models announce
+"CPU: the corpus policy" at inference rather than staying silent about it.
+What flipping the policy would take: install CUDA torch, re-run the corpus
+pass (`docs/agents/style-layer.md`), and diff the beat grids — if they
+match to tolerance, the profiles survive; if not, they were learned from
+numbers that no longer exist.
+
+Cost of the policy today: beats + applause over a full concert are
+minutes-scale on this box's CPU, not the hours-scale the separator's bug
+was — the wheel decision is cheap where it sits and expensive only if
+copied to the separator, which is exactly what G10 was.
+
+## The separator: GPU-capable, and currently mis-installed on the live box
+
+`config.audio_separator` names a binary and PATH picks the install. The
+2026-08-14 probe of the live box's PATH `audio-separator` reported
+**PyTorch 2.13.0+cpu** (ONNX Runtime GPU 1.28.0 alongside): the demucs
+passes (`htdemucs_ft`, the drum and wind models) run torch, so every
+separation on this box is currently CPU-bound — G10's class of bug, live.
+The server now probes `--env_info` before each fresh separation, logs the
+build, carries it in the job record, and warns on `+cpu`. The fix — CUDA
+torch installed into whatever environment owns the PATH
+`audio-separator`, or `RESOLVE_MCP_AUDIO_SEPARATOR` pointed at one that
+has it — is an install action on the box, recorded on ticket #202.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,8 @@ warn_unused_ignores = true
 # The analysis extras ship no stubs, and are not installed at all in CI or on a machine
 # that only drives Resolve — so the imports are unresolvable rather than untyped. scipy
 # ships no type information either; the two functions used from it are filters over arrays.
+# torch does ship types, so a box with the analysis extra typechecks it for real; the
+# override only quiets CI, where analysis/device.py's guarded import has nothing to resolve.
 [[tool.mypy.overrides]]
-module = ["faster_whisper.*", "scipy.*"]
+module = ["faster_whisper.*", "scipy.*", "torch.*"]
 ignore_missing_imports = true

--- a/src/resolve_mcp/analysis/applause.py
+++ b/src/resolve_mcp/analysis/applause.py
@@ -69,6 +69,7 @@ import numpy as np
 
 from ..errors import AnalysisDependencyError, AnalysisFailedError, ResolveMcpError
 from ..logging_config import get_logger
+from . import device
 
 log = get_logger("analysis")
 
@@ -319,6 +320,7 @@ def panns_tagger(path: Path) -> Curve:
     job dies on the GPU rather than returning a boundary list.
     """
     module = _loaded()
+    device.announce("PANNs")
     detector = module.SoundEventDetection(checkpoint_path=None)
     wanted = _wanted(module)
     log.info("Tagging %s for applause with PANNs", path.name)

--- a/src/resolve_mcp/analysis/beats.py
+++ b/src/resolve_mcp/analysis/beats.py
@@ -19,6 +19,7 @@ from typing import Any, NamedTuple
 
 from ..errors import AnalysisDependencyError, AnalysisFailedError, ResolveMcpError
 from ..logging_config import get_logger
+from . import device
 
 log = get_logger("analysis")
 
@@ -101,6 +102,7 @@ def detect(path: Path, detector: Detector | None = None) -> BeatGrid:
 def beat_this_detector(path: Path) -> BeatGrid:
     """The real thing: beat_this over the whole file, beats and downbeats in seconds."""
     module = _loaded()
+    device.announce("beat_this")
     log.info("Running beat_this over %s", path.name)
     beats, downbeats = module.File2Beats()(str(path))
     return BeatGrid(

--- a/src/resolve_mcp/analysis/device.py
+++ b/src/resolve_mcp/analysis/device.py
@@ -1,0 +1,72 @@
+"""Which device the torch-backed analysis models infer on, said out loud.
+
+The beat grid (beat_this) and the applause curve (PANNs) run on whatever torch the
+analysis extra installed. On Windows that is the CPU wheel **by design**: the measured
+corpus — the numbers the style profiles were learned from — came off the CPU build, and a
+GPU build that produced a different beat grid would silently change what those profiles
+mean (see docs/reference/compute-device-inventory.md and the pins in pyproject.toml).
+
+This module keeps that choice honest rather than silent (#202, the G10 failure): every
+inference site announces its build and device once per process, and the jobs that run
+these models carry the same note in their records, so a slow run is diagnosable from the
+log alone.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..logging_config import get_logger
+
+log = get_logger("analysis")
+
+_announced: set[str] = set()
+
+
+def torch_note() -> dict[str, Any] | None:
+    """The installed torch build and the device inference lands on — ``None`` with no torch.
+
+    ``None`` rather than an error: the callers attach this to results whose own imports
+    already fail with the right message when the model stack is missing, and a note about
+    a stack that is not there would only shadow that error.
+    """
+    try:
+        import torch  # noqa: PLC0415 - a torch stack, loaded only when a job asks
+    except ImportError:
+        return None
+    cuda = bool(torch.cuda.is_available())
+    return {
+        "torch": str(torch.__version__),
+        "cuda_available": cuda,
+        "device": "cuda" if cuda else "cpu",
+    }
+
+
+def announce(component: str) -> dict[str, Any] | None:
+    """Log which device ``component`` infers on, once per process, and return the note."""
+    note = torch_note()
+    if note is None:
+        return None
+    if component not in _announced:
+        _announced.add(component)
+        if note["device"] == "cuda":
+            log.info("%s inference on CUDA (torch %s)", component, note["torch"])
+        elif "+cpu" in note["torch"]:
+            log.info(
+                "%s inference on the CPU (torch %s): the CPU build is the corpus policy — "
+                "see docs/reference/compute-device-inventory.md",
+                component,
+                note["torch"],
+            )
+        else:
+            log.warning(
+                "%s inference on the CPU: torch %s cannot see a CUDA device",
+                component,
+                note["torch"],
+            )
+    return note
+
+
+def reset_announcements() -> None:
+    """Forget what was logged, so a test hears the announcement again."""
+    _announced.clear()

--- a/src/resolve_mcp/analysis/music.py
+++ b/src/resolve_mcp/analysis/music.py
@@ -28,7 +28,7 @@ from ..errors import InvalidRequestError
 from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, start_job
 from . import beats as beats_module
-from . import halves
+from . import device, halves
 
 if TYPE_CHECKING:  # pragma: no cover - the worker imports these when it runs
     from .energy import Measurement
@@ -222,6 +222,12 @@ def analyze(
         progress(0.1, "finding beats and downbeats")
         result[BEATS] = beats_of(source, described, identity, detector, refresh, config)
         artifacts.append(Path(result[BEATS]["path"]))
+        # Which torch stack the beat model runs on (#202). Reported per job rather than
+        # only at the inference site, because a cached grid ran nothing and the record
+        # should still say what a fresh run here would use.
+        note = device.torch_note()
+        if note is not None:
+            result["torch"] = note
 
     if settings[ENERGY]:
         progress(0.6, "measuring loudness and onset density")

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -43,7 +43,7 @@ from ..jobs.runner import JobOutput, Progress, start_job
 from ..logging_config import get_logger
 from . import applause as applause_module
 from . import beats as beats_module
-from . import halves, music
+from . import device, halves, music
 from . import solos as solos_module
 
 log = get_logger("analysis")
@@ -364,6 +364,11 @@ def analyze(
             config,
         )
         artifacts.append(Path(result[TUNES]["path"]))
+        # Which torch stack the applause model runs on (#202); same bargain as the music
+        # job's note — a cached curve ran nothing, and the record still says what would run.
+        note = device.torch_note()
+        if note is not None:
+            result["torch"] = note
 
     if settings[SOLOS]:
         progress(0.6, "measuring the stems")

--- a/src/resolve_mcp/analysis/whisper.py
+++ b/src/resolve_mcp/analysis/whisper.py
@@ -58,7 +58,9 @@ def _model(name: str) -> Any:
     cuda.prepare()
     device, compute_type = config.whisper_device, config.whisper_compute_type
     try:
-        return _build(name, device, compute_type)
+        model = _build(name, device, compute_type)
+        _announce_device(name, device, model)
+        return model
     except TranscriberUnavailableError:
         raise
     except Exception as exc:  # noqa: BLE001 - the backend raises its own unrelated types
@@ -72,6 +74,27 @@ def _model(name: str) -> Any:
             fix=_load_fix(device, compute_type),
             detail={"model": name, "device": device, "compute_type": compute_type},
         ) from exc
+
+
+def _announce_device(name: str, requested: str, model: Any) -> None:
+    """Say which device ``auto`` actually landed on — a quiet CPU resolve is the G10 bug (#202).
+
+    CTranslate2 exposes the device the loaded model sits on; a backend that does not is
+    left unannounced rather than guessed at.
+    """
+    resolved = getattr(getattr(model, "model", None), "device", None)
+    if resolved is None:
+        return
+    if str(resolved) == "cpu" and requested != "cpu":
+        log.warning(
+            "faster-whisper %s: device=%r resolved to the CPU — transcription runs at CPU "
+            "speed. The analysis extra ships the CUDA runtime; check `uv sync --extra "
+            "analysis` ran against this venv.",
+            name,
+            requested,
+        )
+    else:
+        log.info("faster-whisper %s transcribes on %s", name, resolved)
 
 
 def _load_fix(device: str, compute_type: str) -> str:

--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -31,6 +31,7 @@ import subprocess
 from collections import deque
 from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
+from typing import Any
 
 from ..config import Config, get_config
 from ..errors import SeparatorUnavailableError, StemSeparationError
@@ -44,6 +45,8 @@ OUTPUT_TAIL = 40
 
 LABEL = re.compile(r"\(([^()]+)\)")
 PERCENT = re.compile(r"(\d{1,3})\s*%")
+TORCH_BUILD = re.compile(r"PyTorch Version:\s*(\S+)", re.IGNORECASE)
+"""What ``--env_info`` prints for its torch build, e.g. ``PyTorch Version: 2.13.0+cpu``."""
 DOWNLOAD = re.compile(r"download", re.IGNORECASE)
 """A first run fetches its model and prints a bar for that too. It is not the separation."""
 
@@ -90,6 +93,57 @@ def collect(out_dir: Path | str) -> dict[str, Path]:
         if label is not None:
             found[label] = one
     return found
+
+
+def environment_command(executable: str) -> list[str]:
+    """Ask the separator CLI what it runs on. Prints one fact a line, torch build included."""
+    return [executable, "--env_info"]
+
+
+def environment(
+    runner: Runner | None = None,
+    config: Config | None = None,
+) -> dict[str, Any]:
+    """Which torch build the resolved separator runs on — G10's bug class, made loud (#202).
+
+    ``config.audio_separator`` names a binary, and PATH decides which install — and which
+    torch — that is. A CPU-build torch turns a forty-minute separation into a day's, and the
+    only symptom used to be that it was slow; here the build goes into the log and the job
+    record, and a ``+cpu`` build is a warning. A separator too old to answer ``--env_info``
+    still separates: the report says the build is unknown rather than failing the job.
+    """
+    config = config or get_config()
+    lines: list[str] = []
+    try:
+        returncode = (runner or _run)(environment_command(config.audio_separator), lines.append)
+    except FileNotFoundError as exc:
+        raise SeparatorUnavailableError(
+            cause=f"No audio-separator at {config.audio_separator!r}.",
+            detail={"executable": config.audio_separator},
+        ) from exc
+
+    found = TORCH_BUILD.search("\n".join(lines))
+    report: dict[str, Any] = {
+        "executable": config.audio_separator,
+        "torch": found.group(1) if found else None,
+    }
+    if found is None or returncode != 0:
+        report["warning"] = (
+            "The separator did not report its torch build (--env_info), so whether this "
+            "separation runs on the GPU is unknown."
+        )
+        log.warning("%s", report["warning"])
+    elif "+cpu" in report["torch"]:
+        report["warning"] = (
+            f"The separator's torch is the CPU build ({report['torch']}): separations run "
+            "on the CPU at a fraction of GPU speed. Install CUDA torch into the "
+            "environment that owns the audio-separator on PATH, or point "
+            "RESOLVE_MCP_AUDIO_SEPARATOR at one that has it."
+        )
+        log.warning("%s", report["warning"])
+    else:
+        log.info("audio-separator torch build: %s", report["torch"])
+    return report
 
 
 def separate(

--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -127,7 +127,11 @@ def environment(
         "executable": config.audio_separator,
         "torch": found.group(1) if found else None,
     }
-    if found is None or returncode != 0:
+    if returncode != 0:
+        log.info("audio-separator --env_info exited %d; reading what it printed", returncode)
+    # A parsed build is believed even off a non-zero exit — the +cpu warning matters most
+    # on exactly the runs where the CLI also grumbled about something else.
+    if found is None:
         report["warning"] = (
             "The separator did not report its torch build (--env_info), so whether this "
             "separation runs on the GPU is unknown."

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -848,6 +848,7 @@ def multi_pass(
     other_dir = directory / OTHER_PASS
     wanted_other = other_dir if split_wind else None
 
+    separator_env: dict[str, Any] | None = None
     reused = reuse and _already_separated(mix_dir, drums_dir, wanted_other)
     if reused:
         log.info("Stems for %s are already on disk at %s", audio["path"], directory)
@@ -869,6 +870,9 @@ def multi_pass(
                 )
                 stems, drums, other = _on_disk(mix_dir, drums_dir, wanted_other)
             else:
+                # Asked only when a separation is actually about to run: the report says
+                # what *this* work ran on, and a reuse ran nothing (#202).
+                separator_env = separator.environment(runner=runner, config=config)
                 stems, drums, other = _passes(
                     audio,
                     mix_dir,
@@ -891,6 +895,8 @@ def multi_pass(
         "audio": audio,
         "reused": reused,
     }
+    if separator_env is not None:
+        result["separator"] = separator_env
     if split_wind:
         # Keyed like ``drums`` is: the name of the stem this pass took apart. Absent rather
         # than empty when the pass is off, so the envelope never offers a stem nobody made.

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -17,6 +17,12 @@ DEFAULT_SCRIPT_LIB = Path("C:/Program Files/Blackmagic Design/DaVinci Resolve/fu
 DEFAULT_LOG_LEVEL = "INFO"
 CACHE_DIR_NAME = "resolve-mcp"
 DEFAULT_FFMPEG = "ffmpeg"
+# Hardware decode for the video routes (#202). "auto" asks the ffmpeg binary what it
+# supports and uses NVDEC when it lists cuda, so the live box decodes on the card and a
+# box without one still runs; "cuda" forces the flag (a wrong box fails loudly rather
+# than quietly decoding in software); "off" never passes it. Whatever is chosen, the
+# route reports the device it decoded on — a silent CPU decode is the G10 failure.
+DEFAULT_FFMPEG_HWACCEL = "auto"
 DEFAULT_AUDIO_SEPARATOR = "audio-separator"
 DEFAULT_STEM_MODEL = "htdemucs_ft.yaml"
 # The name audio-separator 0.44.5 lists for the six-stem MDX23C drum model; the
@@ -51,6 +57,7 @@ class Config:
     log_level: str
     allow_any_python: bool = False
     ffmpeg: str = DEFAULT_FFMPEG
+    ffmpeg_hwaccel: str = DEFAULT_FFMPEG_HWACCEL
     audio_separator: str = DEFAULT_AUDIO_SEPARATOR
     stem_model: str = DEFAULT_STEM_MODEL
     drum_model: str = DEFAULT_DRUM_MODEL
@@ -73,6 +80,7 @@ class Config:
             log_level=env.get("RESOLVE_MCP_LOG_LEVEL") or DEFAULT_LOG_LEVEL,
             allow_any_python=(env.get(BYPASS_ENV) or "").lower() in TRUTHY,
             ffmpeg=env.get("RESOLVE_MCP_FFMPEG") or DEFAULT_FFMPEG,
+            ffmpeg_hwaccel=env.get("RESOLVE_MCP_FFMPEG_HWACCEL") or DEFAULT_FFMPEG_HWACCEL,
             audio_separator=env.get("RESOLVE_MCP_AUDIO_SEPARATOR") or DEFAULT_AUDIO_SEPARATOR,
             stem_model=env.get("RESOLVE_MCP_STEM_MODEL") or DEFAULT_STEM_MODEL,
             drum_model=env.get("RESOLVE_MCP_DRUM_MODEL") or DEFAULT_DRUM_MODEL,
@@ -102,6 +110,7 @@ class Config:
             "RESOLVE_MCP_CACHE": str(self.cache_dir),
             "RESOLVE_MCP_LOG_LEVEL": self.log_level,
             "RESOLVE_MCP_FFMPEG": self.ffmpeg,
+            "RESOLVE_MCP_FFMPEG_HWACCEL": self.ffmpeg_hwaccel,
             "RESOLVE_MCP_AUDIO_SEPARATOR": self.audio_separator,
             "RESOLVE_MCP_STEM_MODEL": self.stem_model,
             "RESOLVE_MCP_DRUM_MODEL": self.drum_model,

--- a/src/resolve_mcp/ffmpeg.py
+++ b/src/resolve_mcp/ffmpeg.py
@@ -15,6 +15,7 @@ one, and the agent needs the fix that belongs to what it asked for.
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -22,6 +23,8 @@ from typing import Any, NamedTuple
 
 from .config import Config, get_config
 from .errors import FfmpegUnavailableError, ResolveMcpError
+
+log = logging.getLogger(__name__)
 
 STDERR_TAIL = 800
 """How much of ffmpeg's own complaint travels back in a failure — the end, where it says why."""
@@ -84,10 +87,19 @@ def hwaccels(config: Config | None = None, runner: Runner | None = None) -> froz
         return cached
 
     finished = invoke(hwaccels_command(config.ffmpeg), runner=runner, config=config)
-    lines = (line.strip() for line in finished.stdout.splitlines())
-    found = frozenset(
-        line for line in lines if line and ":" not in line and finished.returncode == 0
-    )
+    if finished.returncode != 0:
+        # Logged here as well as in the per-route reason: the failure is cached for the
+        # whole process, and the probe moment is the only place its exit code is visible.
+        log.warning(
+            "The hardware-decode probe failed (%s -hwaccels exited %d); "
+            "treating this box as having no hardware decode support",
+            config.ffmpeg,
+            finished.returncode,
+        )
+        found = frozenset[str]()
+    else:
+        lines = (line.strip() for line in finished.stdout.splitlines())
+        found = frozenset(line for line in lines if line and ":" not in line)
     _hwaccel_probes[config.ffmpeg] = found
     return found
 

--- a/src/resolve_mcp/ffmpeg.py
+++ b/src/resolve_mcp/ffmpeg.py
@@ -28,10 +28,15 @@ STDERR_TAIL = 800
 
 
 class Completed(NamedTuple):
-    """What the runner reports back: ffmpeg says why it refused on stderr."""
+    """What the runner reports back: ffmpeg says why it refused on stderr.
+
+    ``stdout`` is empty for every decode and encode — ffmpeg talks on stderr — and carries
+    the answer for the one query that prints one: the ``-hwaccels`` capability probe.
+    """
 
     returncode: int
     stderr: str
+    stdout: str = ""
 
 
 Runner = Callable[[Sequence[str]], Completed]
@@ -39,7 +44,7 @@ Runner = Callable[[Sequence[str]], Completed]
 
 def run(argv: Sequence[str]) -> Completed:
     finished = subprocess.run(argv, capture_output=True, text=True, check=False)
-    return Completed(finished.returncode, finished.stderr or "")
+    return Completed(finished.returncode, finished.stderr or "", finished.stdout or "")
 
 
 def invoke(
@@ -56,6 +61,40 @@ def invoke(
             cause=f"No ffmpeg at {config.ffmpeg!r}.",
             detail={"executable": config.ffmpeg},
         ) from exc
+
+
+def hwaccels_command(executable: str) -> list[str]:
+    """Ask the binary which hardware decoders it was built with. Prints one name a line."""
+    return [executable, "-hide_banner", "-hwaccels"]
+
+
+_hwaccel_probes: dict[str, frozenset[str]] = {}
+
+
+def hwaccels(config: Config | None = None, runner: Runner | None = None) -> frozenset[str]:
+    """The hardware decode methods this box's ffmpeg supports, probed once per process.
+
+    A probe that fails reads as an empty set rather than an error: the video routes degrade
+    to software decode, and the decode report says why. Only a *missing* binary still
+    raises — every route was about to hit the same wall, and the fix is the same one.
+    """
+    config = config or get_config()
+    cached = _hwaccel_probes.get(config.ffmpeg)
+    if cached is not None:
+        return cached
+
+    finished = invoke(hwaccels_command(config.ffmpeg), runner=runner, config=config)
+    lines = (line.strip() for line in finished.stdout.splitlines())
+    found = frozenset(
+        line for line in lines if line and ":" not in line and finished.returncode == 0
+    )
+    _hwaccel_probes[config.ffmpeg] = found
+    return found
+
+
+def reset_hwaccel_probe() -> None:
+    """Forget the probe, so a test (or a config change) asks again."""
+    _hwaccel_probes.clear()
 
 
 def refused(

--- a/src/resolve_mcp/video/ffmpeg.py
+++ b/src/resolve_mcp/video/ffmpeg.py
@@ -30,6 +30,10 @@ or JPEG passes over pixels, so decoded frames have to land in RAM either way."""
 
 HWACCEL_MODES = ("auto", "cuda", "off")
 
+INTERNAL_FALLBACK = "Failed setup for format"
+"""What ffmpeg prints (at warning level, exit 0) when the hardware decoder cannot take the
+stream — e.g. NVDEC on 4:2:2 profiles — and it silently finishes the decode in software."""
+
 
 class Decode(NamedTuple):
     """The decode this box gets: which flags to pass, and the report the record carries.
@@ -112,7 +116,24 @@ def _decoded(
     choice = choose_decode(config, runner)
     finished = invoke(build(choice.flags), runner=runner, config=config)
     report = choice.report()
-    if finished.returncode != 0 and choice.flags and config.ffmpeg_hwaccel != "cuda":
+    if finished.returncode == 0 and choice.flags and INTERNAL_FALLBACK in finished.stderr:
+        # The sneakiest fallback of the three: NVDEC lacks the codec profile (this box's
+        # 4:2:2 concert footage, measured 2026-08-14), so ffmpeg warns on stderr, decodes
+        # in software and exits 0 — the frames are good, but the card never touched them.
+        # The exit-code retry below cannot see it; the stderr line is the only witness.
+        # Deliberately also reached when ``cuda`` is forced: the frames arrived, so failing
+        # would discard good work — here the loudness *is* the record.
+        log.warning(
+            "Hardware decode of %s fell back inside ffmpeg: the decoder lacks this codec "
+            "profile, so the frames were decoded in software",
+            source,
+        )
+        report = {
+            "device": "cpu",
+            "reason": "ffmpeg fell back internally: the hardware decoder lacks this "
+            "codec profile",
+        }
+    elif finished.returncode != 0 and choice.flags and config.ffmpeg_hwaccel != "cuda":
         log.warning(
             "Hardware decode of %s failed (exit %d); retrying in software",
             source,
@@ -145,7 +166,7 @@ def still_command(
         executable,
         "-nostdin",
         "-loglevel",
-        "error",
+        "warning",
         "-y",
         *decode,
         "-ss",
@@ -171,8 +192,9 @@ def scene_command(
     """Decode the whole file, keep the frames that differ from the last one, print their times.
 
     ``showinfo`` writes one line per kept frame to stderr, which is why the log level goes
-    up to info for this command alone. Nothing is encoded — the output is the null muxer, so
-    what this costs is one decode pass.
+    up to info here where the others sit at warning — the floor every decode command keeps
+    so ffmpeg's internal hwaccel fallback line stays visible (#202). Nothing is encoded —
+    the output is the null muxer, so what this costs is one decode pass.
     """
     return [
         executable,
@@ -219,7 +241,7 @@ def sample_command(
         executable,
         "-nostdin",
         "-loglevel",
-        "error",
+        "warning",
         "-y",
         *decode,
         "-ss",

--- a/src/resolve_mcp/video/ffmpeg.py
+++ b/src/resolve_mcp/video/ffmpeg.py
@@ -128,11 +128,9 @@ def _decoded(
             "profile, so the frames were decoded in software",
             source,
         )
-        report = {
-            "device": "cpu",
-            "reason": "ffmpeg fell back internally: the hardware decoder lacks this "
-            "codec profile",
-        }
+        report = Decode(
+            (), "cpu", "ffmpeg fell back internally: the hardware decoder lacks this codec profile"
+        ).report()
     elif finished.returncode != 0 and choice.flags and config.ffmpeg_hwaccel != "cuda":
         log.warning(
             "Hardware decode of %s failed (exit %d); retrying in software",
@@ -140,7 +138,7 @@ def _decoded(
             finished.returncode,
         )
         finished = invoke(build(()), runner=runner, config=config)
-        report = {"device": "cpu", "reason": "hardware decode failed; retried in software"}
+        report = Decode((), "cpu", "hardware decode failed; retried in software").report()
     return finished, report
 
 

--- a/src/resolve_mcp/video/ffmpeg.py
+++ b/src/resolve_mcp/video/ffmpeg.py
@@ -9,17 +9,118 @@ ends the filter and starts the next: ``min(iw,1568)`` would be read as a filter 
 
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
 from pathlib import Path
+from typing import Any, NamedTuple
 
 from ..config import Config, get_config
-from ..errors import FrameGrabError, OcclusionScanError, SceneDetectionError
-from ..ffmpeg import Runner, invoke, refused
+from ..errors import FrameGrabError, InvalidRequestError, OcclusionScanError, SceneDetectionError
+from ..ffmpeg import Completed, Runner, hwaccels, invoke, refused
 from ..logging_config import get_logger
 
 log = get_logger("video")
 
 JPEG_QUALITY = "3"
 """ffmpeg's ``-q:v`` scale, 2 (best) to 31. Three is visually clean at a fraction of 2's size."""
+
+CUDA_FLAGS = ("-hwaccel", "cuda")
+"""NVDEC, without ``-hwaccel_output_format cuda``: the frames decode on the card and come
+back to system memory, which is the shape every consumer here wants — all of them are numpy
+or JPEG passes over pixels, so decoded frames have to land in RAM either way."""
+
+HWACCEL_MODES = ("auto", "cuda", "off")
+
+
+class Decode(NamedTuple):
+    """The decode this box gets: which flags to pass, and the report the record carries.
+
+    ``reason`` is only ever set on a software decode — it is the answer to "why did this
+    not use the GPU", which is the question G10 cost a session to ask (#202).
+    """
+
+    flags: tuple[str, ...]
+    device: str  # "cuda" | "cpu"
+    reason: str | None = None
+
+    def report(self) -> dict[str, Any]:
+        return {"device": self.device, "reason": self.reason}
+
+
+_announced: set[tuple[str, str]] = set()
+"""Which (executable, device) choices have already been logged, so a session's log says
+where decodes run once, not once per frame grab."""
+
+
+def reset_decode_announcements() -> None:
+    _announced.clear()
+
+
+def choose_decode(config: Config | None = None, runner: Runner | None = None) -> Decode:
+    """What ``config.ffmpeg_hwaccel`` means on this box, probed rather than assumed.
+
+    ``auto`` uses NVDEC when the binary lists cuda and degrades to software when it does
+    not; ``cuda`` forces the flag so a box that cannot honour it fails loudly; ``off``
+    never decodes on the card. Every software choice carries its reason, and each choice
+    is logged once per process — a CPU decode that says nothing is the G10 failure.
+    """
+    config = config or get_config()
+    mode = config.ffmpeg_hwaccel
+    if mode not in HWACCEL_MODES:
+        raise InvalidRequestError(
+            cause=f"ffmpeg_hwaccel={mode!r} is not a hardware-decode mode.",
+            fix=(
+                "Set RESOLVE_MCP_FFMPEG_HWACCEL to auto (probe the binary and use NVDEC "
+                "when it lists cuda), cuda (force it), or off (software decode)."
+            ),
+            detail={"requested": mode, "modes": list(HWACCEL_MODES)},
+        )
+
+    if mode == "off":
+        choice = Decode((), "cpu", "hardware decode disabled (ffmpeg_hwaccel=off)")
+    elif mode == "cuda" or "cuda" in hwaccels(config, runner):
+        choice = Decode(CUDA_FLAGS, "cuda")
+    else:
+        supported = ", ".join(sorted(hwaccels(config, runner))) or "none"
+        choice = Decode((), "cpu", f"ffmpeg lists no cuda hwaccel (supported: {supported})")
+
+    marker = (config.ffmpeg, choice.device)
+    if marker not in _announced:
+        _announced.add(marker)
+        if choice.device == "cuda":
+            log.info("Video decode on NVDEC (-hwaccel cuda) via %s", config.ffmpeg)
+        else:
+            log.info("Video decode in software via %s: %s", config.ffmpeg, choice.reason)
+    return choice
+
+
+def _decoded(
+    build: Callable[[Sequence[str]], list[str]],
+    source: Path | str,
+    runner: Runner | None,
+    config: Config,
+) -> tuple[Completed, dict[str, Any]]:
+    """Run a decode with the configured hardware choice, falling back loudly if it fails.
+
+    A hardware decode that exits non-zero is retried once in software before the failure
+    is believed: NVDEC refuses codecs it does not know, and the file may be fine. The
+    report says the retry happened — a fallback nothing records is the bug this ticket
+    exists for — and a file that is truly unreadable fails the software attempt with
+    ffmpeg's own message, which is the error worth relaying. Forcing ``ffmpeg_hwaccel=cuda``
+    turns the retry off: forcing is a claim about the box, and a box that cannot honour it
+    should fail in the caller's face rather than quietly decode in software.
+    """
+    choice = choose_decode(config, runner)
+    finished = invoke(build(choice.flags), runner=runner, config=config)
+    report = choice.report()
+    if finished.returncode != 0 and choice.flags and config.ffmpeg_hwaccel != "cuda":
+        log.warning(
+            "Hardware decode of %s failed (exit %d); retrying in software",
+            source,
+            finished.returncode,
+        )
+        finished = invoke(build(()), runner=runner, config=config)
+        report = {"device": "cpu", "reason": "hardware decode failed; retried in software"}
+    return finished, report
 
 
 def still_command(
@@ -28,6 +129,7 @@ def still_command(
     target: Path | str,
     seconds: float,
     max_edge: int,
+    decode: Sequence[str] = (),
 ) -> list[str]:
     """Seek, take one frame, scale it to fit inside ``max_edge``, write a JPEG.
 
@@ -45,6 +147,7 @@ def still_command(
         "-loglevel",
         "error",
         "-y",
+        *decode,
         "-ss",
         f"{seconds:.6f}",
         "-i",
@@ -59,7 +162,12 @@ def still_command(
     ]
 
 
-def scene_command(executable: str, source: Path | str, threshold: float) -> list[str]:
+def scene_command(
+    executable: str,
+    source: Path | str,
+    threshold: float,
+    decode: Sequence[str] = (),
+) -> list[str]:
     """Decode the whole file, keep the frames that differ from the last one, print their times.
 
     ``showinfo`` writes one line per kept frame to stderr, which is why the log level goes
@@ -72,6 +180,7 @@ def scene_command(executable: str, source: Path | str, threshold: float) -> list
         "-loglevel",
         "info",
         "-y",
+        *decode,
         "-i",
         str(source),
         "-filter:v",
@@ -92,6 +201,7 @@ def sample_command(
     rate: float,
     width: int,
     height: int,
+    decode: Sequence[str] = (),
 ) -> list[str]:
     """Seek, take ``rate`` frames a second of the next ``duration_seconds``, write raw grey.
 
@@ -111,6 +221,7 @@ def sample_command(
         "-loglevel",
         "error",
         "-y",
+        *decode,
         "-ss",
         f"{start_seconds:.6f}",
         "-i",
@@ -128,6 +239,21 @@ def sample_command(
     ]
 
 
+class Grabbed(NamedTuple):
+    path: Path
+    decode: dict[str, Any]
+
+
+class Scanned(NamedTuple):
+    printed: str
+    decode: dict[str, Any]
+
+
+class Sampled(NamedTuple):
+    path: Path
+    decode: dict[str, Any]
+
+
 def grab(
     source: Path | str,
     target: Path | str,
@@ -135,13 +261,17 @@ def grab(
     max_edge: int,
     runner: Runner | None = None,
     config: Config | None = None,
-) -> Path:
+) -> Grabbed:
     """Write one frame of ``source`` to ``target`` as a JPEG, or fail with ffmpeg's message."""
     config = config or get_config()
     destination = Path(target)
     destination.parent.mkdir(parents=True, exist_ok=True)
-    argv = still_command(config.ffmpeg, source, destination, seconds, max_edge)
-    finished = invoke(argv, runner=runner, config=config)
+    finished, decode = _decoded(
+        lambda flags: still_command(config.ffmpeg, source, destination, seconds, max_edge, flags),
+        source,
+        runner,
+        config,
+    )
 
     if finished.returncode != 0:
         raise refused(source, finished, FrameGrabError, seconds=seconds)
@@ -155,7 +285,7 @@ def grab(
             detail={"source": str(source), "seconds": seconds, "expected": str(destination)},
         )
     log.info("Grabbed a frame of %s at %.3fs to %s", source, seconds, destination)
-    return destination
+    return Grabbed(destination, decode)
 
 
 def scan(
@@ -163,16 +293,20 @@ def scan(
     threshold: float,
     runner: Runner | None = None,
     config: Config | None = None,
-) -> str:
+) -> Scanned:
     """Run the scene filter over ``source`` and hand back the log it printed."""
     config = config or get_config()
-    argv = scene_command(config.ffmpeg, source, threshold)
-    finished = invoke(argv, runner=runner, config=config)
+    finished, decode = _decoded(
+        lambda flags: scene_command(config.ffmpeg, source, threshold, flags),
+        source,
+        runner,
+        config,
+    )
 
     if finished.returncode != 0:
         raise refused(source, finished, SceneDetectionError, threshold=threshold)
     log.info("Scanned %s for scene cuts at threshold %.2f", source, threshold)
-    return finished.stderr
+    return Scanned(finished.stderr, decode)
 
 
 def sample(
@@ -185,7 +319,7 @@ def sample(
     height: int,
     runner: Runner | None = None,
     config: Config | None = None,
-) -> Path:
+) -> Sampled:
     """Write the sampled frames of a range to ``target`` as raw grey, or say why not.
 
     An empty file is a failure rather than an empty scan: ffmpeg seeked past the end of a
@@ -195,17 +329,22 @@ def sample(
     config = config or get_config()
     destination = Path(target)
     destination.parent.mkdir(parents=True, exist_ok=True)
-    argv = sample_command(
-        config.ffmpeg,
+    finished, decode = _decoded(
+        lambda flags: sample_command(
+            config.ffmpeg,
+            source,
+            destination,
+            start_seconds,
+            duration_seconds,
+            rate,
+            width,
+            height,
+            flags,
+        ),
         source,
-        destination,
-        start_seconds,
-        duration_seconds,
-        rate,
-        width,
-        height,
+        runner,
+        config,
     )
-    finished = invoke(argv, runner=runner, config=config)
 
     if finished.returncode != 0:
         raise refused(source, finished, OcclusionScanError, start_seconds=start_seconds)
@@ -231,7 +370,7 @@ def sample(
         rate,
         destination,
     )
-    return destination
+    return Sampled(destination, decode)
 
 
 def selected_seconds(log_text: str) -> list[float]:

--- a/src/resolve_mcp/video/frames.py
+++ b/src/resolve_mcp/video/frames.py
@@ -46,10 +46,11 @@ dozen is a scene-cut scan or a render, not a grab."""
 
 
 class _Grab(NamedTuple):
-    """One frame and whether it was already in the cache."""
+    """One frame, whether it was already in the cache, and what decoded it if anything did."""
 
     frame: dict[str, Any]
     cached: bool
+    decode: dict[str, Any] | None = None
 
 
 def grab_frames(
@@ -82,6 +83,7 @@ def grab_frames(
     ]
 
     hits = sum(1 for one in grabs if one.cached)
+    decodes = [one.decode for one in grabs if one.decode is not None]
     log.info("Returned %d frame(s) of %s, %d of them from cache", len(grabs), clip, hits)
     return {
         "clip": source.name,
@@ -89,6 +91,9 @@ def grab_frames(
         "source": source.path,
         "max_edge": edge,
         "frames": [one.frame for one in grabs],
+        # Null when every frame came off the cache — nothing decoded, so there is no
+        # device to report (#202). Every fresh grab in one call decodes the same way.
+        "decode": decodes[0] if decodes else None,
         "cached": hits == len(grabs),
     }
 
@@ -111,7 +116,7 @@ def _one_frame(
             return _Grab(hit, True)
 
     target = config.frame_dir / f"{slug(source.name, 'frame')}-{key[:12]}.jpg"
-    ffmpeg.grab(
+    written = ffmpeg.grab(
         source.path,
         target,
         seconds=source.seek_seconds(frame),
@@ -121,7 +126,7 @@ def _one_frame(
     )
     grabbed = {"time": dual_time(frame, source.fps), **jpeg.describe(target)}
     cache.remember(key, KIND, grabbed, (target,), config)
-    return _Grab(grabbed, False)
+    return _Grab(grabbed, False, written.decode)
 
 
 def _readable_edge(max_edge: int) -> int:

--- a/src/resolve_mcp/video/occlusion.py
+++ b/src/resolve_mcp/video/occlusion.py
@@ -135,7 +135,7 @@ def scan_occlusion(
     raw = config.analysis_dir / f"{stem}-{os.getpid()}-{uuid4().hex[:8]}.gray"
     progress(0.1, f"decoding {duration:.0f}s of {source.name} at {rate:g} samples a second")
     try:
-        ffmpeg.sample(
+        sampled = ffmpeg.sample(
             source.path,
             raw,
             start_seconds=source.seek_seconds(first),
@@ -166,6 +166,8 @@ def scan_occlusion(
         "fps": source.fps,
         "sample_fps": rate,
         "threshold": level,
+        # Which device decoded the range, and why not the GPU when it was the CPU (#202).
+        "decode": sampled.decode,
         "grid": {"width": blocking.GRID_WIDTH, "height": blocking.GRID_HEIGHT},
         # What this shot covers even unobstructed: the scan's own floor, subtracted from
         # every score. A high baseline is worth seeing — it means the framing itself is tight.
@@ -204,6 +206,7 @@ def _gist(
         "range": catalog["range"],
         "sample_fps": catalog["sample_fps"],
         "threshold": catalog["threshold"],
+        "decode": catalog["decode"],
         "baseline": catalog["baseline"],
         "samples": len(samples),
         "blocked_samples": len(blocked),

--- a/src/resolve_mcp/video/scenes.py
+++ b/src/resolve_mcp/video/scenes.py
@@ -85,10 +85,10 @@ def scan_scene_cuts(
     threshold = float(params["threshold"])
 
     progress(0.1, "decoding the clip to find scene cuts")
-    printed = ffmpeg.scan(source.path, threshold, runner=runner, config=config)
+    scanned = ffmpeg.scan(source.path, threshold, runner=runner, config=config)
 
     progress(0.9, "cataloguing the cuts")
-    cuts = _cut_frames(printed, source)
+    cuts = _cut_frames(scanned.printed, source)
     shots = _shots(cuts, source)
     target = config.analysis_dir / f"{slug(source.name, 'scenes')}-{key[:12]}.scenes.json"
     catalog = {
@@ -98,6 +98,9 @@ def scan_scene_cuts(
         "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
         "threshold": threshold,
         "fps": source.fps,
+        # Which device decoded the pass, and why not the GPU when it was the CPU (#202):
+        # the whole file is decoded here, so a silent software pass is minutes, not noise.
+        "decode": scanned.decode,
         # The bounds the shots below are cut against. An out of null is why the last shot is
         # missing: Resolve reported no End for this clip, so where the tail stops is unknown.
         "bounds": source.bounds,
@@ -118,6 +121,7 @@ def _gist(catalog: dict[str, Any], target: Path, shots: list[dict[str, Any]]) ->
         "path": str(target),
         "clip": catalog["clip"],
         "threshold": catalog["threshold"],
+        "decode": catalog["decode"],
         "cuts": len(catalog["cuts"]),
         "shots": len(shots),
         "first_cuts": catalog["cuts"][:INLINE_CUTS],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,12 @@ from typing import Protocol
 import pytest
 
 from resolve_mcp import config as config_module
+from resolve_mcp import ffmpeg as ffmpeg_module
+from resolve_mcp.analysis import device as device_module
 from resolve_mcp.config import Config
 from resolve_mcp.resolve import connection as connection_module
 from resolve_mcp.resolve.connection import ResolveConnection
+from resolve_mcp.video import ffmpeg as video_ffmpeg_module
 
 from .fakes import FakeConnector, FakeResolve
 
@@ -35,9 +38,15 @@ def _clean_globals(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[N
     config_module.set_config(
         Config.from_env({**base, "RESOLVE_MCP_CACHE": str(tmp_path / "cache")})
     )
+    ffmpeg_module.reset_hwaccel_probe()
+    video_ffmpeg_module.reset_decode_announcements()
+    device_module.reset_announcements()
     yield
     connection_module.reset_connection()
     config_module.reset_config()
+    ffmpeg_module.reset_hwaccel_probe()
+    video_ffmpeg_module.reset_decode_announcements()
+    device_module.reset_announcements()
 
 
 @pytest.fixture

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -57,6 +57,7 @@ from .fixtures import ffmpeg_refusing as ffmpeg_refusing
 from .fixtures import ffmpeg_sampling as ffmpeg_sampling
 from .fixtures import ffmpeg_writing_nothing as ffmpeg_writing_nothing
 from .fixtures import gray_frame as gray_frame
+from .fixtures import hwaccel_probe_reply as hwaccel_probe_reply
 from .fixtures import write_clicks as write_clicks
 from .fixtures import write_extensible_pcm_wav as write_extensible_pcm_wav
 from .fixtures import write_float_wav as write_float_wav

--- a/tests/fakes/fixtures.py
+++ b/tests/fakes/fixtures.py
@@ -415,6 +415,18 @@ def gray_frame(
     return bytes(pixels)
 
 
+def hwaccel_probe_reply(argv: Sequence[str], methods: Sequence[str] = ()) -> Completed | None:
+    """The ``-hwaccels`` capability probe, answered the way the binary prints it — or ``None``
+    for any other command. Fake runners answer this first, so the probe the video routes now
+    send (#202) never reads as a decode: a fake that parsed the probe's argv for a target
+    path would write a file named ``-hwaccels``.
+    """
+    if "-hwaccels" in argv:
+        listing = "\n".join(["Hardware acceleration methods:", *methods])
+        return Completed(0, "", listing + "\n")
+    return None
+
+
 def ffmpeg_sampling(calls: list[Sequence[str]], frames: Sequence[bytes]) -> Runner:
     """An ffmpeg that writes the raw grey a sampling command asked for, and records the call.
 
@@ -423,6 +435,9 @@ def ffmpeg_sampling(calls: list[Sequence[str]], frames: Sequence[bytes]) -> Runn
     """
 
     def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv)
+        if probed is not None:
+            return probed
         calls.append(list(argv))
         target = Path(argv[-1])
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -436,6 +451,9 @@ def ffmpeg_writing_nothing(calls: list[Sequence[str]]) -> Runner:
     """An ffmpeg that exits zero and writes no frames — what a seek past the end does."""
 
     def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv)
+        if probed is not None:
+            return probed
         calls.append(list(argv))
         return Completed(0, "")
 
@@ -451,6 +469,9 @@ def ffmpeg_refusing(stderr: str) -> Runner:
     """An ffmpeg that ran and would not have the file, complaining the way it does."""
 
     def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv)
+        if probed is not None:
+            return probed
         return Completed(1, stderr)
 
     return runner

--- a/tests/fakes/separator.py
+++ b/tests/fakes/separator.py
@@ -24,13 +24,23 @@ class FakeSeparator:
         *passes: Sequence[str],
         returncode: int = 0,
         output: Sequence[str] = (),
+        torch_build: str = "2.13.0+cu126",
     ) -> None:
         self.passes = [tuple(one) for one in passes]
         self.returncode = returncode
         self.output = tuple(output)
+        self.torch_build = torch_build
         self.calls: list[list[str]] = []
+        self.probes: list[list[str]] = []
 
     def __call__(self, argv: Sequence[str], on_line: Callable[[str], None]) -> int:
+        if "--env_info" in argv:
+            # The build report (#202), answered the way the real CLI prints it and kept off
+            # ``calls`` so the pass cycle still counts separations alone.
+            self.probes.append(list(argv))
+            prefix = "2026-01-01 00:00:00,000 - INFO - separator"
+            on_line(f"{prefix} - PyTorch Version: {self.torch_build}")
+            return 0
         self.calls.append(list(argv))
         for line in self.output:
             on_line(line)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -137,3 +137,20 @@ def test_ffmpeg_is_a_bare_name_on_path_until_told_otherwise() -> None:
     assert Config.from_env({"RESOLVE_MCP_FFMPEG": r"D:\tools\ffmpeg.exe"}).ffmpeg == (
         r"D:\tools\ffmpeg.exe"
     )
+
+
+def test_hardware_decode_probes_by_default_and_is_overridable() -> None:
+    """"auto" probes the binary, so the live box gets NVDEC and a box without a card still
+    runs (#202); the overrides exist to force the flag or turn it off without a reinstall.
+    """
+    assert Config.from_env({}).ffmpeg_hwaccel == "auto"
+    assert Config.from_env({"RESOLVE_MCP_FFMPEG_HWACCEL": "off"}).ffmpeg_hwaccel == "off"
+    assert Config.from_env({"RESOLVE_MCP_FFMPEG_HWACCEL": "cuda"}).ffmpeg_hwaccel == "cuda"
+
+
+def test_the_hardware_decode_setting_survives_the_env_round_trip() -> None:
+    """A detached worker rebuilds config from ``to_env``; a field it dropped would silently
+    decode in software in exactly the process that does the long decodes.
+    """
+    config = Config.from_env({"RESOLVE_MCP_FFMPEG_HWACCEL": "off"})
+    assert Config.from_env(config.to_env()).ffmpeg_hwaccel == "off"

--- a/tests/test_detached_jobs.py
+++ b/tests/test_detached_jobs.py
@@ -182,6 +182,7 @@ def test_a_config_survives_the_trip_through_the_environment() -> None:
         log_level="DEBUG",
         allow_any_python=True,
         ffmpeg="D:/tools/ffmpeg.exe",
+        ffmpeg_hwaccel="off",
         audio_separator="D:/tools/audio-separator.exe",
         stem_model="some-stem-model.ckpt",
         drum_model="some-drum-model.ckpt",
@@ -1353,6 +1354,8 @@ def test_a_separation_long_enough_to_pass_the_ceiling_still_owns_its_directory(
     stamps: list[float] = []
 
     def watching(argv: Sequence[str], on_line: Callable[[str], None]) -> int:
+        if "--env_info" in argv:  # the build probe (#202) is not a pass
+            return separating(argv, on_line)
         out_dir = Path(argv[list(argv).index("--output_dir") + 1])
         marker = out_dir.parent / CLAIM
         held = json.loads(marker.read_text(encoding="utf-8"))
@@ -1381,6 +1384,8 @@ def test_a_finished_separation_holds_the_claim_for_the_passes_and_leaves_none_be
     held: list[bool] = []
 
     def watching(argv: Sequence[str], on_line: Callable[[str], None]) -> int:
+        if "--env_info" in argv:  # the build probe (#202) is not a pass
+            return separating(argv, on_line)
         out_dir = Path(argv[list(argv).index("--output_dir") + 1])
         held.append((out_dir.parent / CLAIM).exists())
         return separating(argv, on_line)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,100 @@
+"""``analysis/device.py``: the torch paths say which device they infer on (#202).
+
+The stub stands in for torch via ``sys.modules`` so the decisions — what the note carries,
+when the announcement warns, that it logs once — verify on a box with any torch or none.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from resolve_mcp.analysis import device
+
+
+class _Cuda:
+    def __init__(self, available: bool) -> None:
+        self._available = available
+
+    def is_available(self) -> bool:
+        return self._available
+
+
+class _Torch:
+    def __init__(self, version: str, available: bool) -> None:
+        self.__version__ = version
+        self.cuda = _Cuda(available)
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, version: str, available: bool) -> None:
+    monkeypatch.setitem(sys.modules, "torch", _Torch(version, available))
+
+
+def test_the_note_carries_the_build_and_the_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, "2.13.0+cu126", available=True)
+    assert device.torch_note() == {
+        "torch": "2.13.0+cu126",
+        "cuda_available": True,
+        "device": "cuda",
+    }
+
+
+def test_a_cpu_build_notes_the_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, "2.13.0+cpu", available=False)
+    note = device.torch_note()
+    assert note is not None
+    assert note["device"] == "cpu"
+    assert note["cuda_available"] is False
+
+
+def test_no_torch_is_no_note_rather_than_an_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "torch", None)  # import machinery reads None as absent
+    assert device.torch_note() is None
+    assert device.announce("beat_this") is None
+
+
+def test_the_cpu_build_announcement_names_the_corpus_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _install(monkeypatch, "2.13.0+cpu", available=False)
+    with caplog.at_level("INFO"):
+        device.announce("beat_this")
+    assert any("corpus policy" in one.message for one in caplog.records)
+
+
+def test_a_cuda_build_that_cannot_see_a_card_warns_instead(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A CUDA build on the CPU is not the corpus policy — it is a box with a driver problem,
+    and calling it policy would hide exactly the failure the announcement exists for."""
+    _install(monkeypatch, "2.13.0+cu126", available=False)
+    with caplog.at_level("INFO"):
+        device.announce("beat_this")
+    warned = [one for one in caplog.records if one.levelname == "WARNING"]
+    assert warned and "cannot see a CUDA device" in warned[0].message
+
+
+def test_each_component_announces_once_per_process(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _install(monkeypatch, "2.13.0+cpu", available=False)
+    with caplog.at_level("INFO"):
+        device.announce("beat_this")
+        device.announce("beat_this")
+        device.announce("PANNs")
+    mentions = [one for one in caplog.records if "inference on the CPU" in one.message]
+    assert len(mentions) == 2
+
+
+def test_the_note_still_returns_when_the_announcement_is_already_made(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The job record needs the note every time; only the log line is deduplicated."""
+    _install(monkeypatch, "2.13.0+cpu", available=False)
+    first = device.announce("beat_this")
+    second = device.announce("beat_this")
+    assert first == second and second is not None

--- a/tests/test_frame_grabs.py
+++ b/tests/test_frame_grabs.py
@@ -33,6 +33,7 @@ from .fakes import (
     FakeResolve,
     ffmpeg_absent,
     ffmpeg_refusing,
+    hwaccel_probe_reply,
     media_pool,
     studio,
     write_jpeg,
@@ -462,6 +463,9 @@ def _drawing(calls: list[Sequence[str]], width: int = 1568, height: int = 882) -
     """Stand in for ffmpeg by writing the JPEG header it would have written."""
 
     def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv)
+        if probed is not None:
+            return probed
         calls.append(list(argv))
         write_jpeg(Path(argv[-1]), width=width, height=height)
         return Completed(0, "")
@@ -471,7 +475,7 @@ def _drawing(calls: list[Sequence[str]], width: int = 1568, height: int = 882) -
 
 def _pretending(argv: Sequence[str]) -> Completed:
     """Exit zero and write nothing — the failure mode that would otherwise cache a lie."""
-    return Completed(0, "")
+    return hwaccel_probe_reply(argv) or Completed(0, "")
 
 
 def _seek(argv: Sequence[str]) -> float:

--- a/tests/test_hardware_decode.py
+++ b/tests/test_hardware_decode.py
@@ -170,7 +170,7 @@ def test_a_grab_on_a_cuda_box_decodes_with_the_flag_and_reports_the_device(
     assert written.decode == {"device": "cuda", "reason": None}
 
 
-def test_a_grab_on_a_boxwithout_cuda_reports_the_cpu_and_the_reason(tmp_path: Path) -> None:
+def test_a_grab_on_a_box_without_cuda_reports_the_cpu_and_the_reason(tmp_path: Path) -> None:
     def runner(argv: Sequence[str]) -> Completed:
         probed = hwaccel_probe_reply(argv, ())
         if probed is not None:

--- a/tests/test_hardware_decode.py
+++ b/tests/test_hardware_decode.py
@@ -1,0 +1,242 @@
+"""Hardware decode (#202): one device policy across the probe, the flags and the record.
+
+This file is a device file in the ``test_cut_devices.py`` sense: NVDEC is one decision
+spread over ``ffmpeg.py`` (the capability probe), ``video/ffmpeg.py`` (the flag shaping,
+the software fallback and the report) and the three video routes that carry the report in
+their results — and the failure worth testing is the disagreement, a decode that ran one
+way and reported another. The G10 rule everything here serves: a CPU decode may happen,
+but it may never happen silently.
+
+The probe and the commands are argv shaping, so the whole file runs on fakes; whether
+NVDEC actually decodes on the live box is ``test_live_smoke.py``'s business.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.config import get_config
+from resolve_mcp.errors import FrameGrabError, InvalidRequestError
+from resolve_mcp.ffmpeg import Completed, Runner, hwaccels, hwaccels_command
+from resolve_mcp.video import ffmpeg as video_ffmpeg
+from resolve_mcp.video.ffmpeg import (
+    CUDA_FLAGS,
+    choose_decode,
+    sample_command,
+    scene_command,
+    still_command,
+)
+
+from .fakes import hwaccel_probe_reply, write_jpeg
+
+CUDA_BOX = ("cuda", "d3d11va", "vulkan")
+"""What the live box's ffmpeg lists (among others). Order and extras must not matter."""
+
+
+def _answering(methods: Sequence[str], calls: list[list[str]] | None = None) -> Runner:
+    """A runner that answers the probe with ``methods`` and succeeds at everything else."""
+
+    def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv, methods)
+        if probed is not None:
+            return probed
+        if calls is not None:
+            calls.append(list(argv))
+        return Completed(0, "")
+
+    return runner
+
+
+# --- the probe -----------------------------------------------------------------------------
+
+
+def test_the_probe_asks_the_binary_and_reads_one_method_a_line() -> None:
+    assert hwaccels_command("ffmpeg") == ["ffmpeg", "-hide_banner", "-hwaccels"]
+    found = hwaccels(runner=_answering(CUDA_BOX))
+    assert found == frozenset(CUDA_BOX)
+
+
+def test_the_probe_drops_the_header_line_the_binary_prints() -> None:
+    assert "Hardware acceleration methods:" not in hwaccels(runner=_answering(("cuda",)))
+
+
+def test_the_probe_runs_once_per_process_not_once_per_decode() -> None:
+    probes: list[list[str]] = []
+
+    def counting(argv: Sequence[str]) -> Completed:
+        probes.append(list(argv))
+        return hwaccel_probe_reply(argv, ("cuda",)) or Completed(0, "")
+
+    assert hwaccels(runner=counting) == hwaccels(runner=counting)
+    assert len(probes) == 1
+
+
+def test_a_probe_the_binary_refuses_reads_as_no_hardware_support() -> None:
+    def refusing(argv: Sequence[str]) -> Completed:
+        return Completed(1, "Unrecognized option 'hwaccels'")
+
+    assert hwaccels(runner=refusing) == frozenset()
+
+
+# --- the choice ----------------------------------------------------------------------------
+
+
+def test_auto_uses_cuda_when_the_binary_lists_it() -> None:
+    choice = choose_decode(runner=_answering(CUDA_BOX))
+    assert choice.flags == CUDA_FLAGS
+    assert choice.device == "cuda"
+    assert choice.reason is None
+
+
+def test_auto_degrades_to_software_and_says_why_when_cuda_is_not_listed() -> None:
+    choice = choose_decode(runner=_answering(("d3d11va", "vulkan")))
+    assert choice.flags == ()
+    assert choice.device == "cpu"
+    assert choice.reason is not None and "d3d11va" in choice.reason
+
+
+def test_off_never_probes_and_says_it_was_disabled() -> None:
+    config = replace(get_config(), ffmpeg_hwaccel="off")
+
+    def exploding(argv: Sequence[str]) -> Completed:
+        raise AssertionError(f"probed with {argv}")
+
+    choice = choose_decode(config, runner=exploding)
+    assert choice.flags == ()
+    assert choice.reason is not None and "off" in choice.reason
+
+
+def test_forcing_cuda_never_probes_and_passes_the_flag() -> None:
+    config = replace(get_config(), ffmpeg_hwaccel="cuda")
+
+    def exploding(argv: Sequence[str]) -> Completed:
+        raise AssertionError(f"probed with {argv}")
+
+    choice = choose_decode(config, runner=exploding)
+    assert choice.flags == CUDA_FLAGS
+    assert choice.device == "cuda"
+
+
+def test_an_unknown_mode_is_refused_naming_the_valid_ones() -> None:
+    config = replace(get_config(), ffmpeg_hwaccel="nvdec")
+    with pytest.raises(InvalidRequestError) as caught:
+        choose_decode(config, runner=_answering(CUDA_BOX))
+    assert "auto" in str(caught.value.fix)
+
+
+# --- the flags in the commands -------------------------------------------------------------
+
+
+def test_every_decode_command_takes_the_flags_on_the_input_side() -> None:
+    """``-hwaccel`` is an input option: it must come before ``-i`` or ffmpeg refuses it."""
+    for argv in (
+        still_command("ffmpeg", "in.mp4", "out.jpg", 1.0, 1568, CUDA_FLAGS),
+        scene_command("ffmpeg", "in.mp4", 0.4, CUDA_FLAGS),
+        sample_command("ffmpeg", "in.mp4", "out.gray", 0.0, 5.0, 1.0, 96, 54, CUDA_FLAGS),
+    ):
+        assert argv.index("-hwaccel") < argv.index("-i")
+        assert argv[argv.index("-hwaccel") + 1] == "cuda"
+
+
+def test_without_the_flags_the_commands_are_the_software_ones() -> None:
+    assert "-hwaccel" not in still_command("ffmpeg", "in.mp4", "out.jpg", 1.0, 1568)
+    assert "-hwaccel" not in scene_command("ffmpeg", "in.mp4", 0.4)
+    assert "-hwaccel" not in sample_command("ffmpeg", "in.mp4", "out.gray", 0.0, 5.0, 1.0, 96, 54)
+
+
+# --- the routes carry the choice -----------------------------------------------------------
+
+
+def test_a_grab_on_a_cuda_box_decodes_with_the_flag_and_reports_the_device(
+    tmp_path: Path,
+) -> None:
+    calls: list[list[str]] = []
+
+    def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv, CUDA_BOX)
+        if probed is not None:
+            return probed
+        calls.append(list(argv))
+        write_jpeg(Path(argv[-1]), width=64, height=36)
+        return Completed(0, "")
+
+    written = video_ffmpeg.grab(tmp_path / "in.mp4", tmp_path / "out.jpg", 1.0, 1568, runner)
+
+    assert "-hwaccel" in calls[0]
+    assert written.decode == {"device": "cuda", "reason": None}
+
+
+def test_a_grab_on_a_boxwithout_cuda_reports_the_cpu_and_the_reason(tmp_path: Path) -> None:
+    def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv, ())
+        if probed is not None:
+            return probed
+        write_jpeg(Path(argv[-1]), width=64, height=36)
+        return Completed(0, "")
+
+    written = video_ffmpeg.grab(tmp_path / "in.mp4", tmp_path / "out.jpg", 1.0, 1568, runner)
+
+    assert written.decode["device"] == "cpu"
+    assert written.decode["reason"]
+
+
+def test_a_hardware_decode_that_fails_retries_in_software_and_reports_the_fallback(
+    tmp_path: Path,
+) -> None:
+    """NVDEC refuses codecs it does not know; the file may be fine. The retry must both
+    succeed and confess — a fallback the record does not carry is the G10 silence."""
+    calls: list[list[str]] = []
+
+    def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv, CUDA_BOX)
+        if probed is not None:
+            return probed
+        calls.append(list(argv))
+        if "-hwaccel" in argv:
+            return Completed(1, "No decoder surface left")
+        write_jpeg(Path(argv[-1]), width=64, height=36)
+        return Completed(0, "")
+
+    written = video_ffmpeg.grab(tmp_path / "in.mp4", tmp_path / "out.jpg", 1.0, 1568, runner)
+
+    assert len(calls) == 2
+    assert "-hwaccel" in calls[0] and "-hwaccel" not in calls[1]
+    assert written.decode["device"] == "cpu"
+    assert "retried" in written.decode["reason"]
+
+
+def test_a_forced_cuda_decode_that_fails_fails_rather_than_quietly_going_software(
+    tmp_path: Path,
+) -> None:
+    config = replace(get_config(), ffmpeg_hwaccel="cuda")
+    calls: list[list[str]] = []
+
+    def runner(argv: Sequence[str]) -> Completed:
+        calls.append(list(argv))
+        return Completed(1, "Cannot load nvcuda.dll")
+
+    with pytest.raises(FrameGrabError):
+        video_ffmpeg.grab(tmp_path / "in.mp4", tmp_path / "out.jpg", 1.0, 1568, runner, config)
+    assert len(calls) == 1
+
+
+def test_a_scan_and_a_sample_carry_the_same_report_shape(tmp_path: Path) -> None:
+    def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv, CUDA_BOX)
+        if probed is not None:
+            return probed
+        if "rawvideo" in argv:
+            Path(argv[-1]).write_bytes(bytes(96 * 54))
+        return Completed(0, "pts_time:1.0")
+
+    scanned = video_ffmpeg.scan(tmp_path / "in.mp4", 0.4, runner)
+    sampled = video_ffmpeg.sample(
+        tmp_path / "in.mp4", tmp_path / "o.gray", 0.0, 5.0, 1.0, 96, 54, runner
+    )
+
+    assert scanned.decode == {"device": "cuda", "reason": None}
+    assert sampled.decode == {"device": "cuda", "reason": None}

--- a/tests/test_hardware_decode.py
+++ b/tests/test_hardware_decode.py
@@ -209,6 +209,53 @@ def test_a_hardware_decode_that_fails_retries_in_software_and_reports_the_fallba
     assert "retried" in written.decode["reason"]
 
 
+def test_a_decode_ffmpeg_quietly_finished_in_software_is_reported_as_the_cpu(
+    tmp_path: Path,
+) -> None:
+    """ffmpeg's own fallback is the sneakiest one: NVDEC lacks the codec profile (this
+    box's 4:2:2 concert footage, live-measured 2026-08-14), ffmpeg warns on stderr,
+    decodes in software and exits 0 — so the exit-code retry never fires and the record
+    would claim a decode the card never did. The stderr line is the only witness."""
+    calls: list[list[str]] = []
+
+    def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv, CUDA_BOX)
+        if probed is not None:
+            return probed
+        calls.append(list(argv))
+        write_jpeg(Path(argv[-1]), width=64, height=36)
+        return Completed(
+            0,
+            "[hevc @ 0x1] Hardware is lacking required capabilities\n"
+            "[hevc @ 0x1] Failed setup for format cuda: hwaccel initialisation returned error.",
+        )
+
+    written = video_ffmpeg.grab(tmp_path / "in.mp4", tmp_path / "out.jpg", 1.0, 1568, runner)
+
+    assert len(calls) == 1, "the frames arrived — nothing to retry"
+    assert written.decode["device"] == "cpu"
+    assert written.decode["reason"] is not None and "codec" in written.decode["reason"]
+
+
+def test_even_a_forced_cuda_decode_confesses_ffmpegs_internal_fallback(
+    tmp_path: Path,
+) -> None:
+    """Forcing fails loudly on a broken decode, but an internal fallback still exits 0
+    with good frames — discarding them helps nobody, so the loudness is the record."""
+    config = replace(get_config(), ffmpeg_hwaccel="cuda")
+
+    def runner(argv: Sequence[str]) -> Completed:
+        write_jpeg(Path(argv[-1]), width=64, height=36)
+        return Completed(0, "[hevc @ 0x1] Failed setup for format cuda: nope.")
+
+    written = video_ffmpeg.grab(
+        tmp_path / "in.mp4", tmp_path / "out.jpg", 1.0, 1568, runner, config
+    )
+
+    assert written.decode["device"] == "cpu"
+    assert written.decode["reason"]
+
+
 def test_a_forced_cuda_decode_that_fails_fails_rather_than_quietly_going_software(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -26,6 +26,7 @@ import os
 import shutil
 import zlib
 from collections.abc import Iterator
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -42,6 +43,7 @@ from resolve_mcp.audio.stems import (
 )
 from resolve_mcp.config import get_config
 from resolve_mcp.errors import BinNotFoundError, FfmpegUnavailableError
+from resolve_mcp.ffmpeg import hwaccels
 from resolve_mcp.jobs import cache
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.naming import timestamped_name
@@ -76,6 +78,7 @@ from resolve_mcp.tools.timeline import (
 )
 from resolve_mcp.tools.titles import apply_titles, edit_title, list_titles
 from resolve_mcp.tools.video import detect_scene_cuts, grab_frames
+from resolve_mcp.video import ffmpeg as video_ffmpeg
 
 from . import otio
 from .fakes import write_wav
@@ -1196,6 +1199,30 @@ def test_a_real_frame_grab_lands_on_the_moment_resolve_numbers_it_at() -> None:
 
     again = grab_frames(footage["name"], [middle], bin=footage["bin"])
     assert again["cached"] is True, "unchanged media must be a cache hit"
+
+
+def test_nvdec_decodes_a_real_clip_on_this_box(tmp_path: Path) -> None:
+    """#202's live AC: the fakes prove the flag shaping, only a real decode proves NVDEC.
+
+    Forcing ``cuda`` disables the software retry, so a frame coming back here means the
+    hardware decoder itself produced it — an ffmpeg that ran ``-hwaccel cuda`` and quietly
+    decoded in software anyway would still pass, but that substitution is ffmpeg's
+    documented contract violation, not ours to test. A box whose ffmpeg lists no cuda
+    skips: degrading there is the design (``auto`` records the reason), not a failure.
+    """
+    try:
+        methods = hwaccels()
+    except FfmpegUnavailableError as unavailable:
+        pytest.skip(f"No ffmpeg to probe: {unavailable.cause}")
+    if "cuda" not in methods:
+        pytest.skip("this box's ffmpeg lists no cuda hwaccel")
+    source = write_hard_cut_clip(tmp_path / "resolve-mcp-nvdec.mp4")
+
+    forced = replace(get_config(), ffmpeg_hwaccel="cuda")
+    grabbed = video_ffmpeg.grab(source, tmp_path / "nvdec.jpg", 1.5, 1568, config=forced)
+
+    assert grabbed.path.exists() and grabbed.path.stat().st_size > 0
+    assert grabbed.decode == {"device": "cuda", "reason": None}
 
 
 def _sweep_scan_bin(pool: Any) -> None:

--- a/tests/test_scene_cuts.py
+++ b/tests/test_scene_cuts.py
@@ -34,6 +34,7 @@ from .fakes import (
     FakeResolve,
     ffmpeg_absent,
     ffmpeg_refusing,
+    hwaccel_probe_reply,
     media_pool,
     studio,
 )
@@ -346,6 +347,9 @@ def _finding(calls: list[Sequence[str]], seconds: Sequence[float]) -> Runner:
     """Replay the showinfo lines ffmpeg prints for the frames the select filter kept."""
 
     def runner(argv: Sequence[str]) -> Completed:
+        probed = hwaccel_probe_reply(argv)
+        if probed is not None:
+            return probed
         calls.append(list(argv))
         lines = [
             f"[Parsed_showinfo_1 @ 000001] n:{index:4d} pts:{int(one * 1000):8d} "

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -846,6 +846,21 @@ def test_a_separator_too_old_to_answer_still_reports_rather_than_failing() -> No
     assert "warning" in report
 
 
+def test_a_parsed_build_is_believed_even_when_the_probe_exits_nonzero() -> None:
+    """A CLI can print its env_info and still exit non-zero (a stray warning at teardown).
+    The build was seen — reporting it as *unknown* would swallow the +cpu warning AC 6
+    exists for, on exactly the runs where it matters."""
+
+    def grumbling(argv: Sequence[str], on_line: separator.Lines) -> int:
+        on_line("2026-01-01 00:00:00,000 - INFO - separator - PyTorch Version: 2.13.0+cpu")
+        return 1
+
+    report = separator.environment(runner=grumbling)
+
+    assert report["torch"] == "2.13.0+cpu"
+    assert "CPU build" in report["warning"]
+
+
 def test_a_missing_separator_fails_the_probe_by_name() -> None:
     with pytest.raises(SeparatorUnavailableError):
         separator.environment(runner=_absent)

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -41,7 +41,11 @@ from resolve_mcp.audio.stems import (
     separation_params,
 )
 from resolve_mcp.config import Config, get_config, set_config
-from resolve_mcp.errors import InvalidRequestError, StemSeparationError
+from resolve_mcp.errors import (
+    InvalidRequestError,
+    SeparatorUnavailableError,
+    StemSeparationError,
+)
 from resolve_mcp.ffmpeg import Completed as FfmpegCompleted
 from resolve_mcp.ffmpeg import Runner as FfmpegRunner
 from resolve_mcp.jobs import cache
@@ -807,3 +811,63 @@ def _copying() -> FfmpegRunner:
 
 def _absent(argv: Sequence[str], on_line: separator.Lines) -> int:
     raise FileNotFoundError(argv[0])
+
+
+# --- the torch build the separator runs on (#202) ----------------------------------------
+
+
+def test_the_environment_report_reads_the_torch_build_off_env_info() -> None:
+    fake = FakeSeparator(torch_build="2.13.0+cu126")
+
+    report = separator.environment(runner=fake)
+
+    assert report["torch"] == "2.13.0+cu126"
+    assert "warning" not in report
+    assert fake.probes == [[get_config().audio_separator, "--env_info"]]
+
+
+def test_a_cpu_torch_build_is_a_warning_naming_the_fix() -> None:
+    """G10's bug class: PATH picked a separator whose torch is the CPU wheel, and the only
+    symptom used to be that a forty-minute job took a day."""
+    report = separator.environment(runner=FakeSeparator(torch_build="2.13.0+cpu"))
+
+    assert report["torch"] == "2.13.0+cpu"
+    assert "CPU build" in report["warning"]
+    assert "RESOLVE_MCP_AUDIO_SEPARATOR" in report["warning"]
+
+
+def test_a_separator_too_old_to_answer_still_reports_rather_than_failing() -> None:
+    def mute(argv: Sequence[str], on_line: separator.Lines) -> int:
+        return 2
+
+    report = separator.environment(runner=mute)
+
+    assert report["torch"] is None
+    assert "warning" in report
+
+
+def test_a_missing_separator_fails_the_probe_by_name() -> None:
+    with pytest.raises(SeparatorUnavailableError):
+        separator.environment(runner=_absent)
+
+
+def test_a_fresh_separation_carries_the_torch_build_in_its_record(tmp_path: Path) -> None:
+    fake = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, torch_build="2.13.0+cpu")
+
+    output = multi_pass(_acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake)
+
+    assert output.result["separator"]["torch"] == "2.13.0+cpu"
+    assert "CPU build" in output.result["separator"]["warning"]
+
+
+def test_a_reused_separation_reports_no_environment_because_nothing_ran(
+    tmp_path: Path,
+    separating: FakeSeparator,
+) -> None:
+    audio = _acquired(tmp_path)
+    multi_pass(audio, {"scope": "timeline"}, _ignored, runner=separating)
+
+    output = multi_pass(audio, {"scope": "timeline"}, _ignored, runner=separating)
+
+    assert output.result["reused"] is True
+    assert "separator" not in output.result


### PR DESCRIPTION
Closes #202.

## What this is

Every compute path in `src/` audited for GPU use, and every CPU fallback made loud — the G10 rule ("a CPU fallback may happen, but never silently") wired through decode, analysis and separation:

- **`ffmpeg_hwaccel` config** (`auto`/`cuda`/`off`, env `RESOLVE_MCP_FFMPEG_HWACCEL`): `auto` probes `ffmpeg -hwaccels` once per process and passes `-hwaccel cuda` when listed; a cardless box degrades with the reason recorded. All three video decode routes (scene scan, occlusion sampling, frame grabs) carry a `decode` block in their catalogs/payloads.
- **Three fallback classes, all detected and recorded:** probe says no cuda (reason in record); hardware decode exits non-zero (one software retry, WARNING + reason); and ffmpeg's *internal* fallback — NVDEC lacks the codec profile, ffmpeg warns on stderr and exits 0 — sniffed off stderr and rewritten to `cpu` in the record. That third class is live on this box: Ada has no 4:2:2 decode, and the real concert footage is all 4:2:2 (benchmarks on the ticket).
- **Separator torch report:** `--env_info` probed before every fresh separation; build in the log and job record; `+cpu` build is a WARNING naming the fix. Live probe found the PATH separator on `2.13.0+cpu` — the G10 bug class, active now (install action recorded on the ticket).
- **torch policy:** beats/PANNs stay on the CPU deliberately (the corpus was measured on the CPU wheel); `analysis/device.py` announces the device per component and the music/structure records carry a `torch` note. Whisper announces its resolved device after model load.
- **Inventory:** `docs/reference/compute-device-inventory.md` — the full per-path table, the `auto` default's measured rationale, the corpus policy, the separator finding.

**Seams:** decisions in the fake tier (`test_hardware_decode.py`, `test_device.py`, extensions to config/stems/detached-jobs tests — command shaping, probe caching, fallback reporting, record carriage); the attach-adjacent reality in live smoke (`test_nvdec_decodes_a_real_clip_on_this_box`, forced-cuda grab, **passed on the RTX 4080 SUPER**, plus the decode-path subset re-run after the stderr-sniff change). Benchmarks (AC 3) recorded on #202.

## Review record

`/code-review` two-axis (Standards + Spec as parallel sub-agents), diff pinned to `origin/main` (f01857a).

**Standards** — no hard documented-standard violations. Judgement calls and resolutions:
- Decode report dict built three ways in `video/ffmpeg.py` → **fixed**: every cpu rewrite now goes through `Decode.report()`.
- `hwaccels()` buried the loop-invariant returncode check in a comprehension → **fixed**: hoisted.
- CONTEXT.md fixtures list missing `hwaccel_probe_reply` → **fixed**.
- Test-name typo (`boxwithout`) → **fixed**.
- Once-per-process announce/reset shape appears three times → **skipped**: three caches with different semantics (a result cache and two log-once sets) in two layers; a shared helper is churn for ~6 lines.
- `Grabbed`/`Sampled` structurally identical; torch-note hunk repeated in music/structure → **skipped**: reviewer noted both as readability-defensible.

**Spec** — live/benchmark ACs satisfied by the ticket comments; corpus decision documented and left to the human. Findings and resolutions:
- Separator wrong-warning path: a parsed build on a non-zero `--env_info` exit was reported *unknown*, swallowing the `+cpu` warning exactly where it matters → **fixed** (with a fake-tier test).
- Failed `-hwaccels` probe cached for the process but never logged at probe time → **fixed**: WARNING with the exit code.
- Gauntlet `ab_pack` decodes not named in the inventory → **fixed**: recorded as deliberately out of scope (dev-only tool, attended runs); `video/framing.py` (#184) not on this branch, takes its own row when it lands.
- Inventory DSP row didn't name `correlate` → **fixed**.

Fix diff re-checked focused (no second full pass): fake tier 1971 passed, mypy strict clean (185 files), ruff clean.

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Post-open commit (CI fix): CI's mypy runs without the analysis extra and could not resolve `analysis/device.py`'s guarded `import torch`; added `torch.*` to the existing `ignore_missing_imports` override beside `faster_whisper`/`scipy` — the same unresolvable-extra class that override exists for. torch ships real types, so boxes with the extra still typecheck it fully. Three-line config diff, re-checked focused; local mypy strict clean.

Review: clean
