### PR TITLE
Point G18 at its proving round

### DIFF
--- a/gauntlet/GAPS.md
+++ b/gauntlet/GAPS.md
@@ -368,8 +368,11 @@ keep their spread with no orphan flashes; what raises it is unequal
 holds, a reframe or push-in where the footage has one, a scale change)
 + server (`gears.quiet_floor` finds the passages off a smoothed level
 curve and reports `cv_less_orphans` / `reads_locked`, a blocker in
-`docs/agents/concert.md`). **Open until a full-song build passes it** —
-the measurement and the rule exist, the proving round does not.
+`docs/agents/concert.md`), merged as PR #198. **Open until a full-song
+build passes it — #206 is that round.** The measurement and the rule
+exist; the proving round does not. Both constants the check leans on
+(the 0.65 floor, the 0.5× orphan fraction) are one song wide and
+provisional — #191 tracks graduating or moving them.
 
 ## Round record
 


### PR DESCRIPTION
Three lines of prose in `gauntlet/GAPS.md`, closing the loop left open when #190's build half merged.

G18 said "Open until a full-song build passes it" with nothing behind it. Now it names the round (#206), records that the fix merged (PR #198), and says out loud that the 0.65 floor and the 0.5× orphan fraction are one song wide with #191 tracking them.

Why bother: the gap ledger is the one place a later session reads to find out what is still unproven. As written it could be read as "rule shipped, gap handled" — the rule shipped, the gap did not.

Review: clean — prose only, single-pass
