### PR TITLE
Harden four dormant build-path risks (#186)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -181,8 +181,10 @@ unreadable-WAV error).
 
 `cut/` — cut-file schema v1: `document` (read off disk), `schema`
 (verbatim, served by `get_cut_schema`), `validate` (12 errors + W1, W2,
-W8 — W3-W7 are `virtual_transcript`'s over the same document — shared by
-dry run and build pre-flight), `tail` (the optional **tail** device: one
+W8, W9 — W3-W7 are `virtual_transcript`'s over the same document — shared by
+dry run and build pre-flight; W9 is the one that reports a rule that *could
+not run*, where Resolve named no media bounds for E5 or E7 to check a range
+against, #186), `tail` (the optional **tail** device: one
 reading of `{type, duration_frames, audio_fade_frames}` for both the rules
 and the build). A `segments` entry is a shot or a **gap**
 (`{"id", "gap": <frames>}`, literal black); `is_gap`/`entry_duration`/

--- a/src/resolve_mcp/cut/schema.py
+++ b/src/resolve_mcp/cut/schema.py
@@ -193,7 +193,9 @@ project, named, and the error says so."""
 _RULES: Final = """\
 ## 7. Validation
 
-12 hard errors (E1-E12) block a build; 3 warnings (W1, W2, W8) never do. W3-W7 are
+12 hard errors (E1-E12) block a build; 4 warnings (W1, W2, W8, W9) never do. W9 is the
+one that says a rule *could not run*: Resolve reported no media bounds for that clip, so
+the range was never checked against them. W3-W7 are
 `virtual_transcript`'s and describe the same cut file — one document, one numbering.
 The list is identical in the `validate_cut` dry run and `build_timeline`'s pre-flight,
 and a failing file aborts before Resolve is touched. Every finding is

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -1,4 +1,4 @@
-"""The cut-file validation rules: 12 hard errors, 3 warnings, one implementation.
+"""The cut-file validation rules: 12 hard errors, 4 warnings, one implementation.
 
 The list is identical in the ``validate_cut`` dry run and in ``build_timeline``'s
 pre-flight, so it lives here once and both call it. A failing file must abort before
@@ -12,8 +12,9 @@ Two passes, because they need different things:
   W8). W3-W7 are
   ``virtual_transcript``'s over this same document — one file, one numbering.
 * :func:`validate_project` takes clip facts already gathered from the media pool and
-  answers everything about the media behind the aliases (E4-E7). It is a pure function
-  over those facts, so every rule in this file is unit-testable without Resolve.
+  answers everything about the media behind the aliases (E4-E7, and W9 where a bounds
+  check could not run). It is a pure function over those facts, so every rule in this
+  file is unit-testable without Resolve.
 
 E11 is the build-time rule — a locked target track fails *silently* in the Resolve API,
 so the build checks it and reports it in the same shape as everything else.
@@ -73,6 +74,7 @@ RULE_DESCRIPTIONS: Final[dict[str, str]] = {
     "W1": "segment or gap shorter than min_segment_frames (flash-frame guard)",
     "W2": "V1 total does not match the master-audio span",
     "W8": "the cut ends on black that nothing runs under, so it materialises as nothing",
+    "W9": "a range could not be checked against its clip's media bounds (E5/E7 failed open)",
 }
 
 _FIX_HINTS: Final[dict[str, str]] = {
@@ -95,6 +97,8 @@ _FIX_HINTS: Final[dict[str, str]] = {
     "W2": "Expected when the cut opens cold or runs past the mix; otherwise check the ends.",
     "W8": "Anchor an overlay over the trailing gap, or let the master mix run past the "
     "last picture — either makes the black real. Otherwise drop the gap.",
+    "W9": "Call inspect_clip: if the bounds are blank there too, relink or re-import the "
+    "clip so the range can be checked before the build reaches Resolve.",
 }
 
 
@@ -1145,7 +1149,7 @@ def resolve_aliases(
 
 
 def _bounds_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[Finding]:
-    """E5: every range has to name frames the media actually has."""
+    """E5: every range has to name frames the media actually has — or W9 where it cannot be said."""
     findings: list[Finding] = []
     for segment in shots(doc):
         id = str(segment["id"])
@@ -1160,6 +1164,11 @@ def _bounds_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[
     return findings
 
 
+def _bounds_unknown(clip: ClipFacts) -> bool:
+    """Whether Resolve reported enough of the clip's extent for a range check to mean anything."""
+    return clip.start is None or clip.end_exclusive is None
+
+
 def _outside_media(item: dict[str, Any], clip: ClipFacts) -> bool:
     """Whether a half-open range asks for frames the clip's media does not have.
 
@@ -1167,7 +1176,7 @@ def _outside_media(item: dict[str, Any], clip: ClipFacts) -> bool:
     check fails open — the same stance E7's has-audio leg takes on an unreported
     channel count, because "Resolve did not say" is not evidence of an overrun.
     """
-    if clip.start is None or clip.end_exclusive is None:
+    if _bounds_unknown(clip):
         return False
     return bool(item["in"] < clip.start or item["out"] > clip.end_exclusive)
 
@@ -1176,6 +1185,13 @@ def _overrun_message(item: dict[str, Any], clip: ClipFacts, subject: str) -> str
     return (
         f"{subject} asks for frames {item['in']}-{item['out']} of {clip.name!r}, whose "
         f"media runs {clip.start}-{clip.end_exclusive}."
+    )
+
+
+def _unverifiable_message(item: dict[str, Any], clip: ClipFacts, subject: str) -> str:
+    return (
+        f"{subject} asks for frames {item['in']}-{item['out']} of {clip.name!r}, whose media "
+        f"bounds Resolve does not report, so nothing checked the range against them."
     )
 
 
@@ -1192,6 +1208,11 @@ def _bounds_error(
         # A still has one frame of media and any duration on a timeline — the
         # end-frame workaround is what makes that exact. Bounds do not apply.
         return []
+    if _bounds_unknown(clip):
+        # Failing open is right — an unreported extent is not an overrun — but a check
+        # that passed because it could not run is not the same answer as one that ran,
+        # and silence made them look alike. W9 is that difference, said out loud (#186).
+        return [_finding("W9", id, _unverifiable_message(item, clip, subject))]
     if not _outside_media(item, clip):
         return []
     return [_finding("E5", id, _overrun_message(item, clip, subject))]
@@ -1240,7 +1261,13 @@ def _audio_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[F
         findings.append(
             _finding("E7", None, f"The audio source {alias!r} ({clip.name}) has no audio.")
         )
-    if _outside_media(audio, clip):
+    if _bounds_unknown(clip):
+        # The mix is the one clip a whole cut is laid over, and the bounds leg fails open on
+        # it exactly as E5's does — so it gets the same W9 rather than a quieter silence.
+        findings.append(
+            _finding("W9", None, _unverifiable_message(audio, clip, "The audio block"))
+        )
+    elif _outside_media(audio, clip):
         findings.append(_finding("E7", None, _overrun_message(audio, clip, "The audio block")))
     return findings
 

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -1172,9 +1172,10 @@ def _bounds_unknown(clip: ClipFacts) -> bool:
 def _outside_media(item: dict[str, Any], clip: ClipFacts) -> bool:
     """Whether a half-open range asks for frames the clip's media does not have.
 
-    Unknown bounds cannot convict: when Resolve never reported the clip's extent the
-    check fails open — the same stance E7's has-audio leg takes on an unreported
-    channel count, because "Resolve did not say" is not evidence of an overrun.
+    Only answerable against bounds Resolve reported. What to do when it reported none is
+    not this function's call any more — both callers ask :func:`_bounds_unknown` first and
+    raise W9 — so the guard below is a precondition rather than a decision: unknown bounds
+    still cannot convict, and reaching here with them is a caller that forgot to ask.
     """
     if _bounds_unknown(clip):
         return False

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -31,7 +31,11 @@ found it full of silent failures. Everything in this file exists to make one gua
   TimelineItems and places nothing; an append that overlaps existing media slides to the
   next free frame and reports success; a still ignores ``endFrame`` until an out point has
   been written to it once. So tracks are checked for locks before the append, stills are
-  unlocked before it, and every placement is read back off the track afterwards.
+  unlocked before it, and afterwards every placement is read back off the track *and* every
+  shot's source frames off the item — a shot on the right frame for the right length out of
+  the wrong part of its clip is a cut no return value tells apart from the one asked for.
+  The one thing the return value does say is how many items Resolve made, and fewer than
+  were asked for is counted as shots that were never placed.
 * **Record frames are absolute.** ``recordFrame`` counts from the timeline's own start
   (an hour of timecode on a normal project) and is not clamped — a cut frame of 0 would
   land before the timeline begins. Every position is the timeline start plus the cut
@@ -125,6 +129,10 @@ class Shot:
     source_in: int
     record: int
     duration: int
+    is_still: bool = False
+    """A still plays one frame of media for any duration, so it has no source frame to read
+    back: ``GetLeftOffset`` on one answers with the timeline's clock (ADR 0005). Carried here
+    because the read-back has to skip exactly the clips E5's bounds rule already exempts."""
 
     @property
     def source_out(self) -> int:
@@ -173,7 +181,7 @@ def build_timeline(
     superseded = latest_version(base, existing)
     name = next_version_name(base, existing)
     clips = cut.clips_by_alias(checked)
-    _unlock_stills(clips)
+    stills = _read_sources(clips)
 
     # A cut whose tail has something to cut in is appended to a staging timeline and
     # round-tripped into its own name, because the scripting API cannot cut a transition
@@ -190,11 +198,12 @@ def build_timeline(
     # round-tripped build reads its placements back on a *second* timeline, whose own start
     # is Resolve's to choose, and the comparison there is offset against offset.
     origin = timeline_read.start_frame(built)
-    shots = _shots(doc, clips, origin)
+    reader = timeline_read.Reader(connection)
+    shots = _shots(doc, clips, origin, stills)
     _make_tracks(built, shots, writing)
     _refuse_locked_tracks(built, shots, writing)
     _append(pool, shots, writing)
-    _verify(built, shots, writing, origin)
+    _verify(reader, built, shots, writing, origin)
     applied: dict[str, Any] | None = None
     if tail is not None and round_tripped:
         # Before takes: the round trip makes a new timeline, and a selector attached to the
@@ -209,7 +218,7 @@ def build_timeline(
             writing,
             name,
             tail,
-            verify=lambda landed: _verify(landed, shots, name, origin),
+            verify=lambda landed: _verify(reader, landed, shots, name, origin),
         )
     elif tail is not None:
         # Nothing was injected and nothing was round-tripped, but the cut file did ask for a
@@ -410,7 +419,12 @@ def _write_entry(marker: dict[str, Any], shift: int) -> dict[str, Any]:
 # --- placement ------------------------------------------------------------------------------
 
 
-def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int) -> list[Shot]:
+def _shots(
+    doc: dict[str, Any],
+    clips: dict[str, media.LocatedClip],
+    start: int,
+    stills: frozenset[int],
+) -> list[Shot]:
     """Every append the cut asks for, positioned absolutely from the timeline start."""
     placed = placements(doc, start)
     shots = []
@@ -430,6 +444,7 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
                 source_in=int(segment["in"]),
                 record=record,
                 duration=duration,
+                stills=stills,
             )
         )
     anchored = overlay_positions(doc)
@@ -446,6 +461,7 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
                 source_in=int(overlay["in"]),
                 record=start + offset,
                 duration=duration,
+                stills=stills,
             )
         )
     audio = doc.get("audio")
@@ -460,6 +476,7 @@ def _shots(doc: dict[str, Any], clips: dict[str, media.LocatedClip], start: int)
                 source_in=int(audio["in"]),
                 record=start,
                 duration=int(audio["out"]) - int(audio["in"]),
+                stills=stills,
             )
         )
     return shots
@@ -472,6 +489,7 @@ def _shot(
     source_in: int,
     record: int,
     duration: int,
+    stills: frozenset[int],
 ) -> Shot:
     return Shot(
         id=id,
@@ -481,6 +499,7 @@ def _shot(
         source_in=source_in,
         record=record,
         duration=duration,
+        is_still=_handle(located.clip) in stills,
     )
 
 
@@ -623,30 +642,93 @@ def _refuse_locked_tracks(timeline: Timeline, shots: list[Shot], name: str) -> N
     )
 
 
-def _unlock_stills(clips: dict[str, media.LocatedClip]) -> None:
-    """Write each still's out point once, so its ``endFrame`` is honoured exactly (#18 (a))."""
+def _handle(clip: Clip) -> int:
+    """A clip's handle identity. Two aliases on one clip are the same object, and Resolve's
+    handles define no equality of their own, so identity is the only key that groups them."""
+    return id(clip)
+
+
+def _read_sources(clips: dict[str, media.LocatedClip]) -> frozenset[int]:
+    """Read every source clip once, before the append: the one place its properties are needed.
+
+    Two things come out of the read. Each still gets its out point written, so its
+    ``endFrame`` is honoured exactly (#18 (a)) — and the stills are named, because they are
+    the clips whose source frames cannot be read back off the timeline (ADR 0005).
+
+    A clip whose media does not start at frame 0 is logged. Nothing here rebases on it: the
+    cut file's ranges are absolute media frames — the space ``Start`` and ``End`` report and
+    E5 checks against — and ``startFrame`` is sent in that same space. Whether Resolve reads
+    it that way on a start-stamped clip has never been measured, because every clip the
+    pillar has built from starts at 0. So the assumption is not silently held: the read-back
+    in :func:`_verify` proves it per shot, and this line is what a live log needs to say
+    which project was the one that could have broken it.
+    """
+    stills: set[int] = set()
     seen: set[int] = set()
     for located in clips.values():
-        if id(located.clip) in seen:
+        if _handle(located.clip) in seen:
             continue
-        seen.add(id(located.clip))
-        if media.apply_still_workaround(located.clip, media.properties(located.clip)):
+        seen.add(_handle(located.clip))
+        reported = media.properties(located.clip)
+        start, _ = media.frame_bounds(reported)
+        if start:
+            log.info(
+                "%s counts its own frames from %d, not 0; source frames are read back per shot",
+                located.clip.GetName(),
+                start,
+            )
+        if not media.is_still(reported):
+            continue
+        stills.add(_handle(located.clip))
+        if media.apply_still_workaround(located.clip, reported):
             log.info("Unlocked exact durations on the still %s", located.clip.GetName())
+    return frozenset(stills)
 
 
 def _append(pool: Pool, shots: list[Shot], name: str) -> None:
-    """One call for the whole cut. Its return value is counted, never believed."""
+    """One call for the whole cut. Its return value is counted, never believed.
+
+    Counted, though — a short answer is the one thing the return value does say. Resolve
+    hands back the items it made, so fewer than were asked for means shots it did not make,
+    and the placement read-back that follows would report them as misplaced without ever
+    saying they were never attempted. More is not the same evidence and is not treated as
+    any: Resolve spreads a multi-channel clip over one item per track it fills, so an answer
+    longer than the request is an ordinary mix, not a drop.
+    """
     appended = pool.AppendToTimeline([shot.clip_info() for shot in shots])
     if not appended:
         raise BuildFailedError(
             cause=f"Resolve appended nothing to {name!r}.",
             detail={"timeline": name, "clips": len(shots)},
         )
+    if len(appended) < len(shots):
+        log.error(
+            "Appended %d clips to %s; Resolve made only %d", len(shots), name, len(appended)
+        )
+        raise BuildFailedError(
+            cause=f"Resolve made {len(appended)} timeline item(s) for the {len(shots)} clip(s) "
+            f"the cut appends to {name!r}, so part of the cut was never placed.",
+            fix="Delete the timeline it made, check that every source is online and that no "
+            "target track is locked, and build again.",
+            detail={"timeline": name, "clips": len(shots), "appended": len(appended)},
+        )
     log.info("Appended %d clips to %s; Resolve returned %d", len(shots), name, len(appended))
 
 
-def _verify(timeline: Timeline, shots: list[Shot], name: str, origin: int) -> None:
+def _verify(
+    reader: timeline_read.Reader,
+    timeline: Timeline,
+    shots: list[Shot],
+    name: str,
+    origin: int,
+) -> None:
     """Read the tracks back: the only way to know an append landed where it was told to.
+
+    Two questions, and a shot has to answer both. *Where* it landed comes off the track as
+    an offset and a duration. *What it plays* comes off the item itself — the frames of its
+    own media it begins on — because a shot placed on the right frame for the right length
+    out of the wrong part of the clip is a cut nothing in the return value distinguishes
+    from the one that was asked for. The build's own bookkeeping cannot answer either.
 
     ``origin`` is the timeline start the shots were positioned against. Placement is judged
     as an offset from each timeline's own first frame, never as an absolute frame, because
@@ -665,43 +747,97 @@ def _verify(timeline: Timeline, shots: list[Shot], name: str, origin: int) -> No
             landed_origin,
             origin,
         )
-    misplaced = [
-        shot
-        for track in _tracks(shots)
-        for shot in _adrift(timeline, shots, track, origin, landed_origin)
-    ]
-    if not misplaced:
+    placed = {
+        track: _landed(timeline, track, landed_origin) for track in _tracks(shots)
+    }
+    misplaced = [shot for shot in shots if _key(shot, origin) not in placed[shot.track]]
+    if misplaced:
+        log.error(
+            "%d of %d clips did not land where %s puts them", len(misplaced), len(shots), name
+        )
+        raise BuildFailedError(
+            cause=f"{len(misplaced)} of {len(shots)} clips did not land where the cut puts them "
+            f"in {name!r}, so the timeline does not match the cut file.",
+            fix="Resolve slides an append that overlaps existing media and drops one onto a "
+            "track it cannot reach, both while reporting success. Delete the timeline it made, "
+            "check the cut file's ranges, and build again.",
+            detail={
+                "timeline": name,
+                "misplaced": [_expected(shot) for shot in misplaced[:MISPLACED_CAP]],
+                "misplaced_total": len(misplaced),
+            },
+        )
+    drifted = _wrong_source(reader, shots, placed, origin)
+    if not drifted:
         return
+    log.error("%d of %d clips in %s play the wrong source frames", len(drifted), len(shots), name)
     raise BuildFailedError(
-        cause=f"{len(misplaced)} of {len(shots)} clips did not land where the cut puts them in "
-        f"{name!r}, so the timeline does not match the cut file.",
-        fix="Resolve slides an append that overlaps existing media and drops one onto a track "
-        "it cannot reach, both while reporting success. Delete the timeline it made, check "
-        "the cut file's ranges, and build again.",
+        cause=f"{len(drifted)} of {len(shots)} clips in {name!r} landed on source frames the "
+        f"cut file did not ask for, so the timeline holds the wrong footage.",
+        fix="The cut file's in and out points are frames of the clip's own media, counted the "
+        "way inspect_clip reports its bounds. Delete the timeline it made, check those bounds "
+        "against the ranges, and build again.",
         detail={
             "timeline": name,
-            "misplaced": [_expected(shot) for shot in misplaced[:MISPLACED_CAP]],
-            "misplaced_total": len(misplaced),
+            "wrong_source": [
+                {**_expected(shot), "source_frame": shot.source_in, "landed_on": landed}
+                for shot, landed in drifted[:MISPLACED_CAP]
+            ],
+            "wrong_source_total": len(drifted),
         },
     )
 
 
-def _adrift(
-    timeline: Timeline,
-    shots: list[Shot],
-    track: Track,
-    origin: int,
-    landed_origin: int,
-) -> list[Shot]:
-    """The shots this track does not hold, matched on ``(offset from start, duration)``."""
-    wanted = [shot for shot in shots if shot.track == track]
-    if not wanted:
-        return []
-    landed = {
-        (item.GetStart() - landed_origin, item.GetDuration())
+def _key(shot: Shot, origin: int) -> tuple[int, int]:
+    """How a shot is found on the track it was appended to: where it starts, and how long."""
+    return (shot.record - origin, shot.duration)
+
+
+def _landed(timeline: Timeline, track: Track, landed_origin: int) -> dict[tuple[int, int], Any]:
+    """Everything this track holds, keyed the way a shot is looked up.
+
+    Positions repeat only where Resolve spread one clip over several items at the same
+    offset — a multi-channel mix — and those items play the same frames, so keeping the
+    last is keeping one of a set of equals.
+    """
+    return {
+        (item.GetStart() - landed_origin, item.GetDuration()): item
         for item in timeline.GetItemListInTrack(track.type, track.index) or []
     }
-    return [shot for shot in wanted if (shot.record - origin, shot.duration) not in landed]
+
+
+def _wrong_source(
+    reader: timeline_read.Reader,
+    shots: list[Shot],
+    placed: dict[Track, dict[tuple[int, int], Any]],
+    origin: int,
+) -> list[tuple[Shot, int]]:
+    """Every shot that plays frames the cut file did not name, with the frame it begins on.
+
+    Stills are exempt for the same reason E5's bounds rule exempts them: one frame of media
+    held for any duration has no in point to read, and its left offset answers with the
+    timeline's clock instead (ADR 0005). A shot whose source frame Resolve will not report
+    is logged rather than convicted — an unreadable getter is not a wrong placement — and
+    the comparison allows the one frame of slip that ADR measured, so the guard fires on a
+    cut that is playing the wrong part of a clip and never on a getter's rounding.
+    """
+    drifted: list[tuple[Shot, int]] = []
+    for shot in shots:
+        if shot.is_still:
+            continue
+        item = placed[shot.track].get(_key(shot, origin))
+        landed, _ = timeline_read.source_bounds(reader, item, shot.duration)
+        if landed is None:
+            log.info(
+                "%s on %s reports no source frame, so the cut's %d could not be confirmed",
+                shot.id,
+                shot.track.label,
+                shot.source_in,
+            )
+            continue
+        if abs(landed - shot.source_in) > timeline_read.SOURCE_SLIP:
+            drifted.append((shot, landed))
+    return drifted
 
 
 def _expected(shot: Shot) -> dict[str, Any]:

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -69,9 +69,18 @@ from .session import frame_rate
 log = get_logger("build")
 
 Clip = Any
+Item = Any
 Pool = Any
 Project = Any
 Timeline = Any
+
+Stills = frozenset[int]
+"""Which source clips are single-frame media, by handle identity.
+
+Resolve's handles define no equality of their own and two aliases can name one clip, so
+identity is what groups them. Read once before the append (:func:`_prepare_sources`) and
+carried on each :class:`Shot`, because the source read-back has to skip exactly the clips
+E5's bounds rule already exempts."""
 
 MEDIA_TYPES: Final[dict[str, int]] = {"video": 1, "audio": 2}
 """Resolve's ``mediaType``: 1 appends video only, 2 audio only. Never omitted."""
@@ -82,8 +91,12 @@ TRACK_PREFIXES: Final[dict[str, str]] = {"video": "V", "audio": "A"}
 AUDIO_TRACK_TYPE: Final = "stereo"
 """What a master mix is. ``AddTrack`` defaults to mono, which would fold a stereo mix."""
 
-MISPLACED_CAP: Final = 20
-"""A drifted build misplaces everything downstream of the blockage; the count says how many."""
+REPORTED_SHOT_CAP: Final = 20
+"""How many bad shots a build failure lists before it only counts them.
+
+One blockage misplaces everything downstream of it, and one misread of ``startFrame`` moves
+every shot off the same clip, so either list runs to the length of the cut. Both are capped
+here and both carry their own total beside the list."""
 
 REFUSED_MARKER_CAP: Final = 20
 """Carried markers that would not land are listed, not just counted — up to this many."""
@@ -181,7 +194,7 @@ def build_timeline(
     superseded = latest_version(base, existing)
     name = next_version_name(base, existing)
     clips = cut.clips_by_alias(checked)
-    stills = _read_sources(clips)
+    stills = _prepare_sources(clips)
 
     # A cut whose tail has something to cut in is appended to a staging timeline and
     # round-tripped into its own name, because the scripting API cannot cut a transition
@@ -423,7 +436,7 @@ def _shots(
     doc: dict[str, Any],
     clips: dict[str, media.LocatedClip],
     start: int,
-    stills: frozenset[int],
+    stills: Stills,
 ) -> list[Shot]:
     """Every append the cut asks for, positioned absolutely from the timeline start."""
     placed = placements(doc, start)
@@ -489,7 +502,7 @@ def _shot(
     source_in: int,
     record: int,
     duration: int,
-    stills: frozenset[int],
+    stills: Stills,
 ) -> Shot:
     return Shot(
         id=id,
@@ -648,12 +661,14 @@ def _handle(clip: Clip) -> int:
     return id(clip)
 
 
-def _read_sources(clips: dict[str, media.LocatedClip]) -> frozenset[int]:
-    """Read every source clip once, before the append: the one place its properties are needed.
+def _prepare_sources(clips: dict[str, media.LocatedClip]) -> Stills:
+    """Get every source clip ready to be appended, and answer with the stills among them.
 
-    Two things come out of the read. Each still gets its out point written, so its
-    ``endFrame`` is honoured exactly (#18 (a)) — and the stills are named, because they are
-    the clips whose source frames cannot be read back off the timeline (ADR 0005).
+    One pass, because each clip's properties are a round trip to Resolve and there is
+    nothing to be gained by making two. Each still gets its out point written, so its
+    ``endFrame`` is honoured exactly (#18 (a)) — and the stills are the return value,
+    because they are the clips whose source frames cannot be read back off the timeline
+    (ADR 0005).
 
     A clip whose media does not start at frame 0 is logged. Nothing here rebases on it: the
     cut file's ranges are absolute media frames — the space ``Start`` and ``End`` report and
@@ -763,7 +778,7 @@ def _verify(
             "check the cut file's ranges, and build again.",
             detail={
                 "timeline": name,
-                "misplaced": [_expected(shot) for shot in misplaced[:MISPLACED_CAP]],
+                "misplaced": [_expected(shot) for shot in misplaced[:REPORTED_SHOT_CAP]],
                 "misplaced_total": len(misplaced),
             },
         )
@@ -775,13 +790,15 @@ def _verify(
         cause=f"{len(drifted)} of {len(shots)} clips in {name!r} landed on source frames the "
         f"cut file did not ask for, so the timeline holds the wrong footage.",
         fix="The cut file's in and out points are frames of the clip's own media, counted the "
-        "way inspect_clip reports its bounds. Delete the timeline it made, check those bounds "
-        "against the ranges, and build again.",
+        "way inspect_clip reports its bounds. Delete the timeline it made and compare the two "
+        "numbers below: where the landed frame is the one asked for plus the clip's own start, "
+        "Resolve is counting from that stamp rather than from zero, the ranges are not the "
+        "thing to change, and the build log names the clip that carries the stamp.",
         detail={
             "timeline": name,
             "wrong_source": [
                 {**_expected(shot), "source_frame": shot.source_in, "landed_on": landed}
-                for shot, landed in drifted[:MISPLACED_CAP]
+                for shot, landed in drifted[:REPORTED_SHOT_CAP]
             ],
             "wrong_source_total": len(drifted),
         },
@@ -793,7 +810,7 @@ def _key(shot: Shot, origin: int) -> tuple[int, int]:
     return (shot.record - origin, shot.duration)
 
 
-def _landed(timeline: Timeline, track: Track, landed_origin: int) -> dict[tuple[int, int], Any]:
+def _landed(timeline: Timeline, track: Track, landed_origin: int) -> dict[tuple[int, int], Item]:
     """Everything this track holds, keyed the way a shot is looked up.
 
     Positions repeat only where Resolve spread one clip over several items at the same
@@ -809,7 +826,7 @@ def _landed(timeline: Timeline, track: Track, landed_origin: int) -> dict[tuple[
 def _wrong_source(
     reader: timeline_read.Reader,
     shots: list[Shot],
-    placed: dict[Track, dict[tuple[int, int], Any]],
+    placed: dict[Track, dict[tuple[int, int], Item]],
     origin: int,
 ) -> list[tuple[Shot, int]]:
     """Every shot that plays frames the cut file did not name, with the frame it begins on.

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -158,6 +158,12 @@ def _facts(bin_path: str, clip: Clip, timeline_fps: float) -> ClipFacts:
     # The timeline's rate is what the Duration fallback counts at: an audio-only clip
     # reports no Start/End/Frames and no rate of its own (#46), only a Duration timecode.
     start, out = media.frame_bounds(reported, fps=timeline_fps)
+    if start is None or out is None:
+        # The condition W9 reports to the agent, said once here as well: the warning rides
+        # in a result the agent may or may not read back, and a build that went wrong over a
+        # range nothing checked is diagnosed from the log or not at all (#186).
+        log.info("No usable media bounds on %s (%s-%s); E5 and E7 cannot check a range "
+                 "against them", name, start, out)
     channels = media.audio_channels(reported)
     if channels is None:
         # E7's has-audio leg reads an undocumented property key. If Resolve renames it

--- a/tests/fakes/pool.py
+++ b/tests/fakes/pool.py
@@ -82,6 +82,11 @@ class FakeMediaPool:
         # places every shot as far past its in point as the media's start stamp is from
         # zero while reporting a perfectly ordinary success.
         self.rebases_source_frames = False
+        # ``GetLeftOffset`` answering with how far into the media the shot begins rather
+        # than the absolute frame it plays. The two are the same number on a clip that
+        # starts at 0, which is all ADR 0005 could measure, so both readings are modelled
+        # and the source read-back has to survive either.
+        self.reports_relative_left_offset = False
         self.appends_share_one_comp = False
         self.appends_land_nowhere = False
         self.created_timelines: list[str] = []
@@ -413,6 +418,12 @@ class FakeMediaPool:
             # The span is still the one that was asked for; only where it begins moves,
             # which is what makes the drift invisible to a check that reads durations.
             source_start += _clip_start(clip)
+        # Which frame ``GetLeftOffset`` answers with is the other half of the same unknown:
+        # how far into the media the shot begins, or the absolute frame it plays. ADR 0005
+        # measured it on media starting at 0, where the two readings are the same number.
+        left_offset = None
+        if self.reports_relative_left_offset:
+            left_offset = source_start - _clip_start(clip)
         media_type = info.get("mediaType")
         track_type = "audio" if media_type == AUDIO_TYPE else "video"
         index = int(info.get("trackIndex", 1))
@@ -429,6 +440,7 @@ class FakeMediaPool:
             record,
             duration,
             source_start=source_start,
+            left_offset=left_offset,
             media_item=clip,
             comps=comps,
             owner=self._owner,

--- a/tests/fakes/pool.py
+++ b/tests/fakes/pool.py
@@ -74,6 +74,14 @@ class FakeMediaPool:
         self.take_quirks: dict[str, Any] = {}
         self.append_calls: list[list[dict[str, Any]]] = []
         self.append_result: list[FakeTimelineItem] | None = None
+        # ``startFrame`` read as an offset from the clip's own ``Start`` rather than as an
+        # absolute media frame. Which reading Resolve takes is unmeasured: every clip the
+        # pillar has built from reports ``Start = 0``, where the two coincide, so the
+        # difference has never shown. The build sends absolute frames — the space ``Start``
+        # and ``End`` report and E5 checks against — and this is the other reading, which
+        # places every shot as far past its in point as the media's start stamp is from
+        # zero while reporting a perfectly ordinary success.
+        self.rebases_source_frames = False
         self.appends_share_one_comp = False
         self.appends_land_nowhere = False
         self.created_timelines: list[str] = []
@@ -401,6 +409,10 @@ class FakeMediaPool:
         clip: FakeMediaPoolItem = info["mediaPoolItem"]
         source_start = int(info.get("startFrame", 0))
         duration = _appended_duration(clip, source_start, info.get("endFrame"))
+        if self.rebases_source_frames:
+            # The span is still the one that was asked for; only where it begins moves,
+            # which is what makes the drift invisible to a check that reads durations.
+            source_start += _clip_start(clip)
         media_type = info.get("mediaType")
         track_type = "audio" if media_type == AUDIO_TYPE else "video"
         index = int(info.get("trackIndex", 1))
@@ -458,6 +470,18 @@ class FakeMediaPool:
         for sub in folder.subfolders:
             found.extend(self._walk(sub))
         return found
+
+
+def _clip_start(clip: FakeMediaPoolItem) -> int:
+    """The first frame of the clip's own media — zero on everything without a start stamp.
+
+    Resolve answers with a string, and with an empty one on media that carries no stamp at
+    all (audio, #46), so anything that is not a number reads as no stamp.
+    """
+    reported = clip.GetClipProperty("Start")
+    if not isinstance(reported, str) or not reported.isdigit():
+        return 0
+    return int(reported)
 
 
 def media_pool(bins: dict[str, list[FakeMediaPoolItem]] | None = None) -> FakeMediaPool:

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -1088,3 +1088,156 @@ def test_a_missing_video_track_is_created_before_the_append(
     assert result["ok"] is True
     assert len(placements(built(resolve, "sunset-set v1"))) == 3
     assert placements(built(resolve, "sunset-set v1"), "audio")
+
+
+# --- the dormant risks: assumptions the build now checks instead of holding (#186) ---------
+
+
+def a_stamped_pool() -> Any:
+    """A pool whose picture clip counts its own frames from an hour of timecode.
+
+    Every clip the pillar has built from reports ``Start = 0``, which is exactly why the
+    two readings of ``startFrame`` — absolute media frame, or offset from the clip's own
+    start — have never been told apart. A differently conformed project is where they part.
+    """
+    return a_pool(
+        gtr_close=FakeMediaPoolItem(
+            "C0012.mp4",
+            file_path="D:/media/C0012.mp4",
+            properties={"Frames": "20000", "Start": "86400", "End": "106399"},
+        )
+    )
+
+
+def a_stamped_doc() -> dict[str, Any]:
+    """One shot, cut from frames the start-stamped clip really holds."""
+    doc = valid_doc()
+    doc["segments"] = [{"id": "s001", "source": "gtr_close", "in": 87400, "out": 87500}]
+    doc["audio"]["out"] = 100
+    return doc
+
+
+def test_a_start_stamped_clip_builds_when_resolve_reads_its_frames_as_the_cut_does(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The check must not convict the ordinary case: same frames in, same frames back."""
+    resolve = empty_project(a_stamped_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, a_stamped_doc()))
+
+    assert result["ok"] is True
+    items = built(resolve, "sunset-set v1").GetItemListInTrack("video", 1) or []
+    assert [item.GetLeftOffset() for item in items] == [87400]
+
+
+def test_a_pool_that_rebases_source_frames_off_the_clip_start_fails_the_build(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Risk 1: the cut file's frames are absolute, and the append is not assumed to agree.
+
+    Nothing about the placement gives it away — the shot lands on the record frame the cut
+    puts it on, for exactly the duration it asked for, an hour of source footage away.
+    """
+    pool = a_stamped_pool()
+    pool.rebases_source_frames = True
+    resolve = empty_project(pool)
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, a_stamped_doc()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    assert placements(built(resolve, "sunset-set v1")) == [("C0012.mp4", 0, 100)]
+    drifted = result["error"]["detail"]["wrong_source"]
+    assert [finding["id"] for finding in drifted] == ["s001"]
+    assert drifted[0]["source_frame"] == 87400
+    assert drifted[0]["landed_on"] == 87400 + 86400
+
+
+def test_an_append_that_hands_back_fewer_items_than_it_was_given_fails_the_build(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Risk 3: one call places the whole cut, so a short answer is shots that never landed.
+
+    Before the count, the read-back caught it a step later and blamed placement — a failure
+    telling the agent to check its ranges for a cut whose ranges were never the problem.
+    """
+    pool = a_pool()
+    pool.append_result = [FakeTimelineItem("C0012.mp4", 0, 100)]
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    assert result["error"]["detail"]["clips"] == 4
+    assert result["error"]["detail"]["appended"] == 1
+
+
+def test_an_append_that_spreads_a_clip_over_more_items_than_it_was_given_builds(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """More items back is not evidence of a drop: Resolve spreads a multi-channel mix."""
+    pool = a_pool()
+    pool.append_result = [
+        FakeTimelineItem("C0012.mp4", 0, 100, source_start=1000),
+        FakeTimelineItem("C0012.mp4", 0, 100, source_start=1000),
+    ]
+    resolve = empty_project(pool)
+    attach(resolve)
+
+    doc = valid_doc()
+    del doc["audio"]
+    doc["segments"] = [{"id": "s001", "source": "gtr_close", "in": 1000, "out": 1100}]
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is True
+    assert len(placements(built(resolve, "sunset-set v1"))) == 2
+
+
+def test_a_shot_that_landed_on_the_wrong_source_frames_fails_the_build(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Risk 4: the frames a shot plays are read off the track, not off the build's own books.
+
+    The item Resolve hands back is placed exactly where the cut file puts it and plays
+    something else entirely — a return value that agrees with the plan on every axis a
+    build was checking.
+    """
+    pool = a_pool()
+    pool.append_result = [FakeTimelineItem("C0012.mp4", 0, 100, source_start=0)]
+    attach(empty_project(pool))
+
+    doc = valid_doc()
+    del doc["audio"]
+    doc["segments"] = [{"id": "s001", "source": "gtr_close", "in": 1000, "out": 1100}]
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "build_failed"
+    drifted = result["error"]["detail"]["wrong_source"]
+    assert [finding["id"] for finding in drifted] == ["s001"]
+    assert drifted[0]["source_frame"] == 1000
+    assert drifted[0]["landed_on"] == 0
+
+
+def test_a_still_is_exempt_from_the_source_frame_read_back(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A still's left offset is the timeline's clock, not a source frame (ADR 0005)."""
+    still = FakeMediaPoolItem(
+        "backdrop.png",
+        file_path="D:/media/backdrop.png",
+        properties={"Type": "Still", "FPS": "", "Frames": "1", "Start": "27", "End": "27"},
+    )
+    doc = valid_doc()
+    doc["sources"]["keys_wide"] = {"clip": "backdrop.png", "bin": "Angles"}
+    pool = a_pool(keys_wide=still)
+    # Only the still carries a start stamp, so it is the only shot the rebase moves.
+    pool.rebases_source_frames = True
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is True

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -1155,6 +1155,46 @@ def test_a_pool_that_rebases_source_frames_off_the_clip_start_fails_the_build(
     assert drifted[0]["landed_on"] == 87400 + 86400
 
 
+def test_a_relative_left_offset_on_a_start_stamped_clip_is_not_a_false_alarm(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The read-back must survive the other reading of ``GetLeftOffset`` too.
+
+    ADR 0005 measured the offset against ``GetSourceStartFrame`` on media starting at 0,
+    where "how far into the media" and "which frame it plays" are the same number. A start
+    stamp separates them, and ``source_bounds`` is what keeps the comparison honest: the
+    two getters then disagree by the whole stamp, well past the measured slip, so it falls
+    back to the absolute one — the space the cut file's ranges are written in.
+    """
+    pool = a_stamped_pool()
+    pool.reports_relative_left_offset = True
+    resolve = empty_project(pool)
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, a_stamped_doc()))
+
+    assert result["ok"] is True
+    items = built(resolve, "sunset-set v1").GetItemListInTrack("video", 1) or []
+    assert [item.GetLeftOffset() for item in items] == [1000]
+
+
+def test_a_rebase_is_caught_whichever_frame_the_left_offset_reports(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Both unknowns at once: a rebasing append read through a relative offset still fails."""
+    pool = a_stamped_pool()
+    pool.rebases_source_frames = True
+    pool.reports_relative_left_offset = True
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, a_stamped_doc()))
+
+    assert result["ok"] is False
+    drifted = result["error"]["detail"]["wrong_source"]
+    assert [finding["id"] for finding in drifted] == ["s001"]
+    assert drifted[0]["landed_on"] == 87400 + 86400
+
+
 def test_an_append_that_hands_back_fewer_items_than_it_was_given_fails_the_build(
     attach: Attach, tmp_path: Path
 ) -> None:

--- a/tests/test_cut_tools.py
+++ b/tests/test_cut_tools.py
@@ -88,6 +88,7 @@ def test_the_schema_lists_every_rule_with_its_severity(attach: Attach) -> None:
         "W1",
         "W2",
         "W8",
+        "W9",
     ]
 
 

--- a/tests/test_cut_validate.py
+++ b/tests/test_cut_validate.py
@@ -305,6 +305,55 @@ def test_e5_covers_alternates_and_overlays() -> None:
     assert rules(findings).count("E5") == 2
 
 
+# --- W9: E5 fails open on unknown bounds, and says so (#186) ----------------------------
+
+
+def test_w9_warns_when_a_clips_media_bounds_were_never_reported() -> None:
+    """Fail-open is right — 'Resolve did not say' is not an overrun — but not silent."""
+    doc = valid_doc()
+    doc["segments"][0]["alternates"] = []
+    facts = [
+        c if c.name != "C0012.mp4" else replace(c, start=None, end_exclusive=None)
+        for c in clip_facts()
+    ]
+
+    finding = only(validate_project(doc, facts), "W9")
+
+    assert finding.id == "s001"
+    assert "C0012.mp4" in finding.message
+    assert "E5" not in rules(validate_project(doc, facts))
+
+
+def test_w9_covers_the_master_mix_whose_bounds_e7_checks_the_same_way() -> None:
+    doc = valid_doc()
+    facts = [
+        c if c.name != "sunset-master.wav" else replace(c, start=None, end_exclusive=None)
+        for c in clip_facts()
+    ]
+
+    finding = only(validate_project(doc, facts), "W9")
+
+    assert finding.id is None
+    assert "sunset-master.wav" in finding.message
+
+
+def test_w9_exempts_stills_which_have_no_bounds_to_check() -> None:
+    doc = valid_doc()
+    doc["segments"][0]["alternates"] = []
+    facts = [
+        c
+        if c.name != "C0012.mp4"
+        else replace(c, start=None, end_exclusive=None, fps=None, is_still=True)
+        for c in clip_facts()
+    ]
+
+    assert "W9" not in rules(validate_project(doc, facts))
+
+
+def test_w9_stays_quiet_when_the_bounds_are_known() -> None:
+    assert "W9" not in rules(validate_project(valid_doc(), clip_facts()))
+
+
 # --- E6: source fps matches timeline fps ------------------------------------------------
 
 


### PR DESCRIPTION
Closes #186 (gauntlet gap G7).

Four dormant build-path risks, each a fail-open or an unchecked assumption on the path a cut takes into Resolve. None has fired — every clip the pillar has built from reports `Start = 0` and every append has come back whole, which is exactly why none of them was visible.

## What changed

**1. startFrame rebase.** The cut file's `in`/`out` are absolute media frames — the space `Start`/`End` report and E5 checks against — and `startFrame` is sent in that same space. Whether Resolve reads it that way on a start-stamped clip is unmeasured, so the build no longer *holds* the assumption: the read-back proves it per shot, and a clip whose media does not start at 0 is logged as the condition that makes it live. Deliberately **not** a rebase — rebasing would be guessing the other reading just as blindly, and the guard catches whichever one Resolve takes.

**2. Fail-open bounds validation.** A range against a clip whose bounds Resolve never reported still cannot be convicted — #46's stance ("Resolve did not say" is not evidence of an overrun) is a prior decision this ticket did not ask to overturn, and escalating E5 to a hard error would block cuts over audio that carries no start stamp. What changes is that a check which *could not run* is no longer indistinguishable from one that passed: **W9** says so, on E5's items and on E7's master-mix leg alike, and the condition is logged where it is discovered.

**3. Unchecked append length.** Fewer items back than clips asked for is Resolve saying it made fewer, and is now named at the append. Before, the read-back caught it a step later and blamed placement — telling the agent to check the ranges of a cut whose ranges were never the problem. More items is not the same evidence and is not treated as any: Resolve spreads a multi-channel mix over one item per track it fills, so the comparison is `<`, not `!=`.

**4. Verify without readback.** `_verify` read positions off the track and took the source frames on trust. It now reads those back too, through `source_bounds` (ADR 0005) with its one frame of measured slip, exempting stills for the same reason E5 does — a still's left offset is the timeline's clock, not a source frame.

## Test seam

The fake tier, per CLAUDE.md. `tests/fakes/pool.py` gains two knobs for the two halves of the same unknown: `rebases_source_frames` (the other reading of `startFrame`, which places every shot as far past its in point as the clip's start stamp while reporting an ordinary success) and `reports_relative_left_offset` (the other reading of `GetLeftOffset`). Each risk has a test that was confirmed to fail without its fix, plus the non-regression cases: a start-stamped clip that Resolve reads as the cut does builds, an append that spreads a clip over more items builds, and a still is exempt.

Fake tier: 2004 passed. mypy strict and ruff clean.

## Live smoke (AC 2)

Run on the live Windows 11 box with Resolve Studio up, `uv run pytest -m live`: **31 passed, 10 skipped, 0 failed** — so the new read-back verify ran against real builds. (An earlier run of the same tier failed `test_the_real_separator_produces_the_stems_the_passes_expect` with an access violation out of the audio-separator subprocess; it passed on re-run. Unrelated to this diff — stems, not the build path.)

**What the live run does not settle:** the live pool's media all reports `Start = 0`, where both readings of `startFrame` coincide. The rebase question is therefore still open, and is held by the fake alone — which is the CLAUDE.md caveat about fakes proving decisions rather than the attach. That is the point of the guard: the build now refuses instead of shipping the wrong footage if a start-stamped project ever turns up. Noted under `## Needs from you` on the ticket.

## Review

Two-axis `/code-review` against `origin/main`, both axes as parallel sub-agents.

**Spec axis — 4 findings, all resolved:**

- *W9 never reached the log; AC 3 asks failure paths to log.* Fixed — logged in `resolve/cut.py` where the bounds come back unreadable, beside the same-shaped line E7's has-audio leg already writes.
- *The wrong-source failure's `fix` text is unactionable on a genuinely rebasing project.* Fixed — it now names the start-stamp case and points at the build log instead of sending the agent to re-author ranges no cut file could satisfy.
- *The fake encodes only one reading of `GetLeftOffset`, so it asserts the assumption rather than testing it.* Fixed — `reports_relative_left_offset` models the other, with two tests.
- *Scope: W9 also fires on E7's master-mix leg, while the ticket names only E5.* Kept, deliberately. The mix is the clip a whole cut is laid over and its bounds leg fails open identically; warning on segments while staying silent on the mix would be the odd choice.

**Spec axis — 1 finding rejected, with reasons:** the axis argued that a Resolve which both rebases `startFrame` *and* reports a media-relative `GetLeftOffset` would have the two errors cancel, leaving the drift silent. It does not. `source_bounds` (`timeline.py:810`) prefers the left offset only where it agrees with `GetSourceStartFrame` within `SOURCE_SLIP`; a start stamp puts them the whole stamp apart, so it falls back to the absolute getter — the space the cut file is written in. All four combinations of (rebases / doesn't) × (relative / absolute offset) were worked through: the drift is caught in both rebasing cases and no false alarm fires in either correct one. The Standards axis traced the same path independently and reached the same conclusion. Rather than leave it resting on reasoning, both combinations are now tests.

**Standards axis — no hard violations, no correctness findings.** Five judgement-call smells, four fixed:

- *`_read_sources` — the name says "read", the return value is the stills.* Renamed `_prepare_sources`, docstring leads with what it answers.
- *Primitive obsession: a bare `frozenset[int]` of `id()` values threaded through three signatures.* Named: the `Stills` type carries the explanation, and the timeline item behind `_landed` is now `Item` alongside the file's other handle aliases.
- *`MISPLACED_CAP` is a mysterious name at the `drifted[...]` site.* Renamed `REPORTED_SHOT_CAP`; it caps two lists now.
- *`_outside_media`'s guard is unreachable and its docstring explains a fail-open that moved to the callers.* Docstring rewritten to say the guard is a precondition, not the decision. The guard itself stays: reaching it with unknown bounds should answer "cannot convict", not raise.
- *Duplicated shape between the two `log.error` + `raise BuildFailedError` blocks in `_verify`.* Not extracted — they share a skeleton but differ in cause, fix hint and detail keys, and a five-argument helper would read worse than the two blocks do.

Review: clean
