### PR TITLE
Run only the stems passes a directory is missing (#192)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -176,7 +176,10 @@ IEEE float and extensible headers, because stdlib `wave` opens PCM only),
 `separator` (python-audio-separator out of process), `stems` (two passes —
 mix into four, then the drum stem into the kit — plus an opt-in third,
 `split_wind`, splitting `other` into `wind` and `comp`; `comp` is
-accompaniment, never a piano stem), `wav` (header facts + the one
+accompaniment, never a piano stem. A directory is judged pass by pass and
+only the passes it owes are run, so turning the third one on costs that pass
+alone — but a missing first pass redoes all three, since the later two are cut
+from what it wrote, #192), `wav` (header facts + the one
 unreadable-WAV error).
 
 `cut/` — cut-file schema v1: `document` (read off disk), `schema`
@@ -308,8 +311,11 @@ never asked for one. `test_hardware_decode.py` (#202) is the fourth: NVDEC is
 one decision across `ffmpeg` (the probe), `video/ffmpeg` (flags, fallback,
 report) and the three video routes that carry the report, and the failure worth
 testing is a decode that ran one way and reported another. Live tier: `test_live_smoke.py` (module-level
-`pytest.mark.live`) and two `@pytest.mark.live` tests in
-`test_live_analysis.py`; everything else is fake-tier. The live tier assumes no
+`pytest.mark.live`) and five `@pytest.mark.live` tests in
+`test_live_analysis.py` — four over installed models, plus the #192 wind split
+over the director's own separated stems, the one test that opts out of the
+per-test cache redirect through conftest's `machine_cache` fixture; everything
+else is fake-tier. The live tier assumes no
 project state it can build itself (#135): a session-scoped sweep clears the last
 run's timelines, `a_known_cut` builds and makes current the short cut the export
 and round-trip tests read, and `a_clip_with_hard_cuts` generates the scan clip

--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -115,7 +115,7 @@ def environment(
     config = config or get_config()
     lines: list[str] = []
     try:
-        returncode = (runner or _run)(environment_command(config.audio_separator), lines.append)
+        returncode = (runner or run)(environment_command(config.audio_separator), lines.append)
     except FileNotFoundError as exc:
         raise SeparatorUnavailableError(
             cause=f"No audio-separator at {config.audio_separator!r}.",
@@ -177,7 +177,7 @@ def separate(
 
     log.info("Separating %s with %s", Path(source).name, model)
     try:
-        returncode = (runner or _run)(argv, on_line)
+        returncode = (runner or run)(argv, on_line)
     except FileNotFoundError as exc:
         raise SeparatorUnavailableError(
             cause=f"No audio-separator at {config.audio_separator!r}.",
@@ -231,8 +231,12 @@ def _percent(line: str) -> float | None:
     return min(int(found.group(1)) / FULL, 1.0)
 
 
-def _run(argv: Sequence[str], on_line: Lines) -> int:
+def run(argv: Sequence[str], on_line: Lines) -> int:
     """The real call: stderr folded into stdout, read as it arrives.
+
+    Named rather than private because a ``Runner`` that wants the real thing under it — a live
+    test counting the passes a run actually paid for — has nowhere else to reach for it, and a
+    second copy of this function is a second chance to get the encoding wrong.
 
     Universal newlines makes the progress bar's carriage returns line breaks, which is the
     only reason a tqdm bar can be followed line by line at all.

--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -40,8 +40,15 @@ from ..logging_config import get_logger
 log = get_logger("audio")
 
 OUTPUT_FORMAT = "WAV"
-OUTPUT_TAIL = 40
-"""Lines of the separator's own output kept for a failure message."""
+OUTPUT_TAIL = 200
+"""Lines of the separator's own output kept for a failure message.
+
+Deep enough that a traceback survives what is printed under it. A pass prints a progress bar
+several times a second, so the forty this used to keep were forty redraws of the bar on any
+failure the model took a moment to die of — the account of a pass that died halfway through
+writing its output was the one thing worth keeping and the first thing pushed out (#192).
+Matched to ``store.WORKER_TAIL_LINES``, which is the same salvage one process further out.
+"""
 
 LABEL = re.compile(r"\(([^()]+)\)")
 PERCENT = re.compile(r"(\d{1,3})\s*%")

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -152,9 +152,9 @@ def separate_stems(
     """Start a separation job. Returns the job record, not the stems.
 
     ``split_wind`` adds the third pass over ``other``. It is a job param but not a stems-key
-    param, so it stays in one stems directory rather than separating the same audio twice —
-    but a directory missing the pass this run wants is partial, and partial is redone whole,
-    so turning it on for audio already separated re-runs the earlier passes too.
+    param, so it stays in one stems directory rather than separating the same audio twice, and
+    turning it on for audio already separated runs that pass alone against the stems on disk
+    (#192).
 
     ``detach`` moves the separation into a process of its own once the audio exists, so a
     half-hour pass survives this process exiting (G4). The acquisition stays here: it drives
@@ -883,6 +883,7 @@ def multi_pass(
                     refresh=refresh,
                     runner=runner,
                     config=config,
+                    reuse=reuse,
                 )
 
     progress(COLLECTING, "collecting the stems")
@@ -939,40 +940,59 @@ def _passes(
     refresh: Callable[[], None],
     runner: separator.Runner | None,
     config: Config,
+    reuse: bool = True,
 ) -> _Sets:
     """The two passes, and the third when it is asked for — run with the claim already held.
 
-    Every reading of the bar refreshes that claim, so the ceiling that reads a claim as
+    Only the passes this directory is actually missing are run (#192). The wind flag is not
+    part of the stems key, so turning it on lands in the directory the first two passes already
+    filled, and treating that as partial-so-redo-it-whole spent the better part of an hour of
+    GPU rewriting two byte-identical answers to add a third. What a pass costs is the reason
+    the flag is opt-in at all; paying for the other two as well was the same mistake twice.
+
+    Every reading of the bar refreshes the claim, so the ceiling that reads a claim as
     abandoned measures how long it has been since anybody was working — not how long this
     separation has run. A full set can take the better part of an hour.
     """
     beat = _keeping_the_claim(progress, refresh)
-    stems = separator.separate(
-        audio["path"],
-        mix_dir,
-        config.stem_model,
-        FOUR_STEMS,
-        progress=_pass(beat, ACQUIRE_CEILING, PASS_ONE_CEILING, "separating four stems"),
-        runner=runner,
-        config=config,
-    )
-    beat(PASS_ONE_CEILING, "decomposing the drum stem")
-    drums = separator.separate(
-        stems[DRUM_SOURCE],
-        drums_dir,
-        config.drum_model,
-        DRUM_STEMS,
-        progress=_pass(
-            beat,
-            PASS_ONE_CEILING,
-            WIND_FLOOR if split_wind else SEPARATED,
-            "decomposing the drums",
-        ),
-        runner=runner,
-        config=config,
-    )
+    done = _complete(mix_dir, drums_dir, other_dir if split_wind else None) if reuse else _Done()
+    if done.mix:
+        log.info("Reusing the four stems already at %s", mix_dir)
+        stems = separator.collect(mix_dir)
+    else:
+        stems = separator.separate(
+            audio["path"],
+            mix_dir,
+            config.stem_model,
+            FOUR_STEMS,
+            progress=_pass(beat, ACQUIRE_CEILING, PASS_ONE_CEILING, "separating four stems"),
+            runner=runner,
+            config=config,
+        )
+    if done.drums:
+        log.info("Reusing the drum stems already at %s", drums_dir)
+        drums = separator.collect(drums_dir)
+    else:
+        beat(PASS_ONE_CEILING, "decomposing the drum stem")
+        drums = separator.separate(
+            stems[DRUM_SOURCE],
+            drums_dir,
+            config.drum_model,
+            DRUM_STEMS,
+            progress=_pass(
+                beat,
+                PASS_ONE_CEILING,
+                WIND_FLOOR if split_wind else SEPARATED,
+                "decomposing the drums",
+            ),
+            runner=runner,
+            config=config,
+        )
     other: dict[str, Path] = {}
-    if split_wind:
+    if split_wind and done.other:
+        log.info("Reusing the wind split already at %s", other_dir)
+        other = separator.collect(other_dir)
+    elif split_wind:
         beat(WIND_FLOOR, "splitting the winds out of the other stem")
         other = separator.separate(
             stems[OTHER_SOURCE],
@@ -1003,17 +1023,44 @@ def _waiting_for(progress: Progress) -> Waiting:
     return report
 
 
-def _already_separated(mix_dir: Path, drums_dir: Path, other_dir: Path | None = None) -> bool:
-    """Every pass this run was asked for is on disk in full — a partial run is worth redoing.
+class _Done(NamedTuple):
+    """Which passes are already on disk in full. Nothing is, until it has been looked for."""
 
-    ``other_dir`` is ``None`` when the third pass is off, and then a two-pass directory is
-    complete rather than partial. The flag is not part of the stems key, so both shapes share
-    a directory: what completeness means has to come from what was asked for, or a job with
-    the pass off would rerun everything to fill a directory it does not want.
+    mix: bool = False
+    drums: bool = False
+    other: bool = False
+
+
+def _complete(mix_dir: Path, drums_dir: Path, other_dir: Path | None) -> _Done:
+    """Read each pass's directory for the stems that pass is supposed to have left there.
+
+    A missing first pass makes the other two unreusable whatever is in their directories: both
+    are cut from files the first pass wrote, so a mix that has to run again would leave one
+    separation's drums sitting beside another's under a name that promises they came from the
+    same run. The dependency only runs that way — the drum pass and the wind pass never read
+    each other — so either can be the one thing a directory owes.
+
+    ``other_dir`` is ``None`` when the third pass is off, and then nothing is asked about it:
+    the flag is not part of the stems key, so a two-pass and a three-pass run share a
+    directory, and what completeness means has to come from what this run asked for.
     """
-    if separator.missing_from(mix_dir, FOUR_STEMS) or separator.missing_from(drums_dir, DRUM_STEMS):
-        return False
-    return other_dir is None or not separator.missing_from(other_dir, WIND_STEMS)
+    if separator.missing_from(mix_dir, FOUR_STEMS):
+        return _Done()
+    return _Done(
+        mix=True,
+        drums=not separator.missing_from(drums_dir, DRUM_STEMS),
+        other=other_dir is not None and not separator.missing_from(other_dir, WIND_STEMS),
+    )
+
+
+def _already_separated(mix_dir: Path, drums_dir: Path, other_dir: Path | None = None) -> bool:
+    """Nothing is owed at all: every pass this run was asked for is on disk in full.
+
+    The question the claim is taken on. A directory that owes one pass is not this, and is not
+    redone whole either — ``_passes`` runs the passes it is missing (#192).
+    """
+    done = _complete(mix_dir, drums_dir, other_dir)
+    return done.mix and done.drums and (other_dir is None or done.other)
 
 
 def _keeping_the_claim(progress: Progress, refresh: Callable[[], None]) -> Progress:

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -305,6 +305,23 @@ def stem_key(audio: dict[str, Any], params: dict[str, Any]) -> str:
     return cache.cache_key(KIND, [{"content_sha256": audio["content_sha256"]}], settings)
 
 
+def stem_directory(
+    audio: dict[str, Any],
+    params: dict[str, Any],
+    config: Config | None = None,
+) -> Path:
+    """Where this audio's stems sit: the key, behind a name a human can recognise in a cache.
+
+    The slug is for the person opening the directory; the key is what makes it this audio's and
+    no other's. Named rather than spelled out at its one caller because anything that wants to
+    look at a separation from outside — a live test measuring what a run cost — would otherwise
+    have to write the same expression again, and a second copy of a key is a key that can drift.
+    """
+    config = config or get_config()
+    key = stem_key(audio, params)
+    return config.stems_dir / f"{slug(Path(str(audio['path'])).stem, 'stems')}-{key[:12]}"
+
+
 CLAIM = ".separating.json"
 """The file that says a process is writing this stems directory right now. See ``claimed``."""
 
@@ -842,14 +859,14 @@ def multi_pass(
     """The worker: four stems, the drum stem decomposed, and on request the ``other`` stem too."""
     config = config or get_config()
     key = stem_key(audio, params)
-    directory = config.stems_dir / f"{slug(Path(str(audio['path'])).stem, 'stems')}-{key[:12]}"
+    directory = stem_directory(audio, params, config)
     mix_dir = directory / MIX_PASS
     drums_dir = directory / DRUM_PASS
     other_dir = directory / OTHER_PASS
     wanted_other = other_dir if split_wind else None
 
     separator_env: dict[str, Any] | None = None
-    reused = reuse and _already_separated(mix_dir, drums_dir, wanted_other)
+    reused = reuse and _already_separated(mix_dir, drums_dir, other_dir, split_wind)
     if reused:
         log.info("Stems for %s are already on disk at %s", audio["path"], directory)
         stems, drums, other = _on_disk(mix_dir, drums_dir, wanted_other)
@@ -861,7 +878,7 @@ def multi_pass(
             # was about to compute are the ones that run has just finished writing, so asking
             # only once is asking too early: it is half an hour of GPU spent overwriting a
             # byte-identical answer, and the wait was for those very files.
-            reused = reuse and _already_separated(mix_dir, drums_dir, wanted_other)
+            reused = reuse and _already_separated(mix_dir, drums_dir, other_dir, split_wind)
             if reused:
                 log.info(
                     "The separation this run waited out has left the stems for %s at %s",
@@ -940,7 +957,7 @@ def _passes(
     refresh: Callable[[], None],
     runner: separator.Runner | None,
     config: Config,
-    reuse: bool = True,
+    reuse: bool,
 ) -> _Sets:
     """The two passes, and the third when it is asked for — run with the claim already held.
 
@@ -955,7 +972,7 @@ def _passes(
     separation has run. A full set can take the better part of an hour.
     """
     beat = _keeping_the_claim(progress, refresh)
-    done = _complete(mix_dir, drums_dir, other_dir if split_wind else None) if reuse else _Done()
+    done = _complete(mix_dir, drums_dir, other_dir, split_wind) if reuse else _Done()
     if done.mix:
         log.info("Reusing the four stems already at %s", mix_dir)
         stems = separator.collect(mix_dir)
@@ -989,10 +1006,12 @@ def _passes(
             config=config,
         )
     other: dict[str, Path] = {}
-    if split_wind and done.other:
+    if not split_wind:
+        return _Sets(stems, drums, other)
+    if done.other:
         log.info("Reusing the wind split already at %s", other_dir)
         other = separator.collect(other_dir)
-    elif split_wind:
+    else:
         beat(WIND_FLOOR, "splitting the winds out of the other stem")
         other = separator.separate(
             stems[OTHER_SOURCE],
@@ -1024,14 +1043,15 @@ def _waiting_for(progress: Progress) -> Waiting:
 
 
 class _Done(NamedTuple):
-    """Which passes are already on disk in full. Nothing is, until it has been looked for."""
+    """Which passes this run does not owe. Every one is owed until it has been looked for."""
 
     mix: bool = False
     drums: bool = False
     other: bool = False
+    """On disk in full — or not asked for, which costs the same nothing to satisfy."""
 
 
-def _complete(mix_dir: Path, drums_dir: Path, other_dir: Path | None) -> _Done:
+def _complete(mix_dir: Path, drums_dir: Path, other_dir: Path, split_wind: bool) -> _Done:
     """Read each pass's directory for the stems that pass is supposed to have left there.
 
     A missing first pass makes the other two unreusable whatever is in their directories: both
@@ -1040,27 +1060,28 @@ def _complete(mix_dir: Path, drums_dir: Path, other_dir: Path | None) -> _Done:
     same run. The dependency only runs that way — the drum pass and the wind pass never read
     each other — so either can be the one thing a directory owes.
 
-    ``other_dir`` is ``None`` when the third pass is off, and then nothing is asked about it:
-    the flag is not part of the stems key, so a two-pass and a three-pass run share a
-    directory, and what completeness means has to come from what this run asked for.
+    The wind flag is answered here and nowhere else. It is not part of the stems key, so a
+    two-pass and a three-pass run share a directory, and what completeness means has to come
+    from what this run asked for: with the pass off, an empty ``other`` is nothing owed rather
+    than something missing. Reading that off the flag in each caller was three chances to read
+    it differently.
     """
     if separator.missing_from(mix_dir, FOUR_STEMS):
         return _Done()
     return _Done(
         mix=True,
         drums=not separator.missing_from(drums_dir, DRUM_STEMS),
-        other=other_dir is not None and not separator.missing_from(other_dir, WIND_STEMS),
+        other=not split_wind or not separator.missing_from(other_dir, WIND_STEMS),
     )
 
 
-def _already_separated(mix_dir: Path, drums_dir: Path, other_dir: Path | None = None) -> bool:
+def _already_separated(mix_dir: Path, drums_dir: Path, other_dir: Path, split_wind: bool) -> bool:
     """Nothing is owed at all: every pass this run was asked for is on disk in full.
 
     The question the claim is taken on. A directory that owes one pass is not this, and is not
     redone whole either — ``_passes`` runs the passes it is missing (#192).
     """
-    done = _complete(mix_dir, drums_dir, other_dir)
-    return done.mix and done.drums and (other_dir is None or done.other)
+    return all(_complete(mix_dir, drums_dir, other_dir, split_wind))
 
 
 def _keeping_the_claim(progress: Progress, refresh: Callable[[], None]) -> Progress:

--- a/src/resolve_mcp/jobs/detached.py
+++ b/src/resolve_mcp/jobs/detached.py
@@ -112,8 +112,13 @@ def spawn_options(platform: str = sys.platform) -> list[dict[str, Any]]:
 
 
 def worker_log(job_id: str, config: Config) -> Path:
-    """Where the detached worker's own output lands: beside the record, never inside it."""
-    return config.job_dir / f"{job_id}.worker.log"
+    """Where the detached worker's own output lands: beside the record, never inside it.
+
+    ``store`` owns the name, because ``store`` is what reads the file back onto the record of a
+    worker that died without writing its own failure (#192). This is the launcher's word for
+    the same file, kept so callers here do not have to know which module named it.
+    """
+    return store.worker_log(job_id, config)
 
 
 def child_env(config: Config, env: dict[str, str] | None = None) -> dict[str, str]:

--- a/src/resolve_mcp/jobs/detached.py
+++ b/src/resolve_mcp/jobs/detached.py
@@ -111,16 +111,6 @@ def spawn_options(platform: str = sys.platform) -> list[dict[str, Any]]:
     return [{"start_new_session": True}]
 
 
-def worker_log(job_id: str, config: Config) -> Path:
-    """Where the detached worker's own output lands: beside the record, never inside it.
-
-    ``store`` owns the name, because ``store`` is what reads the file back onto the record of a
-    worker that died without writing its own failure (#192). This is the launcher's word for
-    the same file, kept so callers here do not have to know which module named it.
-    """
-    return store.worker_log(job_id, config)
-
-
 def child_env(config: Config, env: dict[str, str] | None = None) -> dict[str, str]:
     """The parent's environment with this config's settings written over it."""
     return {**(os.environ if env is None else env), **config.to_env()}
@@ -148,7 +138,7 @@ def launch(
     store.save(record, config)
 
     argv = command(record.job_id)
-    destination = worker_log(record.job_id, config)
+    destination = store.worker_log(record.job_id, config)
     destination.parent.mkdir(parents=True, exist_ok=True)
     config.cache_dir.mkdir(parents=True, exist_ok=True)
     pid = (spawn or _spawn)(argv, destination, config)

--- a/src/resolve_mcp/jobs/store.py
+++ b/src/resolve_mcp/jobs/store.py
@@ -104,6 +104,20 @@ them, because closing a live separation is a worse failure than a dead record re
 for an afternoon. See ``_recovered_detached``.
 """
 
+WORKER_TAIL_LINES = 200
+"""Lines of a dead worker's own output kept on the record.
+
+Enough that a traceback survives the progress bar printed under it, and few enough that a
+record an agent reads into its context does not arrive as half an hour of percentages.
+"""
+
+WORKER_TAIL_BYTES = 64 * 1024
+"""How far back from the end those lines are looked for, so the whole file is never read.
+
+A separation's log is a bar redrawn for half an hour; the tail is all that is ever wanted, and
+seeking to it costs the same whether the file is a kilobyte or a hundred megabytes.
+"""
+
 _sequence = itertools.count()
 """Breaks ties in "newest first": the Windows clock is coarser than two starts in a row."""
 
@@ -161,6 +175,42 @@ def _job_id(kind: str) -> str:
 
 def _path(job_id: str, config: Config) -> Path:
     return config.job_dir / f"{job_id}.json"
+
+
+def worker_log(job_id: str, config: Config) -> Path:
+    """Where a detached worker's own output lands: beside the record, never inside it.
+
+    Named here rather than in ``detached``, which is what opens it, because this module is
+    what reads it back: a worker that dies mid-pass never writes its own failure, and
+    ``_interrupted`` is where the last thing it said is put on the record. ``detached``
+    borrows the name from here so the two can never drift apart.
+    """
+    return config.job_dir / f"{job_id}.worker.log"
+
+
+def worker_tail(job_id: str, config: Config) -> str | None:
+    """The end of what that worker printed, or ``None`` when it printed nothing readable.
+
+    Blank lines are dropped and the rest is capped at ``WORKER_TAIL_LINES``, read from the
+    last ``WORKER_TAIL_BYTES`` of the file. Decoded with ``replace`` for two reasons: the seek
+    lands mid-character whenever the file is long, and the output being salvaged is a progress
+    bar with a crash at the end of it — no byte in one is worth losing the crash over.
+
+    Unreadable is ``None`` rather than a raise. This runs while a job is being failed, and a
+    log that cannot be opened must not turn "the worker died" into an error about a log file.
+    """
+    path = worker_log(job_id, config)
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            if size > WORKER_TAIL_BYTES:
+                handle.seek(size - WORKER_TAIL_BYTES)
+            raw = handle.read()
+    except OSError as exc:
+        log.info("No worker output to read at %s (%s)", path, exc)
+        return None
+    lines = [one for one in raw.decode("utf-8", "replace").splitlines() if one.strip()]
+    return "\n".join(lines[-WORKER_TAIL_LINES:]) or None
 
 
 def new_job(
@@ -894,7 +944,14 @@ def _age(stamp: str) -> float | None:
 
 
 def _interrupted(record: JobRecord, cause: str, config: Config) -> JobRecord:
-    """Close a job nothing is running any more, under this session, saying why."""
+    """Close a job nothing is running any more, under this session, saying why.
+
+    Every route here is a detached job whose worker is gone, and a process that is gone cannot
+    write its own failure onto the record — so what it printed before it went is the only
+    account of it there will ever be, and it is folded in here rather than left in a file
+    beside the record for somebody to think of looking in (#192). The path goes on too: the
+    tail is the end of the story, and the whole of it stays where it was written.
+    """
     interrupted = JobInterruptedError(
         cause=cause,
         detail={
@@ -902,6 +959,8 @@ def _interrupted(record: JobRecord, cause: str, config: Config) -> JobRecord:
             "pid": record.pid,
             "progress": record.progress,
             "step": record.step,
+            "worker_log": str(worker_log(record.job_id, config)),
+            "output": worker_tail(record.job_id, config),
         },
     )
     record.session = SESSION

--- a/src/resolve_mcp/tools/stems.py
+++ b/src/resolve_mcp/tools/stems.py
@@ -36,7 +36,7 @@ def separate_stems(
     back near-silent; it is not a piano stem). Ask for it when a horn or reed is what you
     need to hear apart from the piano, and leave it off otherwise: on a band with no piano
     "other" is already the winds, and the pass costs time to recover nothing. Turning it on
-    for audio already separated re-runs the earlier passes too.
+    for audio already separated costs that one pass and reuses the stems on disk.
 
     The separation runs in a process of its own and keeps running if this server exits, so a
     half-hour pass on a full set is not lost with the session that started it; get_job reads

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,23 @@ def _clean_globals(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[N
 
 
 @pytest.fixture
+def machine_cache() -> Config:
+    """The machine's own cache, for the live tests that are about what is already in it.
+
+    ``_clean_globals`` redirects every test's cache into ``tmp_path``, which is right for every
+    test that makes its own inputs: nothing one writes can be read by the next. A live test over
+    the director's separated stems has the opposite need — the directory it is about is keyed on
+    a gigabyte of audio's own bytes and exists in exactly one place, and a temporary copy of it
+    under a temporary key would be a different question wearing the same shape.
+
+    Declared here, beside the redirect, so the exception is part of the contract rather than a
+    config a test quietly re-derives. It is never autouse: a test asking for this is asking to
+    read and write the real cache, and that has to be visible in its signature.
+    """
+    return Config.from_env(dict(os.environ))
+
+
+@pytest.fixture
 def attach() -> Attach:
     """Substitute the Resolve singleton with fakes, one per connect attempt."""
 

--- a/tests/test_detached_jobs.py
+++ b/tests/test_detached_jobs.py
@@ -229,7 +229,7 @@ def test_a_handed_off_job_stays_running_and_names_the_process_that_has_it() -> N
     assert (landed.state, landed.detached, landed.pid) == (store.RUNNING, True, pid)
     assert str(pid) in landed.step
     assert spawn.calls[0][0] == detached.command(record.job_id)
-    assert spawn.calls[0][1] == detached.worker_log(record.job_id, get_config())
+    assert spawn.calls[0][1] == store.worker_log(record.job_id, get_config())
 
 
 def test_a_worker_that_hands_off_neither_finishes_the_job_nor_caches_a_result(
@@ -527,7 +527,7 @@ def test_a_dead_workers_own_output_arrives_on_the_record_that_says_it_died() -> 
     """
     pid = _a_pid_that_has_exited()
     record = _running_under_a_dead_server(pid, step="splitting the winds (50%)")
-    log_file = detached.worker_log(record.job_id, get_config())
+    log_file = store.worker_log(record.job_id, get_config())
     log_file.write_text(
         "loading 17_HP-Wind_Inst-UVR\nCUDA error: out of memory\n", encoding="utf-8"
     )
@@ -561,7 +561,7 @@ def test_only_the_end_of_a_long_worker_log_travels_on_the_record() -> None:
     pid = _a_pid_that_has_exited()
     record = _running_under_a_dead_server(pid)
     chatter = "\n".join(f"separating {index}%" for index in range(5000))
-    detached.worker_log(record.job_id, get_config()).write_text(
+    store.worker_log(record.job_id, get_config()).write_text(
         f"{chatter}\nAccess violation\n", encoding="utf-8"
     )
 
@@ -1060,7 +1060,7 @@ def test_a_real_detached_worker_finds_the_record_and_closes_it() -> None:
     assert finished.pid is not None
     assert finished.pid != os.getpid()
     assert finished.session != store.SESSION
-    assert detached.worker_log(record.job_id, get_config()).exists()
+    assert store.worker_log(record.job_id, get_config()).exists()
 
 
 # --- the separation itself -----------------------------------------------------------------
@@ -1787,7 +1787,7 @@ def _why_the_worker_did_not_finish(record: JobRecord) -> str:
     import error, a cache directory it could not write. That is all in the log file the
     launcher opened for it.
     """
-    log_file = detached.worker_log(record.job_id, get_config())
+    log_file = store.worker_log(record.job_id, get_config())
     output = log_file.read_text(encoding="utf-8") if log_file.exists() else "(no worker log)"
     return f"job {record.job_id} is {record.state} at step {record.step!r}; worker log:\n{output}"
 

--- a/tests/test_detached_jobs.py
+++ b/tests/test_detached_jobs.py
@@ -517,6 +517,63 @@ def test_a_detached_job_whose_worker_is_gone_is_failed_and_says_so() -> None:
     assert store.load(record.job_id).state == store.FAILED  # written back, judged once
 
 
+def test_a_dead_workers_own_output_arrives_on_the_record_that_says_it_died() -> None:
+    """#192: a detached worker's log is the only witness to how it died, so it is folded in.
+
+    The child has no console and nothing reading its pipes: everything the pass printed —
+    the separator's own complaint included — is in that file and nowhere else. A failure that
+    named only the pid left a crash halfway through a pass to be diagnosed from the half of
+    the stems that made it to disk.
+    """
+    pid = _a_pid_that_has_exited()
+    record = _running_under_a_dead_server(pid, step="splitting the winds (50%)")
+    log_file = detached.worker_log(record.job_id, get_config())
+    log_file.write_text(
+        "loading 17_HP-Wind_Inst-UVR\nCUDA error: out of memory\n", encoding="utf-8"
+    )
+
+    failed = store.load(record.job_id)
+
+    assert failed.state == store.FAILED
+    assert failed.error is not None
+    assert "CUDA error: out of memory" in failed.error["detail"]["output"]
+    assert failed.error["detail"]["worker_log"] == str(log_file)
+
+
+def test_a_worker_that_died_before_it_printed_anything_still_names_where_it_would_have() -> None:
+    """No log is not a failure to report — the path is the answer to "where would it be"."""
+    record = _running_under_a_dead_server(_a_pid_that_has_exited())
+
+    failed = store.load(record.job_id)
+
+    assert failed.state == store.FAILED
+    assert failed.error is not None
+    assert failed.error["detail"]["output"] is None
+    assert failed.error["detail"]["worker_log"].endswith(".worker.log")
+
+
+def test_only_the_end_of_a_long_worker_log_travels_on_the_record() -> None:
+    """A separation prints a progress bar for half an hour, and a record is read into context.
+
+    The whole file stays on disk under the path beside it — what goes on the record is the end,
+    which is where a crash writes.
+    """
+    pid = _a_pid_that_has_exited()
+    record = _running_under_a_dead_server(pid)
+    chatter = "\n".join(f"separating {index}%" for index in range(5000))
+    detached.worker_log(record.job_id, get_config()).write_text(
+        f"{chatter}\nAccess violation\n", encoding="utf-8"
+    )
+
+    failed = store.load(record.job_id)
+
+    assert failed.error is not None
+    output = failed.error["detail"]["output"]
+    assert "Access violation" in output
+    assert "separating 0%" not in output
+    assert len(output.splitlines()) == store.WORKER_TAIL_LINES
+
+
 def test_a_worker_that_has_said_nothing_far_longer_than_any_job_takes_is_not_believed() -> None:
     """A live pid is not an answer for ever either — and a reboot reissues every one of them.
 

--- a/tests/test_live_analysis.py
+++ b/tests/test_live_analysis.py
@@ -12,12 +12,16 @@ is to be run on the machine that has it, and to say so on the ticket when it has
 
 from __future__ import annotations
 
+import os
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
 
 from resolve_mcp.analysis import applause, bars, beats
-from resolve_mcp.audio import wav
+from resolve_mcp.audio import separator, stems, wav
+from resolve_mcp.config import Config
+from resolve_mcp.jobs import cache
 
 from .fakes import write_clicks, write_hits, write_sections
 
@@ -147,6 +151,79 @@ def test_the_five_tunes_of_a_board_mix_are_found_where_the_human_cut_them() -> N
     assert len(starts) == len(BOARD_TUNE_STARTS)
     for want in BOARD_TUNE_STARTS:
         assert min(abs(one - want) for one in starts) <= BOARD_TOLERANCE_SECONDS
+
+
+ACQUIRED_SET = "Zinc-Set-2-Reaper-v4.wav-8833f33949fe.wav"
+"""The board mix as the acquisition left it in the cache — what the stems on disk were cut from.
+
+Named rather than re-acquired: the export needs Resolve and the project open, and what this
+test is about is the directory the separation already filled, which is keyed on this file's
+bytes. Reaching it any other way would separate a second copy under a second key.
+"""
+
+
+@pytest.mark.live
+def test_a_wind_split_on_the_zinc_stems_runs_that_pass_and_no_other() -> None:
+    """#192's live acceptance: the third pass over a two-pass directory is one pass.
+
+    The fake tier proves the decision — which passes a directory owes — with the separator
+    substituted. What it cannot say is that the real ``17_HP-Wind_Inst-UVR`` reads the
+    ``other`` stem the first pass wrote and labels its halves the way ``WIND_STEMS`` spells
+    them, which is the half of this that only a real model on a real set can answer. Skips
+    where the Zinc stems are not on this machine — record the run on the ticket when they are.
+    """
+    config = _machine_cache()
+    acquired = config.audio_dir / ACQUIRED_SET
+    if not acquired.exists():
+        pytest.skip(f"the acquired Zinc set is not in this cache at {acquired}")
+    audio = {"path": str(acquired), "content_sha256": cache.content_hash(acquired)}
+    params = {**stems.separation_params(config), "split_wind": True}
+    counting = _CountingSeparator()
+
+    output = stems.multi_pass(
+        audio, params, _no_progress, split_wind=True, runner=counting, config=config
+    )
+
+    assert len(counting.calls) <= 1  # nothing to run at all once this test has run once
+    for argv in counting.calls:
+        assert argv[3] == config.wind_model
+        assert argv[1] == output.result["stems"][stems.OTHER_SOURCE]
+    assert set(output.result[stems.OTHER_PASS]) == set(stems.WIND_KEYS.values())
+    assert all(Path(one).exists() for one in output.result[stems.OTHER_PASS].values())
+    assert len(output.result["stems"]) == len(stems.FOUR_STEMS)
+    assert len(output.result["drums"]) >= len(stems.DRUM_STEMS)
+
+
+def _machine_cache() -> Config:
+    """The machine's own cache, not the per-test one redirected into ``tmp_path``.
+
+    That redirect is right everywhere else — nothing a test writes should be readable by the
+    next one — and wrong here. What this verifies is a directory the director's separations
+    filled, reached by a 1.2 GB file's bytes; a temporary copy of it would be a differently
+    keyed directory answering a question the fake tier already answers. The pass this runs is
+    the one that directory is missing, so the run leaves the cache more complete, not dirtier.
+    """
+    return Config.from_env(dict(os.environ))
+
+
+class _CountingSeparator:
+    """The real separator call with a note of every pass it was asked for.
+
+    ``environment`` goes through the same seam, so its probe is kept off the count — what is
+    being measured is separations, and a run that reused everything still asks what it runs on.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: Sequence[str], on_line: separator.Lines) -> int:
+        if "--env_info" not in argv:
+            self.calls.append(list(argv))
+        return separator.run(argv, on_line)
+
+
+def _no_progress(fraction: float, step: str) -> None:
+    """A live pass reports for minutes and there is nobody here to read it."""
 
 
 def _loudness_of(path: Path) -> applause.Loudness:

--- a/tests/test_live_analysis.py
+++ b/tests/test_live_analysis.py
@@ -12,7 +12,6 @@ is to be run on the machine that has it, and to say so on the ticket when it has
 
 from __future__ import annotations
 
-import os
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -163,47 +162,57 @@ bytes. Reaching it any other way would separate a second copy under a second key
 
 
 @pytest.mark.live
-def test_a_wind_split_on_the_zinc_stems_runs_that_pass_and_no_other() -> None:
+def test_a_wind_split_on_the_zinc_stems_runs_that_pass_and_no_other(
+    machine_cache: Config,
+) -> None:
     """#192's live acceptance: the third pass over a two-pass directory is one pass.
 
     The fake tier proves the decision — which passes a directory owes — with the separator
     substituted. What it cannot say is that the real ``17_HP-Wind_Inst-UVR`` reads the
     ``other`` stem the first pass wrote and labels its halves the way ``WIND_STEMS`` spells
-    them, which is the half of this that only a real model on a real set can answer. Skips
-    where the Zinc stems are not on this machine — record the run on the ticket when they are.
+    them, which is the half of this only a real model on a real set can answer.
+
+    The wind pass's own output is cleared first, so what the run owes is the same on the
+    hundredth run as on the first. Measuring the directory as found would make this pass while
+    proving nothing the moment the split is complete, which is a green test that has stopped
+    being an acceptance criterion. Only that pass's output is cleared, and the run rebuilds it;
+    the two passes it must *not* redo are the ones deliberately left alone.
+
+    Skips where the Zinc set is not on this machine — record the run on the ticket when it is.
     """
-    config = _machine_cache()
+    config = machine_cache
     acquired = config.audio_dir / ACQUIRED_SET
     if not acquired.exists():
         pytest.skip(f"the acquired Zinc set is not in this cache at {acquired}")
     audio = {"path": str(acquired), "content_sha256": cache.content_hash(acquired)}
     params = {**stems.separation_params(config), "split_wind": True}
+    _clear_the_wind_pass(stems.stem_directory(audio, params, config))
     counting = _CountingSeparator()
 
     output = stems.multi_pass(
         audio, params, _no_progress, split_wind=True, runner=counting, config=config
     )
 
-    assert len(counting.calls) <= 1  # nothing to run at all once this test has run once
-    for argv in counting.calls:
-        assert argv[3] == config.wind_model
-        assert argv[1] == output.result["stems"][stems.OTHER_SOURCE]
+    assert len(counting.calls) == 1
+    assert counting.calls[0][3] == config.wind_model
+    assert counting.calls[0][1] == output.result["stems"][stems.OTHER_SOURCE]
+    assert output.result["reused"] is False
     assert set(output.result[stems.OTHER_PASS]) == set(stems.WIND_KEYS.values())
     assert all(Path(one).exists() for one in output.result[stems.OTHER_PASS].values())
     assert len(output.result["stems"]) == len(stems.FOUR_STEMS)
     assert len(output.result["drums"]) >= len(stems.DRUM_STEMS)
 
 
-def _machine_cache() -> Config:
-    """The machine's own cache, not the per-test one redirected into ``tmp_path``.
+def _clear_the_wind_pass(directory: Path) -> None:
+    """Undo the third pass, and refuse to run at all if the first two are not there to reuse.
 
-    That redirect is right everywhere else — nothing a test writes should be readable by the
-    next one — and wrong here. What this verifies is a directory the director's separations
-    filled, reached by a 1.2 GB file's bytes; a temporary copy of it would be a differently
-    keyed directory answering a question the fake tier already answers. The pass this runs is
-    the one that directory is missing, so the run leaves the cache more complete, not dirtier.
+    The skip is the point: with no stems on disk this would separate a 74-minute set from
+    scratch and then assert that it did not, which is a twenty-minute way of learning nothing.
     """
-    return Config.from_env(dict(os.environ))
+    if not (directory / stems.MIX_PASS).is_dir() or not (directory / stems.DRUM_PASS).is_dir():
+        pytest.skip(f"the Zinc set has no two-pass separation at {directory} to add a pass to")
+    for stem in (directory / stems.OTHER_PASS).glob("*.wav"):
+        stem.unlink()
 
 
 class _CountingSeparator:

--- a/tests/test_live_analysis.py
+++ b/tests/test_live_analysis.py
@@ -172,11 +172,12 @@ def test_a_wind_split_on_the_zinc_stems_runs_that_pass_and_no_other(
     ``other`` stem the first pass wrote and labels its halves the way ``WIND_STEMS`` spells
     them, which is the half of this only a real model on a real set can answer.
 
-    The wind pass's own output is cleared first, so what the run owes is the same on the
-    hundredth run as on the first. Measuring the directory as found would make this pass while
-    proving nothing the moment the split is complete, which is a green test that has stopped
-    being an acceptance criterion. Only that pass's output is cleared, and the run rebuilds it;
-    the two passes it must *not* redo are the ones deliberately left alone.
+    A directory that owes nothing **skips** rather than passes. Measured as found, this would
+    go green on zero passes the moment the split was complete — an acceptance criterion that
+    has stopped being one. Clearing the wind output first would keep the assertion honest, but
+    it makes every run destroy stems it then has to spend half an hour rebuilding, and a run
+    killed in between leaves the director short of what it deleted (which is how this test lost
+    the Zinc split's orphan half once). A skip costs nobody anything and lies about nothing.
 
     Skips where the Zinc set is not on this machine — record the run on the ticket when it is.
     """
@@ -186,7 +187,7 @@ def test_a_wind_split_on_the_zinc_stems_runs_that_pass_and_no_other(
         pytest.skip(f"the acquired Zinc set is not in this cache at {acquired}")
     audio = {"path": str(acquired), "content_sha256": cache.content_hash(acquired)}
     params = {**stems.separation_params(config), "split_wind": True}
-    _clear_the_wind_pass(stems.stem_directory(audio, params, config))
+    _owing_the_wind_pass(stems.stem_directory(audio, params, config))
     counting = _CountingSeparator()
 
     output = stems.multi_pass(
@@ -203,16 +204,24 @@ def test_a_wind_split_on_the_zinc_stems_runs_that_pass_and_no_other(
     assert len(output.result["drums"]) >= len(stems.DRUM_STEMS)
 
 
-def _clear_the_wind_pass(directory: Path) -> None:
-    """Undo the third pass, and refuse to run at all if the first two are not there to reuse.
+def _owing_the_wind_pass(directory: Path) -> None:
+    """Run only where this directory owes exactly the third pass and nothing else.
 
-    The skip is the point: with no stems on disk this would separate a 74-minute set from
-    scratch and then assert that it did not, which is a twenty-minute way of learning nothing.
+    Both halves are skips rather than assertions because both mean the same thing — the state
+    this measures is not here — and neither is news about the code. With no first two passes
+    on disk this would separate a 74-minute set from scratch and then assert it had not, which
+    is half an hour spent learning nothing; with the split already done it would assert over a
+    run that did nothing at all.
     """
-    if not (directory / stems.MIX_PASS).is_dir() or not (directory / stems.DRUM_PASS).is_dir():
-        pytest.skip(f"the Zinc set has no two-pass separation at {directory} to add a pass to")
-    for stem in (directory / stems.OTHER_PASS).glob("*.wav"):
-        stem.unlink()
+    if separator.missing_from(directory / stems.MIX_PASS, stems.FOUR_STEMS):
+        pytest.skip(f"the Zinc set has no first pass at {directory} to add a pass to")
+    if separator.missing_from(directory / stems.DRUM_PASS, stems.DRUM_STEMS):
+        pytest.skip(f"the Zinc set has no drum pass at {directory} to reuse")
+    if not separator.missing_from(directory / stems.OTHER_PASS, stems.WIND_STEMS):
+        pytest.skip(
+            f"the wind split at {directory} is already complete, so this run would owe nothing "
+            "— delete that pass's directory to measure the split again"
+        )
 
 
 class _CountingSeparator:

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -313,9 +313,8 @@ def test_a_wind_split_on_stems_already_on_disk_runs_only_the_missing_pass(
 ) -> None:
     """#192: the pass a directory is missing is the only work that run owes.
 
-    The flag is not a stems-key param, so a two-pass and a three-pass run share a directory —
-    and reading that directory as partial-so-redo-it-whole spent the better part of an hour of
-    GPU rewriting two passes that were already correct, byte for byte, to add a third.
+    The count is the assertion. What the third pass costs is the whole reason it is opt-in, and
+    the bug was that asking for it charged for the first two as well.
     """
     audio = _acquired(tmp_path)
     two = multi_pass(audio, _params(), _ignored, runner=separating)

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -30,6 +30,7 @@ from resolve_mcp.audio.stems import (
     KIND,
     MIX_PASS,
     OTHER_PASS,
+    OTHER_SOURCE,
     SEPARATED,
     SEPARATION,
     WIND_FLOOR,
@@ -283,18 +284,18 @@ def test_a_wind_model_that_leaves_a_half_out_fails_naming_it(attach: Attach) -> 
 def test_the_flag_keys_the_job_while_the_model_keys_the_stems(
     attach: Attach,
     separating: FakeSeparator,
-    splitting: FakeSeparator,
 ) -> None:
     """Both halves of where the third pass lives in the two keys.
 
     The flag is a job param, or the run that asks for the wind pass is handed the cached
     two-pass answer and never runs anything. It is *not* a stems-key param, or turning it on
-    would separate the same audio into a second directory and orphan the first.
+    would separate the same audio into a second directory and orphan the first — so the
+    second run here reaches the first run's directory and owes it one pass.
     """
     attach(studio(timeline=with_a_mix(FakeTimeline("sunset-set v3", "59.94"))))
     two = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
 
-    three = separate_stems(get_connection(), runner=splitting, split_wind=True)
+    three = separate_stems(get_connection(), runner=FakeSeparator(WIND_STEMS), split_wind=True)
 
     assert three["cached"] is False
     record = wait_for(three["job_id"])
@@ -306,20 +307,69 @@ def test_the_flag_keys_the_job_while_the_model_keys_the_stems(
     assert separation_params()["wind_stems"] == list(WIND_STEMS)
 
 
-def test_a_two_pass_result_on_disk_does_not_read_as_complete_when_the_wind_pass_is_on(
+def test_a_wind_split_on_stems_already_on_disk_runs_only_the_missing_pass(
     tmp_path: Path,
     separating: FakeSeparator,
+) -> None:
+    """#192: the pass a directory is missing is the only work that run owes.
+
+    The flag is not a stems-key param, so a two-pass and a three-pass run share a directory —
+    and reading that directory as partial-so-redo-it-whole spent the better part of an hour of
+    GPU rewriting two passes that were already correct, byte for byte, to add a third.
+    """
+    audio = _acquired(tmp_path)
+    two = multi_pass(audio, _params(), _ignored, runner=separating)
+    wind = FakeSeparator(WIND_STEMS)
+
+    output = multi_pass(audio, _params(), _ignored, runner=wind, split_wind=True)
+
+    assert len(wind.calls) == 1
+    assert _flag(wind.calls[0], "--model_filename") == get_config().wind_model
+    assert wind.calls[0][1] == two.result["stems"][OTHER_SOURCE]
+    assert set(output.result[OTHER_PASS]) == set(WIND_KEYS.values())
+    assert output.result["stems"] == two.result["stems"]
+    assert output.result["drums"] == two.result["drums"]
+    # Something ran, so this is not the reuse that reports no separator environment (#202).
+    assert output.result["reused"] is False
+
+
+def test_a_directory_whose_drum_pass_is_gone_redoes_that_pass_alone(
+    tmp_path: Path,
     splitting: FakeSeparator,
 ) -> None:
-    """A directory missing the pass this run wants is partial, and partial is redone whole."""
+    """The same rule, one pass earlier: what is on disk in full is not separated again."""
     audio = _acquired(tmp_path)
-    multi_pass(audio, _params(), _ignored, runner=separating)
+    first = multi_pass(audio, _params(), _ignored, runner=splitting, split_wind=True)
+    for stem in (Path(first.result["directory"]) / DRUM_PASS).glob("*.wav"):
+        stem.unlink()
+    again = FakeSeparator(SIX_DRUM_STEMS)
 
-    output = multi_pass(audio, _params(), _ignored, runner=splitting, split_wind=True)
+    output = multi_pass(audio, _params(), _ignored, runner=again, split_wind=True)
 
-    assert output.result["reused"] is False
-    assert len(splitting.calls) == 3
-    assert set(output.result[OTHER_PASS]) == set(WIND_KEYS.values())
+    assert len(again.calls) == 1
+    assert _flag(again.calls[0], "--model_filename") == get_config().drum_model
+    assert output.result[OTHER_PASS] == first.result[OTHER_PASS]
+
+
+def test_a_directory_missing_its_first_pass_is_redone_whole(
+    tmp_path: Path,
+    splitting: FakeSeparator,
+) -> None:
+    """Only a pass whose own input is on disk can be skipped.
+
+    The later two are cut from files the first pass wrote, so a mix pass that has to run again
+    makes both of them provisional: reusing them would decompose one separation's drums beside
+    another's, in a directory whose name promises they came from the same run.
+    """
+    audio = _acquired(tmp_path)
+    first = multi_pass(audio, _params(), _ignored, runner=splitting, split_wind=True)
+    for stem in (Path(first.result["directory"]) / MIX_PASS).glob("*.wav"):
+        stem.unlink()
+    again = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, WIND_STEMS)
+
+    multi_pass(audio, _params(), _ignored, runner=again, split_wind=True)
+
+    assert len(again.calls) == 3
 
 
 def test_a_two_pass_result_on_disk_is_complete_when_the_wind_pass_is_off(
@@ -533,13 +583,16 @@ def test_the_stems_a_job_owns_are_what_its_cache_entry_verifies(
     first = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
     assert first.result is not None
     Path(first.result["drums"]["kick"]).unlink()
+    redoing = FakeSeparator(SIX_DRUM_STEMS)
 
-    again = wait_for(separate_stems(get_connection(), runner=separating)["job_id"])
+    again = wait_for(separate_stems(get_connection(), runner=redoing)["job_id"])
 
     assert again.cached is False
     assert again.state == "completed", again.error
     assert again.result is not None
     assert Path(again.result["drums"]["kick"]).exists()
+    # The pass the missing stem belongs to, and no other: the mix is still whole (#192).
+    assert len(redoing.calls) == 1
 
 
 # --- failures ----------------------------------------------------------------------------
@@ -727,7 +780,7 @@ def test_a_byte_the_consoles_codepage_cannot_decode_does_not_kill_the_run() -> N
     """
     seen: list[str] = []
 
-    returncode = separator._run(_emitting(b"separating four stems (1%): \x8f"), seen.append)
+    returncode = separator.run(_emitting(b"separating four stems (1%): \x8f"), seen.append)
 
     assert returncode == 0
     assert seen == ["separating four stems (1%): �\n"]
@@ -738,7 +791,7 @@ def test_the_output_is_read_as_utf_8_whatever_the_console_is() -> None:
     """The bar audio-separator draws is UTF-8; decoded as cp1252 it comes back as mojibake."""
     seen: list[str] = []
 
-    separator._run(_emitting("100%|██████| 4/4 café".encode()), seen.append)
+    separator.run(_emitting("100%|██████| 4/4 café".encode()), seen.append)
 
     assert seen == ["100%|██████| 4/4 café\n"]
 


### PR DESCRIPTION
Closes #192.

Two defects from the gauntlet, both confirmed against real artifacts on the live box.

## Defect 1 — a wind split redid the whole key

`split_wind` is a job param but deliberately not a stems-key param, so two-pass
and three-pass runs share one stems directory. That directory was judged
all-or-nothing: missing the third pass made it *partial*, and partial was redone
whole. Asking for the opt-in third pass therefore charged for the first two as
well — the better part of an hour of GPU rewriting two byte-identical answers,
which is the one cost the flag exists to avoid.

`_complete` now reads each pass's directory separately and `_passes` runs only
what the directory owes, collecting the rest off disk. The dependency runs one
way — the later two passes are cut from files the first wrote — so a missing mix
pass still redoes all three.

## Defect 2 — the pass's output tail was not captured

Traced to the detached worker, not the separator. `separator.separate` already
put its output tail in the failure detail; what was lost is a worker process that
*dies* mid-pass and so never writes its own failure. The record named only the
dead pid, while the worker's log — the only account of the crash — sat unread
beside it.

`store._interrupted` now folds the tail of `<job-id>.worker.log` onto the record
and names the path to the whole file. `store.worker_log` is the one owner of that
name (it reads the file back; `detached` cannot own it, since `store` cannot
import `detached`).

The bug's artifact is still on this box and is what the ticket describes: the
Zinc stems directory holds `mix=4 drums=6 other=1` — the crashed wind pass wrote
`(No Woodwinds)` and never the other half, and the failure had to be diagnosed
from that.

## Test seams

- **Fake tier** — AC1: a wind split over stems on disk runs one pass, and the one
  call is the wind model against the `other` stem the first pass wrote. Plus the
  drum-pass-alone case, and the guard that a missing first pass still redoes all
  three. AC2: a dead worker's output lands on the record, a worker that printed
  nothing still names where the log would be, and a long log is tailed rather
  than swallowed whole.
- **Live smoke** — AC3: `test_a_wind_split_on_the_zinc_stems_runs_that_pass_and_no_other`,
  which clears the wind pass's own output and asserts exactly one real pass runs
  with the real `17_HP-Wind_Inst-UVR` underneath. **Not yet recorded as run** —
  see below.

## Scope note

Per-pass reuse applies to all three passes, not only the wind one. Special-casing
the third would have been more code for less coherence, and `missing_from` only
ever checked presence, so no corruption backstop is lost by it.

## Review

Two-axis `/code-review` against `origin/main`, both axes as parallel sub-agents.

**Standards — 2 hard findings, both on the live test, both fixed:**

1. The test re-derived the machine config to escape the per-test cache redirect,
   reversing an invariant `conftest` states for both tiers. Now a named
   `machine_cache` fixture declared beside the redirect, so a test that wants the
   real cache says so in its signature.
2. Its assertion (`len(calls) <= 1`) held only on the first run — once the split
   was complete it passed on *zero* passes, green while proving nothing. It now
   clears the wind pass's own output first and asserts exactly one pass, so it
   holds on every run.

**Standards — smells, all judgement calls, all taken:** "is the wind pass owed"
was derived in three places (now answered once, in `_complete`);
`detached.worker_log` was a pure delegate (deleted, callers point at the owner);
`_passes(reuse=...)` had a default its one call site never used; the third pass's
branch tested a condition the first half already implied; duplicated rationale
prose between `stems.py` and its test, trimmed. CONTEXT.md now carries the
pass-by-pass rule and a corrected live-test count (already stale by two before
this branch).

**Spec — 1 partial finding, taken:** AC2 asks for *complete* output, and the
surviving-worker route still capped its tail at 40 lines — 40 redraws of a
progress bar on any failure the model took a moment to die of. Raised to match
the dead-worker tail. The spec axis found nothing implemented wrongly.

**Fix-diff self-review** caught one smell introduced by the fixes themselves: the
live test re-implementing the stems directory name. Extracted to
`stems.stem_directory`, now called by `multi_pass` and the test alike.

Fake tier green, mypy strict clean, ruff clean after every round.

## Needs from you

- **AC3, the live wind split, is not recorded as run.** Four attempts on this box.
  Two were killed part-way through the pass (background commands here have a
  wall-clock limit shorter than this pass takes), one skipped against the wrong
  cache, and one exited 1 while another worktree session held a second separator.
  The pass itself is fine: run directly with the box quiet, it separated happily
  past the point every test run died.

- **Two environment facts behind that, neither of them this ticket's:**
  - **The resolved `audio-separator` runs a CPU torch build (`2.13.0+cpu`)**,
    confirmed identically inside and outside `uv run`, so it is the machine's
    install rather than the invocation. Every separation on this box is paying CPU
    prices, which is why a wind pass over a 74-minute stem takes tens of minutes
    here. That is G10/#188's subject; the #202 probe is what reported it. Worth
    deciding whether `RESOLVE_MCP_AUDIO_SEPARATOR` should point at a CUDA install.
  - Several worktree sessions were running at once (issue-182/183/186), and C: is
    down to ~17 GB free while each stem written is ~1.1 GB.

- **I removed one file from your cache, and should say so.** An earlier version of
  this test cleared the wind pass's output before running, so its assertion would
  hold on every run; a killed run then left nothing rebuilt. What went was the
  crashed pass's orphan `(No Woodwinds)` half — one half of an unusable pair, not
  a working split — and `mix/` and `drums/` are untouched. The last commit on this
  branch removes that clearing: the test now **skips** where it owes nothing
  rather than deleting anything, so no run of it can cost you stems again. I also
  cleared the stale `.separating.json` my killed run left; the abandoned-claim
  path handles that by itself, but it was my litter.

- **To run the AC** (it needs the machine to itself, and a terminal that will not
  time out — worth running yourself with the `!` prefix rather than handing it to
  a background session):

      uv run pytest -m live -k zinc_stems_runs_that_pass -q -rs

  The preconditions are already right for a real run: the Zinc `mix/` and `drums/`
  passes are complete and will be reused, and `other/` owes both halves, so the
  test runs exactly one pass — which is the criterion.

Review: clean — findings above are resolved; fake tier, mypy strict and ruff green.


Review: clean — focused pass over the follow-up commit (live AC skips instead of clearing stems); no findings, fake tier + mypy strict + ruff green.
