### PR TITLE
Record the device each separation pass ran on (#188)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -173,7 +173,9 @@ self-review, warnings only, touches no Resolve handle), `whisper`
 `audio/` — concert audio out of Resolve onto disk: `acquire` (both routes),
 `ffmpeg` (per-source-clip route), `riff` (the WAV container itself: PCM,
 IEEE float and extensible headers, because stdlib `wave` opens PCM only),
-`separator` (python-audio-separator out of process), `stems` (two passes —
+`separator` (python-audio-separator out of process; its torch build probed
+before a fresh separation and the device each pass announces read off that
+pass's banner, both onto the job record — #202, #188), `stems` (two passes —
 mix into four, then the drum stem into the kit — plus an opt-in third,
 `split_wind`, splitting `other` into `wind` and `comp`; `comp` is
 accompaniment, never a piano stem. A directory is judged pass by pass and

--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -20,7 +20,7 @@ says so in the log and the job record.**
 | Beat grid | `analysis/beats` (beat_this, torch) | **CPU by policy** — see below | exists upstream (CUDA torch) | `device.announce("beat_this")` at inference; `torch` note in the music/structure job results |
 | Applause curve | `analysis/applause` (PANNs, torch) | **CPU by policy** — same decision | exists upstream | `device.announce("PANNs")`; same `torch` note |
 | Transcription | `analysis/whisper` (faster-whisper/CTranslate2) | **CUDA** (`whisper_device=auto`, runtime shipped by the analysis extra, #128) | yes — already wired | resolved device logged after model load; `auto`→CPU resolve is a WARNING |
-| Stem separation | `audio/separator` (external CLI, its own torch) | whatever the PATH install has — **found `2.13.0+cpu` on the live box, 2026-08-14** | yes — CUDA torch in the separator's env | `--env_info` probed before every fresh separation; build in the log + job record; `+cpu` build is a WARNING |
+| Stem separation | `audio/separator` (external CLI, its own torch) | whatever the PATH install has — **found `2.13.0+cpu` on the live box, 2026-08-14** | yes — CUDA torch in the separator's env | `--env_info` probed before every fresh separation; build in the log + job record; `+cpu` build is a WARNING; each pass's own device read off its banner into `separator.device` (#188), CPU under a GPU build is a WARNING |
 | Rendering | `resolve/render`, `deliver` | Resolve's own GPU pipeline | Resolve's business | out of scope — Resolve manages its own devices |
 
 Deliberately out of scope: the gauntlet A/B pack's decodes
@@ -108,3 +108,13 @@ build, carries it in the job record, and warns on `+cpu`. The fix — CUDA
 torch installed into whatever environment owns the PATH
 `audio-separator`, or `RESOLVE_MCP_AUDIO_SEPARATOR` pointed at one that
 has it — is an install action on the box, recorded on ticket #202.
+
+The build says what the install *can* do; it does not say what a run
+*did*. Each pass announces its own device in its opening banner, and that
+line is read back into `separator.device` on the job record — `cuda`,
+`cpu`, or `unknown` where the banner named nothing (#188). The last pass's
+reading is the one recorded, because a run that reached the card once and
+then could not is a CPU run. A CPU device under a GPU-capable build is the
+fallback G10 hid behind "it was slow": it is a WARNING in the log and a
+`warning` on the record, except where the `+cpu` build already warned —
+that message names the fix and this one would only replace it.

--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -111,10 +111,14 @@ has it — is an install action on the box, recorded on ticket #202.
 
 The build says what the install *can* do; it does not say what a run
 *did*. Each pass announces its own device in its opening banner, and that
-line is read back into `separator.device` on the job record — `cuda`,
-`cpu`, or `unknown` where the banner named nothing (#188). The last pass's
+line is read back into `separator.device` on the job record — whatever the
+banner named, lowercased (`cuda`, `cuda:0`, `mps`, `cpu`), or `unknown`
+where it named nothing (#188). A reader after the GPU wants "not `cpu`",
+not `== "cuda"`: the device is a reading, not an enum. The last pass's
 reading is the one recorded, because a run that reached the card once and
 then could not is a CPU run. A CPU device under a GPU-capable build is the
-fallback G10 hid behind "it was slow": it is a WARNING in the log and a
-`warning` on the record, except where the `+cpu` build already warned —
-that message names the fix and this one would only replace it.
+fallback G10 hid behind "it was slow": it is a WARNING in the log at the
+pass that announced it, and a `warning` on the record — except under a
+`+cpu` build, whose warning is the same news with the fix attached. A
+build the probe could not read is not that case: its warning says whether
+this ran on the GPU is unknown, which a CPU reading has just answered.

--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -188,7 +188,7 @@ def environment(
     return report
 
 
-def record_device(report: dict[str, Any], readings: Sequence[str]) -> dict[str, Any]:
+def record_device(report: dict[str, Any], readings: Sequence[str]) -> None:
     """Fold what the passes announced into the environment report, as ``device`` (#188).
 
     The *last* reading wins: each pass is its own process and answers for itself, so a run
@@ -196,20 +196,22 @@ def record_device(report: dict[str, Any], readings: Sequence[str]) -> dict[str, 
     ``cuda`` would hide the fallback this record exists to show. No reading at all is
     ``unknown``, never an error.
 
-    A CPU device earns a warning only where nothing has warned already: a ``+cpu`` build is
-    the same news with the fix attached, and replacing that message would cost the reader the
-    one line that says what to do.
+    A CPU device earns a warning against every build but ``+cpu``: that one is the same news
+    with the fix attached, and replacing it would cost the reader the one line that says what
+    to do. A build that could not be read is *not* that case — "whether this runs on the GPU
+    is unknown" is exactly the sentence a known CPU device has just answered.
+
+    The reading is not logged again here. Each pass already warned as it announced, which is
+    where a run diagnosed from the log alone is read from; this only shapes the record.
     """
     report["device"] = readings[-1] if readings else UNKNOWN_DEVICE
-    if report["device"] == CPU_DEVICE and "warning" not in report:
+    if report["device"] == CPU_DEVICE and "+cpu" not in (report.get("torch") or ""):
         report["warning"] = (
-            "The separator ran on the CPU although its torch build "
-            f"({report.get('torch')}) can use a GPU: separations run at a fraction of GPU "
-            "speed. Check that the GPU is visible to the environment that owns the "
-            "audio-separator on PATH (drivers, CUDA runtime, another process holding the card)."
+            f"The separator ran on the CPU under torch {report.get('torch') or 'unknown'}: "
+            "separations run at a fraction of GPU speed. Check that the GPU is visible to the "
+            "environment that owns the audio-separator on PATH (drivers, CUDA runtime, another "
+            "process already holding the card)."
         )
-        log.warning("%s", report["warning"])
-    return report
 
 
 def separate(
@@ -256,6 +258,9 @@ def separate(
             detail={"executable": config.audio_separator, "model": model},
         ) from exc
 
+    # Reported before the refusals below are raised: a pass that died still ran somewhere, and
+    # on the CPU that is often why it died (a wall-clock ceiling, a watchdog). The caller keeps
+    # the reading only if the job survives to write a record.
     if announced is None:
         log.info("audio-separator named no device while running %s; it stays unknown", model)
     elif on_device is not None:

--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -57,6 +57,18 @@ TORCH_BUILD = re.compile(r"PyTorch Version:\s*(\S+)", re.IGNORECASE)
 DOWNLOAD = re.compile(r"download", re.IGNORECASE)
 """A first run fetches its model and prints a bar for that too. It is not the separation."""
 
+DEVICE_SET = re.compile(r"setting\s+(?:the\s+)?torch\s+device\s+to\s+(\S+)", re.IGNORECASE)
+"""The line a pass opens with: ``CUDA is available in Torch, setting Torch device to CUDA``."""
+DEVICE_NAMED = re.compile(r"torch\s+device\s*[:=]\s*(\S+)", re.IGNORECASE)
+"""The other shape the same fact is printed in, ``Torch device: cuda:0``."""
+CPU_MODE = re.compile(r"running\s+in\s+CPU\s+mode", re.IGNORECASE)
+"""What it says instead when it configured no acceleration at all — G10's own line."""
+
+CPU_DEVICE = "cpu"
+UNKNOWN_DEVICE = "unknown"
+"""A banner that named no device. Not a failure: half an hour of GPU is not worth a
+wording change."""
+
 FULL = 100.0
 
 
@@ -70,6 +82,9 @@ the process exits.
 """
 
 Fraction = Callable[[float], None]
+
+Device = Callable[[str], None]
+"""Told which device a pass announced, once, as the pass announces it."""
 
 
 def command(executable: str, model: str, source: Path | str, out_dir: Path | str) -> list[str]:
@@ -90,6 +105,22 @@ def label_of(path: Path | str) -> str | None:
     """The stem this file holds, read off the label the separator wrote into its name."""
     found = LABEL.findall(Path(path).stem)
     return found[-1].strip().lower() if found else None
+
+
+def device_of(line: str) -> str | None:
+    """The device this line of a pass's banner names — ``None`` for every other line.
+
+    Read off the pass's own output rather than off ``--env_info``, because the probe answers
+    for the *install* and this answers for the *run*: a CUDA build that cannot reach the card
+    falls back to the CPU and says so here, in a line that used to scroll past between two
+    progress bars. That fallback, unseen, is the whole of G10 (#188).
+    """
+    if CPU_MODE.search(line):
+        return CPU_DEVICE
+    found = DEVICE_SET.search(line) or DEVICE_NAMED.search(line)
+    if found is None:
+        return None
+    return found.group(1).strip().strip(".,;:'\"").lower() or None
 
 
 def collect(out_dir: Path | str) -> dict[str, Path]:
@@ -157,6 +188,30 @@ def environment(
     return report
 
 
+def record_device(report: dict[str, Any], readings: Sequence[str]) -> dict[str, Any]:
+    """Fold what the passes announced into the environment report, as ``device`` (#188).
+
+    The *last* reading wins: each pass is its own process and answers for itself, so a run
+    whose second pass could not reach the card ran on the CPU — reporting the first pass's
+    ``cuda`` would hide the fallback this record exists to show. No reading at all is
+    ``unknown``, never an error.
+
+    A CPU device earns a warning only where nothing has warned already: a ``+cpu`` build is
+    the same news with the fix attached, and replacing that message would cost the reader the
+    one line that says what to do.
+    """
+    report["device"] = readings[-1] if readings else UNKNOWN_DEVICE
+    if report["device"] == CPU_DEVICE and "warning" not in report:
+        report["warning"] = (
+            "The separator ran on the CPU although its torch build "
+            f"({report.get('torch')}) can use a GPU: separations run at a fraction of GPU "
+            "speed. Check that the GPU is visible to the environment that owns the "
+            "audio-separator on PATH (drivers, CUDA runtime, another process holding the card)."
+        )
+        log.warning("%s", report["warning"])
+    return report
+
+
 def separate(
     source: Path | str,
     out_dir: Path | str,
@@ -165,6 +220,7 @@ def separate(
     progress: Fraction | None = None,
     runner: Runner | None = None,
     config: Config | None = None,
+    on_device: Device | None = None,
 ) -> dict[str, Path]:
     """Run one pass, and return the stems it wrote — or fail naming what it left out."""
     config = config or get_config()
@@ -172,12 +228,21 @@ def separate(
     destination.mkdir(parents=True, exist_ok=True)
     argv = command(config.audio_separator, model, source, destination)
     tail: deque[str] = deque(maxlen=OUTPUT_TAIL)
+    announced: str | None = None
 
     def on_line(line: str) -> None:
+        nonlocal announced
         text = line.strip()
         if not text:
             return
         tail.append(text)
+        # Only until the pass has named its device: it names it once, in the banner, and the
+        # lines after that are a progress bar redrawn several times a second.
+        if announced is None:
+            named = device_of(text)
+            if named is not None:
+                announced = named
+                _report_device(named, model)
         fraction = _percent(text)
         if fraction is not None and progress is not None:
             progress(fraction)
@@ -190,6 +255,11 @@ def separate(
             cause=f"No audio-separator at {config.audio_separator!r}.",
             detail={"executable": config.audio_separator, "model": model},
         ) from exc
+
+    if announced is None:
+        log.info("audio-separator named no device while running %s; it stays unknown", model)
+    elif on_device is not None:
+        on_device(announced)
 
     output = "\n".join(tail)
     if returncode != 0:
@@ -220,6 +290,22 @@ def missing_from(out_dir: Path | str, wanted: Iterable[str]) -> list[str]:
     """Which of these stems are not already sitting in this directory."""
     produced = collect(out_dir)
     return [one for one in wanted if one not in produced]
+
+
+def _report_device(device: str, model: str) -> None:
+    """Say what this pass runs on, at the moment it says so itself.
+
+    A CPU pass is a warning even where the build explains it: this is the line a live failure
+    outside a session gets diagnosed from, and "it was slow" is not a diagnosis.
+    """
+    if device == CPU_DEVICE:
+        log.warning(
+            "audio-separator is running %s on the CPU: a pass that takes minutes on the GPU "
+            "takes hours here. See docs/reference/compute-device-inventory.md",
+            model,
+        )
+    else:
+        log.info("audio-separator is running %s on %s", model, device)
 
 
 def _percent(line: str) -> float | None:

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -918,7 +918,8 @@ def multi_pass(
     if separator_env is not None:
         # What the passes said they ran on, beside the build they ran under (#188). Only the
         # fresh path has either: a reuse ran no process, and no process said anything.
-        result["separator"] = separator.record_device(separator_env, devices)
+        separator.record_device(separator_env, devices)
+        result["separator"] = separator_env
     if split_wind:
         # Keyed like ``drums`` is: the name of the stem this pass took apart. Absent rather
         # than empty when the pass is off, so the envelope never offers a stem nobody made.

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -866,6 +866,7 @@ def multi_pass(
     wanted_other = other_dir if split_wind else None
 
     separator_env: dict[str, Any] | None = None
+    devices: list[str] = []
     reused = reuse and _already_separated(mix_dir, drums_dir, other_dir, split_wind)
     if reused:
         log.info("Stems for %s are already on disk at %s", audio["path"], directory)
@@ -901,6 +902,7 @@ def multi_pass(
                     runner=runner,
                     config=config,
                     reuse=reuse,
+                    on_device=devices.append,
                 )
 
     progress(COLLECTING, "collecting the stems")
@@ -914,7 +916,9 @@ def multi_pass(
         "reused": reused,
     }
     if separator_env is not None:
-        result["separator"] = separator_env
+        # What the passes said they ran on, beside the build they ran under (#188). Only the
+        # fresh path has either: a reuse ran no process, and no process said anything.
+        result["separator"] = separator.record_device(separator_env, devices)
     if split_wind:
         # Keyed like ``drums`` is: the name of the stem this pass took apart. Absent rather
         # than empty when the pass is off, so the envelope never offers a stem nobody made.
@@ -958,6 +962,7 @@ def _passes(
     runner: separator.Runner | None,
     config: Config,
     reuse: bool,
+    on_device: separator.Device | None = None,
 ) -> _Sets:
     """The two passes, and the third when it is asked for — run with the claim already held.
 
@@ -985,6 +990,7 @@ def _passes(
             progress=_pass(beat, ACQUIRE_CEILING, PASS_ONE_CEILING, "separating four stems"),
             runner=runner,
             config=config,
+            on_device=on_device,
         )
     if done.drums:
         log.info("Reusing the drum stems already at %s", drums_dir)
@@ -1004,6 +1010,7 @@ def _passes(
             ),
             runner=runner,
             config=config,
+            on_device=on_device,
         )
     other: dict[str, Path] = {}
     if not split_wind:
@@ -1021,6 +1028,7 @@ def _passes(
             progress=_pass(beat, WIND_FLOOR, SEPARATED, "splitting the winds"),
             runner=runner,
             config=config,
+            on_device=on_device,
         )
     return _Sets(stems, drums, other)
 

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -83,6 +83,8 @@ from .pool import FakeMediaPool as FakeMediaPool
 from .pool import media_pool as media_pool
 from .project import FakeProject as FakeProject
 from .project import FakeProjectManager as FakeProjectManager
+from .separator import CPU_BANNER as CPU_BANNER
+from .separator import CUDA_BANNER as CUDA_BANNER
 from .separator import FakeSeparator as FakeSeparator
 from .timeline import FakeTimeline as FakeTimeline
 from .timeline import FakeTrack as FakeTrack

--- a/tests/fakes/separator.py
+++ b/tests/fakes/separator.py
@@ -7,6 +7,13 @@ from pathlib import Path
 
 from .fixtures import write_wav
 
+PREFIX = "2026-01-01 00:00:00,000 - INFO - separator"
+"""How the real CLI stamps every line it prints."""
+
+CUDA_BANNER = (f"{PREFIX} - CUDA is available in Torch, setting Torch device to CUDA",)
+CPU_BANNER = (f"{PREFIX} - No hardware acceleration could be configured, running in CPU mode",)
+"""The two device lines a pass opens with — the second one is G10's failure, spelled out."""
+
 
 class FakeSeparator:
     """Stand in for the audio-separator CLI, one pass per call.
@@ -17,6 +24,11 @@ class FakeSeparator:
     positional argument is one pass's labels, and the sequence starts over on the call
     after the last: a second separation of the same audio is another first pass, not a
     seventh one.
+
+    ``banners`` cycles the same way, one entry per pass, because the device is read off what
+    each pass prints and each pass is its own process: a run that reached the GPU once and
+    then could not is the case the reading exists for. ``banners=()`` prints no device line
+    at all — a version too old to name one.
     """
 
     def __init__(
@@ -25,11 +37,13 @@ class FakeSeparator:
         returncode: int = 0,
         output: Sequence[str] = (),
         torch_build: str = "2.13.0+cu126",
+        banners: Sequence[Sequence[str]] = (CUDA_BANNER,),
     ) -> None:
         self.passes = [tuple(one) for one in passes]
         self.returncode = returncode
         self.output = tuple(output)
         self.torch_build = torch_build
+        self.banners = [tuple(one) for one in banners]
         self.calls: list[list[str]] = []
         self.probes: list[list[str]] = []
 
@@ -38,16 +52,22 @@ class FakeSeparator:
             # The build report (#202), answered the way the real CLI prints it and kept off
             # ``calls`` so the pass cycle still counts separations alone.
             self.probes.append(list(argv))
-            prefix = "2026-01-01 00:00:00,000 - INFO - separator"
-            on_line(f"{prefix} - PyTorch Version: {self.torch_build}")
+            on_line(f"{PREFIX} - PyTorch Version: {self.torch_build}")
             return 0
         self.calls.append(list(argv))
+        for line in self._banner():
+            on_line(line)
         for line in self.output:
             on_line(line)
         if self.returncode == 0:
             for label in self._labels():
                 write_wav(self._target(argv, label), seconds=0.2)
         return self.returncode
+
+    def _banner(self) -> tuple[str, ...]:
+        if not self.banners:
+            return ()
+        return self.banners[(len(self.calls) - 1) % len(self.banners)]
 
     def _labels(self) -> tuple[str, ...]:
         if not self.passes:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -33,6 +33,7 @@ from typing import Any, NamedTuple
 
 import pytest
 
+from resolve_mcp.audio import separator
 from resolve_mcp.audio.acquire import acquire_timeline_audio
 from resolve_mcp.audio.stems import (
     DRUM_STEMS,
@@ -1136,6 +1137,7 @@ def test_the_real_separator_produces_the_stems_the_passes_expect(tmp_path: Path)
         separation_params(),
         lambda fraction, step: None,
         split_wind=True,
+        reuse=False,
     )
 
     assert set(output.result["stems"]) >= set(FOUR_STEMS)
@@ -1144,6 +1146,11 @@ def test_the_real_separator_produces_the_stems_the_passes_expect(tmp_path: Path)
     assert all(Path(one).stat().st_size > 0 for one in output.result["stems"].values())
     assert all(Path(one).stat().st_size > 0 for one in output.result["drums"].values())
     assert all(Path(one).stat().st_size > 0 for one in output.result["other"].values())
+    # The other thing no fake can answer: that the real banner still names its device in
+    # words ``device_of`` reads (#188). Which device it is depends on the install and is the
+    # box's business — that it parsed at all is this tier's. ``reuse=False`` because the
+    # fixture tone hashes the same every run, and stems read off disk announce nothing.
+    assert output.result["separator"]["device"] != separator.UNKNOWN_DEVICE
 
 
 @pytest.mark.skipif(

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -56,6 +56,8 @@ from resolve_mcp.tools import stems as stems_tool
 
 from .conftest import Attach
 from .fakes import (
+    CPU_BANNER,
+    CUDA_BANNER,
     FakeMediaPoolItem,
     FakeSeparator,
     FakeTimeline,
@@ -938,3 +940,98 @@ def test_a_reused_separation_reports_no_environment_because_nothing_ran(
 
     assert output.result["reused"] is True
     assert "separator" not in output.result
+
+
+# --- the device the separation actually ran on (#188) ------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("CUDA is available in Torch, setting Torch device to CUDA", "cuda"),
+        ("Apple Silicon MPS/CoreML is available in Torch, setting Torch device to MPS", "mps"),
+        ("No hardware acceleration could be configured, running in CPU mode", "cpu"),
+        ("Torch device: cuda:0", "cuda:0"),
+        ("Setting Torch device to cuda:1.", "cuda:1"),
+    ],
+)
+def test_the_device_is_read_off_the_lines_the_separator_prints(line: str, expected: str) -> None:
+    assert separator.device_of(f"2026-01-01 00:00:00,000 - INFO - separator - {line}") == expected
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "PyTorch Version: 2.13.0+cu126",
+        "Separator version 1.2.3 instantiating with output_dir: /stems",
+        "  32%|###       | 8/25 [00:04<00:09,  1.77it/s]",
+        "",
+    ],
+)
+def test_a_line_that_names_no_device_reads_as_no_device(line: str) -> None:
+    assert separator.device_of(line) is None
+
+
+def test_a_fresh_separation_carries_the_device_its_passes_ran_on(tmp_path: Path) -> None:
+    fake = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, banners=(CUDA_BANNER,))
+
+    output = multi_pass(_acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake)
+
+    assert output.result["separator"]["device"] == "cuda"
+
+
+def test_a_cpu_fallback_on_a_cuda_build_is_on_the_record_and_warned_about(
+    tmp_path: Path,
+) -> None:
+    """G10 itself: the models are CUDA-capable, the run fell back to the CPU, and the only
+    symptom was that it took a day. The build says nothing is wrong here, so the device is
+    the only thing that can."""
+    fake = FakeSeparator(
+        FOUR_STEMS, SIX_DRUM_STEMS, torch_build="2.13.0+cu126", banners=(CPU_BANNER,)
+    )
+
+    output = multi_pass(_acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake)
+
+    report = output.result["separator"]
+    assert report["device"] == "cpu"
+    assert "CPU" in report["warning"]
+
+
+def test_a_cpu_build_keeps_its_own_warning_because_that_one_names_the_fix(
+    tmp_path: Path,
+) -> None:
+    """A ``+cpu`` build already explains the CPU device and says how to replace it. The
+    device warning would only overwrite that with less."""
+    fake = FakeSeparator(
+        FOUR_STEMS, SIX_DRUM_STEMS, torch_build="2.13.0+cpu", banners=(CPU_BANNER,)
+    )
+
+    output = multi_pass(_acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake)
+
+    report = output.result["separator"]
+    assert report["device"] == "cpu"
+    assert "RESOLVE_MCP_AUDIO_SEPARATOR" in report["warning"]
+
+
+def test_a_separator_that_names_no_device_records_unknown_rather_than_failing(
+    tmp_path: Path,
+) -> None:
+    """A banner that changed wording, or a version too old to print one, is not a reason to
+    fail half an hour of GPU: the record says the device is unknown and the stems still land."""
+    fake = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, banners=())
+
+    output = multi_pass(_acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake)
+
+    assert output.result["separator"]["device"] == separator.UNKNOWN_DEVICE
+    assert output.result["stems"]
+
+
+def test_the_device_the_last_pass_ran_on_is_the_one_recorded(tmp_path: Path) -> None:
+    """Each pass is its own process and says so for itself. A run whose second process could
+    not reach the GPU is a CPU run — reporting the first pass's ``cuda`` would hide exactly
+    the fallback this record exists to show."""
+    fake = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, banners=(CUDA_BANNER, CPU_BANNER))
+
+    output = multi_pass(_acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake)
+
+    assert output.result["separator"]["device"] == "cpu"

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -1013,6 +1013,19 @@ def test_a_cpu_build_keeps_its_own_warning_because_that_one_names_the_fix(
     assert "RESOLVE_MCP_AUDIO_SEPARATOR" in report["warning"]
 
 
+def test_an_unreadable_build_plus_a_cpu_device_is_still_warned_about(tmp_path: Path) -> None:
+    """The probe's own warning says whether this runs on the GPU is *unknown*. The passes have
+    since answered that, so the CPU warning replaces it rather than being suppressed by it."""
+    fake = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, torch_build="", banners=(CPU_BANNER,))
+
+    output = multi_pass(_acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake)
+
+    report = output.result["separator"]
+    assert report["torch"] is None
+    assert report["device"] == "cpu"
+    assert "ran on the CPU" in report["warning"]
+
+
 def test_a_separator_that_names_no_device_records_unknown_rather_than_failing(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #188.

The torch build says what the separator install *can* do; it does not say what a run *did*. A CUDA-capable build that cannot reach the card falls back to the CPU and says so once, in a banner line between two progress bars — unseen, that is G10 exactly: everything worked, 40× slower.

Each pass's banner is now read as it prints:

* `separator.device_of` parses the three shapes the CLI uses — `setting Torch device to CUDA`, `Torch device: cuda:0`, `running in CPU mode` — and returns the reading lowercased, verbatim.
* `separate` reports the first device a pass names through an `on_device` sink, and warns at that moment when it is the CPU (the lifecycle line a live failure gets diagnosed from).
* `multi_pass` folds the readings into the `separator` block already on the record (#202) as `separator.device`. The **last** pass's reading wins: each pass is its own process, so a run that reached the card once and then could not is a CPU run.
* A banner naming nothing is `device: unknown` — never a failed job.
* A CPU device also puts a `warning` on the record, against every build but `+cpu` (that one already warns and names the fix).

## Test seam

Fake tier (`tests/test_stem_separation.py`) — `device_of` over canned banner lines, and every record outcome through `multi_pass` with `FakeSeparator(banners=...)`: cuda, a CPU fallback under a CUDA build, a `+cpu` build keeping its own warning, an unreadable build still warned about, no banner → `unknown`, and a run whose second pass lost the card recording `cpu`. Live smoke (`tests/test_live_smoke.py`) — the one thing no fake answers: that the real CLI's banner still parses.

**Live run, 2026-08-14, Windows 11 box, python.org 3.11 + Resolve Studio up:** `uv run pytest tests/test_live_smoke.py -m live -k separator` — **1 passed** in 109s (ran, not skipped). All three real passes (`htdemucs_ft.yaml`, `MDX23C-DrumSep`, `17_HP-Wind_Inst-UVR`) announced and parsed as `cpu`, under this box's PATH `audio-separator` (torch `2.13.0+cpu`). So AC 2's *`cuda` on the record* is not yet observable here — the CUDA install is #202's open box action; the code path is proven live for parsing and for the CPU fallback the record now shows instead of hiding.

Fake tier: 2090 passed. mypy strict and ruff clean.

## Review

`/code-review` since `origin/main`, two axes in parallel sub-agents.

**Standards** — no documented-standard violations. Six judgement calls; four taken, two accepted:

1. *Doc/behaviour mismatch* — the inventory doc said `cuda`/`cpu`/`unknown` while `device_of` keeps `cuda:0`/`mps` verbatim. **Fixed:** doc widened, and it now says a GPU check reads "not `cpu`", not `== "cuda"`.
2. *Suppression wider than documented* — `"warning" not in report` also suppressed the CPU warning under the *unreadable build* warning. **Fixed:** suppresses against `+cpu` alone.
3. *Duplicated CPU warning / logged twice* — **Fixed:** `record_device` no longer logs; the pass that announced already warned.
4. *Mutate-and-return* — **Fixed:** `record_device` returns `None`.
5. *`report.get("torch")` guarded nothing* — now genuinely reachable with `torch is None`, and the message reads `torch unknown`. **Fixed** with (2).
6. *`on_device` fires before the failure raise* — **accepted, documented:** a pass that died still ran somewhere, and on the CPU that is often why; the caller keeps the reading only if the job writes a record.

**Spec** — no requirement implemented wrongly. Three notes, all accepted:

1. *AC 2 unproven* — the live assertion is `!= unknown`, which is what this box can prove (`2.13.0+cpu` install). Recorded above and on the ticket as the one unrun live AC.
2. *A reused separation carries no `device`* — deliberate, and tested: a reuse ran no process and no process said anything. Same rule as #202's `separator` block.
3. *`device` nests under `separator` rather than the record's top level* — deliberate: it belongs beside the build it qualifies.

Scope note raised and kept: the record-side `warning` slightly exceeds "store `device`", but it is what makes AC 3's *alertable* true for a reader of the record rather than of the log. The pre-existing live test gained `reuse=False` — the fixture tone hashes the same every run, and stems read off disk announce nothing; it also means that test now proves the real models ran rather than that a previous run's files exist.

Review: clean
