### PR TITLE
Let the cut file state the resolution it delivers at (#187)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -182,7 +182,11 @@ alone — but a missing first pass redoes all three, since the later two are cut
 from what it wrote, #192), `wav` (header facts + the one
 unreadable-WAV error).
 
-`cut/` — cut-file schema v1: `document` (read off disk), `schema`
+`cut/` — cut-file schema v1: `document` (read off disk), `resolution` (the
+optional **delivery resolution**: `timeline.resolution`, one reading of
+`{width, height}` for both the rules and the build — omitted means the timeline
+is created at the project's default, which on the corpus project is 4K against
+1080p deliverables, #187), `schema`
 (verbatim, served by `get_cut_schema`), `validate` (12 errors + W1, W2,
 W8, W9 — W3-W7 are `virtual_transcript`'s over the same document — shared by
 dry run and build pre-flight; W9 is the one that reports a rule that *could
@@ -221,7 +225,10 @@ mix sits under a timeline — the one axis a rebuild does not move; read by
 queue), `camera_sidecar` (camera model off the card's own XML, for media
 Resolve reports no camera metadata for — #94; not an **angle sidecar**),
 `scripting` (`run_python` with handles pre-bound), `session`
-(session/project wrappers), `tail` (materialising a cut's tail: the OTIO
+(session/project wrappers), `settings` (the timeline settings the server
+*writes*, through the string-typed `GetSetting`/`SetSetting` pair: resolution,
+which needs `useCustomSettings` first and is judged by the read-back, never by
+the return value — #187), `tail` (materialising a cut's tail: the OTIO
 document edit + the export/import round trip `build` takes when a tail has
 a transition to cut in — a hard out that fades nothing builds directly —
 because the scripting API cannot cut a transition at all), `takes`
@@ -334,7 +341,11 @@ tail is one device across `cut/tail`, `cut/validate`, `resolve/tail` and
 never asked for one. `test_hardware_decode.py` (#202) is the fourth: NVDEC is
 one decision across `ffmpeg` (the probe), `video/ffmpeg` (flags, fallback,
 report) and the three video routes that carry the report, and the failure worth
-testing is a decode that ran one way and reported another. Live tier: `test_live_smoke.py` (module-level
+testing is a decode that ran one way and reported another. `test_cut_resolution.py`
+(#187) is the fifth: the delivery resolution is one device across `cut/resolution`,
+`cut/validate`, `resolve/settings` and `resolve/build`, and a timeline that ignored
+the setting is indistinguishable from one that never asked for it until the render
+exists. Live tier: `test_live_smoke.py` (module-level
 `pytest.mark.live`) and five `@pytest.mark.live` tests in
 `test_live_analysis.py` — four over installed models, plus the #192 wind split
 over the director's own separated stems, the one test that opts out of the

--- a/gauntlet/GAPS.md
+++ b/gauntlet/GAPS.md
@@ -345,6 +345,33 @@ is visible in one glance instead of being inferred from a rate. The same
 seam would have made this gap a five-second read rather than a process-tree
 excavation.
 
+## G13 — built timelines inherit the project's 4K default (in-work, #187)
+
+Recurring nit across every round: the Zinc project creates timelines at
+3840×2160, every deliverable is 1920×1080, and a built timeline is born at
+the project's size — so each round set the resolution by hand in Resolve
+before rendering, and a round that forgot rendered 4K and said nothing.
+
+Fixed on the server side by an optional `timeline.resolution`
+(`{width, height}`) on the cut file — `get_cut_schema` §9. One reading in
+`cut/resolution.py`, shape refused as E1 in `cut/validate.py` (both sides,
+integers, plausible), applied by `resolve/settings.py` and called from
+`resolve/build.py` **before the first append** and again after a tail round
+trip, since the import is a new timeline born at the project's default like
+any other.
+
+`SetSetting` is not evidence: the resolution keys are inert until
+`useCustomSettings` is `'1'`, and a write that changed nothing answers the
+same as one that landed (`gauntlet/recon/r3_reso.py`). So the wrapper writes
+the flag first and judges by the read-back, and a size that did not land
+**fails the build** rather than reporting a resolution the timeline does not
+have. `timeline.resolution` on the build report — and on `list_timelines` —
+is what it ended up at.
+
+Live proof owed: `test_a_real_build_delivers_the_resolution_the_cut_asked_for`
+builds 1080p in the 4K project, renders it, and reads the delivered frame's
+dimensions back off the file.
+
 ## G14 — cut-file schema cannot express a dissolve (CLOSED 2026-08-13)
 
 Piece 2 R1, unanimous 0–3 loss. The measured Taurus tail is a 5.923 s

--- a/src/resolve_mcp/cut/resolution.py
+++ b/src/resolve_mcp/cut/resolution.py
@@ -1,0 +1,62 @@
+"""The optional delivery resolution: one reading of it for both the rules and the build.
+
+A cut file that says nothing about resolution builds the way v1 always did — the timeline
+inherits whatever the project creates timelines at, which on the corpus project is 4K while
+every deliverable is 1920x1080. That gap is the whole device: the resolution the cut is
+*for* was a hand step before every render (gauntlet G13), and a hand step that is skipped
+delivers a 4K file nobody asked for and no return value mentions.
+
+Stated on the timeline block, beside the frame rate it belongs with::
+
+    "timeline": {"name": "sunset-set", "fps": 59.94,
+                 "resolution": {"width": 1920, "height": 1080}}
+
+Both sides are required together: a width with no height is a half-stated delivery, and
+guessing the other from an aspect ratio the file never gave would be the server deciding.
+Shape is judged as E1 in :mod:`resolve_mcp.cut.validate` — this module holds the reading
+the rules and :mod:`resolve_mcp.resolve.build` share, so a cut cannot validate against one
+reading and build against another.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+KEYS: Final[tuple[str, ...]] = ("width", "height")
+"""Every field the block defines. Anything else is a typo, and E1 says so rather than
+ignoring it — a misspelt side would silently keep the project default."""
+
+MIN_SIDE: Final = 16
+MAX_SIDE: Final = 16384
+"""A typo guard, not a Resolve limit — the same reasoning as ``MAX_OVERLAY_TRACK``.
+
+``"width": 19200`` is an author slip, and without a ceiling the build would set it, report
+success, and hand back a render nothing can play. 16384 is past DCI 8K; a delivery that
+genuinely needs more is a conversation, not a typo."""
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """What the built timeline is to be, in pixels."""
+
+    width: int
+    height: int
+
+    def as_dict(self) -> dict[str, int]:
+        return {"width": self.width, "height": self.height}
+
+
+def read(doc: dict[str, Any]) -> Resolution | None:
+    """The cut's stated resolution, or ``None`` for "whatever the project makes".
+
+    Only ever called on a document the rules have already passed, so the fields are the
+    integers E1 checked for; a malformed block reaches the build as an error, never here.
+    """
+    timeline = doc.get("timeline")
+    if not isinstance(timeline, dict):
+        return None
+    stated = timeline.get("resolution")
+    if not isinstance(stated, dict):
+        return None
+    return Resolution(width=int(stated["width"]), height=int(stated["height"]))

--- a/src/resolve_mcp/cut/resolution.py
+++ b/src/resolve_mcp/cut/resolution.py
@@ -60,3 +60,6 @@ def read(doc: dict[str, Any]) -> Resolution | None:
     if not isinstance(stated, dict):
         return None
     return Resolution(width=int(stated["width"]), height=int(stated["height"]))
+
+
+__all__ = ["KEYS", "MAX_SIDE", "MIN_SIDE", "Resolution", "read"]

--- a/src/resolve_mcp/cut/schema.py
+++ b/src/resolve_mcp/cut/schema.py
@@ -17,7 +17,8 @@ ANNOTATED_EXAMPLE: Final = """\
   "timeline": {
     "name": "sunset-set",            // version base name (§6)
     "fps": 59.94,                    // declared; sources validated against it
-    "bin": "Cuts"                    // optional; default media pool root
+    "bin": "Cuts",                   // optional; default media pool root
+    "resolution": { "width": 1920, "height": 1080 }  // optional; §9
   },
 
   // Source aliases: segments reference by alias. Identity = clip name
@@ -201,6 +202,25 @@ The list is identical in the `validate_cut` dry run and `build_timeline`'s pre-f
 and a failing file aborts before Resolve is touched. Every finding is
 `{rule, id, message, fix_hint}` — see the `rules` field of this result."""
 
+_RESOLUTION: Final = """\
+## 9. Delivery resolution
+
+`timeline.resolution` is the frame size the cut is *for*: `{"width": 1920, "height": 1080}`,
+stated beside the frame rate because it is the same kind of fact. Omit it and the build does
+what v1 always did — the timeline is created at whatever the project creates timelines at,
+which is the right answer only when the project's default already is the delivery.
+
+It is worth stating because the two differ exactly when it matters. A 4K project cutting a
+1080p deliverable produces a timeline at 4K, a render at 4K, and no message anywhere saying
+so; the correction was a hand step in Resolve before every render. With the field set, the
+build puts the timeline on its own settings before the first shot lands, reads the size back
+off it, and **fails** if what it reads is not what was asked for — a build that reported a
+resolution the timeline does not have would be worse than no field at all.
+
+Both sides are required together and both are integers in pixels: half a frame size is not a
+delivery, and the missing half is not the server's to infer. The build report echoes what the
+timeline ended up at under `timeline.resolution`."""
+
 SCHEMA_DOC: Final = "\n\n".join(
     [
         "# Cut-file schema v1",
@@ -213,6 +233,7 @@ SCHEMA_DOC: Final = "\n\n".join(
         _VERSIONING,
         _RULES,
         _TAIL,
+        _RESOLUTION,
     ]
 )
 """The full schema document: prose contract with the annotated example embedded."""

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -32,6 +32,7 @@ from typing import Any, Final, TypeGuard
 from ..findings import Finding, ordered
 from ..logging_config import get_logger
 from ..timing import duration_frames, ranges_overlap
+from . import resolution as cut_resolution
 from . import tail as tail_device
 from .schema import SCHEMA_VERSION
 from .tail import Tail
@@ -203,6 +204,51 @@ def _timeline_errors(doc: dict[str, Any]) -> Iterator[Finding]:
         yield _finding("E1", None, f"'timeline.fps' must be a positive number, got {fps!r}.")
     if "bin" in timeline and not isinstance(timeline["bin"], str):
         yield _finding("E1", None, "'timeline.bin' must be a string when present.")
+    yield from _resolution_shape_errors(timeline)
+
+
+def _resolution_shape_errors(timeline: dict[str, Any]) -> Iterator[Finding]:
+    """E1 for ``timeline.resolution``: a block that does not read builds at the wrong size.
+
+    Every failure here is silent otherwise. A misspelt side, a string ``"1920"``, a height
+    left out — each one would leave the timeline on the project's own default and report a
+    successful build, which is the hand step this device exists to remove (G13, #187).
+    """
+    if "resolution" not in timeline:
+        return
+    stated = timeline["resolution"]
+    if not isinstance(stated, dict):
+        yield _finding(
+            "E1",
+            None,
+            f"'timeline.resolution' must be an object with 'width' and 'height', got "
+            f"{_kind(stated)}.",
+        )
+        return
+
+    unknown = sorted(key for key in stated if key not in cut_resolution.KEYS)
+    if unknown:
+        yield _finding(
+            "E1",
+            None,
+            f"'timeline.resolution' carries {_listed(unknown)}, which the schema does not "
+            f"define; it takes {_listed(list(cut_resolution.KEYS))}.",
+        )
+    for side in cut_resolution.KEYS:
+        value = stated.get(side)
+        if not _is_int(value):
+            yield _finding(
+                "E1",
+                None,
+                f"'timeline.resolution.{side}' must be an integer pixel count, got {value!r}.",
+            )
+        elif not cut_resolution.MIN_SIDE <= value <= cut_resolution.MAX_SIDE:
+            yield _finding(
+                "E1",
+                None,
+                f"'timeline.resolution.{side}' is {value}; it must be between "
+                f"{cut_resolution.MIN_SIDE} and {cut_resolution.MAX_SIDE} pixels.",
+            )
 
 
 def _sources_errors(doc: dict[str, Any]) -> Iterator[Finding]:

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -207,6 +207,29 @@ def _timeline_errors(doc: dict[str, Any]) -> Iterator[Finding]:
     yield from _resolution_shape_errors(timeline)
 
 
+def _unknown_key_errors(
+    where: str,
+    block: dict[str, Any],
+    defined: Sequence[str],
+) -> Iterator[Finding]:
+    """E1 for a key the schema does not define, on the blocks that refuse rather than ignore.
+
+    Both blocks this serves are optional and silent when a field is missing, which is what
+    makes a typo in one dangerous: ``audio_fade`` for ``audio_fade_frames`` builds a dissolve
+    over a hot mix, ``w`` for ``width`` builds at the project's own size — and both report
+    success. One reading of "that key is not in the schema", so the next device that needs it
+    does not write a third.
+    """
+    unknown = sorted(key for key in block if key not in defined)
+    if unknown:
+        yield _finding(
+            "E1",
+            None,
+            f"'{where}' carries {_listed(unknown)}, which the schema does not define; "
+            f"it takes {_listed(list(defined))}.",
+        )
+
+
 def _resolution_shape_errors(timeline: dict[str, Any]) -> Iterator[Finding]:
     """E1 for ``timeline.resolution``: a block that does not read builds at the wrong size.
 
@@ -226,14 +249,7 @@ def _resolution_shape_errors(timeline: dict[str, Any]) -> Iterator[Finding]:
         )
         return
 
-    unknown = sorted(key for key in stated if key not in cut_resolution.KEYS)
-    if unknown:
-        yield _finding(
-            "E1",
-            None,
-            f"'timeline.resolution' carries {_listed(unknown)}, which the schema does not "
-            f"define; it takes {_listed(list(cut_resolution.KEYS))}.",
-        )
+    yield from _unknown_key_errors("timeline.resolution", stated, cut_resolution.KEYS)
     for side in cut_resolution.KEYS:
         value = stated.get(side)
         if not _is_int(value):
@@ -296,14 +312,7 @@ def _tail_shape_errors(doc: dict[str, Any]) -> Iterator[Finding]:
         yield _finding("E1", None, "'tail' must be an object with a 'type'.")
         return
 
-    unknown = sorted(key for key in tail if key not in tail_device.KEYS)
-    if unknown:
-        yield _finding(
-            "E1",
-            None,
-            f"'tail' carries {_listed(unknown)}, which the schema does not define; "
-            f"it takes {_listed(list(tail_device.KEYS))}.",
-        )
+    yield from _unknown_key_errors("tail", tail, tail_device.KEYS)
 
     kind = tail.get("type")
     if kind not in tail_device.TYPES:

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Final
 
+from ..cut import resolution as cut_resolution
 from ..cut import tail as cut_tail
 from ..cut.validate import gaps as cut_gaps
 from ..cut.validate import (
@@ -60,7 +61,7 @@ from ..cut.validate import (
 from ..errors import BuildFailedError, CutInvalidError, TimelineNotFoundError
 from ..logging_config import get_logger
 from ..naming import latest_version, next_version_name, version_name
-from . import cut, markers, media, mix, takes
+from . import cut, markers, media, mix, settings, takes
 from . import tail as tail_route
 from . import timeline as timeline_read
 from .connection import ResolveConnection
@@ -207,6 +208,14 @@ def build_timeline(
     writing = tail_route.staging_name(name, existing) if round_tripped else name
 
     built = _create(pool, project, writing)
+    # Before anything is appended, because the cut states the size it is *for* and a
+    # timeline is created at the project's own default — 4K on the corpus project, against
+    # 1080p deliverables (G13). A cut that says nothing keeps the v1 behaviour: whatever the
+    # project makes. A round-tripped build sets it again on the timeline the import made,
+    # below: the staging timeline's settings are not the ones that ship.
+    stated = cut_resolution.read(doc)
+    if stated is not None:
+        settings.apply_resolution(built, stated, writing)
     # The frame the shots are positioned against. Kept, rather than re-read per check: a
     # round-tripped build reads its placements back on a *second* timeline, whose own start
     # is Resolve's to choose, and the comparison there is offset against offset.
@@ -233,6 +242,11 @@ def build_timeline(
             tail,
             verify=lambda landed: _verify(reader, landed, shots, name, origin),
         )
+        if stated is not None:
+            # The import is a different timeline and Resolve creates it at the project's
+            # default like any other, so the staging timeline's setting does not travel with
+            # the OTIO document. This is the one that ships.
+            settings.apply_resolution(built, stated, name)
     elif tail is not None:
         # Nothing was injected and nothing was round-tripped, but the cut file did ask for a
         # tail — so the report says what it asked for and that it took no route.

--- a/src/resolve_mcp/resolve/settings.py
+++ b/src/resolve_mcp/resolve/settings.py
@@ -1,0 +1,127 @@
+"""Timeline settings the server writes, and the string-typed API they go through.
+
+Resolve's ``GetSetting``/``SetSetting`` are one untyped pair over every setting a timeline
+has: values go in as strings and come back as strings, ``1920`` and ``"1920"`` are not the
+same argument, and the return value is the usual Resolve "true" — an answer about whether
+the call was understood, not about whether anything changed.
+
+Resolution is the one setting a build has to write, because a timeline is created at the
+project's default and the cut states what it is *for* (gauntlet G13, #187). Two things make
+it more than a single call:
+
+* **A timeline ignores its own resolution until it owns its settings.** ``useCustomSettings``
+  is what detaches a timeline from the project's, and the resolution keys are inert while it
+  is off — the write is taken and the timeline stays 4K. So the flag goes first, always
+  (established live on 21.0.3: ``gauntlet/recon/r3_reso.py``).
+* **The read-back is the evidence.** Every write here is followed by a read of what the
+  timeline now says, parsed back from the strings it answers in, and a value that did not
+  land fails the build. A render is the only other place the number would show up, by which
+  point the file exists and is the wrong size.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from ..cut.resolution import Resolution
+from ..errors import BuildFailedError
+from ..logging_config import get_logger
+
+log = get_logger("timeline")
+
+Timeline = Any
+
+CUSTOM_SETTINGS: Final = "useCustomSettings"
+"""Whether the timeline holds its own settings rather than the project's. ``"1"`` is on."""
+
+WIDTH: Final = "timelineResolutionWidth"
+HEIGHT: Final = "timelineResolutionHeight"
+"""The two halves of the frame, each written and read as a string of pixels."""
+
+ON: Final = "1"
+"""What ``useCustomSettings`` takes — the API's boolean, spelled as the string it wants."""
+
+
+def read_resolution(timeline: Timeline) -> dict[str, int] | None:
+    """What the timeline says it is, in pixels, or ``None`` if it will not say.
+
+    Both sides or neither: half a frame size is not a reading, and a caller reporting one
+    would be stating a delivery that no timeline has.
+    """
+    width = _setting_int(timeline, WIDTH)
+    height = _setting_int(timeline, HEIGHT)
+    if width is None or height is None:
+        return None
+    return {"width": width, "height": height}
+
+
+def apply_resolution(timeline: Timeline, resolution: Resolution, name: str) -> dict[str, int]:
+    """Put ``timeline`` on the cut's stated frame size, and prove it took.
+
+    Raises :class:`BuildFailedError` when the timeline reads back as anything other than
+    what was asked for — including when it will not say what it is at all. A build that
+    carried on here would deliver a timeline at the project's default and report the
+    resolution the cut asked for, which is the one outcome worse than not offering the
+    setting.
+    """
+    _write(timeline, CUSTOM_SETTINGS, ON, name)
+    _write(timeline, WIDTH, str(resolution.width), name)
+    _write(timeline, HEIGHT, str(resolution.height), name)
+
+    landed = read_resolution(timeline)
+    if landed != resolution.as_dict():
+        raise BuildFailedError(
+            cause=(
+                f"Resolve would not put {name!r} on {resolution.width}x{resolution.height}: "
+                f"it reads back as {_described(landed)}."
+            ),
+            fix="Check the timeline's own settings in Resolve (Timeline > Timeline "
+            "Settings), or drop 'timeline.resolution' from the cut file to build at the "
+            "project's default.",
+            detail={
+                "timeline": name,
+                "requested": resolution.as_dict(),
+                "reported": landed,
+            },
+        )
+    log.info("%s is on %dx%d (custom timeline settings)", name, resolution.width, resolution.height)
+    return landed
+
+
+def _write(timeline: Timeline, key: str, value: str, name: str) -> None:
+    """One ``SetSetting``. A refusal is logged, never raised — the read-back is the judge.
+
+    The return value says the call was understood, not that the timeline changed: writing a
+    resolution key with ``useCustomSettings`` off answers the same as writing it with the
+    flag on. So a False is a log line rather than a failure, and what fails the build is the
+    number the timeline reads back with.
+    """
+    try:
+        taken = timeline.SetSetting(key, value)
+    except Exception as exc:  # noqa: BLE001 - a bridge error here is a build failure, not a crash
+        raise BuildFailedError(
+            cause=f"Resolve failed while setting {key} on {name!r}: {exc}.",
+            detail={"timeline": name, "setting": key, "value": value},
+        ) from exc
+    if not taken:
+        log.warning("Resolve answered false to %s=%s on %s", key, value, name)
+
+
+def _setting_int(timeline: Timeline, key: str) -> int | None:
+    """One setting as the number it means, through the string the API answers in."""
+    try:
+        value = timeline.GetSetting(key)
+    except Exception:  # noqa: BLE001 - an unreadable setting is "will not say", not a failure
+        log.debug("Unreadable %s", key)
+        return None
+    if value in (None, ""):
+        return None
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        log.debug("Unparseable %s: %r", key, value)
+        return None
+
+
+def _described(landed: dict[str, int] | None) -> str:
+    return "nothing" if landed is None else f"{landed['width']}x{landed['height']}"

--- a/src/resolve_mcp/resolve/settings.py
+++ b/src/resolve_mcp/resolve/settings.py
@@ -42,20 +42,21 @@ ON: Final = "1"
 """What ``useCustomSettings`` takes — the API's boolean, spelled as the string it wants."""
 
 
-def read_resolution(timeline: Timeline) -> dict[str, int] | None:
-    """What the timeline says it is, in pixels, or ``None`` if it will not say.
+def read_resolution(timeline: Timeline) -> Resolution | None:
+    """What the timeline says it is, or ``None`` if it will not say.
 
     Both sides or neither: half a frame size is not a reading, and a caller reporting one
-    would be stating a delivery that no timeline has.
+    would be stating a delivery that no timeline has. The same type the cut file states, so
+    the comparison below is a value comparison rather than two dicts agreeing by accident.
     """
     width = _setting_int(timeline, WIDTH)
     height = _setting_int(timeline, HEIGHT)
     if width is None or height is None:
         return None
-    return {"width": width, "height": height}
+    return Resolution(width=width, height=height)
 
 
-def apply_resolution(timeline: Timeline, resolution: Resolution, name: str) -> dict[str, int]:
+def apply_resolution(timeline: Timeline, resolution: Resolution, name: str) -> None:
     """Put ``timeline`` on the cut's stated frame size, and prove it took.
 
     Raises :class:`BuildFailedError` when the timeline reads back as anything other than
@@ -69,7 +70,7 @@ def apply_resolution(timeline: Timeline, resolution: Resolution, name: str) -> d
     _write(timeline, HEIGHT, str(resolution.height), name)
 
     landed = read_resolution(timeline)
-    if landed != resolution.as_dict():
+    if landed != resolution:
         raise BuildFailedError(
             cause=(
                 f"Resolve would not put {name!r} on {resolution.width}x{resolution.height}: "
@@ -81,11 +82,10 @@ def apply_resolution(timeline: Timeline, resolution: Resolution, name: str) -> d
             detail={
                 "timeline": name,
                 "requested": resolution.as_dict(),
-                "reported": landed,
+                "reported": landed.as_dict() if landed is not None else None,
             },
         )
     log.info("%s is on %dx%d (custom timeline settings)", name, resolution.width, resolution.height)
-    return landed
 
 
 def _write(timeline: Timeline, key: str, value: str, name: str) -> None:
@@ -123,5 +123,8 @@ def _setting_int(timeline: Timeline, key: str) -> int | None:
         return None
 
 
-def _described(landed: dict[str, int] | None) -> str:
-    return "nothing" if landed is None else f"{landed['width']}x{landed['height']}"
+def _described(landed: Resolution | None) -> str:
+    return "nothing" if landed is None else f"{landed.width}x{landed.height}"
+
+
+__all__ = ["CUSTOM_SETTINGS", "HEIGHT", "ON", "WIDTH", "apply_resolution", "read_resolution"]

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -43,6 +43,7 @@ from ..spill import spill
 from ..timing import dual_time, to_frames
 from .connection import ResolveConnection
 from .session import current_project, frame_rate
+from .settings import read_resolution
 
 log = get_logger("timeline")
 
@@ -380,6 +381,10 @@ def summarise(
         "version": version,
         "current": name == current,
         "fps": fps,
+        # What the frames are, beside how fast they run. ``None`` when the timeline will not
+        # say — never a guess off the project, because the two differ exactly when it
+        # matters (a 1080p cut in a 4K project, #187).
+        "resolution": read_resolution(timeline),
         **_bounds(timeline, fps),
         "tracks": _track_counts(reader, timeline),
     }

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -365,6 +365,12 @@ def _track_counts(reader: Reader, timeline: Timeline) -> dict[str, int]:
     }
 
 
+def _resolution_of(timeline: Timeline) -> dict[str, int] | None:
+    """The timeline's frame size as the report carries it — the one place it is flattened."""
+    landed = read_resolution(timeline)
+    return landed.as_dict() if landed is not None else None
+
+
 def summarise(
     reader: Reader,
     timeline: Timeline,
@@ -384,7 +390,7 @@ def summarise(
         # What the frames are, beside how fast they run. ``None`` when the timeline will not
         # say — never a guess off the project, because the two differ exactly when it
         # matters (a 1080p cut in a 4K project, #187).
-        "resolution": read_resolution(timeline),
+        "resolution": _resolution_of(timeline),
         **_bounds(timeline, fps),
         "tracks": _track_counts(reader, timeline),
     }

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -116,6 +116,13 @@ def build_timeline(
     *shot* lands on the same music, and moving the shots is what this build just did — so
     re-read those against the new cut.
 
+    `timeline.resolution` in the cut file is the frame size the build delivers: the new
+    timeline is put on it before the first shot lands, and the build fails rather than hand
+    back a size the timeline does not have. Leave it out and the timeline is created at the
+    project's own default — which is the wrong frame whenever the project cuts at a
+    different size from the delivery, and nothing downstream says so. `timeline.resolution`
+    in the report is what it ended up at.
+
     The validate_cut rules run first: a single error aborts before any timeline is created,
     and comes back with the same per-segment findings. The report echoes the cut file's
     content hash, which is what ties the timeline back to the exact cut that made it —

--- a/src/resolve_mcp/tools/render.py
+++ b/src/resolve_mcp/tools/render.py
@@ -46,6 +46,13 @@ def render_timeline(
     back to another preset, because a wrong-shaped file under a right-sounding name is worse
     than a refusal you can act on.
 
+    The frame size comes from the timeline, not from here: build a cut with
+    `timeline.resolution` set and the render follows it (live-confirmed on 21.0.3 —
+    a 1080p timeline in a 4K project delivers 1920x1080). Nothing in this call states a
+    size, so a preset that was saved in the Deliver page with a resolution of its own is the
+    one thing that can still override the timeline — check inspect_timeline's `resolution`
+    against the file you get if a delivery ever comes back the wrong shape.
+
     start and end cut one deliverable out of a longer timeline — a song off a concert set.
     They are frames on the timeline's own clock, the numbers inspect_timeline and
     list_markers report (a timeline starting at 01:00:00:00 starts at frame 86400, not 0),

--- a/src/resolve_mcp/tools/timeline.py
+++ b/src/resolve_mcp/tools/timeline.py
@@ -20,7 +20,11 @@ from .envelope import tool
 
 @tool
 def list_timelines(limit: int = timelines.DEFAULT_LIST_LIMIT) -> dict[str, Any]:
-    """List the project's timelines with version, duration, fps and track stack.
+    """List the project's timelines with version, duration, fps, resolution and track stack.
+
+    resolution is the frame size each timeline is actually on — which is not the project's
+    default whenever a cut file stated one, and is what a render of that timeline delivers.
+    null means the timeline would not say.
 
     version is the number parsed off a "<name> v<N>" name, and latest_versions names the
     newest one per base name — the cut to carry on from. The sync reference is the timeline
@@ -46,6 +50,10 @@ def inspect_timeline(
     names, lock and enable state) or clips (every shot in the range). start and end take
     frames (96) or seconds with an explicit snap ({"seconds": 2.52, "snap": "floor"}), and
     default to the whole timeline; a shot is in range when it overlaps it.
+
+    The timeline block carries fps and resolution together: how fast the frames run and what
+    they are. The frame size is what a render of this timeline delivers, so read it before
+    delivering anything a cut file stated a resolution for.
 
     Each shot carries its record position, its source position, and sync_offset — the
     difference between the two, so that timeline_frame = source_frame + sync_offset. On the

--- a/tests/fakes/pool.py
+++ b/tests/fakes/pool.py
@@ -45,6 +45,8 @@ class FakeMediaPool:
         # Held-open exports on the timeline a build makes for itself, which is the only
         # timeline whose export a tail build ever rewrites.
         self.new_timeline_locks_exports = False
+        #: Settings a timeline created here takes and drops — see ``FakeTimeline.SetSetting``.
+        self.new_timeline_settings_that_ignore_writes: set[str] = set()
         # An import that answers with a timeline and leaves the transitions out — the
         # failure a tail build cannot see from the return value, since the cut it hands
         # back is a perfectly good cut with a hard edge where its tail should be.
@@ -223,6 +225,7 @@ class FakeMediaPool:
             timeline.adopt(self._owner)
             project = self._owner.current_project
             if project is not None:
+                timeline.created_by(project)
                 project.add_timeline(timeline)
         return timeline
 
@@ -291,6 +294,9 @@ class FakeMediaPool:
         timeline = FakeTimeline(
             name,
             fps=project_fps or "59.94",
+            # Born at the project's size, on the project's settings — the inheritance a cut
+            # file's own resolution has to override (#187).
+            resolution=project.timeline_resolution() if project is not None else None,
             start_frame=self.new_timeline_start,
             video=[
                 FakeTrack(
@@ -311,6 +317,7 @@ class FakeMediaPool:
         # export failure has to be settable *before* the timeline the test never sees exists.
         timeline.export_result = self.new_timeline_export_result
         timeline.locks_written_exports = self.new_timeline_locks_exports
+        timeline.settings_that_ignore_writes = set(self.new_timeline_settings_that_ignore_writes)
         if project is not None:
             project.add_timeline(timeline)
             if self.switches_current_timeline:

--- a/tests/fakes/project.py
+++ b/tests/fakes/project.py
@@ -30,11 +30,16 @@ class FakeProject:
         fps: str = "24",
         media_pool: FakeMediaPool | None = None,
         timelines: list[FakeTimeline | None] | None = None,
+        # The size every timeline this project creates is born at. 4K by default because
+        # that is the corpus project's own default and the reason G13 exists: the
+        # deliverables are 1080p, so a build that inherits silently ships the wrong frame.
+        resolution: tuple[str, str] = ("3840", "2160"),
     ) -> None:
         """``timelines`` may hold a ``None``: Resolve sometimes answers an index with one."""
         self._name = name
         self._timeline = timeline
         self._fps = fps
+        self._resolution = resolution
         self._media_pool = media_pool
         if timelines is not None:
             self._timelines = list(timelines)
@@ -202,7 +207,15 @@ class FakeProject:
         return None
 
     def GetSetting(self, key: str) -> str | None:  # noqa: N802
-        return self._fps if key == "timelineFrameRate" else None
+        return {
+            "timelineFrameRate": self._fps,
+            "timelineResolutionWidth": self._resolution[0],
+            "timelineResolutionHeight": self._resolution[1],
+        }.get(key)
+
+    def timeline_resolution(self) -> tuple[str, str]:
+        """What a timeline created here starts at — read by the pool, as Resolve does."""
+        return self._resolution
 
     def GetMediaPool(self) -> FakeMediaPool | None:  # noqa: N802
         return self._media_pool

--- a/tests/fakes/timeline.py
+++ b/tests/fakes/timeline.py
@@ -17,6 +17,12 @@ from .media import IMAGE_SUFFIXES, STILL_DEFAULT_FRAMES
 READ_ONLY = 0o444
 """What a file Resolve is holding open behaves like to a rewrite — see ``Export``."""
 
+CUSTOM_SETTINGS = "useCustomSettings"
+WIDTH = "timelineResolutionWidth"
+HEIGHT = "timelineResolutionHeight"
+"""The settings a build writes. Spelled here rather than imported from the server, so a
+rename in the wrapper has to face a fake that still says what Resolve calls them."""
+
 if TYPE_CHECKING:
     from .connection import FakeResolve
     from .media import FakeMediaPoolItem
@@ -65,10 +71,26 @@ class FakeTimeline(AnswersNone):
         end_frame: int | None = None,
         missing: frozenset[str] | set[str] | None = None,
         owner: FakeResolve | None = None,
+        # Strings, like every other setting: Resolve answers "1920", never 1920. A timeline
+        # that says nothing about its size is one whose project said nothing either.
+        resolution: tuple[str, str] | None = None,
     ) -> None:
         self._missing = set(missing or ())
         self._name = name
         self._fps = fps
+        self._settings: dict[str, str] = {"timelineFrameRate": fps, CUSTOM_SETTINGS: "0"}
+        if resolution is not None:
+            self._settings[WIDTH], self._settings[HEIGHT] = resolution
+        #: Every ``SetSetting`` this timeline was given, refused and ignored ones included.
+        self.setting_writes: list[tuple[str, Any]] = []
+        #: How many items stood on the timeline as each of those writes went in. A cut that
+        #: was filled and then resized is not the same edit as one built at its own size,
+        #: and nothing in the finished timeline tells the two apart.
+        self.setting_writes_at_item_count: list[int] = []
+        #: Keys whose writes are taken and dropped — a caller that trusts the return value
+        #: cannot tell them from the ones that landed. Models the real failure the build's
+        #: read-back exists for: a timeline that will not leave the project's settings.
+        self.settings_that_ignore_writes: set[str] = set()
         self._start_frame = start_frame
         self._end_frame = end_frame
         self._tracks: dict[str, list[FakeTrack]] = {
@@ -114,6 +136,15 @@ class FakeTimeline(AnswersNone):
         self.delete_clips_leaves_them = False
         self.deleted_clips: list[tuple[list[FakeTimelineItem], bool]] = []
 
+    def created_by(self, project: Any) -> None:
+        """Take the project's timeline settings, as any newly created timeline does.
+
+        The import half of the tail round trip needs this as much as ``CreateEmptyTimeline``
+        does: the timeline the import makes is new, so it is born at the project's size and
+        not at the size of the staging timeline the document came out of.
+        """
+        self._settings[WIDTH], self._settings[HEIGHT] = project.timeline_resolution()
+
     def adopt(self, owner: FakeResolve) -> None:
         self._owner = owner
         for tracks in self._tracks.values():
@@ -155,7 +186,33 @@ class FakeTimeline(AnswersNone):
 
     def GetSetting(self, key: str) -> str | None:  # noqa: N802
         self._check()
-        return self._fps if key == "timelineFrameRate" else None
+        return self._settings.get(key)
+
+    def SetSetting(self, key: str, value: Any) -> bool:  # noqa: N802
+        """Write one setting, with the two ways Resolve takes a write and changes nothing.
+
+        A non-string value is refused outright — the API is string-in, string-out, and
+        ``SetSetting("timelineResolutionWidth", 1920)`` is not the same call. The resolution
+        keys are inert while ``useCustomSettings`` is off: the write answers True and the
+        timeline stays on the project's size, which is the order the live probe established
+        (``gauntlet/recon/r3_reso.py``) and the reason the build reads back rather than
+        trusting the answer.
+        """
+        self._check()
+        self.setting_writes.append((key, value))
+        self.setting_writes_at_item_count.append(
+            sum(len(track.items) for tracks in self._tracks.values() for track in tracks)
+        )
+        if not isinstance(value, str):
+            return False
+        if key in self.settings_that_ignore_writes:
+            return True
+        if key in (WIDTH, HEIGHT) and self._settings.get(CUSTOM_SETTINGS) != "1":
+            return True
+        self._settings[key] = value
+        if key == "timelineFrameRate":
+            self._fps = value
+        return True
 
     def GetStartFrame(self) -> int:  # noqa: N802
         self._check()

--- a/tests/test_cut_resolution.py
+++ b/tests/test_cut_resolution.py
@@ -1,0 +1,235 @@
+"""The delivery resolution: what the rules refuse, what the build writes, what it reads back.
+
+One device over four modules. :mod:`resolve_mcp.cut.resolution` is the reading;
+``cut/validate`` refuses a block that would not read; :mod:`resolve_mcp.resolve.settings`
+puts a timeline on the size and proves it took; and the build applies it before the first
+append — and again after a tail round trip, because the import is a new timeline born at
+the project's default like any other.
+
+The failure being designed against is quiet at every one of those seams. A timeline created
+in the corpus project is 4K; every deliverable is 1080p; ``SetSetting`` answers the same
+whether it changed anything or not. So a build that trusted the return value would hand back
+"built at 1920x1080" over a 4K timeline, and the only place the difference would surface is
+the render — after the file exists (gauntlet G13, #187).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.cut import resolution as cut_resolution
+from resolve_mcp.cut.validate import validate_structure
+from resolve_mcp.resolve import settings
+from resolve_mcp.resolve.settings import CUSTOM_SETTINGS, HEIGHT, WIDTH
+from resolve_mcp.tools.cut import build_timeline, validate_cut
+
+from .conftest import Attach
+from .cutfile import a_cut, a_pool, built, empty_project, valid_doc
+from .fakes import FakeTimeline
+
+HD = {"width": 1920, "height": 1080}
+"""What the corpus delivers, against a project that creates timelines at 4K."""
+
+
+def at(**resolution: Any) -> dict[str, Any]:
+    """The shared three-shot cut, stating the size it is for."""
+    doc = valid_doc()
+    doc["timeline"]["resolution"] = resolution
+    return doc
+
+
+def rules(doc: dict[str, Any]) -> list[str]:
+    return [finding.rule for finding in validate_structure(doc)]
+
+
+def messages(doc: dict[str, Any], rule: str) -> list[str]:
+    return [finding.message for finding in validate_structure(doc) if finding.rule == rule]
+
+
+# --- the rules ------------------------------------------------------------------------------
+
+
+def test_a_delivery_resolution_validates_clean() -> None:
+    assert rules(at(**HD)) == []
+
+
+def test_a_cut_that_says_nothing_is_still_the_ordinary_shape() -> None:
+    """Every cut written before this device stays valid and stays on the project's size."""
+    assert rules(valid_doc()) == []
+    assert cut_resolution.read(valid_doc()) is None
+
+
+def test_the_reading_is_the_frame_the_cut_asked_for() -> None:
+    assert cut_resolution.read(at(**HD)) == cut_resolution.Resolution(1920, 1080)
+
+
+def test_a_resolution_that_is_not_an_object_is_unreadable() -> None:
+    doc = valid_doc()
+    doc["timeline"]["resolution"] = "1920x1080"
+
+    assert rules(doc) == ["E1"]
+
+
+@pytest.mark.parametrize("side", ["width", "height"])
+def test_half_a_frame_size_is_refused(side: str) -> None:
+    """A width with no height is a half-stated delivery, and the other half is not guessable."""
+    stated = dict(HD)
+    del stated[side]
+
+    assert "E1" in rules(at(**stated))
+    assert side in messages(at(**stated), "E1")[0]
+
+
+@pytest.mark.parametrize("value", ["1920", 1920.0, True, None])
+def test_a_side_that_is_not_an_integer_is_refused(value: Any) -> None:
+    """The API is string-typed, so ``"1920"`` looks harmless — and it is the author's slip.
+
+    Booleans go with it: ``True`` is an ``int`` to Python and 1 pixel to Resolve.
+    """
+    assert "E1" in rules(at(width=value, height=1080))
+
+
+@pytest.mark.parametrize("value", [0, -1080, 15, 16385])
+def test_an_implausible_side_is_refused_as_a_typo(value: int) -> None:
+    assert "E1" in rules(at(width=1920, height=value))
+
+
+def test_an_unknown_resolution_key_is_refused_rather_than_ignored() -> None:
+    """``w``/``h`` would leave the timeline at 4K and report a successful build."""
+    doc = at(width=1920, height=1080, pixel_aspect=1.0)
+
+    assert "E1" in rules(doc)
+    assert "pixel_aspect" in messages(doc, "E1")[0]
+
+
+def test_the_dry_run_reports_it_before_resolve_is_touched(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(empty_project(a_pool()))
+
+    result = validate_cut(a_cut(tmp_path, at(width=1920, height=0)))
+
+    assert result["ok"] is True
+    assert [error["rule"] for error in result["errors"]] == ["E1"]
+
+
+# --- the settings wrapper -------------------------------------------------------------------
+
+
+def test_the_flag_goes_first_or_the_size_does_not_land() -> None:
+    """``useCustomSettings`` detaches the timeline from the project's settings.
+
+    The resolution keys are inert while it is off — the write is taken and the timeline
+    stays where it was — so the order here is the whole call, not a nicety.
+    """
+    timeline = FakeTimeline("sunset-set v1", resolution=("3840", "2160"))
+
+    settings.apply_resolution(timeline, cut_resolution.Resolution(1920, 1080), "sunset-set v1")
+
+    assert [key for key, _ in timeline.setting_writes] == [CUSTOM_SETTINGS, WIDTH, HEIGHT]
+    assert timeline.GetSetting(WIDTH) == "1920"
+    assert timeline.GetSetting(HEIGHT) == "1080"
+
+
+def test_the_settings_round_trip_as_the_strings_the_api_speaks() -> None:
+    """Written as strings, read back as strings, reported as the integers they mean."""
+    timeline = FakeTimeline("sunset-set v1", resolution=("3840", "2160"))
+
+    settings.apply_resolution(timeline, cut_resolution.Resolution(1920, 1080), "sunset-set v1")
+
+    assert timeline.setting_writes == [(CUSTOM_SETTINGS, "1"), (WIDTH, "1920"), (HEIGHT, "1080")]
+    assert settings.read_resolution(timeline) == HD
+
+
+def test_a_timeline_that_will_not_take_the_size_fails_rather_than_reporting_it() -> None:
+    """The one outcome worse than not offering the setting: claiming a size nothing has."""
+    timeline = FakeTimeline("sunset-set v1", resolution=("3840", "2160"))
+    timeline.settings_that_ignore_writes = {WIDTH}
+
+    with pytest.raises(Exception) as raised:  # noqa: PT011 - the message is what is under test
+        settings.apply_resolution(timeline, cut_resolution.Resolution(1920, 1080), "sunset-set v1")
+
+    assert "3840x1080" in str(raised.value)
+
+
+def test_a_timeline_that_says_nothing_about_its_size_reads_as_nothing() -> None:
+    assert settings.read_resolution(FakeTimeline("sync reference")) is None
+
+
+# --- the build ------------------------------------------------------------------------------
+
+
+def test_the_built_timeline_carries_the_stated_resolution(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The end of G13: a 1080p cut in a 4K project, with no hand step before the render."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, at(**HD)))
+
+    assert result["ok"] is True, result.get("error")
+    assert result["timeline"]["resolution"] == HD
+    assert built(resolve, "sunset-set v1").GetSetting(CUSTOM_SETTINGS) == "1"
+
+
+def test_a_build_that_states_nothing_stays_on_the_project_default(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """v1 behaviour, unchanged: the project decides, and the report says which size that was."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    result = build_timeline(a_cut(tmp_path, valid_doc()))
+
+    assert result["timeline"]["resolution"] == {"width": 3840, "height": 2160}
+    assert built(resolve, "sunset-set v1").setting_writes == []
+
+
+def test_the_size_is_set_before_the_first_append(attach: Attach, tmp_path: Path) -> None:
+    """A timeline that took the shots at 4K and was resized after is not the same edit."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+
+    build_timeline(a_cut(tmp_path, at(**HD)))
+
+    landed = built(resolve, "sunset-set v1")
+    assert landed.setting_writes_at_item_count == [0, 0, 0]
+
+
+def test_a_round_tripped_cut_is_resized_after_the_import(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The import is a new timeline, born at the project's 4K like any other.
+
+    The staging timeline's own settings do not travel in the OTIO document, so a build that
+    set the size once would round-trip a tail straight back to the project default — and the
+    tail is exactly the shape the corpus delivers.
+    """
+    resolve = empty_project(a_pool())
+    attach(resolve)
+    doc = at(**HD)
+    doc["tail"] = {"type": "dissolve_to_black", "duration_frames": 40, "audio_fade_frames": 35}
+
+    result = build_timeline(a_cut(tmp_path, doc))
+
+    assert result["ok"] is True, result.get("error")
+    assert result["tail"]["route"] == "otio_round_trip"
+    assert result["timeline"]["resolution"] == HD
+    assert settings.read_resolution(built(resolve, "sunset-set v1")) == HD
+
+
+def test_a_build_whose_size_will_not_land_fails_instead_of_delivering_4k(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = a_pool()
+    pool.new_timeline_settings_that_ignore_writes = {HEIGHT}
+    attach(empty_project(pool))
+
+    result = build_timeline(a_cut(tmp_path, at(**HD)))
+
+    assert result["ok"] is False
+    assert "1920x2160" in result["error"]["cause"]

--- a/tests/test_cut_resolution.py
+++ b/tests/test_cut_resolution.py
@@ -141,7 +141,25 @@ def test_the_settings_round_trip_as_the_strings_the_api_speaks() -> None:
     settings.apply_resolution(timeline, cut_resolution.Resolution(1920, 1080), "sunset-set v1")
 
     assert timeline.setting_writes == [(CUSTOM_SETTINGS, "1"), (WIDTH, "1920"), (HEIGHT, "1080")]
-    assert settings.read_resolution(timeline) == HD
+    assert settings.read_resolution(timeline) == cut_resolution.Resolution(1920, 1080)
+
+
+@pytest.mark.parametrize("answer", ["  1920  ", "1920"])
+def test_a_setting_padded_the_way_a_c_bridge_pads_it_still_reads(answer: str) -> None:
+    """The values cross a C bridge, and nothing promises they arrive trimmed."""
+    timeline = FakeTimeline("sunset-set v1", resolution=(answer, "1080"))
+
+    assert settings.read_resolution(timeline) == cut_resolution.Resolution(1920, 1080)
+
+
+@pytest.mark.parametrize("answer", ["", "1920x1080", "auto"])
+def test_a_setting_that_is_not_a_number_reads_as_nothing_rather_than_a_guess(
+    answer: str,
+) -> None:
+    """An unreadable size is "will not say" — the build then fails rather than assuming."""
+    timeline = FakeTimeline("sunset-set v1", resolution=(answer, "1080"))
+
+    assert settings.read_resolution(timeline) is None
 
 
 def test_a_timeline_that_will_not_take_the_size_fails_rather_than_reporting_it() -> None:
@@ -219,7 +237,8 @@ def test_a_round_tripped_cut_is_resized_after_the_import(
     assert result["ok"] is True, result.get("error")
     assert result["tail"]["route"] == "otio_round_trip"
     assert result["timeline"]["resolution"] == HD
-    assert settings.read_resolution(built(resolve, "sunset-set v1")) == HD
+    landed = settings.read_resolution(built(resolve, "sunset-set v1"))
+    assert landed == cut_resolution.Resolution(1920, 1080)
 
 
 def test_a_build_whose_size_will_not_land_fails_instead_of_delivering_4k(

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -79,6 +79,7 @@ from resolve_mcp.tools.timeline import (
 from resolve_mcp.tools.titles import apply_titles, edit_title, list_titles
 from resolve_mcp.tools.video import analyze_quality, detect_scene_cuts, grab_frames
 from resolve_mcp.video import ffmpeg as video_ffmpeg
+from resolve_mcp.video import jpeg
 
 from . import otio
 from .fakes import write_wav
@@ -559,6 +560,7 @@ def a_smoke_cut(
     alternate_at: int | None = None,
     audio_in: int | None = None,
     name: str = "smoke.cut.json",
+    resolution: tuple[int, int] | None = None,
 ) -> str:
     """A rough-cut shaped file (no master audio) built from one real clip.
 
@@ -594,6 +596,8 @@ def a_smoke_cut(
         "sources": {"angle": angle},
         "segments": segments,
     }
+    if resolution is not None:
+        doc["timeline"]["resolution"] = {"width": resolution[0], "height": resolution[1]}
     if audio_in is not None:
         doc["audio"] = {"source": "angle", "in": audio_in, "out": audio_in + sum(durations)}
     path = tmp_path / name
@@ -677,6 +681,60 @@ def test_a_real_build_places_every_shot_exactly_where_the_cut_puts_it(tmp_path: 
     timeline_start = built["timeline"]["start"]["frames"]
     assert [item["record"]["duration"]["frames"] for item in video["items"]] == list(durations)
     assert starts == [timeline_start, timeline_start + 48, timeline_start + 72]
+
+
+def test_a_real_build_delivers_the_resolution_the_cut_asked_for(tmp_path: Path) -> None:
+    """#187's live AC: 1920x1080 out of a project that creates timelines at 4K.
+
+    Nothing below this is checkable against a fake. Whether ``useCustomSettings`` is what
+    detaches a timeline from its project, whether the resolution keys take a string, and
+    whether a render then follows the *timeline* rather than the project are three facts
+    about Resolve, and the whole device is worthless if any of them is different from what
+    the wrapper assumes.
+
+    The render is the evidence, not the timeline setting: the frame grabbed back off the
+    file is what the delivery actually is. ``max_edge`` is far past 4K on purpose — the
+    still command only ever scales down, so an unchanged grab is the render's own size.
+
+    Skips unless the open project creates timelines at something other than the cut's own
+    resolution: a 1080p project would pass this test without the device doing anything.
+    Leaves one more ``resolve-mcp-smoke`` version and one rendered file behind.
+    """
+    if get_status()["context"]["project"] is None:
+        pytest.skip("No project open in Resolve")
+    project_size = run_python("result = [project.GetSetting('timelineResolutionWidth')]")
+    assert project_size["ok"] is True, project_size.get("error")
+    if str(project_size["result"][0]) == "1920":
+        pytest.skip("This project already creates timelines at 1920 wide")
+
+    presets = list_render_presets()
+    assert presets["ok"] is True, presets.get("error")
+    if not presets["presets"]:
+        pytest.skip("No render presets in this project")
+    preset = os.environ.get("RESOLVE_MCP_RENDER_PRESET") or presets["presets"][0]
+
+    source = a_source_clip()
+    built = build_timeline(a_smoke_cut(tmp_path, source, (48, 24), resolution=(1920, 1080)))
+    assert built["ok"] is True, built.get("error")
+    assert built["timeline"]["resolution"] == {"width": 1920, "height": 1080}
+
+    project = current_project(get_connection())
+    with current_timeline(project, find_timeline(project, str(built["timeline"]["name"]))):
+        started = render_timeline(
+            preset=preset,
+            name="resolve-mcp-smoke-1080",
+            target_dir=str(tmp_path),
+        )
+        assert started["ok"] is True, started.get("error")
+        record = wait_for(started["job"]["job_id"], timeout=1800.0)
+
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    written = Path(record.result["path"])
+    grabbed = video_ffmpeg.grab(written, tmp_path / "delivered.jpg", seconds=0.2, max_edge=8192)
+    delivered = jpeg.describe(grabbed.path)
+    print(f"\n{written} delivered {delivered['width']}x{delivered['height']}")
+    assert (delivered["width"], delivered["height"]) == (1920, 1080)
 
 
 def a_device_cut(tmp_path: Path, source: dict[str, Any]) -> str:

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -702,9 +702,11 @@ def test_a_real_build_delivers_the_resolution_the_cut_asked_for(tmp_path: Path) 
     """
     if get_status()["context"]["project"] is None:
         pytest.skip("No project open in Resolve")
-    project_size = run_python("result = [project.GetSetting('timelineResolutionWidth')]")
-    assert project_size["ok"] is True, project_size.get("error")
-    if str(project_size["result"][0]) == "1920":
+    probe = run_python("result = project.GetSetting('timelineResolutionWidth')")
+    assert probe["ok"] is True, probe.get("error")
+    # run_python renders its value with repr, so the setting comes back as source text.
+    project_width = str(ast.literal_eval(probe["result"]))
+    if project_width == "1920":
         pytest.skip("This project already creates timelines at 1920 wide")
 
     presets = list_render_presets()
@@ -733,8 +735,29 @@ def test_a_real_build_delivers_the_resolution_the_cut_asked_for(tmp_path: Path) 
     written = Path(record.result["path"])
     grabbed = video_ffmpeg.grab(written, tmp_path / "delivered.jpg", seconds=0.2, max_edge=8192)
     delivered = jpeg.describe(grabbed.path)
-    print(f"\n{written} delivered {delivered['width']}x{delivered['height']}")
+    print(
+        f"\npreset {preset!r} delivered {delivered['width']}x{delivered['height']} "
+        f"from a {project_width}-wide project: {written}"
+    )
     assert (delivered["width"], delivered["height"]) == (1920, 1080)
+
+    # The tail route ships the *import*, not the timeline the shots were appended to, and
+    # Resolve creates that one at the project's default like any other. A fake can only
+    # agree with itself about that, and the tail is the shape the corpus actually delivers —
+    # so the second build is checked here rather than assumed. No second render: what is
+    # under test is which timeline the setting landed on.
+    tailed_file = Path(
+        a_smoke_cut(tmp_path, source, (48, 24), resolution=(1920, 1080), name="tailed.cut.json")
+    )
+    tailed_doc = json.loads(tailed_file.read_text(encoding="utf-8"))
+    tailed_doc["tail"] = {"type": "dissolve_to_black", "duration_frames": 12}
+    tailed_file.write_text(json.dumps(tailed_doc), encoding="utf-8")
+
+    tailed = build_timeline(str(tailed_file))
+
+    assert tailed["ok"] is True, tailed.get("error")
+    assert tailed["tail"]["route"] == "otio_round_trip"
+    assert tailed["timeline"]["resolution"] == {"width": 1920, "height": 1080}
 
 
 def a_device_cut(tmp_path: Path, source: dict[str, Any]) -> str:


### PR DESCRIPTION
Closes #187 (gauntlet G13).

A built timeline was created at the project default — 3840×2160 on the corpus project, against 1080p deliverables — so every gauntlet round set 1920×1080 by hand in Resolve before rendering, and a round that forgot rendered 4K and said nothing.

`timeline.resolution` (`{width, height}`) on the cut file is that fact, stated beside the frame rate — `get_cut_schema` §9. One reading in `cut/resolution.py`, shape refused as E1 in `cut/validate.py`, applied by the new `resolve/settings.py` (the one place the server *writes* a timeline setting) and called from `resolve/build.py` before the first append, then again after a tail round trip, since the import is a new timeline born at the project default like any other. Omit the field and v1 behaviour is unchanged.

`SetSetting` is not evidence: the resolution keys are inert until `useCustomSettings` is `'1'`, and a write that changed nothing answers the same as one that landed. So the flag goes first and the read-back is the judge — a size that did not land **fails the build** rather than reporting a resolution the timeline does not have.

**Seams.** Fake tier: `tests/test_cut_resolution.py` (the device across `cut/resolution`, `cut/validate`, `resolve/settings`, `resolve/build`), with the fakes modelling both silent failures — writes are string-in/string-out, and a resolution write with the flag off is taken and dropped. Live smoke: `test_a_real_build_delivers_the_resolution_the_cut_asked_for`.

**Live AC — run, passed** (AC 3): DaVinci Resolve Studio 21.0.3.7, Windows 11, project `mcp-tests-zinc` (timeline default 3840×2160), worktree venv interpreter. Built a 1080p cut, rendered it with the stock `H.264 Master` preset, grabbed a frame back off the file: **1920×1080**, no hand step. The same test then builds a tailed cut through the OTIO round trip and confirms the *import* carries 1920×1080. Fake tier, mypy strict and ruff all green.

## Review

Two-axis `/code-review` against `origin/main`, parallel sub-agents, on the branch before this PR existed.

**Standards — no hard violations.** CONTEXT.md updated in the same PR, test seams named, no implicit re-export, idiom matched. Five judgement calls, four taken:
- *Duplicated Code* — the unknown-key block was copied from the tail rule. Extracted `_unknown_key_errors`; both blocks now share one reading. **Fixed.**
- *Primitive Obsession* — `read_resolution` returned a dict while `Resolution` existed. Now returns `Resolution`, so `apply_resolution` compares values; the report boundary is the only place it flattens. **Fixed.**
- *Speculative Generality* — `apply_resolution` returned a value both call sites discarded. Returns `None`. **Fixed.**
- *Missing `__all__`* — added to both new modules, as `cut/tail.py` has. **Fixed.**
- *Data Clump (fakes)* — the `tuple[str, str]` threading `FakeProject` → `FakeMediaPool` → `FakeTimeline`. **Not taken:** the fakes deliberately refuse to import server types, so the fix would be a duplicate local type for two strings.

**Spec — 3 findings, all addressed:**
- *The render half is not implemented.* Judged partly fair. The delivery does follow the timeline — live-confirmed here, and by `gauntlet/recon/full_pixelcheck.json` before it — and the ticket's end-to-end wording ("no manual timeline-settings edit") is met. But nothing said so at the tool boundary: `render_timeline`, `list_timelines` and `inspect_timeline` now state that the frame size comes from the timeline, and name the one thing that can still override it (a preset saved with a resolution of its own). **Addressed.**
- *Live AC owed, and the preset decides the outcome.* Run and recorded above, with the preset named. **Addressed.**
- *The tail route is fake-proven only.* Real: the round trip ships the import, and a fake can only agree with itself about which timeline that is. The live test now builds a tailed cut too and asserts the import carries the resolution. **Addressed.**
- Also found while fixing: the live test's project-width probe read a character out of a repr string, so its skip could never fire. **Fixed.**

Fix diff re-checked on its own; no new findings.

Review: clean — two-axis review on the branch; 5 standards judgement calls (4 taken, 1 declined with reason) and 3 spec findings, all addressed; fix diff re-checked.
