### PR TITLE
blocking raises ValueError; occlusion owns the job error

### DIFF
--- a/src/resolve_mcp/video/blocking.py
+++ b/src/resolve_mcp/video/blocking.py
@@ -86,8 +86,6 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy import ndimage
 
-from ..errors import OcclusionScanError
-
 GRID_WIDTH = 128
 GRID_HEIGHT = 72
 """The grid every sample is measured on, 16:9. Small enough that a scan of a whole song is
@@ -185,7 +183,7 @@ class Scan(NamedTuple):
 
 
 def read_grid(data: bytes, width: int = GRID_WIDTH, height: int = GRID_HEIGHT) -> NDArray[np.uint8]:
-    """Raw 8-bit grey bytes as ``(samples, height, width)``, or a refusal.
+    """Raw 8-bit grey bytes as ``(samples, height, width)``, or ``ValueError``.
 
     A trailing partial frame fails the read rather than being dropped. ffmpeg killed mid-write
     leaves one, and so does a second scan writing over this one's scratch file; either way the
@@ -193,21 +191,17 @@ def read_grid(data: bytes, width: int = GRID_WIDTH, height: int = GRID_HEIGHT) -
     would answer for footage nobody decoded. The answer that gets invented is the dangerous
     direction — a truncated tail reads as a clear stretch, so the cut goes where the blocker
     was.
+
+    The refusal is about the buffer, so it is a ``ValueError`` about the buffer: this module is
+    grey bytes in and scores out, and knows nothing of the job that produced the bytes. Whoever
+    ran the decode catches it and says what to do about it — for the scan, ``occlusion``.
     """
     frame_bytes = width * height
     remainder = len(data) % frame_bytes
     if remainder:
-        raise OcclusionScanError(
-            cause=(
-                f"The sampled grey is {len(data)} bytes — {remainder} past a whole number of "
-                f"{width}x{height} frames, so the decode did not finish."
-            ),
-            fix=(
-                "Run the scan again. Half a frame is what a decode killed mid-write leaves "
-                "behind; scoring the frames that survived would report on a shorter range "
-                "than the one asked about, and report it as clear."
-            ),
-            detail={"bytes": len(data), "frame_bytes": frame_bytes, "remainder": remainder},
+        raise ValueError(
+            f"{len(data)} bytes of grey is {remainder} past a whole number of "
+            f"{width}x{height} frames"
         )
     return np.asarray(np.frombuffer(data, dtype=np.uint8).reshape(-1, height, width))
 

--- a/src/resolve_mcp/video/occlusion.py
+++ b/src/resolve_mcp/video/occlusion.py
@@ -182,12 +182,18 @@ def scan_occlusion(
         grey = raw.read_bytes()
         try:
             frames = blocking.read_grid(grey)
-        except ValueError as short:
+        except ValueError as partial:
             # The arithmetic only knows the buffer is the wrong size. This is the job that
             # asked ffmpeg for those bytes, so this is where a short read becomes a cause and
-            # a fix the agent can act on.
+            # a fix the agent can act on — and the grid is this job's own number, the one it
+            # handed ffmpeg to decode onto a few lines up.
             frame_bytes = blocking.GRID_WIDTH * blocking.GRID_HEIGHT
             remainder = len(grey) % frame_bytes
+            if not remainder:
+                # Some other refusal from the read, and this job has nothing to say about it:
+                # dressing it as a short decode would report a frame count that is not the
+                # problem. Let it travel as itself.
+                raise
             raise OcclusionScanError(
                 cause=(
                     f"The sampled grey is {len(grey)} bytes — {remainder} past a whole number "
@@ -200,7 +206,7 @@ def scan_occlusion(
                     "than the one asked about, and report it as clear."
                 ),
                 detail={"bytes": len(grey), "frame_bytes": frame_bytes, "remainder": remainder},
-            ) from short
+            ) from partial
         scan = blocking.measure(frames)
     finally:
         # The grey file is scratch: the catalog is the artifact, and a cache hit must not

--- a/src/resolve_mcp/video/occlusion.py
+++ b/src/resolve_mcp/video/occlusion.py
@@ -179,7 +179,28 @@ def scan_occlusion(
             config=config,
         )
         progress(0.6, "scoring the samples for near-field blocking")
-        frames = blocking.read_grid(raw.read_bytes())
+        grey = raw.read_bytes()
+        try:
+            frames = blocking.read_grid(grey)
+        except ValueError as short:
+            # The arithmetic only knows the buffer is the wrong size. This is the job that
+            # asked ffmpeg for those bytes, so this is where a short read becomes a cause and
+            # a fix the agent can act on.
+            frame_bytes = blocking.GRID_WIDTH * blocking.GRID_HEIGHT
+            remainder = len(grey) % frame_bytes
+            raise OcclusionScanError(
+                cause=(
+                    f"The sampled grey is {len(grey)} bytes — {remainder} past a whole number "
+                    f"of {blocking.GRID_WIDTH}x{blocking.GRID_HEIGHT} frames, so the decode "
+                    "did not finish."
+                ),
+                fix=(
+                    "Run the scan again. Half a frame is what a decode killed mid-write leaves "
+                    "behind; scoring the frames that survived would report on a shorter range "
+                    "than the one asked about, and report it as clear."
+                ),
+                detail={"bytes": len(grey), "frame_bytes": frame_bytes, "remainder": remainder},
+            ) from short
         scan = blocking.measure(frames)
     finally:
         # The grey file is scratch: the catalog is the artifact, and a cache hit must not

--- a/tests/test_occlusion.py
+++ b/tests/test_occlusion.py
@@ -14,6 +14,7 @@ whose bottom half goes black halfway through, and the scan has to find it.
 
 from __future__ import annotations
 
+import ast
 import json
 import shutil
 import subprocess
@@ -227,13 +228,33 @@ def test_a_wipe_can_never_lift_a_clear_frame() -> None:
 
 def test_half_a_frame_is_not_a_sample_and_not_a_verdict_either() -> None:
     """A partial tail is a refusal: reading the frames that survived answers for a range that
-    was never decoded, and the answer it gives is that the shot is clear."""
+    was never decoded, and the answer it gives is that the shot is clear. The refusal is about
+    the buffer — a plain ``ValueError``; the job that asked for the decode is where it becomes
+    an error with a cause and a fix."""
     grid = blocking.GRID_WIDTH * blocking.GRID_HEIGHT
 
-    with pytest.raises(OcclusionScanError) as raised:
+    with pytest.raises(ValueError, match=str(grid // 2)) as raised:
         blocking.read_grid(CLEAN + BLOCKED[: grid // 2])
 
-    assert raised.value.detail["remainder"] == grid // 2
+    assert type(raised.value) is ValueError
+
+
+def test_the_arithmetic_module_carries_no_job_knowledge() -> None:
+    """``blocking`` is grey bytes in, scores out. Importing a job's error to raise it inverts
+    the dependency: the pure measurement would then only be importable where its wrapper is."""
+    tree = ast.parse(Path(blocking.__file__).read_text(encoding="utf-8"))
+    imported = [
+        node.module or ""
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+    ] + [
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    ]
+
+    assert not [name for name in imported if name.split(".")[-1] == "errors"]
 
 
 def test_a_whole_number_of_frames_reshapes_onto_the_grid() -> None:
@@ -506,6 +527,11 @@ def test_a_grey_file_cut_short_fails_the_scan_rather_than_reading_clear(
     assert record.state == "failed"
     assert record.error is not None
     assert record.error["code"] == "occlusion_scan_failed"
+    # The buffer's own arithmetic reaches the agent from here, where the job owns the error:
+    # how far past a whole frame the grey stopped is what says the decode was cut short.
+    assert record.error["detail"]["remainder"] == 1000
+    assert record.error["detail"]["bytes"] == len(CLEAN) * 2 + 1000
+    assert "did not finish" in record.error["cause"]
     assert list(get_config().analysis_dir.glob("*.gray")) == []
 
 

--- a/tests/test_occlusion.py
+++ b/tests/test_occlusion.py
@@ -243,15 +243,14 @@ def test_the_arithmetic_module_carries_no_job_knowledge() -> None:
     """``blocking`` is grey bytes in, scores out. Importing a job's error to raise it inverts
     the dependency: the pure measurement would then only be importable where its wrapper is."""
     tree = ast.parse(Path(blocking.__file__).read_text(encoding="utf-8"))
+    # Both halves of every import statement: ``from ..errors import X`` names the module on the
+    # statement, ``from .. import errors`` names it on the alias, and a guard that reads only
+    # one of them passes the import it exists to catch.
     imported = [
-        node.module or ""
+        name
         for node in ast.walk(tree)
-        if isinstance(node, ast.ImportFrom)
-    ] + [
-        alias.name
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Import)
-        for alias in node.names
+        if isinstance(node, ast.Import | ast.ImportFrom)
+        for name in [getattr(node, "module", None) or "", *(alias.name for alias in node.names)]
     ]
 
     assert not [name for name in imported if name.split(".")[-1] == "errors"]
@@ -533,6 +532,28 @@ def test_a_grey_file_cut_short_fails_the_scan_rather_than_reading_clear(
     assert record.error["detail"]["bytes"] == len(CLEAN) * 2 + 1000
     assert "did not finish" in record.error["cause"]
     assert list(get_config().analysis_dir.glob("*.gray")) == []
+
+
+def test_a_read_that_refuses_for_another_reason_is_not_dressed_as_a_short_decode(
+    attach: Attach,
+    fixture_video: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The job shapes the refusal it can explain and no other. A whole number of frames that
+    the read still turns down is not a decode cut short, and reporting it as one would send the
+    agent to run the scan again over a grey file that was never the problem."""
+    attach(_studio_holding(fixture_video))
+
+    def refusing(data: bytes, width: int = 0, height: int = 0) -> object:
+        raise ValueError("the grid is not a grid")
+
+    monkeypatch.setattr(blocking, "read_grid", refusing)
+    record = wait_for(_scan([], _run(2, 2, 2))["job_id"])
+
+    assert record.state == "failed"
+    assert record.error is not None
+    assert record.error["code"] != "occlusion_scan_failed"
+    assert "the grid is not a grid" in record.error["cause"]
 
 
 # --- the cache -------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #230.

`video/blocking.py` is pure obstruction arithmetic — grey bytes in, scores out — except that `read_grid` imported `OcclusionScanError` to refuse a buffer that was not a whole number of frames. That inverted the dependency: a measurement importable only where its job wrapper is.

A wrong-sized buffer is now a `ValueError` about the buffer. `scan_occlusion` — the job that asked ffmpeg for those bytes — catches it at the seam and shapes the same cause, fix, code and `detail` the agent saw before.

**Seam:** fake tier (`tests/test_occlusion.py`), both sides of the seam. The arithmetic test asserts a plain `ValueError`; the job-seam test that already covered a grey file cut short now asserts the structured error reaching the agent; an AST test holds the boundary that `blocking` imports nothing named `errors`. No live AC.

## Review

Two-axis `/code-review` against `origin/main`, run on the branch before this PR existed.

**Spec — no findings.** All three ACs met. The shaped error was diffed against `git show origin/main:src/resolve_mcp/video/blocking.py`: cause text, fix text and all three `detail` keys (`bytes`, `frame_bytes`, `remainder`) are identical, and `code` is unchanged because the exception class is. Every caller of `blocking.read_grid` was audited; none still expects the old type. Its two low-severity notes overlapped the Standards findings below and are resolved with them.

**Standards — four findings, two fixed, two declined with reasons.**

1. *Fixed — the `except ValueError` was broader than the refusal it shaped.* Any other `ValueError` out of the read would have reached the agent as "the decode did not finish… `remainder: 0`", sending it to re-run a scan that was never the problem. The handler now shapes the short read and re-raises anything else as itself, covered by a new fake-tier test.
2. *Fixed — the import guard had a hole.* It read only the module half of an import statement, so `from .. import errors` would have walked past the invariant the test exists to hold. It reads both halves now.
3. *Declined — "use the repo's inject-the-error-class idiom" (`ffmpeg.py`'s `failure: type[ResolveMcpError]`, `locate(...)`).* That parameter has to be annotated, and the annotation is an import from `errors` — which is exactly what AC1 forbids: "The blocking module imports nothing from the errors module." #230 prescribes the catch-at-the-seam shape; the ticket wins over the neighbouring idiom here.
4. *Declined as out of scope — `picture.read_grid` is the same function and still raises `QualityScanError` directly.* Real, and worth its own ticket; #230 names `blocking` only, and moving `picture` too would put a second module's job seam in a diff scoped to one. Noted on the issue.

Verification after the fixes: `uv run pytest -m 'not live'` → 2115 passed, 43 deselected; `uv run mypy src tests` → clean, 193 files; `uv run ruff check src tests` → clean.

Review: clean — Spec no findings; Standards four, two fixed on the branch, two declined with reasons above.
