### PR TITLE
Split the cut layout out of the validation rules

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -199,15 +199,19 @@ optional **delivery resolution**: `timeline.resolution`, one reading of
 `{width, height}` for both the rules and the build — omitted means the timeline
 is created at the project's default, which on the corpus project is 4K against
 1080p deliverables, #187), `schema`
-(verbatim, served by `get_cut_schema`), `validate` (12 errors + W1, W2,
-W8, W9 — W3-W7 are `virtual_transcript`'s over the same document — shared by
+(verbatim, served by `get_cut_schema`), `layout` (**where every entry lands** —
+pure, documents in and positions out: `positions`/`placements`/`total_frames`/
+`overlay_positions` are the one derivation the rules judge, the build places
+against and `virtual_transcript` reads back, #218), `validate` (12 errors + W1,
+W2, W8, W9 — W3-W7 are `virtual_transcript`'s over the same document — shared by
 dry run and build pre-flight; W9 is the one that reports a rule that *could
 not run*, where Resolve named no media bounds for E5 or E7 to check a range
-against, #186), `tail` (the optional **tail** device: one
-reading of `{type, duration_frames, audio_fade_frames}` for both the rules
-and the build). A `segments` entry is a shot or a **gap**
+against, #186; E11 is the exception it cannot answer, raised in
+`resolve/build` where a live locked track can be observed), `tail` (the optional
+**tail** device: one reading of `{type, duration_frames, audio_fade_frames}` for
+both the rules and the build). A `segments` entry is a shot or a **gap**
 (`{"id", "gap": <frames>}`, literal black); `is_gap`/`entry_duration`/
-`overlay_track` are the accessors every walker of that array shares.
+`overlay_track` are the `layout` accessors every walker of that array shares.
 
 `jobs/` — `cache` (hash-keyed results; `audio_identity` is the content hash
 wherever the file sits, read off a `known_hash` note remembered against a
@@ -349,8 +353,8 @@ all three agreed about. `test_rough_cut_pillar.py` is one of two other
 exceptions: it covers no single module, walking the P4 pillar across `cut`,
 `build`, `takes` and `virtual` in one pass because the joins are what a
 per-module test cannot see. `test_cut_devices.py` (#141) is the second, for the
-same reason: gaps and overlay tracks are one device each across `cut/validate`,
-`resolve/build`, `resolve/takes` and `analysis/virtual`, and the interesting
+same reason: gaps and overlay tracks are one device each across `cut/layout`,
+`cut/validate`, `resolve/build`, `resolve/takes` and `analysis/virtual`, and the interesting
 failures are the disagreements between them. `test_cut_tail.py` is the third: the
 tail is one device across `cut/tail`, `cut/validate`, `resolve/tail` and
 `resolve/build`, and a dissolve that did not land looks exactly like a cut that

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -354,8 +354,8 @@ exceptions: it covers no single module, walking the P4 pillar across `cut`,
 `build`, `takes` and `virtual` in one pass because the joins are what a
 per-module test cannot see. `test_cut_devices.py` (#141) is the second, for the
 same reason: gaps and overlay tracks are one device each across `cut/layout`,
-`cut/validate`, `resolve/build`, `resolve/takes` and `analysis/virtual`, and the interesting
-failures are the disagreements between them. `test_cut_tail.py` is the third: the
+`cut/validate`, `resolve/build`, `resolve/takes` and `analysis/virtual`, and the
+interesting failures are the disagreements between them. `test_cut_tail.py` is the third: the
 tail is one device across `cut/tail`, `cut/validate`, `resolve/tail` and
 `resolve/build`, and a dissolve that did not land looks exactly like a cut that
 never asked for one. `test_hardware_decode.py` (#202) is the fourth: NVDEC is

--- a/src/resolve_mcp/analysis/virtual.py
+++ b/src/resolve_mcp/analysis/virtual.py
@@ -32,7 +32,7 @@ from typing import Any, Final
 
 from ..config import Config, get_config
 from ..cut.document import read_cut_file
-from ..cut.validate import is_gap, overlay_positions, positions, total_frames
+from ..cut.layout import is_gap, overlay_positions, positions, total_frames
 from ..document import LoadedDocument
 from ..errors import InvalidRequestError
 from ..findings import Finding, ordered

--- a/src/resolve_mcp/cut/layout.py
+++ b/src/resolve_mcp/cut/layout.py
@@ -1,0 +1,181 @@
+"""The cut layout: where every entry in a cut document lands, answered once.
+
+A cut file names no absolute frame. A segment's position is the sum of everything
+before it, an overlay's is its anchor's position plus an offset, and the cut's length
+is the sum of the lot — all *computed*, so a tightening pass moves the numbers instead
+of the author maintaining them. This module is the only place those sums are taken.
+
+That single place is the point. The rules in :mod:`resolve_mcp.cut.validate` judge
+these numbers, :mod:`resolve_mcp.resolve.build` places against them, and
+``virtual_transcript`` reads the cut back through them: a second derivation of "where
+does segment N start" is a shot validated at one frame and built at another. The
+deletion test says as much — remove this and build and virtual each grow their own copy
+of the sum, which is precisely the drift it exists to prevent.
+
+Pure by construction: documents in, positions out. No findings, no clip facts, no
+Resolve handle — so the rules can import it without circularity and every consumer gets
+the same answer from the same code.
+
+The document is assumed shape-valid (E1 has passed). Reading an unvalidated document
+here raises rather than reporting, because reporting is the rules module's job.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, Final, TypeGuard
+
+from ..timing import duration_frames
+
+V1_TRACK: Final = 1
+"""The sequential cut's own track — the one ``segments`` lays out."""
+
+FIRST_OVERLAY_TRACK: Final = 2
+"""V1 is the sequential cut's own track, so the lowest an overlay can claim is V2."""
+
+
+def _is_int(value: Any) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def is_gap(entry: Any) -> bool:
+    """Whether a ``segments`` entry is black rather than a shot.
+
+    Public because the build, the swap and the read-back all walk the same array and each
+    has to answer this the same way: a second definition of what black looks like is how a
+    gap ends up placed on one side of the seam and ignored on the other.
+    """
+    return isinstance(entry, dict) and "gap" in entry
+
+
+def entry_duration(entry: dict[str, Any]) -> int:
+    """How much record time one ``segments`` entry takes — a gap's is the black itself."""
+    if is_gap(entry):
+        return int(entry["gap"])
+    return duration_frames(entry["in"], entry["out"])
+
+
+def overlay_track(overlay: dict[str, Any]) -> int:
+    """Which video track an overlay rides on. Absent means V2, the layer above the cut."""
+    track = overlay.get("track")
+    return int(track) if _is_int(track) else FIRST_OVERLAY_TRACK
+
+
+def entries(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """``segments`` as authored: picture and black, in the order that lays out the V1."""
+    laid_out: list[dict[str, Any]] = doc["segments"]
+    return laid_out
+
+
+def shots(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """Only the entries that place a clip — *not* the same list as ``doc["segments"]``.
+
+    Every rule about *media* — aliases, bounds, rates, takes — reads this rather than the
+    raw array, so a gap is skipped by all of them at once instead of by a guard each of
+    them could be written without. Public alongside :func:`gaps` because the build and the
+    summaries need the same two counts, and counting them by hand at each call site is how
+    one of them ends up disagreeing about what black is.
+    """
+    return [entry for entry in entries(doc) if not is_gap(entry)]
+
+
+def gaps(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """Only the entries that are black."""
+    return [entry for entry in entries(doc) if is_gap(entry)]
+
+
+def overlays(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """The ``overlays`` array, or an empty one — the block is optional."""
+    riding: list[dict[str, Any]] = doc.get("overlays") or []
+    return riding
+
+
+def positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
+    """Each ``segments`` id to its computed ``(start, duration)`` — sequential V1, in order.
+
+    The overlay rules and the build both place against these numbers, and they have to be
+    the same numbers: an offset validated against one layout and built against another
+    would put the overlay somewhere nobody checked.
+
+    A gap is here with the rest. It places no clip, but it occupies record time and so it
+    moves everything after it — and an overlay may anchor over it, which is what makes a
+    V2 bridge across black expressible at all. Positions stay *computed* either way: black
+    is a duration in the array, never a frame number an author had to keep up to date.
+    """
+    placed: dict[str, tuple[int, int]] = {}
+    at = 0
+    for entry in entries(doc):
+        duration = entry_duration(entry)
+        placed[str(entry["id"])] = (at, duration)
+        at += duration
+    return placed
+
+
+def placements(doc: dict[str, Any], start: int) -> dict[str, tuple[int, int]]:
+    """Each segment id to its ``(record frame, duration)`` on a timeline starting at ``start``.
+
+    The one place a cut's own offsets become absolute frames. A build sends these as
+    ``recordFrame`` and a swap finds a shot by them, so a second derivation of the same sum
+    somewhere else is a swap that quietly reads the wrong shot — there is only this one.
+    """
+    return {
+        id: (start + offset, duration) for id, (offset, duration) in positions(doc).items()
+    }
+
+
+def total_frames(doc: dict[str, Any]) -> int:
+    """The V1 span: sequential entries, so the sum of their durations, black included."""
+    return sum(entry_duration(entry) for entry in entries(doc))
+
+
+def overlay_positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
+    """Each overlay id to its computed ``(start, duration)`` on V2 — start measured from
+    the cut's first frame, exactly as :func:`positions` measures a segment's.
+
+    An overlay names no absolute frame: its position is its anchor segment's computed
+    start plus the offset, which is what makes it ride the content it covers through a
+    tightening pass. E9 judges these numbers and the build places against them, from this
+    one function — a position validated one way and built another is exactly the drift
+    anchoring exists to prevent. An overlay whose anchor does not exist has no position
+    and is absent here; E9 has already refused that document.
+    """
+    return {str(overlay["id"]): at for overlay, at in anchored(doc) if at is not None}
+
+
+def anchored(doc: dict[str, Any]) -> Iterator[tuple[dict[str, Any], tuple[int, int] | None]]:
+    """Every overlay with its resolved span, or ``None`` when its anchor is not a segment.
+
+    Public for E9's sake alone: :func:`overlay_positions` drops the unanchored ones, and
+    the rule that *reports* them needs to see the overlay that has no position rather than
+    infer it from an absence.
+    """
+    placed = positions(doc)
+    for overlay in overlays(doc):
+        anchor = placed.get(str(overlay["over"]["segment"]))
+        yield (
+            overlay,
+            None
+            if anchor is None
+            else (
+                anchor[0] + int(overlay["over"]["offset"]),
+                duration_frames(overlay["in"], overlay["out"]),
+            ),
+        )
+
+
+__all__ = [
+    "FIRST_OVERLAY_TRACK",
+    "V1_TRACK",
+    "anchored",
+    "entries",
+    "entry_duration",
+    "gaps",
+    "is_gap",
+    "overlay_positions",
+    "overlay_track",
+    "overlays",
+    "placements",
+    "positions",
+    "shots",
+    "total_frames",
+]

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -1213,7 +1213,6 @@ def _audio_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[F
 
 __all__ = [
     "DEFAULT_MIN_SEGMENT_FRAMES",
-    "MAX_OVERLAY_TRACK",
     "RULE_DESCRIPTIONS",
     "ClipFacts",
     "parse_failure_finding",

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -16,8 +16,12 @@ Two passes, because they need different things:
   check could not run). It is a pure function over those facts, so every rule in this
   file is unit-testable without Resolve.
 
-E11 is the build-time rule — a locked target track fails *silently* in the Resolve API,
-so the build checks it and reports it in the same shape as everything else.
+E11 is the build-time rule — a locked target track fails *silently* in the Resolve API —
+so it is described in :data:`RULE_DESCRIPTIONS` here with the rest of the catalogue, but
+raised in :mod:`resolve_mcp.resolve.build`, beside the check that can observe it.
+
+Where the entries *land* is not here: :mod:`resolve_mcp.cut.layout` computes that, and
+these rules judge the numbers it returns rather than summing their own (#218).
 
 Every finding is ``{rule, id, message, fix_hint}``: the rule so the agent can look it up,
 the id so it knows which segment to edit, and a fix hint so it does not have to guess.
@@ -34,6 +38,21 @@ from ..logging_config import get_logger
 from ..timing import duration_frames, ranges_overlap
 from . import resolution as cut_resolution
 from . import tail as tail_device
+from .layout import (
+    FIRST_OVERLAY_TRACK,
+    V1_TRACK,
+    anchored,
+    entries,
+    entry_duration,
+    gaps,
+    is_gap,
+    overlay_positions,
+    overlay_track,
+    overlays,
+    positions,
+    shots,
+    total_frames,
+)
 from .schema import SCHEMA_VERSION
 from .tail import Tail
 
@@ -44,12 +63,6 @@ DEFAULT_MIN_SEGMENT_FRAMES: Final = 12
 
 FPS_TOLERANCE: Final = 0.01
 """Reported rates carry float noise; real rate differences (23.976 vs 24) are far wider."""
-
-V1_TRACK: Final = 1
-"""The sequential cut's own track — the one ``segments`` lays out."""
-
-FIRST_OVERLAY_TRACK: Final = 2
-"""V1 is the sequential cut's own track, so the lowest an overlay can claim is V2."""
 
 MAX_OVERLAY_TRACK: Final = 8
 """A ceiling on ``track``, because the build adds every track below the one it is given.
@@ -91,7 +104,6 @@ _FIX_HINTS: Final[dict[str, str]] = {
     "E9": "Anchor the overlay to a segment that exists, at an offset inside it.",
     "E10": "Move one overlay, shorten it, or put it on its own 'track' — one track holds "
     "one clip per frame.",
-    "E11": "Unlock the track in Resolve's timeline header and build again.",
     "E12": "A dissolve reaches back into the last shot on V1 and the audio fade back into "
     "the mix, so each must be shorter than what it fades. Call get_cut_schema §8.",
     "W1": "Lengthen the segment or gap, or keep it if the flash is deliberate.",
@@ -130,16 +142,6 @@ def _finding(rule: str, id: str | None, message: str, fix_hint: str | None = Non
 def parse_failure_finding(detail: str) -> Finding:
     """E1: the file is on disk but is not JSON, so no other rule can be answered."""
     return _finding("E1", None, f"The cut file is not valid JSON: {detail}.")
-
-
-def locked_track_finding(track: str) -> Finding:
-    """E11: Resolve accepts an append onto a locked track and silently drops it."""
-    return _finding(
-        "E11",
-        track,
-        f"Track {track} is locked; Resolve would report the append as successful and "
-        f"place nothing.",
-    )
 
 
 # --- shape (E1) -------------------------------------------------------------------------
@@ -517,62 +519,11 @@ def validate_structure(
     return ordered(findings)
 
 
-def is_gap(entry: Any) -> bool:
-    """Whether a ``segments`` entry is black rather than a shot.
-
-    Public because the build, the swap and the read-back all walk the same array and each
-    has to answer this the same way: a second definition of what black looks like is how a
-    gap ends up placed on one side of the seam and ignored on the other.
-    """
-    return isinstance(entry, dict) and "gap" in entry
-
-
-def entry_duration(entry: dict[str, Any]) -> int:
-    """How much record time one ``segments`` entry takes — a gap's is the black itself."""
-    if is_gap(entry):
-        return int(entry["gap"])
-    return duration_frames(entry["in"], entry["out"])
-
-
-def overlay_track(overlay: dict[str, Any]) -> int:
-    """Which video track an overlay rides on. Absent means V2, the layer above the cut."""
-    track = overlay.get("track")
-    return int(track) if _is_int(track) else FIRST_OVERLAY_TRACK
-
-
-def _entries(doc: dict[str, Any]) -> list[dict[str, Any]]:
-    """``segments`` as authored: picture and black, in the order that lays out the V1."""
-    entries: list[dict[str, Any]] = doc["segments"]
-    return entries
-
-
-def shots(doc: dict[str, Any]) -> list[dict[str, Any]]:
-    """Only the entries that place a clip — *not* the same list as ``doc["segments"]``.
-
-    Every rule about *media* — aliases, bounds, rates, takes — reads this rather than the
-    raw array, so a gap is skipped by all of them at once instead of by a guard each of
-    them could be written without. Public alongside :func:`gaps` because the build and the
-    summaries need the same two counts, and counting them by hand at each call site is how
-    one of them ends up disagreeing about what black is.
-    """
-    return [entry for entry in _entries(doc) if not is_gap(entry)]
-
-
-def gaps(doc: dict[str, Any]) -> list[dict[str, Any]]:
-    """Only the entries that are black."""
-    return [entry for entry in _entries(doc) if is_gap(entry)]
-
-
-def _overlays(doc: dict[str, Any]) -> list[dict[str, Any]]:
-    overlays: list[dict[str, Any]] = doc.get("overlays") or []
-    return overlays
-
-
 def _id_errors(doc: dict[str, Any]) -> list[Finding]:
     """E2: segments, gaps and overlays share one id namespace."""
     seen: set[str] = set()
     findings: list[Finding] = []
-    for item in (*_entries(doc), *_overlays(doc)):
+    for item in (*entries(doc), *overlays(doc)):
         id = str(item["id"])
         if id in seen:
             findings.append(_finding("E2", id, f"The id {id!r} is used more than once."))
@@ -589,7 +540,7 @@ def _range_errors(doc: dict[str, Any]) -> list[Finding]:
             findings += _range_error(
                 alternate, str(segment["id"]), f"Alternate {index} of segment"
             )
-    for overlay in _overlays(doc):
+    for overlay in overlays(doc):
         findings += _range_error(overlay, str(overlay["id"]), "Overlay")
     for gap in gaps(doc):
         findings += _gap_length_error(gap)
@@ -661,7 +612,7 @@ def _alias_uses(doc: dict[str, Any]) -> Iterator[tuple[str, str]]:
         yield str(segment["source"]), str(segment["id"])
         for alternate in segment.get("alternates") or []:
             yield str(alternate["source"]), str(segment["id"])
-    for overlay in _overlays(doc):
+    for overlay in overlays(doc):
         yield str(overlay["source"]), str(overlay["id"])
 
 
@@ -688,74 +639,6 @@ def _alternate_duration_errors(doc: dict[str, Any]) -> list[Finding]:
     return findings
 
 
-def positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
-    """Each ``segments`` id to its computed ``(start, duration)`` — sequential V1, in order.
-
-    The overlay rules and the build both place against these numbers, and they have to be
-    the same numbers: an offset validated against one layout and built against another
-    would put the overlay somewhere nobody checked.
-
-    A gap is here with the rest. It places no clip, but it occupies record time and so it
-    moves everything after it — and an overlay may anchor over it, which is what makes a
-    V2 bridge across black expressible at all. Positions stay *computed* either way: black
-    is a duration in the array, never a frame number an author had to keep up to date.
-    """
-    placed: dict[str, tuple[int, int]] = {}
-    at = 0
-    for entry in _entries(doc):
-        duration = entry_duration(entry)
-        placed[str(entry["id"])] = (at, duration)
-        at += duration
-    return placed
-
-
-def placements(doc: dict[str, Any], start: int) -> dict[str, tuple[int, int]]:
-    """Each segment id to its ``(record frame, duration)`` on a timeline starting at ``start``.
-
-    The one place a cut's own offsets become absolute frames. A build sends these as
-    ``recordFrame`` and a swap finds a shot by them, so a second derivation of the same sum
-    somewhere else is a swap that quietly reads the wrong shot — there is only this one.
-    """
-    return {
-        id: (start + offset, duration) for id, (offset, duration) in positions(doc).items()
-    }
-
-
-def total_frames(doc: dict[str, Any]) -> int:
-    """The V1 span: sequential entries, so the sum of their durations, black included."""
-    return sum(entry_duration(entry) for entry in _entries(doc))
-
-
-def overlay_positions(doc: dict[str, Any]) -> dict[str, tuple[int, int]]:
-    """Each overlay id to its computed ``(start, duration)`` on V2 — start measured from
-    the cut's first frame, exactly as :func:`positions` measures a segment's.
-
-    An overlay names no absolute frame: its position is its anchor segment's computed
-    start plus the offset, which is what makes it ride the content it covers through a
-    tightening pass. E9 judges these numbers and the build places against them, from this
-    one function — a position validated one way and built another is exactly the drift
-    anchoring exists to prevent. An overlay whose anchor does not exist has no position
-    and is absent here; E9 has already refused that document.
-    """
-    return {str(overlay["id"]): at for overlay, at in _anchored(doc) if at is not None}
-
-
-def _anchored(doc: dict[str, Any]) -> Iterator[tuple[dict[str, Any], tuple[int, int] | None]]:
-    """Every overlay with its resolved span, or ``None`` when its anchor is not a segment."""
-    placed = positions(doc)
-    for overlay in _overlays(doc):
-        anchor = placed.get(str(overlay["over"]["segment"]))
-        yield (
-            overlay,
-            None
-            if anchor is None
-            else (
-                anchor[0] + int(overlay["over"]["offset"]),
-                duration_frames(overlay["in"], overlay["out"]),
-            ),
-        )
-
-
 def _overlay_errors(doc: dict[str, Any]) -> list[Finding]:
     """E9 and E10, both judged on the absolute positions resolved from the anchors."""
     placed = positions(doc)
@@ -763,7 +646,7 @@ def _overlay_errors(doc: dict[str, Any]) -> list[Finding]:
     findings: list[Finding] = []
     spans: dict[int, list[tuple[str, int, int]]] = {}
 
-    for overlay, resolved in _anchored(doc):
+    for overlay, resolved in anchored(doc):
         id = str(overlay["id"])
         anchor = str(overlay["over"]["segment"])
         offset = int(overlay["over"]["offset"])
@@ -883,8 +766,8 @@ def _dissolve_errors(doc: dict[str, Any], tail: Tail, declared: dict[str, Any]) 
             )
         ]
 
-    entries = _entries(doc)
-    last = entries[-1]
+    laid_out = entries(doc)
+    last = laid_out[-1]
     if is_gap(last):
         return [
             _finding(
@@ -980,13 +863,13 @@ def _video_ends(doc: dict[str, Any]) -> dict[int, tuple[int, str, int]]:
     """
     ends: dict[int, tuple[int, str, int]] = {}
     at = 0
-    for entry in _entries(doc):
+    for entry in entries(doc):
         duration = entry_duration(entry)
         if not is_gap(entry):
             ends[V1_TRACK] = (at + duration, str(entry["id"]), duration)
         at += duration
     total = total_frames(doc)
-    for overlay, resolved in _anchored(doc):
+    for overlay, resolved in anchored(doc):
         if resolved is None:
             continue
         start, duration = resolved
@@ -1042,7 +925,7 @@ def _segment_length_warnings(doc: dict[str, Any], minimum: int) -> list[Finding]
     duration far more often than as a device.
     """
     findings: list[Finding] = []
-    for entry in _entries(doc):
+    for entry in entries(doc):
         duration = entry_duration(entry)
         if duration < minimum:
             subject = "Gap" if is_gap(entry) else "Segment"
@@ -1126,7 +1009,7 @@ def _trailing_black(doc: dict[str, Any]) -> tuple[int, int] | None:
     placed = positions(doc)
     ends = [
         start + duration
-        for entry in _entries(doc)
+        for entry in entries(doc)
         if not is_gap(entry)
         for start, duration in [placed[str(entry["id"])]]
     ]
@@ -1213,7 +1096,7 @@ def _bounds_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[
             findings += _bounds_error(
                 alternate, resolved, id, f"Alternate {index} of segment {id!r}"
             )
-    for overlay in _overlays(doc):
+    for overlay in overlays(doc):
         id = str(overlay["id"])
         findings += _bounds_error(overlay, resolved, id, f"Overlay {id!r}")
     return findings
@@ -1330,22 +1213,11 @@ def _audio_errors(doc: dict[str, Any], resolved: dict[str, ClipFacts]) -> list[F
 
 __all__ = [
     "DEFAULT_MIN_SEGMENT_FRAMES",
-    "FIRST_OVERLAY_TRACK",
     "MAX_OVERLAY_TRACK",
     "RULE_DESCRIPTIONS",
     "ClipFacts",
-    "entry_duration",
-    "gaps",
-    "is_gap",
-    "locked_track_finding",
-    "overlay_positions",
-    "overlay_track",
     "parse_failure_finding",
-    "placements",
-    "positions",
     "resolve_aliases",
-    "shots",
-    "total_frames",
     "validate_project",
     "validate_structure",
 ]

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -50,15 +50,15 @@ from typing import Any, Final
 
 from ..cut import resolution as cut_resolution
 from ..cut import tail as cut_tail
-from ..cut.validate import gaps as cut_gaps
-from ..cut.validate import (
+from ..cut.layout import gaps as cut_gaps
+from ..cut.layout import (
     is_gap,
-    locked_track_finding,
     overlay_positions,
     overlay_track,
     placements,
 )
 from ..errors import BuildFailedError, CutInvalidError, TimelineNotFoundError
+from ..findings import Finding
 from ..logging_config import get_logger
 from ..naming import latest_version, next_version_name, version_name
 from . import cut, markers, media, mix, settings, takes
@@ -645,6 +645,24 @@ def _tracks(shots: list[Shot]) -> list[Track]:
     return sorted(
         {shot.track for shot in shots},
         key=lambda track: (order.index(track.type), track.index),
+    )
+
+
+def locked_track_finding(track: str) -> Finding:
+    """E11: Resolve accepts an append onto a locked track and silently drops it.
+
+    E11 is the one rule :mod:`resolve_mcp.cut.validate` cannot answer — the condition is a
+    live Resolve track, not anything in the document — so the finding is shaped here, beside
+    the check that can observe it, in the same ``{rule, id, message, fix_hint}`` shape every
+    other rule reports (#218). The catalogue entry stays with the rest in
+    :data:`resolve_mcp.cut.validate.RULE_DESCRIPTIONS`.
+    """
+    return Finding(
+        rule="E11",
+        id=track,
+        message=f"Track {track} is locked; Resolve would report the append as successful "
+        f"and place nothing.",
+        fix_hint="Unlock the track in Resolve's timeline header and build again.",
     )
 
 

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -899,4 +899,4 @@ def _expected(shot: Shot) -> dict[str, Any]:
     }
 
 
-__all__ = ["Shot", "Track", "build_timeline"]
+__all__ = ["Shot", "Track", "build_timeline", "locked_track_finding"]

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -17,15 +17,13 @@ from __future__ import annotations
 from typing import Any, NamedTuple
 
 from ..cut.document import read_cut_file
+from ..cut.layout import gaps, shots, total_frames
 from ..cut.schema import ANNOTATED_EXAMPLE, SCHEMA_DOC, SCHEMA_VERSION
 from ..cut.validate import (
     DEFAULT_MIN_SEGMENT_FRAMES,
     RULE_DESCRIPTIONS,
     ClipFacts,
-    gaps,
     resolve_aliases,
-    shots,
-    total_frames,
     validate_project,
     validate_structure,
 )

--- a/src/resolve_mcp/resolve/takes.py
+++ b/src/resolve_mcp/resolve/takes.py
@@ -27,7 +27,8 @@ from dataclasses import dataclass
 from typing import Any, Final
 
 from ..cut.document import read_cut_file
-from ..cut.validate import is_gap, placements, validate_structure
+from ..cut.layout import is_gap, placements
+from ..cut.validate import validate_structure
 from ..document import LoadedDocument
 from ..errors import (
     BuildFailedError,

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from resolve_mcp.document import content_hash
+from resolve_mcp.resolve.build import locked_track_finding
 from resolve_mcp.tools.cut import build_timeline
 
 from .conftest import Attach
@@ -845,6 +846,21 @@ def test_a_locked_target_track_is_reported_instead_of_silently_dropping_the_cut(
     assert [finding["rule"] for finding in findings] == ["E11", "E11"]
     assert [finding["id"] for finding in findings] == ["V1", "A1"]
     assert "AppendToTimeline" not in pool.calls
+
+
+def test_e11_shapes_a_locked_track_finding_like_every_other_rule() -> None:
+    """E11 is raised here rather than in the rules, and still reports in their shape (#218)."""
+    finding = locked_track_finding("V1")
+
+    assert finding.rule == "E11"
+    assert finding.id == "V1"
+    assert finding.fix_hint
+    assert finding.as_dict() == {
+        "rule": "E11",
+        "id": "V1",
+        "message": finding.message,
+        "fix_hint": finding.fix_hint,
+    }
 
 
 def test_a_still_gets_its_out_written_once_so_endframe_is_honoured(

--- a/tests/test_build_timeline.py
+++ b/tests/test_build_timeline.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from resolve_mcp.cut.validate import RULE_DESCRIPTIONS
 from resolve_mcp.document import content_hash
 from resolve_mcp.resolve.build import locked_track_finding
 from resolve_mcp.tools.cut import build_timeline
@@ -849,9 +850,15 @@ def test_a_locked_target_track_is_reported_instead_of_silently_dropping_the_cut(
 
 
 def test_e11_shapes_a_locked_track_finding_like_every_other_rule() -> None:
-    """E11 is raised here rather than in the rules, and still reports in their shape (#218)."""
+    """E11 is raised here rather than in the rules, and still reports in their shape (#218).
+
+    The catalogue entry stayed behind in ``RULE_DESCRIPTIONS`` when the finding moved, so
+    the rule number is asserted against it: that is the one seam the split can drift at,
+    and a rule the agent cannot look up is a finding it cannot act on.
+    """
     finding = locked_track_finding("V1")
 
+    assert finding.rule in RULE_DESCRIPTIONS
     assert finding.rule == "E11"
     assert finding.id == "V1"
     assert finding.fix_hint

--- a/tests/test_cut_devices.py
+++ b/tests/test_cut_devices.py
@@ -19,12 +19,8 @@ from typing import Any
 
 import pytest
 
-from resolve_mcp.cut.validate import (
-    overlay_positions,
-    positions,
-    total_frames,
-    validate_structure,
-)
+from resolve_mcp.cut.layout import overlay_positions, positions, total_frames
+from resolve_mcp.cut.validate import validate_structure
 from resolve_mcp.findings import Finding
 from resolve_mcp.tools.cut import (
     build_timeline,

--- a/tests/test_cut_layout.py
+++ b/tests/test_cut_layout.py
@@ -1,0 +1,126 @@
+"""Pure-function tests for the cut layout: where every entry lands.
+
+No Resolve, no fakes, and — unlike the rules — no sources table, no clip facts and no
+audio block either. The layout answers ``segments`` and ``overlays`` alone, and these
+documents carry nothing else, which is the split in #218 stated as a test: anything the
+layout needed from the rest of the file would show up here as a KeyError.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from resolve_mcp.cut.layout import (
+    FIRST_OVERLAY_TRACK,
+    entry_duration,
+    gaps,
+    is_gap,
+    overlay_positions,
+    overlay_track,
+    placements,
+    positions,
+    shots,
+    total_frames,
+)
+
+
+def a_layout() -> dict[str, Any]:
+    """Two shots of 200 frames with one overlay anchored 24 frames into the first."""
+    return {
+        "segments": [
+            {"id": "s001", "source": "gtr_close", "in": 1000, "out": 1200},
+            {"id": "s002", "source": "keys_wide", "in": 2000, "out": 2200},
+        ],
+        "overlays": [
+            {
+                "id": "b03",
+                "source": "broll_pan",
+                "in": 1200,
+                "out": 1300,
+                "over": {"segment": "s001", "offset": 24},
+            }
+        ],
+    }
+
+
+# --- one entry at a time ------------------------------------------------------------------
+
+
+def test_a_gap_is_the_entry_that_carries_black_rather_than_a_source() -> None:
+    assert is_gap({"id": "g001", "gap": 58}) is True
+    assert is_gap({"id": "s001", "source": "gtr_close", "in": 0, "out": 10}) is False
+
+
+def test_a_gaps_duration_is_the_black_itself_and_a_shots_is_its_range() -> None:
+    """The one asymmetry in the array: black states its length, a shot implies it."""
+    assert entry_duration({"id": "g001", "gap": 58}) == 58
+    assert entry_duration({"id": "s001", "source": "gtr_close", "in": 1000, "out": 1200}) == 200
+
+
+def test_an_overlay_without_a_track_rides_the_first_layer_above_the_cut() -> None:
+    assert overlay_track({"id": "b03"}) == FIRST_OVERLAY_TRACK
+    assert overlay_track({"id": "b03", "track": 4}) == 4
+
+
+# --- the document, split by what places a clip --------------------------------------------
+
+
+def test_shots_and_gaps_partition_the_segments_array() -> None:
+    """Every rule about media reads ``shots``, so black is skipped by all of them at once."""
+    doc = a_layout()
+    doc["segments"].insert(1, {"id": "g001", "gap": 58})
+
+    assert [entry["id"] for entry in shots(doc)] == ["s001", "s002"]
+    assert [entry["id"] for entry in gaps(doc)] == ["g001"]
+
+
+# --- where the entries land ---------------------------------------------------------------
+
+
+def test_positions_lay_the_segments_out_end_to_end_from_zero() -> None:
+    assert positions(a_layout()) == {"s001": (0, 200), "s002": (200, 200)}
+
+
+def test_a_gap_occupies_record_time_and_moves_everything_after_it() -> None:
+    """Black places no clip, but it is a duration in the array, so the sum has to carry it."""
+    doc = a_layout()
+    doc["segments"].insert(1, {"id": "g001", "gap": 58})
+
+    assert positions(doc) == {"s001": (0, 200), "g001": (200, 58), "s002": (258, 200)}
+    assert total_frames(doc) == 458
+
+
+def test_total_frames_is_the_v1_span_black_included() -> None:
+    assert total_frames(a_layout()) == 400
+
+
+def test_placements_turn_the_cuts_own_offsets_into_absolute_record_frames() -> None:
+    """The one place a cut's offsets become timeline frames — a build and a swap share it."""
+    assert placements(a_layout(), 3600) == {"s001": (3600, 200), "s002": (3800, 200)}
+
+
+# --- overlay placement: the numbers E9 judges and the build places against ----------------
+
+
+def test_overlay_positions_resolve_each_anchor_to_an_absolute_span() -> None:
+    """One function answers where an overlay goes, so the rule and the build cannot differ."""
+    doc = a_layout()
+    doc["overlays"].append(
+        {
+            "id": "b04",
+            "source": "broll_pan",
+            "in": 1400,
+            "out": 1440,
+            "over": {"segment": "s002", "offset": 50},
+        }
+    )
+
+    assert overlay_positions(doc) == {"b03": (24, 100), "b04": (250, 40)}
+
+
+def test_overlay_positions_skip_an_anchor_that_does_not_exist() -> None:
+    """E9 has already refused such a document; there is no position to invent for it."""
+    doc = a_layout()
+    doc["overlays"][0]["over"]["segment"] = "s999"
+
+    assert overlay_positions(doc) == {}

--- a/tests/test_cut_validate.py
+++ b/tests/test_cut_validate.py
@@ -1,7 +1,10 @@
-"""Pure-function tests for the cut-file validation rules E1-E11 and warnings W1-W2.
+"""Pure-function tests for the cut-file validation rules E1-E10, E12 and the warnings.
 
 No Resolve, no fakes: the structural pass takes a parsed document, the project
 pass takes gathered clip facts. Both are plain functions over plain data.
+
+Where the entries land is ``test_cut_layout.py``'s, and E11 — the build-time rule, whose
+condition is a live locked track — is ``test_build_timeline.py``'s (#218).
 """
 
 from __future__ import annotations
@@ -14,8 +17,6 @@ import pytest
 
 from resolve_mcp.cut.validate import (
     ClipFacts,
-    locked_track_finding,
-    overlay_positions,
     validate_project,
     validate_structure,
 )
@@ -494,33 +495,6 @@ def test_e9_catches_an_overlay_running_past_the_end_of_the_cut() -> None:
     assert "E9" in rules(findings)
 
 
-# --- overlay placement: the numbers E9 judges and the build places against ----------------
-
-
-def test_overlay_positions_resolve_each_anchor_to_an_absolute_span() -> None:
-    """One function answers where an overlay goes, so the rule and the build cannot differ."""
-    doc = valid_doc()
-    doc["overlays"].append(
-        {
-            "id": "b04",
-            "source": "broll_pan",
-            "in": 1400,
-            "out": 1440,
-            "over": {"segment": "s002", "offset": 50},
-        }
-    )
-
-    assert overlay_positions(doc) == {"b03": (24, 100), "b04": (250, 40)}
-
-
-def test_overlay_positions_skip_an_anchor_that_does_not_exist() -> None:
-    """E9 has already refused such a document; there is no position to invent for it."""
-    doc = valid_doc()
-    doc["overlays"][0]["over"]["segment"] = "s999"
-
-    assert overlay_positions(doc) == {}
-
-
 # --- E10: overlays do not overlap each other --------------------------------------------
 
 
@@ -603,23 +577,6 @@ def test_e10_compares_positions_across_different_anchors() -> None:
     findings = validate_structure(doc)
 
     assert "E10" in rules(findings)
-
-
-# --- E11: build-time, target tracks unlocked --------------------------------------------
-
-
-def test_e11_shapes_a_locked_track_finding_like_every_other_rule() -> None:
-    finding = locked_track_finding("V1")
-
-    assert finding.rule == "E11"
-    assert finding.id == "V1"
-    assert finding.fix_hint
-    assert finding.as_dict() == {
-        "rule": "E11",
-        "id": "V1",
-        "message": finding.message,
-        "fix_hint": finding.fix_hint,
-    }
 
 
 # --- W1: flash-frame guard --------------------------------------------------------------


### PR DESCRIPTION
Splits `cut/validate.py` in two: `cut/layout.py` (the query language over a cut document — pure, documents in and positions out) and the rule set that judges its numbers.

**Test seam:** fake tier. Layout is pure functions over plain data (`tests/test_cut_layout.py`, 1:1 with the new module); the rules keep `tests/test_cut_validate.py`; E11 moves to `tests/test_build_timeline.py`, where the fakes can model a locked track. Nothing here needs Resolve, so there are no live ACs on this ticket.

### What moved

- `cut/layout.py` holds `is_gap`, `entry_duration`, `overlay_track`, `shots`, `gaps`, `positions`, `placements`, `total_frames`, `overlay_positions`, plus `entries`, `overlays` and `anchored` — the three helpers the rules share, which had to become public names to cross the new boundary rather than be reached into as privates.
- `validate.py` imports layout like any other consumer. Its `__all__` is now `validate_structure`, `validate_project`, `RULE_DESCRIPTIONS`, `ClipFacts`, `resolve_aliases`, `parse_failure_finding`, `DEFAULT_MIN_SEGMENT_FRAMES` — each of the last four has a real external consumer.
- `locked_track_finding` moves to `resolve/build.py`, directly above `_refuse_locked_tracks`, the only code that can observe a locked track. E11 keeps its `RULE_DESCRIPTIONS` entry with the rest of the catalogue.
- `build`, `takes`, `virtual` and `resolve/cut` now import layout names from `cut.layout`; nothing imports a layout name from `cut.validate`.

No rule body changed — findings and validation behaviour are byte-identical.

### Judgement calls

**`resolve_aliases` stays with the rules.** The issue's prose lists it among the layout query language, but AC 1 requires layout to be pure. It takes `ClipFacts` and returns E4 `Finding`s, so moving it would put findings and clip facts back inside the module the AC says must have neither. AC 1 is the binding constraint; both review axes agreed.

**Layout's surface is 14 names against the issue's "~10".** `entries`, `overlays`, `anchored` and `V1_TRACK` were private in `validate.py` and had to go public to cross the module boundary — a consequence of the split, not added scope.

### Review

Two-axis review (`/code-review`) against `origin/main`, both axes as parallel sub-agents.

**Standards — 5 findings.**
1. *`locked_track_finding` missing from `resolve/build.py`'s `__all__`.* **Fixed** in 012fe28 — it is public and imported by the tests, so the declared surface disagreed with the real one.
2. *`_is_int` duplicated in `layout.py` and `validate.py`.* **Declined.** Layout cannot import it from `validate` — `validate` imports layout, so that is a cycle — and per-module `_is_int` is already the repo's shape, `titles/validate.py` carrying its own copy. Hoisting it to a shared home is a change to three modules this ticket does not touch.
3. *E11's catalogue entry and its finding text now live in different modules with nothing asserting they agree.* **Fixed** in 012fe28: the E11 test asserts `finding.rule in RULE_DESCRIPTIONS`. No test referenced `RULE_DESCRIPTIONS` before, so the drift was real and unwatched.
4. *`V1_TRACK` sits in `layout.py` with no layout-internal consumer.* **Declined.** It and `FIRST_OVERLAY_TRACK` state one fact — V1 is the segments' own track, so an overlay starts at V2 — and splitting the pair across modules costs a reader more than the constant's unused-here-ness.
5. *`CONTEXT.md` test-map line over the file's wrap width.* **Fixed** in 012fe28.

**Spec — 2 findings.**
1. *Rules interface only partly shrank: `MAX_OVERLAY_TRACK` exported with no consumer outside `validate.py`.* **Fixed** in 012fe28 — dropped from `__all__`.
2. *`build.py`'s `__all__` not updated.* Same as Standards 1, fixed together.

Spec verified AC 4 independently: exactly three cases left `test_cut_validate.py`, and all three exist elsewhere with their assertions intact — the two `overlay_positions` cases in `test_cut_layout.py` with byte-identical bodies, and the E11 case in `test_build_timeline.py`. The new `a_layout()` fixture's segments match the old `valid_doc()`'s minus `alternates`/`note`, neither of which enters a layout sum, so the moved expectations are the same numbers. ACs 1, 3 and 5 met; no scope creep found on either axis.

Fake tier 2169 passed / 44 deselected, mypy strict clean, ruff clean — before and after the fix commit.

Closes #218

Review: clean — 7 findings across both axes, 4 fixed in 012fe28, 3 declined with reasons above; fix diff re-checked, full tier green.
