### PR TITLE
One stem-discovery convention: halves.collected learns the wind pass (#220)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -157,8 +157,10 @@ no silent CPU fallback, #202; the inventory and the stays-on-CPU corpus policy:
 (loudness curves; `rms_curve` is the cheap level-only pass, no K-weighting and
 no onsets), `fills` (drum-fill candidates), `halves` (shared
 identify/cache/write pattern, plus `collected`/`stem_named` — where a
-separation's stems are and which one was asked for, shared by every detector
-that reads one: `phrases` off the line, `bars` off the pulse),
+separation's stems are, third pass included, and which one was asked for; the
+one stem-discovery convention, shared by every detector that reads one:
+`phrases` off the line, `bars` off the pulse, `structure` off all of them
+(#220)),
 `melody` (notes off one melodic stem —
 monophonic pitch + gating, model injected per ADR 0002; the reading `phrases`
 is a rule layer over, as `drums` is to `fills`), `music` (beats + energy + gist
@@ -170,7 +172,7 @@ of band changes: lead off the stem energy, timbre off one stem's brightness —
 with the third pass on disk the voices are `wind`/`comp` rather than `other`
 and timbre reads `wind`, #157), `structure` (tunes + solo changes job; both
 halves read the shared beats half and the tune half the shared energy half; its
-stem loader is what reaches the third pass), `subject` (what a shot is framed
+stem loader is error shaping over `halves.collected`, #220), `subject` (what a shot is framed
 on crossed with who is out front: the angle sidecar's subject read as
 player/ensemble/other, joined to the solo windows in seconds so a shot that
 outlives its solo is split where the front changed — pure, no I/O, read by

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -157,10 +157,10 @@ no silent CPU fallback, #202; the inventory and the stays-on-CPU corpus policy:
 (loudness curves; `rms_curve` is the cheap level-only pass, no K-weighting and
 no onsets), `fills` (drum-fill candidates), `halves` (shared
 identify/cache/write pattern, plus `collected`/`stem_named` — where a
-separation's stems are, third pass included, and which one was asked for; the
-one stem-discovery convention, shared by every detector that reads one:
-`phrases` off the line, `bars` off the pulse, `structure` off all of them
-(#220)),
+separation's melodic stems are, third pass included, and which one was asked
+for; one convention for every detector that reads one: `phrases` off the line,
+`bars` off the pulse, `structure` off all of them (#220). `fills` still finds
+the drum pass its own way),
 `melody` (notes off one melodic stem —
 monophonic pitch + gating, model injected per ADR 0002; the reading `phrases`
 is a rule layer over, as `drums` is to `fills`), `music` (beats + energy + gist
@@ -171,9 +171,9 @@ cut-placement unit #46 named, #143),
 of band changes: lead off the stem energy, timbre off one stem's brightness —
 with the third pass on disk the voices are `wind`/`comp` rather than `other`
 and timbre reads `wind`, #157), `structure` (tunes + solo changes job; both
-halves read the shared beats half and the tune half the shared energy half; its
-stem loader is error shaping over `halves.collected`, #220), `subject` (what a shot is framed
-on crossed with who is out front: the angle sidecar's subject read as
+halves read the shared beats half and the tune half the shared energy half;
+its stem loader is error shaping over `halves.collected`, #220), `subject`
+(what a shot is framed on crossed with who is out front: the angle sidecar's subject read as
 player/ensemble/other, joined to the solo windows in seconds so a shot that
 outlives its solo is split where the front changed — pure, no I/O, read by
 `correlate`, #181), `transcribe`

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -62,8 +62,8 @@ def sane_floor(minimum_confidence: float, default: float, writes: str = "candida
         )
 
 
-def collected(directory: Path, absent: str | None = None) -> dict[str, Path]:
-    """The stems under a separation's directory — the four-stem pass, the third pass, or both.
+def collected(directory: Path, fix: str | None = None) -> dict[str, Path]:
+    """The melodic stems under a separation's directory — first pass, third pass, or both.
 
     A separation writes a directory per pass — ``<directory>/mix``, ``<directory>/drums``, and
     ``<directory>/other`` when the wind split was asked for — and the job reports the parent of
@@ -72,15 +72,17 @@ def collected(directory: Path, absent: str | None = None) -> dict[str, Path]:
     their own should not have to name a subdirectory that is not there. The opt-in third pass
     sits beside the first and comes along when it is there — see ``_third_pass``.
 
-    Here beside ``readable`` because more than one detector reads a stem now — phrases off the
-    line, bars off the pulse (#180), solo changes off all of them — and two answers to "where
-    are the stems" would be two conventions. That is not a hypothetical: ``structure`` carried
-    its own copy until #220, and the wind and comp stems it discovered reached the solo
-    detector and nothing else.
+    Here beside ``readable`` because more than one detector reads a melodic stem — phrases off
+    the line, bars off the pulse (#180), solo changes off all of them — and two answers to
+    "where are the stems" would be two conventions. That is not a hypothetical: ``structure``
+    carried its own copy until #220, and the wind and comp stems it alone knew how to find
+    reached the solo detector and nothing else. The drum pass is read by ``fills`` through a
+    lookup of its own, because it wants a different pass narrowed to a different set of names;
+    that one is still a second convention, and #220 did not close it.
 
     What a caller says when the stems are *missing* stays with the caller, because the advice
-    differs — ``absent`` shapes the fix for a directory that is not there, and an empty result
-    is left for the caller to refuse in its own words.
+    differs — ``fix``, as in ``readable``, shapes the refusal for a directory that is not
+    there, and an empty result is left for the caller to refuse in its own words.
 
     The imports are function-local: ``audio.stems`` reaches the Resolve seam, and every
     analysis half imports this module.
@@ -91,7 +93,7 @@ def collected(directory: Path, absent: str | None = None) -> dict[str, Path]:
     if not directory.is_dir():
         raise InvalidRequestError(
             cause=f"There is no directory at {directory}.",
-            fix=absent
+            fix=fix
             or "Pass the directory a separate_stems job reported, or the mix pass inside it.",
             detail={"requested": str(directory)},
         )
@@ -113,7 +115,8 @@ def _third_pass(directory: Path) -> dict[str, Path]:
 
     Both halves or neither, and only the two names the envelope knows. One half alone is a
     partial pass, and it would join a voice set that still holds ``other`` — the residual
-    measured twice over, which is the one way this change reads worse than no change.
+    measured twice over, which is the one way reaching for this pass reads worse than not
+    reaching for it at all.
     """
     from ..audio import separator
     from ..audio.stems import MIX_PASS, OTHER_PASS, WIND_KEYS

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -62,19 +62,25 @@ def sane_floor(minimum_confidence: float, default: float, writes: str = "candida
         )
 
 
-def collected(directory: Path) -> dict[str, Path]:
-    """The stems under a separation's directory — the four-stem pass, or the parent of it.
+def collected(directory: Path, absent: str | None = None) -> dict[str, Path]:
+    """The stems under a separation's directory — the four-stem pass, the third pass, or both.
 
     A separation writes a directory per pass — ``<directory>/mix``, ``<directory>/drums``, and
     ``<directory>/other`` when the wind split was asked for — and the job reports the parent of
     all of them. The melodic stems are in the first pass, so that is looked in first; the
     parent itself is checked too, because a director who copied the stems into a folder of
-    their own should not have to name a subdirectory that is not there.
+    their own should not have to name a subdirectory that is not there. The opt-in third pass
+    sits beside the first and comes along when it is there — see ``_third_pass``.
 
     Here beside ``readable`` because more than one detector reads a stem now — phrases off the
-    line, bars off the pulse (#180) — and two answers to "where are the stems" would be two
-    conventions. What each of them says when the stem it wants is *missing* stays with the
-    detector: the advice differs, since a phrase job cannot run without one and a bar job can.
+    line, bars off the pulse (#180), solo changes off all of them — and two answers to "where
+    are the stems" would be two conventions. That is not a hypothetical: ``structure`` carried
+    its own copy until #220, and the wind and comp stems it discovered reached the solo
+    detector and nothing else.
+
+    What a caller says when the stems are *missing* stays with the caller, because the advice
+    differs — ``absent`` shapes the fix for a directory that is not there, and an empty result
+    is left for the caller to refuse in its own words.
 
     The imports are function-local: ``audio.stems`` reaches the Resolve seam, and every
     analysis half imports this module.
@@ -85,14 +91,47 @@ def collected(directory: Path) -> dict[str, Path]:
     if not directory.is_dir():
         raise InvalidRequestError(
             cause=f"There is no directory at {directory}.",
-            fix="Pass the directory a separate_stems job reported, or the mix pass inside it.",
+            fix=absent
+            or "Pass the directory a separate_stems job reported, or the mix pass inside it.",
             detail={"requested": str(directory)},
         )
     for candidate in (directory / MIX_PASS, directory):
         found = separator.collect(candidate)
         if found:
+            found.update(_third_pass(directory))
             return found
     return {}
+
+
+def _third_pass(directory: Path) -> dict[str, Path]:
+    """The third pass's two halves under their envelope names — nothing, if it never ran.
+
+    That pass writes a sibling of the mix pass (#153), so it is reached from whichever of
+    the two accepted directories was given: the job's own directory holds it directly, and
+    the mix pass directory holds it one level up. Anywhere else there is no pass layout to
+    read, and a directory of loose stems gets nothing.
+
+    Both halves or neither, and only the two names the envelope knows. One half alone is a
+    partial pass, and it would join a voice set that still holds ``other`` — the residual
+    measured twice over, which is the one way this change reads worse than no change.
+    """
+    from ..audio import separator
+    from ..audio.stems import MIX_PASS, OTHER_PASS, WIND_KEYS
+
+    if (directory / MIX_PASS).is_dir():
+        outer = directory / OTHER_PASS
+    elif directory.name == MIX_PASS:
+        outer = directory.parent / OTHER_PASS
+    else:
+        return {}
+    if not outer.is_dir():
+        return {}
+    halved = {
+        WIND_KEYS[name]: path
+        for name, path in separator.collect(outer).items()
+        if name in WIND_KEYS
+    }
+    return halved if len(halved) == len(WIND_KEYS) else {}
 
 
 def stem_named(

--- a/src/resolve_mcp/analysis/phrases.py
+++ b/src/resolve_mcp/analysis/phrases.py
@@ -51,7 +51,7 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 from ..audio import wav
-from ..audio.stems import FOUR_STEMS
+from ..audio.stems import FOUR_STEMS, WIND
 from ..config import Config, get_config
 from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, start_job
@@ -68,8 +68,13 @@ PLACES = 3
 
 DEFAULT_STEM = solos.RESIDUAL
 """``other`` — the stem the horns and the piano land in, which is where a solo is."""
-MELODY_STEMS = (solos.RESIDUAL, "vocals")
-"""The stems a line is plausibly in. Naming another is allowed and logged, not refused."""
+MELODY_STEMS = (solos.RESIDUAL, "vocals", WIND)
+"""The stems a line is plausibly in. Naming another is allowed and logged, not refused.
+
+``wind`` joined when #220 made the third pass reachable from here: it is the horns and reeds
+taken *out* of the residual, so it is the most single-line thing on disk and warning about it
+would have been exactly backwards. Its other half stays off the list — ``comp`` is piano plus
+guitar plus vibes, which is the busy reading the warning exists for."""
 
 REST_BEATS = 0.5
 """A gap this wide is the player breathing rather than tonguing the next note."""

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -256,7 +256,7 @@ def _stems(stems: str | Path | None, solos: bool) -> dict[str, Path]:
             detail={SOLOS: solos, "stems": None},
         )
     directory = Path(stems)
-    found = halves.collected(directory, _NO_STEMS_FIX)
+    found = halves.collected(directory, fix=_NO_STEMS_FIX)
     if not found:
         raise InvalidRequestError(
             cause=f"There are no separated stems in {directory}.",

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -34,7 +34,6 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from ..audio import separator
 from ..audio import stems as stems_module
 from ..config import Config, get_config
 from ..errors import AnalysisDependencyError, InvalidRequestError
@@ -51,6 +50,16 @@ log = get_logger("analysis")
 KIND = "analyze_structure"
 TUNES = "tunes"
 SOLOS = "solos"
+
+_NO_STEMS_FIX = (
+    "Pass the directory a separate_stems job returned — the one holding the "
+    f"{stems_module.MIX_PASS} pass — and check the job completed."
+)
+"""What a solo job says when the stems are not where it was told to look.
+
+One sentence for both refusals — a directory that is not there and a directory with nothing
+in it — because the thing to do about either is the same, and because the shared discovery
+raises the first one on this module's behalf."""
 
 APPLAUSE_SHAPE = (
     "threshold",
@@ -229,11 +238,11 @@ def _sane_numbers(
 def _stems(stems: str | Path | None, solos: bool) -> dict[str, Path]:
     """The separated stems to read, from the directory a ``separate_stems`` job returned.
 
-    That job writes each pass into its own directory, so the path it hands back holds the
-    four stems one level down; both that path and the pass directory itself are accepted,
-    because an agent reading the job record has one and an agent looking at the disk has
-    the other. The opt-in third pass sits beside the first, and comes along when it is
-    there — see ``_wind``.
+    Where they are is ``halves.collected``'s answer and only its answer (#220); what is left
+    here is what a solo job says when they are not there, which is the same relationship the
+    bar and phrase jobs have to ``halves.stem_named``. Every pass that function finds — the
+    four melodic stems, and the opt-in third pass beside them — arrives here without this
+    module reaching for any of them.
     """
     if not solos:
         return {}
@@ -247,47 +256,14 @@ def _stems(stems: str | Path | None, solos: bool) -> dict[str, Path]:
             detail={SOLOS: solos, "stems": None},
         )
     directory = Path(stems)
-    inner = directory / stems_module.MIX_PASS
-    found = separator.collect(inner if inner.is_dir() else directory)
+    found = halves.collected(directory, _NO_STEMS_FIX)
     if not found:
         raise InvalidRequestError(
             cause=f"There are no separated stems in {directory}.",
-            fix=(
-                "Pass the directory a separate_stems job returned — the one holding the "
-                f"{stems_module.MIX_PASS} pass — and check the job completed."
-            ),
+            fix=_NO_STEMS_FIX,
             detail={"requested": str(directory)},
         )
-    found.update(_wind(directory))
     return found
-
-
-def _wind(directory: Path) -> dict[str, Path]:
-    """The third pass's two halves under their envelope names — nothing, if it never ran.
-
-    That pass writes a sibling of the mix pass (#153), so it is reached from whichever of
-    the two accepted directories was given: the job's own directory holds it directly, and
-    the mix pass directory holds it one level up. Anywhere else there is no pass layout to
-    read, and a directory of loose stems gets nothing.
-
-    Both halves or neither, and only the two names the envelope knows. One half alone is a
-    partial pass, and it would join a voice set that still holds ``other`` — the residual
-    measured twice over, which is the one way this change reads worse than no change.
-    """
-    if (directory / stems_module.MIX_PASS).is_dir():
-        outer = directory / stems_module.OTHER_PASS
-    elif directory.name == stems_module.MIX_PASS:
-        outer = directory.parent / stems_module.OTHER_PASS
-    else:
-        return {}
-    if not outer.is_dir():
-        return {}
-    halved = {
-        stems_module.WIND_KEYS[name]: path
-        for name, path in separator.collect(outer).items()
-        if name in stems_module.WIND_KEYS
-    }
-    return halved if len(halved) == len(stems_module.WIND_KEYS) else {}
 
 
 def _stem_identity(found: Mapping[str, Path], config: Config) -> dict[str, Any]:

--- a/tests/test_music_structure.py
+++ b/tests/test_music_structure.py
@@ -19,12 +19,13 @@ from typing import Any
 import pytest
 
 from resolve_mcp.analysis import applause as applause_module
+from resolve_mcp.analysis import bars, decode, music, structure
 from resolve_mcp.analysis import beats as beats_module
-from resolve_mcp.analysis import decode, music, structure
 from resolve_mcp.analysis import solos as solos_module
 from resolve_mcp.analysis.beats import BeatGrid
 from resolve_mcp.audio import stems as stems_module
 from resolve_mcp.config import get_config
+from resolve_mcp.errors import InvalidRequestError
 from resolve_mcp.jobs import store
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.tools import analysis as analysis_tools
@@ -237,6 +238,47 @@ def test_the_third_pass_halves_are_read_alongside_the_stems_from_the_first(
     found = structure._stems(split_stems, solos=True)
 
     assert sorted(found) == ["comp", "drums", "other", "vocals", "wind"]
+
+
+def test_one_discovery_carries_the_third_pass_to_every_consumer(split_stems: Path) -> None:
+    """#220: structure and a stem-named detector read the same convention, wind pass included.
+
+    Asserted together because the whole point of the shared function is that there is no
+    "structure sees it and bars does not" — that gap is what the inline copy in ``structure``
+    was.
+    """
+    found = structure._stems(split_stems, solos=True)
+    chosen = bars._stem(split_stems, stems_module.WIND)
+
+    assert {stems_module.WIND, stems_module.COMP} <= set(found)
+    assert chosen == found[stems_module.WIND]
+
+
+def test_each_caller_keeps_its_own_advice_about_a_stem_it_cannot_find(
+    tmp_path: Path,
+    stems: Path,
+) -> None:
+    """One discovery, but the fix sentence still comes from the job that asked."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    with pytest.raises(InvalidRequestError) as for_structure:
+        structure._stems(empty, solos=True)
+    with pytest.raises(InvalidRequestError) as for_bars:
+        bars._stem(stems, "tuba")
+
+    assert "check the job completed" in str(for_structure.value.fix)
+    assert "the master mix is read" in str(for_bars.value.fix)
+
+
+def test_a_stems_directory_that_is_not_there_still_gets_the_structure_job_its_advice(
+    tmp_path: Path,
+) -> None:
+    """The shared function raises; the sentence that tells an agent what to do is structure's."""
+    with pytest.raises(InvalidRequestError) as raised:
+        structure._stems(tmp_path / "never-separated", solos=True)
+
+    assert "check the job completed" in str(raised.value.fix)
 
 
 def test_a_stems_directory_with_no_third_pass_reads_exactly_as_it_did(stems: Path) -> None:

--- a/tests/test_music_structure.py
+++ b/tests/test_music_structure.py
@@ -19,7 +19,7 @@ from typing import Any
 import pytest
 
 from resolve_mcp.analysis import applause as applause_module
-from resolve_mcp.analysis import bars, decode, music, structure
+from resolve_mcp.analysis import bars, decode, music, phrases, structure
 from resolve_mcp.analysis import beats as beats_module
 from resolve_mcp.analysis import solos as solos_module
 from resolve_mcp.analysis.beats import BeatGrid
@@ -254,6 +254,24 @@ def test_one_discovery_carries_the_third_pass_to_every_consumer(split_stems: Pat
     assert chosen == found[stems_module.WIND]
 
 
+def test_the_wind_stem_the_shared_discovery_reaches_is_not_warned_about(
+    split_stems: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The busy-reading warning is for bass and drums, and #220 made ``wind`` reachable.
+
+    The kit is read in the same test as the control: a negative assertion about a log line
+    passes just as well when nothing is being captured at all.
+    """
+    with caplog.at_level("WARNING", logger=phrases.log.name):
+        phrases._stem(split_stems, stems_module.WIND)
+        quiet = "busy reading" in caplog.text
+        phrases._stem(split_stems, "drums")
+
+    assert not quiet
+    assert "busy reading" in caplog.text
+
+
 def test_each_caller_keeps_its_own_advice_about_a_stem_it_cannot_find(
     tmp_path: Path,
     stems: Path,
@@ -266,19 +284,43 @@ def test_each_caller_keeps_its_own_advice_about_a_stem_it_cannot_find(
         structure._stems(empty, solos=True)
     with pytest.raises(InvalidRequestError) as for_bars:
         bars._stem(stems, "tuba")
+    with pytest.raises(InvalidRequestError) as for_phrases:
+        phrases._stem(stems, "tuba")
 
     assert "check the job completed" in str(for_structure.value.fix)
     assert "the master mix is read" in str(for_bars.value.fix)
+    assert "its first pass writes" in str(for_phrases.value.fix)
 
 
 def test_a_stems_directory_that_is_not_there_still_gets_the_structure_job_its_advice(
     tmp_path: Path,
 ) -> None:
-    """The shared function raises; the sentence that tells an agent what to do is structure's."""
+    """The shared function raises, and says so plainly; the advice is still structure's.
+
+    The cause is narrower than it was — the inline copy could only say it found no stems,
+    where the shared function knows the directory itself is missing — and an agent that
+    mistyped a path is told which of the two went wrong.
+    """
     with pytest.raises(InvalidRequestError) as raised:
         structure._stems(tmp_path / "never-separated", solos=True)
 
+    assert "There is no directory at" in raised.value.cause
     assert "check the job completed" in str(raised.value.fix)
+
+
+def test_stems_beside_an_empty_mix_pass_are_still_found(tmp_path: Path) -> None:
+    """The shared function tries the pass and then the parent, where the inline copy tried one.
+
+    A pass directory that exists and holds nothing used to end the search; a director whose
+    stems sit in the parent now gets them, which is what every other detector already did.
+    """
+    loose = _stems(tmp_path)
+    for stem in sorted((loose / stems_module.MIX_PASS).glob("*.wav")):
+        stem.rename(loose / stem.name)
+
+    found = structure._stems(loose, solos=True)
+
+    assert sorted(found) == ["drums", "other", "vocals"]
 
 
 def test_a_stems_directory_with_no_third_pass_reads_exactly_as_it_did(stems: Path) -> None:


### PR DESCRIPTION
Closes #220.

## What changed

`analysis/structure` predated `halves.collected` and carried its own inline stem lookup plus a private third-pass discovery (`_wind`, #153). Wind and comp stems therefore reached `analyze_structure` and no other detector — `bars` and `phrases` route through the shared convention and saw four stems where five or six were on disk.

- `halves.collected` absorbs the third-pass discovery as `_third_pass`, so every consumer of the shared function sees `wind` and `comp`.
- `structure._stems` becomes error-message shaping over it — the relationship `bars` and `phrases` already have to `halves.stem_named` — and keeps its own `fix` sentence through the new optional `fix` argument, the same idiom `halves.readable` uses.
- `phrases.MELODY_STEMS` gains `wind`. Reaching `wind` from a phrase job is newly possible *because* of this change, and the busy-reading warning would have fired on the most single-line stem on disk. `comp` stays off the list.
- `CONTEXT.md` map updated in the same PR.

## Test seam

**Fake tier** (`uv run pytest -m 'not live'`) — the whole change is stem discovery and error shaping, both of which are decisions. 2118 passed, 43 deselected; mypy strict and ruff clean. No live ACs on this ticket.

## Acceptance criteria

- **Exactly one implementation of stem discovery, wind/comp included; `structure` contains no inline copy.** Done for the melodic stems. `fills._collected` still finds the *drum* pass its own way — it wants a different pass narrowed to a different set of names, and unifying it would mean parameterising both, which is a wider function than this ticket needs. Left deliberately, and both the `collected` docstring and the CONTEXT.md map now say so rather than claiming "every detector".
- **Every consumer sees `wind` and `comp`, asserted for structure and a stem-named detector in the same test.** `test_one_discovery_carries_the_third_pass_to_every_consumer`.
- **Per-caller error text preserved.** `test_each_caller_keeps_its_own_advice_about_a_stem_it_cannot_find` covers structure, bars and phrases.
- **Existing structure/bars/phrases tests pass unchanged in outcome.** `git diff origin/main...HEAD -- tests/` is additions only.

## Review

`/code-review` against `origin/main`, two axes in parallel sub-agents, run on the branch before this PR existed.

**Standards — 5 findings, all resolved.**

1. *Overclaim (hard).* The `collected` docstring and the CONTEXT.md map both asserted one convention for "every detector that reads a stem" while `fills._collected` is a third copy. Fixed: both now say melodic stems and name fills as the second convention #220 did not close.
2. *Mysterious Name (judgement).* The new parameter was `absent`, but the sibling `halves.readable` names the identical thing `fix`, and `absent` already means "stem absent" in `stem_named`. Renamed to `fix`.
3. *Moved-docstring deixis (judgement).* `_third_pass` kept "…the one way **this change** reads worse than no change" verbatim from `structure._wind`, where "this change" was #157; in `halves` it had no antecedent. Reworded.
4. *CONTEXT.md line width (minor).* Reflowed the added lines.
5. *Divergent Change (minor).* The new tests live in `tests/test_music_structure.py` and touch `bars`/`phrases`. Accepted: the point of the assertion is that one discovery reaches both, which is not a thing either detector's own test file can state.

**Spec — 5 findings: 3 resolved, 1 accepted as scope, 1 documented.**

1. *AC1 not literally true of the repo.* Same as Standards 1 — `fills` is out of the ticket's stated scope but the AC reads absolutely. Documented above and in the docstring rather than silently left.
2. *`phrases`' fix sentence untested* though the AC says *each* caller's. Now asserted.
3. *Refusal cause changed, unasserted.* A stems directory that does not exist used to fall through to "There are no separated stems in {dir}"; the shared function raises "There is no directory at {dir}" first. `fix` and `detail` are unchanged and it is the narrower, more useful cause — kept, and now asserted deliberately in `test_a_stems_directory_that_is_not_there_still_gets_the_structure_job_its_advice`.
4. *`collected` falls through where `structure` did not.* The shared loop tries `<dir>/mix` and then `<dir>`, so a separation whose `mix/` exists but is empty with loose stems in the parent now succeeds for `structure` where it used to refuse. This is what every other detector already did; kept and pinned by `test_stems_beside_an_empty_mix_pass_are_still_found`.
5. *`phrases` warned on the stem it just gained.* Fixed — see `MELODY_STEMS` above.

No cache-key or name-collision problem: `WIND_KEYS` values cannot clobber first-pass keys, and `structure._stem_identity` still reads a first-pass stem's parent since `update` appends.

Fix diff re-checked on its own after the findings landed; full fake tier, mypy strict and ruff re-run green.

Review: clean



---

**Merge of origin/main (2e29650):** one conflict, CONTEXT.md — main added the `stats` entry (#215) beside the `structure` line this PR reworded. Both kept. Fake tier 2273 passed, mypy clean, ruff clean.

Review: clean — merge resolution, prose only, single-pass
