### PR TITLE
The job-lifecycle verdict becomes a pure function (#216)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -208,16 +208,21 @@ wherever the file sits, read off a `known_hash` note remembered against a
 stat, except under `audio_dir` where it is always read for real;
 `fingerprint` is path+size+mtime and stays the identity for video sources
 and stems — ADR 0007, ADR 0003), `runner` (start heavy work without
-stalling stdio), `store` (one JSON record per job on disk), `detached` (hand
-a job to a process that outlives this one — flags, command, environment),
-`worker` (that process's entry point: `python -m resolve_mcp.jobs.worker
-<job-id>`). A worker returning `runner.Detached` instead of a result moves
-the rest of its job into that process; `separate_stems` does, once the audio
-is acquired, so a half-hour separation survives the server exiting. A
-detached record is judged by its pid rather than by its session, and only the
-worker writes it — the launcher's reading of the worker pid goes to a
-`<job-id>.launcher` note beside the record, folded in by readers only while
-the record has no pid of its own, so a launcher can never overwrite a result.
+stalling stdio), `lifecycle` (the job states, this server's `SESSION`, and
+`verdict(record, now, alive)` — whether anything is still running a job and
+the sentence for it if not, decided from the record alone with liveness
+injected, so the truth table is testable in memory), `store` (one JSON record
+per job on disk; `load` is read file → verdict → maybe write the failure
+back), `detached` (hand a job to a process that outlives this one — flags,
+command, environment), `worker` (that process's entry point: `python -m
+resolve_mcp.jobs.worker <job-id>`). A worker returning `runner.Detached`
+instead of a result moves the rest of its job into that process;
+`separate_stems` does, once the audio is acquired, so a half-hour separation
+survives the server exiting. A detached record is judged by its pid rather
+than by its session, and only the worker writes it — the launcher's reading
+of the worker pid goes to a `<job-id>.launcher` note beside the record,
+folded in by readers only while the record has no pid of its own, so a
+launcher can never overwrite a result.
 
 `resolve/` — connection management + thin scripting-API wrappers: `apply`
 (titles file → owned track), `build` (materialise cut file), `connection`

--- a/gauntlet/recon/analysis_prep.py
+++ b/gauntlet/recon/analysis_prep.py
@@ -34,7 +34,7 @@ def note(where: str, exc: BaseException) -> None:
 
 
 def run(label: str, start, **kwargs: Any) -> dict[str, Any] | None:
-    from resolve_mcp.jobs import runner, store
+    from resolve_mcp.jobs import lifecycle, runner
 
     began = time.time()
     try:
@@ -48,7 +48,7 @@ def run(label: str, start, **kwargs: Any) -> dict[str, Any] | None:
     write()
     while True:
         got = runner.wait_for(job_id, timeout=30.0)
-        if got.state != store.RUNNING:
+        if got.state != lifecycle.RUNNING:
             break
         report["jobs"][label]["step"] = got.step
         report["jobs"][label]["progress"] = got.progress

--- a/gauntlet/recon/board_tunes_job.py
+++ b/gauntlet/recon/board_tunes_job.py
@@ -21,7 +21,7 @@ TOLERANCE = 5.0
 
 def main() -> None:
     from resolve_mcp.analysis import structure
-    from resolve_mcp.jobs import runner, store
+    from resolve_mcp.jobs import lifecycle, runner
 
     began = time.time()
     # refresh, always: the half is keyed on the audio and the settings, neither of which
@@ -31,7 +31,7 @@ def main() -> None:
     job_id = record["job_id"]
     while True:
         got = runner.wait_for(job_id, timeout=60.0)
-        if got.state != store.RUNNING:
+        if got.state != lifecycle.RUNNING:
             break
     payload = got.payload()
     report: dict[str, Any] = {

--- a/gauntlet/recon/occl_classes_live.py
+++ b/gauntlet/recon/occl_classes_live.py
@@ -71,7 +71,7 @@ def main() -> None:
     from resolve_mcp import interpreter as interp
 
     interp.ensure_supported()
-    from resolve_mcp.jobs import runner, store
+    from resolve_mcp.jobs import lifecycle, runner
     from resolve_mcp.tools import video as video_tools
 
     for angle in ANGLES:
@@ -103,7 +103,7 @@ def main() -> None:
             continue
 
         got = runner.wait_for(envelope["job_id"], timeout=120.0)
-        while got.state == store.RUNNING:
+        while got.state == lifecycle.RUNNING:
             entry["step"] = got.step
             write()
             got = runner.wait_for(envelope["job_id"], timeout=120.0)

--- a/gauntlet/recon/occl_ending_scan.py
+++ b/gauntlet/recon/occl_ending_scan.py
@@ -80,7 +80,7 @@ def main() -> None:
     from resolve_mcp import interpreter as interp
 
     interp.ensure_supported()
-    from resolve_mcp.jobs import runner, store
+    from resolve_mcp.jobs import lifecycle, runner
     from resolve_mcp.tools import video as video_tools
 
     for angle in ANGLES:
@@ -119,7 +119,7 @@ def main() -> None:
         job_id = envelope["job_id"]
         entry["job_id"] = job_id
         got = runner.wait_for(job_id, timeout=60.0)
-        while got.state == store.RUNNING:
+        while got.state == lifecycle.RUNNING:
             entry["step"] = got.step
             write()
             got = runner.wait_for(job_id, timeout=60.0)

--- a/gauntlet/recon/occl_full_scan.py
+++ b/gauntlet/recon/occl_full_scan.py
@@ -77,7 +77,7 @@ def main() -> None:
     from resolve_mcp import interpreter as interp
 
     interp.ensure_supported()
-    from resolve_mcp.jobs import runner, store
+    from resolve_mcp.jobs import lifecycle, runner
     from resolve_mcp.tools import video as video_tools
 
     for span in SPANS:
@@ -116,7 +116,7 @@ def main() -> None:
             job_id = envelope["job_id"]
             entry["job_id"] = job_id
             got = runner.wait_for(job_id, timeout=60.0)
-            while got.state == store.RUNNING:
+            while got.state == lifecycle.RUNNING:
                 entry["step"] = got.step
                 write()
                 print(f"  [{key}] {got.step}", flush=True)

--- a/gauntlet/recon/occl_mid_scan.py
+++ b/gauntlet/recon/occl_mid_scan.py
@@ -82,7 +82,7 @@ def main() -> None:
     from resolve_mcp import interpreter as interp
 
     interp.ensure_supported()
-    from resolve_mcp.jobs import runner, store
+    from resolve_mcp.jobs import lifecycle, runner
     from resolve_mcp.tools import video as video_tools
 
     for angle in ANGLES:
@@ -121,7 +121,7 @@ def main() -> None:
         job_id = envelope["job_id"]
         entry["job_id"] = job_id
         got = runner.wait_for(job_id, timeout=60.0)
-        while got.state == store.RUNNING:
+        while got.state == lifecycle.RUNNING:
             entry["step"] = got.step
             write()
             got = runner.wait_for(job_id, timeout=60.0)

--- a/gauntlet/recon/occlusion_probe.py
+++ b/gauntlet/recon/occlusion_probe.py
@@ -133,7 +133,7 @@ def main() -> None:
     from resolve_mcp import interpreter as interp
 
     interp.ensure_supported()
-    from resolve_mcp.jobs import runner, store
+    from resolve_mcp.jobs import lifecycle, runner
     from resolve_mcp.tools import video as video_tools
 
     for angle in ANGLES:
@@ -168,7 +168,7 @@ def main() -> None:
         job_id = envelope["job_id"]
         entry["job_id"] = job_id
         got = runner.wait_for(job_id, timeout=60.0)
-        while got.state == store.RUNNING:
+        while got.state == lifecycle.RUNNING:
             entry["step"] = got.step
             write()
             got = runner.wait_for(job_id, timeout=60.0)

--- a/gauntlet/recon/stems_detached_launch.py
+++ b/gauntlet/recon/stems_detached_launch.py
@@ -36,7 +36,7 @@ def main() -> None:
 
     from resolve_mcp.audio import stems as stems_module
     from resolve_mcp.config import get_config
-    from resolve_mcp.jobs import detached, store
+    from resolve_mcp.jobs import detached, lifecycle, store
     from resolve_mcp.resolve.connection import get_connection
 
     config = get_config()
@@ -51,7 +51,7 @@ def main() -> None:
 
     deadline = time.monotonic() + HANDOFF_BUDGET
     record = store.load(job_id, config)
-    while record.pid is None and record.state == store.RUNNING and time.monotonic() < deadline:
+    while record.pid is None and record.state == lifecycle.RUNNING and time.monotonic() < deadline:
         time.sleep(0.2)
         record = store.load(job_id, config)
 

--- a/gauntlet/recon/stems_gpu_launch.py
+++ b/gauntlet/recon/stems_gpu_launch.py
@@ -45,7 +45,7 @@ def main() -> None:
 
     from resolve_mcp.audio import stems as stems_module
     from resolve_mcp.config import get_config
-    from resolve_mcp.jobs import detached, store
+    from resolve_mcp.jobs import detached, lifecycle, store
     from resolve_mcp.resolve.connection import get_connection
 
     config = get_config()
@@ -63,7 +63,7 @@ def main() -> None:
 
     deadline = time.monotonic() + HANDOFF_BUDGET
     record = store.load(job_id, config)
-    while record.pid is None and record.state == store.RUNNING and time.monotonic() < deadline:
+    while record.pid is None and record.state == lifecycle.RUNNING and time.monotonic() < deadline:
         time.sleep(0.2)
         record = store.load(job_id, config)
 

--- a/gauntlet/recon/stems_run.py
+++ b/gauntlet/recon/stems_run.py
@@ -33,7 +33,7 @@ def main() -> None:
     write()
 
     from resolve_mcp.audio import stems as stems_module
-    from resolve_mcp.jobs import runner, store
+    from resolve_mcp.jobs import lifecycle, runner
     from resolve_mcp.resolve.connection import get_connection
 
     began = time.time()
@@ -46,7 +46,7 @@ def main() -> None:
 
     while True:
         got = runner.wait_for(job_id, timeout=30.0)
-        if got.state != store.RUNNING:
+        if got.state != lifecycle.RUNNING:
             break
         report["step"] = got.step
         report["progress"] = got.progress

--- a/gauntlet/recon/taurus_analysis.py
+++ b/gauntlet/recon/taurus_analysis.py
@@ -64,7 +64,7 @@ def main() -> None:
     from resolve_mcp.audio import separator
     from resolve_mcp.audio import stems as stems_module
     from resolve_mcp.config import get_config
-    from resolve_mcp.jobs import store
+    from resolve_mcp.jobs import lifecycle, store
 
     config = get_config()
 
@@ -125,7 +125,7 @@ def main() -> None:
         for name, job_id in list(pending.items()):
             loaded = store.load(job_id, config)
             report["jobs"][name] = loaded.payload()
-            if loaded.state != store.RUNNING:
+            if loaded.state != lifecycle.RUNNING:
                 del pending[name]
         report["elapsed_seconds"] = round(time.time() - began, 1)
         write()

--- a/gauntlet/recon/tunes_sweep.py
+++ b/gauntlet/recon/tunes_sweep.py
@@ -22,7 +22,7 @@ report: dict[str, Any] = {"mix": MIX, "human_cut_starts_s": TRUTH, "runs": {}}
 
 def main() -> None:
     from resolve_mcp.analysis import structure
-    from resolve_mcp.jobs import runner, store
+    from resolve_mcp.jobs import lifecycle, runner
 
     for threshold in THRESHOLDS:
         began = time.time()
@@ -32,7 +32,7 @@ def main() -> None:
         job_id = record["job_id"]
         while True:
             got = runner.wait_for(job_id, timeout=30.0)
-            if got.state != store.RUNNING:
+            if got.state != lifecycle.RUNNING:
                 break
         payload = got.payload()
         entry: dict[str, Any] = {

--- a/src/resolve_mcp/analysis/transcribe.py
+++ b/src/resolve_mcp/analysis/transcribe.py
@@ -32,7 +32,7 @@ from .. import ffmpeg
 from ..audio.acquire import acquire_clip_audio, acquire_timeline_audio
 from ..config import Config, get_config
 from ..errors import InvalidRequestError, TranscriptionError
-from ..jobs import cache, store
+from ..jobs import cache, lifecycle
 from ..jobs.runner import JobOutput, Progress, start_job, wait_for
 from ..logging_config import get_logger
 from ..naming import keyed_name
@@ -189,7 +189,7 @@ def _hash_of(acquisition: dict[str, Any]) -> str | None:
     job's cache exists for. Otherwise the audio is still being made and there is no hash to
     key on yet — and nothing to hit either, so waiting for one would buy nothing.
     """
-    if acquisition.get("state") != store.COMPLETED:
+    if acquisition.get("state") != lifecycle.COMPLETED:
         return None
     result = acquisition.get("result") or {}
     return str(result["content_sha256"]) if result.get("content_sha256") else None
@@ -198,7 +198,7 @@ def _hash_of(acquisition: dict[str, Any]) -> str | None:
 def _acquired(job_id: str, config: Config) -> dict[str, Any]:
     """Block until the audio is on disk, or fail carrying the acquisition's own advice."""
     record = wait_for(job_id, timeout=ACQUIRE_TIMEOUT, config=config)
-    if record.state == store.COMPLETED and record.result is not None:
+    if record.state == lifecycle.COMPLETED and record.result is not None:
         return dict(record.result)
 
     failure = record.error or {}
@@ -214,7 +214,7 @@ def _acquired(job_id: str, config: Config) -> dict[str, Any]:
 
 def _still_going(state: str) -> str | None:
     """A running acquisition is not a failure to fix — it is one to wait out and re-ask."""
-    if state != store.RUNNING:
+    if state != lifecycle.RUNNING:
         return None
     return (
         "The audio export is still running after an hour. Poll it with get_job, and start "

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -57,13 +57,13 @@ from ..errors import InternalError, InvalidRequestError, SeparationInProgressErr
 from ..ffmpeg import Runner
 from ..jobs import cache
 from ..jobs import runner as job_runner
+from ..jobs.lifecycle import SESSION
+from ..jobs.runner import Detached, JobOutput, Progress, start_job
 
 # ``_sharing`` is the store's, and is reached for by its private name deliberately: a claim file
 # and a job record are the same Windows problem — another handle holding the file for the
 # microsecond of a poll — and a second copy of the retry here would be a second policy to keep in
 # step with that one.
-from ..jobs.lifecycle import SESSION
-from ..jobs.runner import Detached, JobOutput, Progress, start_job
 from ..jobs.store import JobRecord, _sharing, pid_alive
 from ..logging_config import get_logger
 from ..naming import slug

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -57,13 +57,14 @@ from ..errors import InternalError, InvalidRequestError, SeparationInProgressErr
 from ..ffmpeg import Runner
 from ..jobs import cache
 from ..jobs import runner as job_runner
-from ..jobs.runner import Detached, JobOutput, Progress, start_job
 
 # ``_sharing`` is the store's, and is reached for by its private name deliberately: a claim file
 # and a job record are the same Windows problem — another handle holding the file for the
 # microsecond of a poll — and a second copy of the retry here would be a second policy to keep in
 # step with that one.
-from ..jobs.store import SESSION, JobRecord, _sharing, pid_alive
+from ..jobs.lifecycle import SESSION
+from ..jobs.runner import Detached, JobOutput, Progress, start_job
+from ..jobs.store import JobRecord, _sharing, pid_alive
 from ..logging_config import get_logger
 from ..naming import slug
 from ..resolve.connection import ResolveConnection

--- a/src/resolve_mcp/jobs/lifecycle.py
+++ b/src/resolve_mcp/jobs/lifecycle.py
@@ -118,15 +118,15 @@ class Outcome(StrEnum):
 
 @dataclass(frozen=True)
 class Verdict:
-    """The outcome, and the sentence the agent reads when the job is being closed."""
+    """The outcome, and the sentence the agent reads when the job is being closed.
+
+    A cause is set for exactly the four outcomes that close a job, so ``cause is None`` is the
+    same question as "is anything still running it" — and it is the one the store asks, because
+    it narrows the type it is about to pass on.
+    """
 
     outcome: Outcome
     cause: str | None = None
-
-    @property
-    def closes(self) -> bool:
-        """Whether this verdict ends the job. Exactly the verdicts that carry a cause."""
-        return self.cause is not None
 
 
 def verdict(record: JobRecord, now: datetime, alive: Callable[[int], bool]) -> Verdict:

--- a/src/resolve_mcp/jobs/lifecycle.py
+++ b/src/resolve_mcp/jobs/lifecycle.py
@@ -1,0 +1,267 @@
+"""Is anything still running this job, and if not, why not. One pure function, no disk.
+
+``verdict(record, now, alive)`` is a total function of the record's state, its detached flag,
+its session, its two pids and its timestamps, plus whatever the injected ``alive`` says about
+those pids. It reads nothing, writes nothing and decides nothing twice: the store composes it
+(read the file → verdict → maybe write the failure back), and the store is the only thing here
+that touches a disk. Splitting it out is what makes the truth table below testable in memory —
+every row used to cost a save and a load.
+
+Three rules decide all of it.
+
+* **A restart is detected by session, not by pid.** Every record carries the id of the server
+  process that wrote it. A record still marked ``running`` whose session is not this one
+  belongs to a server that is gone — its worker thread died with the process, so nothing will
+  ever finish it. pids get recycled; a per-process uuid cannot be mistaken.
+
+* **A detached job is judged by its pid instead, because the session rule is backwards for
+  it.** A record marked ``detached`` names a worker process of its own, and outliving the
+  server that started it is the whole point (G4: a 30-minute separation died with every
+  session that launched it). So the session check is skipped for those and the pid answers
+  instead: alive means running, gone means interrupted, and no pid yet means a launch still
+  in flight — in this session, or in whichever server is named by ``launcher_pid`` while that
+  process is still alive *and* the record is younger than ``LAUNCH_WINDOW``, because those are
+  the only two processes that will ever write the worker's pid and neither takes two minutes
+  to do it. A pid-less record whose launcher is gone, or one that has sat pid-less far longer
+  than any launch takes, is closed rather than left running forever. pids do get recycled —
+  a recycled one can only make a dead job read as running a while longer, never the reverse,
+  and the worker writes its own ending in every path it can still reach. "A while longer" is
+  the ceiling's doing: a live pid is believed only while the record is still being written to
+  (``HEARTBEAT_CEILING``), because a reboot reissues every number on the machine and nothing
+  else would ever close the record it left behind.
+
+* **A job that is over is not judged at all.** The state on the record is the first question
+  and it ends the matter: a finished detached job names a pid that has of course exited, and
+  asking about it would fail a job that succeeded.
+
+The log lines are here rather than at the call site because each one carries the number the
+reasoning turned on — the silence, the age, the pid — and a verdict nobody can account for
+afterwards is what left a live failure undiagnosable before. What is emitted is a line; what
+is decided is the return value, and that depends on the arguments alone.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from ..logging_config import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .store import JobRecord
+
+log = get_logger("jobs")
+
+RUNNING = "running"
+COMPLETED = "completed"
+FAILED = "failed"
+STATES = (RUNNING, COMPLETED, FAILED)
+
+SESSION = uuid.uuid4().hex
+"""This server process. Records written under any other session predate a restart."""
+
+LAUNCH_WINDOW = 120.0
+"""How long a detached record may go with no worker pid before the launch is not in flight.
+
+Generous by an order of magnitude: what has to fit inside it is a ``Popen`` and the worker's
+own start-up as far as its adopt, which is a second or two even with a cold interpreter and a
+Windows trampoline in the way. Long enough that a slow box is never judged, short enough that
+a recycled launcher pid cannot hold a dead record open for the life of the machine. See
+``_stalled_launch``.
+"""
+
+HEARTBEAT_CEILING = 6 * 60 * 60
+"""How long a detached record may go unwritten before its live pid stops being believed.
+
+The same recycling problem one step later. A worker's pid answers "still running" for as long
+as *some* process wears that number, and a reboot hands every number out again: the record a
+worker left running when the machine went down names a stranger, reads as running at every
+poll for the life of the machine, and the only way out was to delete the file. But a bare
+``LAUNCH_WINDOW`` here would close the jobs this whole path exists to protect — a separation
+is half an hour of GPU work. What separates them is that a worker writes as it works
+(``runner.execute`` saves the bar as it moves), so what ages here is silence, not runtime, and
+the record's own ``updated_at`` is the heartbeat. Deliberately far longer than any job, for
+the same reason stems' ``CLAIM_CEILING`` is: the longest measured pass is under an hour and
+reports throughout, so six of them without one write is nobody working. Long silences are
+legal — a cold model download reports nothing for a while — and the ceiling is set to outlast
+them, because closing a live separation is a worse failure than a dead record read as running
+for an afternoon. See ``_running_or_silent``.
+"""
+
+
+class Outcome(StrEnum):
+    """What the record turned out to be. Two of these leave it alone; four close it."""
+
+    SETTLED = "settled"
+    """Not running any more. Whatever happened to it has already been written."""
+
+    LIVE = "live"
+    """Something is still running it: this session's thread, a worker, or a launch in flight."""
+
+    RESTARTED = "restarted"
+    """A thread job whose server is gone. Nothing survives a restart to finish it."""
+
+    STALLED_LAUNCH = "stalled_launch"
+    """A detached record that never got a worker, and never will."""
+
+    WORKER_GONE = "worker_gone"
+    """The detached worker exited before the job finished."""
+
+    SILENT = "silent"
+    """A live pid on a record nothing has written to for longer than any job runs silently."""
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """The outcome, and the sentence the agent reads when the job is being closed."""
+
+    outcome: Outcome
+    cause: str | None = None
+
+    @property
+    def closes(self) -> bool:
+        """Whether this verdict ends the job. Exactly the verdicts that carry a cause."""
+        return self.cause is not None
+
+
+def verdict(record: JobRecord, now: datetime, alive: Callable[[int], bool]) -> Verdict:
+    """Whether anything is still running this job, and the sentence for it if not.
+
+    ``alive`` is asked about at most one pid: the worker's when the record has one, the
+    launcher's when it does not, and neither when the job is already over.
+    """
+    if record.state != RUNNING:
+        return Verdict(Outcome.SETTLED)
+    if record.detached:
+        return _detached(record, now, alive)
+    if record.session == SESSION:
+        return Verdict(Outcome.LIVE)
+    log.info("Job %s was interrupted by a server restart", record.job_id)
+    return Verdict(
+        Outcome.RESTARTED,
+        f"The server restarted while {record.kind} was running, so the job died with it.",
+    )
+
+
+def _detached(record: JobRecord, now: datetime, alive: Callable[[int], bool]) -> Verdict:
+    """A detached job outlives its session on purpose, so its pid is what gets asked.
+
+    ``None`` is a launch still in flight — the starter marks the record detached before it
+    spawns, so that a reader in the microseconds between never mistakes it for a thread job
+    whose thread has ended. In flight in *some live process*, though: the only process that
+    will ever write that pid is the launcher, between its own two saves. Which session wrote
+    the record does not answer that, in either direction. A foreign session is not a dead one
+    — a second server mid-spawn is a launch in flight exactly as ours is, and judging it by
+    session alone would fail a job whose worker was about to start. And our own session is no
+    proof that the launch is still happening: noting the worker's pid is best-effort by design
+    (``store.note_worker_pid`` swallows a note it cannot write, because the alternative is the
+    launcher failing a job a live worker owns), so a worker that dies before it adopts leaves
+    a pid-less record here, in this session, that nothing will ever write again — read as "in
+    flight in this process" it would run for the life of the server, and a chained job
+    following it would poll for exactly as long (``runner.follow`` skips its stalled-thread
+    escape for a detached job, on purpose: a detached job has no thread to be missing). So
+    every pid-less record is asked the same two questions, its launcher and its age.
+
+    A pid that answers is asked its age too, for the same reason and one step later: a number
+    the OS has reissued — after a reboot, every number — reads as a worker still running at
+    every poll for ever. What is asked is not how long the job has run but how long the record
+    has gone unwritten, because the worker writes as it works. See ``HEARTBEAT_CEILING``.
+    """
+    if record.pid is None:
+        return _stalled_launch(record, now, alive)
+    if alive(record.pid):
+        return _running_or_silent(record, now)
+    log.info("Job %s lost its detached worker (pid %s)", record.job_id, record.pid)
+    return Verdict(
+        Outcome.WORKER_GONE,
+        f"The detached worker running {record.kind} exited before the job finished "
+        f"(pid {record.pid}).",
+    )
+
+
+def _running_or_silent(record: JobRecord, now: datetime) -> Verdict:
+    """A live pid is running, unless nothing has written to the record for longer than any job.
+
+    The worker owns this record from its adopt onwards and writes it as the work moves, so the
+    time since the last write is the worker's heartbeat — the freshest one the record carries,
+    and the only one that does not have to be paid for with a second file. Silence past the
+    ceiling means the pid is a reissued number rather than the worker that wrote the record.
+    """
+    silence = _age(record.updated_at, now)
+    if silence is None or silence <= HEARTBEAT_CEILING:
+        return Verdict(Outcome.LIVE)
+    log.warning(
+        "Job %s has not been written to in %.0f s while pid %s reads as alive; that number "
+        "belongs to some other process now, not to the worker that ran the job",
+        record.job_id,
+        silence,
+        record.pid,
+    )
+    return Verdict(
+        Outcome.SILENT,
+        f"Nothing has written to the record of {record.kind} in {silence:.0f} seconds, far "
+        f"longer than the job can run silently, so pid {record.pid} is a reissued number "
+        "rather than the detached worker — nothing is running the job.",
+    )
+
+
+def _stalled_launch(record: JobRecord, now: datetime, alive: Callable[[int], bool]) -> Verdict:
+    """Why this pid-less record is not a launch in flight, or ``LIVE`` while it still is.
+
+    The launcher's pid is asked first, and its own age second. A pid is a number the OS
+    re-issues: a record left by a server that died mid-launch names a launcher that may since
+    have been recycled onto some long-lived process, and liveness alone then reads that record
+    as launching forever. Nothing is a launch for long — the spawn and the note that follows it
+    are a second's work, and the worker writes the record from its adopt onwards — so a record
+    with no worker pid that has not been touched in ``LAUNCH_WINDOW`` is a launch that is not
+    happening, whatever its launcher's number now belongs to.
+
+    The age question is the one that answers for *this* session's own records: our launcher is
+    alive by definition, so nothing but the clock can tell a hand-off in flight from one whose
+    worker died before it adopted (see ``_detached``).
+    """
+    if record.launcher_pid is None or not alive(record.launcher_pid):
+        log.info("Job %s never got a detached worker: its launcher is gone", record.job_id)
+        return Verdict(
+            Outcome.STALLED_LAUNCH,
+            f"The server handing {record.kind} to a detached worker exited before the worker "
+            "was started, so nothing is running it.",
+        )
+    age = _age(record.updated_at, now)
+    if age is not None and age > LAUNCH_WINDOW:
+        log.warning(
+            "Job %s has had no detached worker for %.0f s; pid %s is either a recycled number "
+            "rather than the launcher that wrote the record, or a launcher that never started "
+            "one",
+            record.job_id,
+            age,
+            record.launcher_pid,
+        )
+        return Verdict(
+            Outcome.STALLED_LAUNCH,
+            f"The server handing {record.kind} to a detached worker never started one: nothing "
+            f"has written to the record in {age:.0f} seconds, so the launch is not in flight.",
+        )
+    log.debug(
+        "Job %s has no worker pid yet, but its launcher (pid %s) is still running",
+        record.job_id,
+        record.launcher_pid,
+    )
+    return Verdict(Outcome.LIVE)
+
+
+def _age(stamp: str, now: datetime) -> float | None:
+    """How long before ``now`` that timestamp was, in seconds; ``None`` if it is not one."""
+    try:
+        written = datetime.fromisoformat(stamp)
+    except ValueError:
+        log.warning("Cannot read a job record's timestamp: %r", stamp)
+        return None
+    if written.tzinfo is None:
+        written = written.replace(tzinfo=UTC)
+    return (now - written).total_seconds()

--- a/src/resolve_mcp/jobs/runner.py
+++ b/src/resolve_mcp/jobs/runner.py
@@ -41,7 +41,7 @@ from typing import Any, NamedTuple
 from ..config import Config, get_config
 from ..errors import ChainedJobError, InternalError, ResolveMcpError
 from ..logging_config import get_logger
-from . import cache, detached, store
+from . import cache, detached, lifecycle, store
 from .store import JobRecord
 
 log = get_logger("jobs")
@@ -53,7 +53,7 @@ WAITING = "waiting for Resolve"
 PROGRESS_INTERVAL = 1.0
 """How often a moving progress bar is written to the record, in seconds. See ``execute``.
 
-Comfortably below ``store.HEARTBEAT_CEILING``, which reads a record nothing has written to as
+Comfortably below ``lifecycle.HEARTBEAT_CEILING``, which reads a record nothing has written to as
 a worker that is gone: the bar is the heartbeat, and a throttle that outran the ceiling would
 have a running job declare itself dead.
 """
@@ -281,22 +281,22 @@ def follow(
     caller has to inspect. A cache hit is already finished and is never waited on at all.
     """
     record = store.load(job_id, config)
-    while record.state == store.RUNNING:
+    while record.state == lifecycle.RUNNING:
         if watch is not None:
             watch(record)
         sleep(poll)
         record = store.load(job_id, config)
-        if record.state == store.RUNNING and not record.detached and not alive(job_id):
+        if record.state == lifecycle.RUNNING and not record.detached and not alive(job_id):
             # The thread may have closed the record between that read and this check, so
             # the answer is the record read *after* the thread is known to be gone.
             record = store.load(job_id, config)
-            if record.state == store.RUNNING:
+            if record.state == lifecycle.RUNNING:
                 raise InternalError(
                     cause=f"The {record.kind} job {job_id} stopped without finishing.",
                     detail={"job_id": job_id, "step": record.step, "progress": record.progress},
                 )
 
-    if record.state == store.FAILED:
+    if record.state == lifecycle.FAILED:
         raise ChainedJobError(record.error or {}, job_id)
     return record
 

--- a/src/resolve_mcp/jobs/store.py
+++ b/src/resolve_mcp/jobs/store.py
@@ -4,10 +4,10 @@
   and would vanish on restart, which is precisely the case ``list_jobs`` exists for. The
   running thread updates its record as it goes; readers always read the file.
 
-* **A restart is detected by session, not by pid.** Every record carries the id of the
-  server process that wrote it. A record still marked ``running`` whose session is not
-  this one belongs to a server that is gone — its worker thread died with the process, so
-  nothing will ever finish it. pids get recycled; a per-process uuid cannot be mistaken.
+* **Whether anything is still running a job is decided elsewhere.** ``lifecycle.verdict``
+  answers that from the record alone — session for a thread job, pid for a detached one —
+  and this module is what reads the file, asks it, and writes the answer back. Nothing here
+  re-decides; nothing there touches a disk.
 
 * **That verdict is written back.** The interrupted record is rewritten as failed under
   this session, so the reasoning happens once and the log carries one line for it rather
@@ -16,22 +16,6 @@
 * **A corrupt record loses itself, not the listing.** A record half-written when the
   process died is skipped with a warning; one unreadable file must not hide every other
   job from the agent.
-
-* **A detached job is judged by its pid instead, because the session rule is backwards for
-  it.** A record marked ``detached`` names a worker process of its own, and outliving the
-  server that started it is the whole point (G4: a 30-minute separation died with every
-  session that launched it). So the session check is skipped for those and the pid answers
-  instead: alive means running, gone means interrupted, and no pid yet means a launch still
-  in flight — in this session, or in whichever server is named by ``launcher_pid`` while that
-  process is still alive *and* the record is younger than ``LAUNCH_WINDOW``, because those are
-  the only two processes that will ever write the worker's pid and neither takes two minutes
-  to do it. A pid-less record whose launcher is gone, or one that has sat pid-less far longer
-  than any launch takes, is closed rather than left running forever. pids do get recycled —
-  a recycled one can only make a dead job read as running a while longer, never the reverse,
-  and the worker writes its own ending in every path it can still reach. "A while longer" is
-  the ceiling's doing: a live pid is believed only while the record is still being written to
-  (``HEARTBEAT_CEILING``), because a reboot reissues every number on the machine and nothing
-  else would ever close the record it left behind.
 
 * **Only the worker writes the record of a detached job.** The launching process has one
   thing to add — its reading of the worker's pid, for the second before the worker adopts —
@@ -61,48 +45,13 @@ from ..config import Config, get_config
 from ..errors import JobInterruptedError, JobNotFoundError
 from ..logging_config import get_logger
 from ..naming import slug
+from .lifecycle import COMPLETED, FAILED, RUNNING, SESSION, Outcome, verdict
 
 log = get_logger("jobs")
-
-RUNNING = "running"
-COMPLETED = "completed"
-FAILED = "failed"
-STATES = (RUNNING, COMPLETED, FAILED)
-
-SESSION = uuid.uuid4().hex
-"""This server process. Records written under any other session predate a restart."""
 
 SHARING_ATTEMPTS = 20
 SHARING_PAUSE = 0.01
 """How long either side of a poll waits out the other's handle. See ``_sharing``."""
-
-LAUNCH_WINDOW = 120.0
-"""How long a detached record may go with no worker pid before the launch is not in flight.
-
-Generous by an order of magnitude: what has to fit inside it is a ``Popen`` and the worker's
-own start-up as far as its adopt, which is a second or two even with a cold interpreter and a
-Windows trampoline in the way. Long enough that a slow box is never judged, short enough that
-a recycled launcher pid cannot hold a dead record open for the life of the machine. See
-``_stalled_launch``.
-"""
-
-HEARTBEAT_CEILING = 6 * 60 * 60
-"""How long a detached record may go unwritten before its live pid stops being believed.
-
-The same recycling problem one step later. A worker's pid answers "still running" for as long
-as *some* process wears that number, and a reboot hands every number out again: the record a
-worker left running when the machine went down names a stranger, reads as running at every
-poll for the life of the machine, and the only way out was to delete the file. But a bare
-``LAUNCH_WINDOW`` here would close the jobs this whole path exists to protect — a separation
-is half an hour of GPU work. What separates them is that a worker writes as it works
-(``runner.execute`` saves the bar as it moves), so what ages here is silence, not runtime, and
-the record's own ``updated_at`` is the heartbeat. Deliberately far longer than any job, for
-the same reason stems' ``CLAIM_CEILING`` is: the longest measured pass is under an hour and
-reports throughout, so six of them without one write is nobody working. Long silences are
-legal — a cold model download reports nothing for a while — and the ceiling is set to outlast
-them, because closing a live separation is a worse failure than a dead record read as running
-for an afternoon. See ``_recovered_detached``.
-"""
 
 WORKER_TAIL_LINES = 200
 """Lines of a dead worker's own output kept on the record.
@@ -784,7 +733,11 @@ else:
 
 
 def _recovered(record: JobRecord, config: Config, sweep: bool = True) -> JobRecord:
-    """A job still running under a dead session cannot finish. Say so, once.
+    """Ask ``lifecycle.verdict`` what this record is, and write the answer back if it closes.
+
+    The whole of the reasoning is over there and none of the writing is: this reads the clock
+    and hands over ``pid_alive``, then either leaves the record alone or fails it, once, with
+    the cause the verdict came with.
 
     Also the launching process's only news of a detached job that ended well. ``finish`` runs
     in the worker, where the handle dict is empty, so a normally-completed detached job would
@@ -795,7 +748,8 @@ def _recovered(record: JobRecord, config: Config, sweep: bool = True) -> JobReco
     remembered worker at once, so a listing runs it once at the end rather than once per
     finished record it happens to contain (see ``load_all``).
     """
-    if record.state != RUNNING:
+    call = verdict(record, datetime.now(UTC), pid_alive)
+    if call.outcome is Outcome.SETTLED:
         if record.detached:
             release_child(record.pid)
             # And the sweep, because the record's pid is not always the pid the handle is
@@ -808,139 +762,26 @@ def _recovered(record: JobRecord, config: Config, sweep: bool = True) -> JobReco
             if sweep:
                 _prune_children()
         return record
-    if record.detached:
-        return _recovered_detached(record, config)
-    if record.session == SESSION:
+    if call.cause is None:
         return record
-    log.info("Job %s was interrupted by a server restart", record.job_id)
+    if call.outcome is Outcome.RESTARTED:
+        return _restarted(record, call.cause, config)
+    return _interrupted(record, call.cause, config)
+
+
+def _restarted(record: JobRecord, cause: str, config: Config) -> JobRecord:
+    """Close a thread job whose server is gone. There is no worker log to fold in.
+
+    Every other way a job stops running is a detached worker that died with something to say
+    (``_interrupted``); this one died as part of a process that took the thread with it, and
+    what it had printed went to the server's own log.
+    """
     interrupted = JobInterruptedError(
-        cause=f"The server restarted while {record.kind} was running, so the job died with it.",
+        cause=cause,
         detail={"job_id": record.job_id, "progress": record.progress, "step": record.step},
     )
     record.session = SESSION
     return finish(record, error=interrupted.payload(), config=config)
-
-
-def _recovered_detached(record: JobRecord, config: Config) -> JobRecord:
-    """A detached job outlives its session on purpose, so its pid is what gets asked.
-
-    ``None`` is a launch still in flight — the starter marks the record detached before it
-    spawns, so that a reader in the microseconds between never mistakes it for a thread job
-    whose thread has ended. In flight in *some live process*, though: the only process that
-    will ever write that pid is the launcher, between its own two saves. Which session wrote
-    the record does not answer that, in either direction. A foreign session is not a dead one
-    — a second server mid-spawn is a launch in flight exactly as ours is, and judging it by
-    session alone would fail a job whose worker was about to start. And our own session is no
-    proof that the launch is still happening: noting the worker's pid is best-effort by design
-    (``note_worker_pid`` swallows a note it cannot write, because the alternative is the
-    launcher failing a job a live worker owns), so a worker that dies before it adopts leaves
-    a pid-less record here, in this session, that nothing will ever write again — read as "in
-    flight in this process" it would run for the life of the server, and a chained job
-    following it would poll for exactly as long (``runner.follow`` skips its stalled-thread
-    escape for a detached job, on purpose: a detached job has no thread to be missing). So
-    every pid-less record is asked the same two questions, its launcher and its age.
-
-    A pid that answers is asked its age too, for the same reason and one step later: a number
-    the OS has reissued — after a reboot, every number — reads as a worker still running at
-    every poll for ever. What is asked is not how long the job has run but how long the record
-    has gone unwritten, because the worker writes as it works. See ``HEARTBEAT_CEILING``.
-    """
-    if record.pid is None:
-        stalled = _stalled_launch(record)
-        if stalled is None:
-            return record
-        return _interrupted(record, stalled, config)
-    if pid_alive(record.pid):
-        return _running_or_silent(record, config)
-    log.info("Job %s lost its detached worker (pid %s)", record.job_id, record.pid)
-    return _interrupted(
-        record,
-        f"The detached worker running {record.kind} exited before the job finished "
-        f"(pid {record.pid}).",
-        config,
-    )
-
-
-def _running_or_silent(record: JobRecord, config: Config) -> JobRecord:
-    """The record of a live pid, unless nothing has written to it for longer than any job runs.
-
-    The worker owns this record from its adopt onwards and writes it as the work moves, so the
-    time since the last write is the worker's heartbeat — the freshest one the record carries,
-    and the only one that does not have to be paid for with a second file. Silence past the
-    ceiling means the pid is a reissued number rather than the worker that wrote the record.
-    """
-    silence = _age(record.updated_at)
-    if silence is None or silence <= HEARTBEAT_CEILING:
-        return record
-    log.warning(
-        "Job %s has not been written to in %.0f s while pid %s reads as alive; that number "
-        "belongs to some other process now, not to the worker that ran the job",
-        record.job_id,
-        silence,
-        record.pid,
-    )
-    return _interrupted(
-        record,
-        f"Nothing has written to the record of {record.kind} in {silence:.0f} seconds, far "
-        f"longer than the job can run silently, so pid {record.pid} is a reissued number "
-        "rather than the detached worker — nothing is running the job.",
-        config,
-    )
-
-
-def _stalled_launch(record: JobRecord) -> str | None:
-    """Why this pid-less record is not a launch in flight, or ``None`` while it still is.
-
-    The launcher's pid is asked first, and its own age second. A pid is a number the OS
-    re-issues: a record left by a server that died mid-launch names a launcher that may since
-    have been recycled onto some long-lived process, and liveness alone then reads that record
-    as launching forever. Nothing is a launch for long — the spawn and the note that follows it
-    are a second's work, and the worker writes the record from its adopt onwards — so a record
-    with no worker pid that has not been touched in ``LAUNCH_WINDOW`` is a launch that is not
-    happening, whatever its launcher's number now belongs to.
-
-    The age question is the one that answers for *this* session's own records: our launcher is
-    alive by definition, so nothing but the clock can tell a hand-off in flight from one whose
-    worker died before it adopted (see ``_recovered_detached``).
-    """
-    if record.launcher_pid is None or not pid_alive(record.launcher_pid):
-        log.info("Job %s never got a detached worker: its launcher is gone", record.job_id)
-        return (
-            f"The server handing {record.kind} to a detached worker exited before the worker "
-            "was started, so nothing is running it."
-        )
-    age = _age(record.updated_at)
-    if age is not None and age > LAUNCH_WINDOW:
-        log.warning(
-            "Job %s has had no detached worker for %.0f s; pid %s is either a recycled number "
-            "rather than the launcher that wrote the record, or a launcher that never started "
-            "one",
-            record.job_id,
-            age,
-            record.launcher_pid,
-        )
-        return (
-            f"The server handing {record.kind} to a detached worker never started one: nothing "
-            f"has written to the record in {age:.0f} seconds, so the launch is not in flight."
-        )
-    log.debug(
-        "Job %s has no worker pid yet, but its launcher (pid %s) is still running",
-        record.job_id,
-        record.launcher_pid,
-    )
-    return None
-
-
-def _age(stamp: str) -> float | None:
-    """How long ago that timestamp was, in seconds; ``None`` if it is not one."""
-    try:
-        written = datetime.fromisoformat(stamp)
-    except ValueError:
-        log.warning("Cannot read a job record's timestamp: %r", stamp)
-        return None
-    if written.tzinfo is None:
-        written = written.replace(tzinfo=UTC)
-    return (datetime.now(UTC) - written).total_seconds()
 
 
 def _interrupted(record: JobRecord, cause: str, config: Config) -> JobRecord:

--- a/src/resolve_mcp/jobs/store.py
+++ b/src/resolve_mcp/jobs/store.py
@@ -1,4 +1,4 @@
-"""One JSON record per job, on disk. Four things here are decisions, not bookkeeping.
+"""One JSON record per job, on disk. Five things here are decisions, not bookkeeping.
 
 * **Disk is the only source of truth.** An in-memory registry would be faster to read
   and would vanish on restart, which is precisely the case ``list_jobs`` exists for. The
@@ -762,7 +762,7 @@ def _recovered(record: JobRecord, config: Config, sweep: bool = True) -> JobReco
             if sweep:
                 _prune_children()
         return record
-    if call.cause is None:
+    if call.cause is None:  # ``Outcome.LIVE`` — the one verdict with nothing to write
         return record
     if call.outcome is Outcome.RESTARTED:
         return _restarted(record, call.cause, config)

--- a/src/resolve_mcp/jobs/worker.py
+++ b/src/resolve_mcp/jobs/worker.py
@@ -31,7 +31,7 @@ from collections.abc import Callable, Sequence
 from ..config import Config, get_config
 from ..errors import InternalError, ResolveMcpError
 from ..logging_config import configure_logging, get_logger
-from . import runner, store
+from . import lifecycle, runner, store
 from .runner import JobOutput, Progress
 from .store import JobRecord
 
@@ -66,7 +66,7 @@ def run(job_id: str, config: Config | None = None) -> JobRecord:
     config = config or get_config()
     record = store.adopt(job_id, config)
     log.info("Detached worker running job %s (%s)", job_id, record.kind)
-    if record.state != store.RUNNING:
+    if record.state != lifecycle.RUNNING:
         log.warning("Job %s was already %s; the worker has nothing to do", job_id, record.state)
         return record
 
@@ -91,7 +91,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ResolveMcpError as exc:
         log.error("The detached worker could not start job %s: %s", args[0], exc.cause)
         return 2
-    return 0 if record.state == store.COMPLETED else 1
+    return 0 if record.state == lifecycle.COMPLETED else 1
 
 
 if __name__ == "__main__":

--- a/src/resolve_mcp/tools/jobs.py
+++ b/src/resolve_mcp/tools/jobs.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..errors import InvalidRequestError
-from ..jobs import store
+from ..jobs import lifecycle, store
 from .envelope import tool
 
 DEFAULT_JOB_LIMIT = 50
@@ -38,11 +38,11 @@ def list_jobs(state: str | None = None, limit: int = DEFAULT_JOB_LIMIT) -> dict[
     went down comes back failed with code job_interrupted, which means start it again —
     finished work is already in the result cache and is not paid for twice.
     """
-    if state is not None and state not in store.STATES:
+    if state is not None and state not in lifecycle.STATES:
         raise InvalidRequestError(
             cause=f"{state!r} is not a job state.",
-            fix=f"Use one of {', '.join(store.STATES)}, or leave state out for all of them.",
-            detail={"requested": state, "states": list(store.STATES)},
+            fix=f"Use one of {', '.join(lifecycle.STATES)}, or leave state out for all of them.",
+            detail={"requested": state, "states": list(lifecycle.STATES)},
         )
     found = store.load_all(state=state)
     shown = found[:limit]

--- a/tests/test_detached_jobs.py
+++ b/tests/test_detached_jobs.py
@@ -53,7 +53,7 @@ from resolve_mcp.errors import (
     InvalidRequestError,
     SeparationInProgressError,
 )
-from resolve_mcp.jobs import cache, detached, store
+from resolve_mcp.jobs import cache, detached, lifecycle, store
 from resolve_mcp.jobs import worker as job_worker
 from resolve_mcp.jobs.runner import (
     Detached,
@@ -215,7 +215,7 @@ def test_the_record_says_detached_before_a_pid_exists_so_no_poller_calls_it_dead
 
     assert seen[0].detached is True
     assert seen[0].pid is None
-    assert seen[0].state == store.RUNNING
+    assert seen[0].state == lifecycle.RUNNING
     assert seen[0].plan == {"audio": {"path": "x.wav"}}
 
 
@@ -226,7 +226,7 @@ def test_a_handed_off_job_stays_running_and_names_the_process_that_has_it() -> N
     pid = detached.launch(record, {"audio": {"path": "x.wav"}}, spawn=spawn)
 
     landed = store.load(record.job_id)
-    assert (landed.state, landed.detached, landed.pid) == (store.RUNNING, True, pid)
+    assert (landed.state, landed.detached, landed.pid) == (lifecycle.RUNNING, True, pid)
     assert str(pid) in landed.step
     assert spawn.calls[0][0] == detached.command(record.job_id)
     assert spawn.calls[0][1] == store.worker_log(record.job_id, get_config())
@@ -242,7 +242,7 @@ def test_a_worker_that_hands_off_neither_finishes_the_job_nor_caches_a_result(
     started = start_job(KIND, {}, lambda progress: Detached({"audio": {}}), "the-key")
     record = wait_for(str(started["job_id"]))
 
-    assert record.state == store.RUNNING
+    assert record.state == lifecycle.RUNNING
     assert record.pid == spawn.pid
     assert cache.lookup("the-key") is None
 
@@ -260,7 +260,7 @@ def test_a_launch_the_operating_system_refuses_fails_the_job_rather_than_strandi
     started = start_job(KIND, {}, lambda progress: Detached({"audio": {}}))
     record = wait_for(str(started["job_id"]))
 
-    assert record.state == store.FAILED
+    assert record.state == lifecycle.FAILED
     assert record.error is not None
     assert "no such interpreter" in record.error["cause"]
 
@@ -392,7 +392,7 @@ def test_a_launcher_does_not_reopen_a_job_its_worker_had_already_finished(
     detached.launch(record, {}, spawn=FakeSpawn(pid=424242, watching=arm))
 
     landed = store.load(record.job_id)
-    assert landed.state == store.FAILED
+    assert landed.state == lifecycle.FAILED
     assert landed.error is not None
     assert landed.error["cause"] == "the worker gave up"
 
@@ -432,7 +432,7 @@ def test_a_worker_that_finished_inside_the_launchers_window_keeps_its_result(
 
     landed = store.load(record.job_id)
     assert ended, "the finish was never injected, so the window was never exercised"
-    assert landed.state == store.COMPLETED
+    assert landed.state == lifecycle.COMPLETED
     assert landed.result == {"directory": "/stems/sunset-set-abc123"}
     assert landed.pid == os.getpid(), "the launcher's note answered for a record that had ended"
 
@@ -469,7 +469,7 @@ def test_a_note_that_lands_after_the_worker_finished_is_taken_back(
     note = store._note_path(store._path(record.job_id, get_config()))
     assert not note.exists(), "the launcher's note outlived the record it answered for"
     landed = store.load(record.job_id)
-    assert landed.state == store.COMPLETED
+    assert landed.state == lifecycle.COMPLETED
     assert landed.result == {"directory": "/stems/sunset-set-abc123"}
 
 
@@ -493,14 +493,14 @@ def test_a_note_that_cannot_be_written_does_not_fail_the_launch(
     pid = detached.launch(record, {}, spawn=FakeSpawn())
 
     assert pid == os.getpid()
-    assert store.load(record.job_id).state == store.RUNNING, "the launcher closed a live job"
+    assert store.load(record.job_id).state == lifecycle.RUNNING, "the launcher closed a live job"
 
 
 def test_a_detached_job_outlives_the_session_that_started_it() -> None:
     """The session rule is backwards for these: surviving the server is the whole point."""
     record = _running_under_a_dead_server(os.getpid())
 
-    assert store.load(record.job_id).state == store.RUNNING
+    assert store.load(record.job_id).state == lifecycle.RUNNING
 
 
 def test_a_detached_job_whose_worker_is_gone_is_failed_and_says_so() -> None:
@@ -509,12 +509,12 @@ def test_a_detached_job_whose_worker_is_gone_is_failed_and_says_so() -> None:
 
     failed = store.load(record.job_id)
 
-    assert failed.state == store.FAILED
+    assert failed.state == lifecycle.FAILED
     assert failed.error is not None
     assert failed.error["code"] == "job_interrupted"
     assert str(pid) in failed.error["cause"]
     assert failed.error["detail"]["step"] == "separating four stems (50%)"
-    assert store.load(record.job_id).state == store.FAILED  # written back, judged once
+    assert store.load(record.job_id).state == lifecycle.FAILED  # written back, judged once
 
 
 def test_a_dead_workers_own_output_arrives_on_the_record_that_says_it_died() -> None:
@@ -534,7 +534,7 @@ def test_a_dead_workers_own_output_arrives_on_the_record_that_says_it_died() -> 
 
     failed = store.load(record.job_id)
 
-    assert failed.state == store.FAILED
+    assert failed.state == lifecycle.FAILED
     assert failed.error is not None
     assert "CUDA error: out of memory" in failed.error["detail"]["output"]
     assert failed.error["detail"]["worker_log"] == str(log_file)
@@ -546,7 +546,7 @@ def test_a_worker_that_died_before_it_printed_anything_still_names_where_it_woul
 
     failed = store.load(record.job_id)
 
-    assert failed.state == store.FAILED
+    assert failed.state == lifecycle.FAILED
     assert failed.error is not None
     assert failed.error["detail"]["output"] is None
     assert failed.error["detail"]["worker_log"].endswith(".worker.log")
@@ -584,16 +584,16 @@ def test_a_worker_that_has_said_nothing_far_longer_than_any_job_takes_is_not_bel
     run.
     """
     record = _running_under_a_dead_server(os.getpid(), step="separating four stems (50%)")
-    _last_written(record.job_id, store.HEARTBEAT_CEILING + 60)
+    _last_written(record.job_id, lifecycle.HEARTBEAT_CEILING + 60)
 
     failed = store.load(record.job_id)
 
-    assert failed.state == store.FAILED
+    assert failed.state == lifecycle.FAILED
     assert failed.error is not None
     assert failed.error["code"] == "job_interrupted"
     assert str(os.getpid()) in failed.error["cause"]
     assert failed.error["detail"]["step"] == "separating four stems (50%)"
-    assert store.load(record.job_id).state == store.FAILED  # written back, judged once
+    assert store.load(record.job_id).state == lifecycle.FAILED  # written back, judged once
 
 
 def test_a_separation_that_has_run_for_half_an_hour_is_not_closed_for_taking_its_time() -> None:
@@ -605,7 +605,7 @@ def test_a_separation_that_has_run_for_half_an_hour_is_not_closed_for_taking_its
     record = _running_under_a_dead_server(os.getpid(), step="decomposing the drum stem")
     _last_written(record.job_id, 30 * 60)
 
-    assert store.load(record.job_id).state == store.RUNNING
+    assert store.load(record.job_id).state == lifecycle.RUNNING
 
 
 def test_a_follower_of_a_detached_job_hears_its_worker_died_not_that_a_thread_is_missing() -> None:
@@ -634,11 +634,11 @@ def test_a_launch_that_never_happened_is_closed_rather_than_left_running_forever
 
     failed = store.load(record.job_id)
 
-    assert failed.state == store.FAILED
+    assert failed.state == lifecycle.FAILED
     assert failed.error is not None
     assert failed.error["code"] == "job_interrupted"
     assert "before the worker was started" in failed.error["cause"]
-    assert store.load(record.job_id).state == store.FAILED  # written back, judged once
+    assert store.load(record.job_id).state == lifecycle.FAILED  # written back, judged once
 
 
 def test_a_launch_in_flight_in_this_session_is_still_a_running_job() -> None:
@@ -653,7 +653,7 @@ def test_a_launch_in_flight_in_this_session_is_still_a_running_job() -> None:
     record.step = detached.HANDING_OFF
     store.save(record)
 
-    assert store.load(record.job_id).state == store.RUNNING
+    assert store.load(record.job_id).state == lifecycle.RUNNING
 
 
 def test_a_launch_of_our_own_that_never_produced_a_worker_is_closed_like_anybody_elses() -> None:
@@ -670,12 +670,12 @@ def test_a_launch_of_our_own_that_never_produced_a_worker_is_closed_like_anybody
     record.launcher_pid = os.getpid()
     record.step = detached.HANDING_OFF
     store.save(record)
-    _last_written(record.job_id, store.LAUNCH_WINDOW + 60)
+    _last_written(record.job_id, lifecycle.LAUNCH_WINDOW + 60)
 
     failed = store.load(record.job_id)
 
-    assert failed.session == store.SESSION
-    assert failed.state == store.FAILED
+    assert failed.session == lifecycle.SESSION
+    assert failed.state == lifecycle.FAILED
     assert failed.error is not None
     assert failed.error["code"] == "job_interrupted"
     assert "never started one" in failed.error["cause"]
@@ -688,7 +688,7 @@ def test_a_follower_of_our_own_stalled_launch_is_not_left_polling_for_ever() -> 
     record.launcher_pid = os.getpid()
     record.step = detached.HANDING_OFF
     store.save(record)
-    _last_written(record.job_id, store.LAUNCH_WINDOW + 60)
+    _last_written(record.job_id, lifecycle.LAUNCH_WINDOW + 60)
 
     with pytest.raises(ChainedJobError) as raised:
         follow(record.job_id, poll=0.0, sleep=lambda seconds: None)
@@ -714,7 +714,7 @@ def test_a_launch_in_flight_in_another_live_server_is_not_closed_as_one_that_nev
     record.step = detached.HANDING_OFF
     store.save(record)
 
-    assert store.load(record.job_id).state == store.RUNNING
+    assert store.load(record.job_id).state == lifecycle.RUNNING
 
 
 def test_a_launch_whose_launcher_died_before_the_spawn_is_still_closed() -> None:
@@ -728,7 +728,7 @@ def test_a_launch_whose_launcher_died_before_the_spawn_is_still_closed() -> None
 
     failed = store.load(record.job_id)
 
-    assert failed.state == store.FAILED
+    assert failed.state == lifecycle.FAILED
     assert failed.error is not None
     assert "before the worker was started" in failed.error["cause"]
 
@@ -749,11 +749,11 @@ def test_a_launch_that_has_had_no_worker_far_longer_than_a_launch_takes_is_close
     record.launcher_pid = os.getpid()
     record.step = detached.HANDING_OFF
     store.save(record)
-    _last_written(record.job_id, store.LAUNCH_WINDOW + 60)
+    _last_written(record.job_id, lifecycle.LAUNCH_WINDOW + 60)
 
     failed = store.load(record.job_id)
 
-    assert failed.state == store.FAILED
+    assert failed.state == lifecycle.FAILED
     assert failed.error is not None
     assert failed.error["code"] == "job_interrupted"
     assert "never started one" in failed.error["cause"]
@@ -767,9 +767,9 @@ def test_a_launch_in_flight_is_not_closed_for_being_a_few_seconds_old() -> None:
     record.launcher_pid = os.getpid()
     record.step = detached.HANDING_OFF
     store.save(record)
-    _last_written(record.job_id, store.LAUNCH_WINDOW / 2)
+    _last_written(record.job_id, lifecycle.LAUNCH_WINDOW / 2)
 
-    assert store.load(record.job_id).state == store.RUNNING
+    assert store.load(record.job_id).state == lifecycle.RUNNING
 
 
 def test_the_launcher_lets_go_of_a_worker_that_finished_the_job_itself() -> None:
@@ -784,7 +784,7 @@ def test_the_launcher_lets_go_of_a_worker_that_finished_the_job_itself() -> None
     record.detached = True
     record.session = "the-worker-that-ran-it"
     record.pid = 4242
-    record.state = store.COMPLETED
+    record.state = lifecycle.COMPLETED
     record.result = {"directory": "/stems/sunset-set-abc123"}
     store.save(record)
     store.remember_child(4242, _FakeProcess(4242, returncode=0))
@@ -808,11 +808,11 @@ def test_the_launcher_lets_go_of_a_trampoline_whose_worker_ran_under_another_pid
     record.detached = True
     record.session = "the-worker-that-ran-it"
     record.pid = 4243  # the real interpreter: what the worker wrote when it adopted the record
-    record.state = store.COMPLETED
+    record.state = lifecycle.COMPLETED
     store.save(record)
     store.remember_child(4242, _FakeProcess(4242, returncode=0))  # the trampoline Popen returned
 
-    assert store.load(record.job_id).state == store.COMPLETED
+    assert store.load(record.job_id).state == lifecycle.COMPLETED
     assert 4242 not in store._children, "the launcher is still holding the trampoline it started"
 
 
@@ -949,10 +949,10 @@ def test_the_worker_takes_the_record_over_closes_it_and_caches_what_it_made(
     monkeypatch.setattr(job_worker, "worker_for", lambda kind: work)
     finished = job_worker.run(record.job_id)
 
-    assert finished.state == store.COMPLETED
+    assert finished.state == lifecycle.COMPLETED
     assert finished.result == {"from": {"audio": {"path": "mix.wav"}}}
     assert finished.pid == os.getpid()
-    assert finished.session == store.SESSION
+    assert finished.session == lifecycle.SESSION
     assert cache.lookup("the-key") == {"from": {"audio": {"path": "mix.wav"}}}
 
 
@@ -987,7 +987,7 @@ def test_the_worker_refuses_a_kind_it_cannot_run_by_failing_the_job() -> None:
 
     finished = job_worker.run(record.job_id)
 
-    assert finished.state == store.FAILED
+    assert finished.state == lifecycle.FAILED
     assert finished.error is not None
     assert "No detached worker" in finished.error["cause"]
 
@@ -1054,12 +1054,12 @@ def test_a_real_detached_worker_finds_the_record_and_closes_it() -> None:
     detached.launch(record, {})
 
     finished = _until_finished(record.job_id)
-    assert finished.state == store.FAILED, _why_the_worker_did_not_finish(finished)
+    assert finished.state == lifecycle.FAILED, _why_the_worker_did_not_finish(finished)
     assert finished.error is not None
     assert "No detached worker" in finished.error["cause"]
     assert finished.pid is not None
     assert finished.pid != os.getpid()
-    assert finished.session != store.SESSION
+    assert finished.session != lifecycle.SESSION
     assert store.worker_log(record.job_id, get_config()).exists()
 
 
@@ -1078,7 +1078,7 @@ def test_the_separation_hands_off_once_the_audio_is_on_disk_and_not_before(
     started = separate_stems(get_connection(), detach=True)
     record = wait_for(str(started["job_id"]))
 
-    assert record.state == store.RUNNING
+    assert record.state == lifecycle.RUNNING
     assert record.detached is True
     assert record.pid == spawn.pid
     assert record.plan is not None
@@ -1190,7 +1190,7 @@ def test_a_stems_claim_left_by_a_run_that_is_gone_is_taken_over_even_wearing_thi
     with claimed(directory):
         held = json.loads((directory / CLAIM).read_text(encoding="utf-8"))
 
-    assert held["session"] == store.SESSION
+    assert held["session"] == lifecycle.SESSION
     assert not (directory / CLAIM).exists()
 
 
@@ -1296,7 +1296,7 @@ def test_a_claim_is_refreshed_by_the_run_that_is_holding_it(tmp_path: Path) -> N
 
     assert refreshed["claimed_at"] > aged + CLAIM_CEILING, "the claim was left at its old age"
     assert refreshed["pid"] == os.getpid()
-    assert refreshed["session"] == store.SESSION
+    assert refreshed["session"] == lifecycle.SESSION
 
 
 def test_a_claim_this_process_no_longer_holds_stops_the_separation(tmp_path: Path) -> None:
@@ -1662,7 +1662,7 @@ def test_a_bar_that_moves_a_thousand_times_does_not_write_the_record_a_thousand_
     assert len(saved) <= 5, f"the bar wrote the record {len(saved)} times: {saved}"
     # A step change is never held back: it is the line an agent reads to know what is happening.
     assert [step for _, step in saved].count("decomposing the drum stem") >= 1
-    assert store.load(record.job_id).state == store.COMPLETED, "the ending was throttled away"
+    assert store.load(record.job_id).state == lifecycle.COMPLETED, "the ending was throttled away"
 
 
 # --- helpers -------------------------------------------------------------------------------
@@ -1796,7 +1796,7 @@ def _until_finished(job_id: str, budget: float = WORKER_BUDGET) -> JobRecord:
     """Poll the record the way an agent does, and give up rather than hang the suite."""
     deadline = time.monotonic() + budget
     record = store.load(job_id)
-    while record.state == store.RUNNING and time.monotonic() < deadline:
+    while record.state == lifecycle.RUNNING and time.monotonic() < deadline:
         time.sleep(POLL)
         record = store.load(job_id)
     return record

--- a/tests/test_job_lifecycle.py
+++ b/tests/test_job_lifecycle.py
@@ -1,0 +1,300 @@
+"""The job-lifecycle verdict, as a truth table over records built in memory.
+
+Every row here used to cost a disk round-trip: the only way to reach a verdict was
+``store.save`` then ``store.load``, which decided *and* wrote the failure back. The decision
+is now ``lifecycle.verdict``, a total function of the record, the clock and an injected
+liveness callable — so the table below is the table, and nothing here touches a file.
+
+The store's composition of it (writing the failure back, folding in the worker's last output,
+letting go of the child handle) is verified where it belongs, in ``test_job_store`` and
+``test_detached_jobs``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from resolve_mcp.jobs import lifecycle
+from resolve_mcp.jobs.lifecycle import Outcome, verdict
+from resolve_mcp.jobs.store import JobRecord
+
+KIND = "separate_stems"
+NOW = datetime(2026, 8, 14, 12, 0, 0, tzinfo=UTC)
+
+WORKER = 4242
+LAUNCHER = 4243
+DEAD = 5150
+"""Three pid-shaped numbers. Which of them is alive is whatever the test says it is."""
+
+LAUNCH_STALL = 300.0
+"""Comfortably past ``LAUNCH_WINDOW``, and a round number to read back out of the cause."""
+
+
+class Liveness:
+    """The liveness callable the verdict is given, remembering what it was asked about."""
+
+    def __init__(self, *live: int) -> None:
+        self.live = live
+        self.asked: list[int] = []
+
+    def __call__(self, pid: int) -> bool:
+        self.asked.append(pid)
+        return pid in self.live
+
+
+def _record(
+    state: str = lifecycle.RUNNING,
+    *,
+    detached: bool = False,
+    session: str = lifecycle.SESSION,
+    pid: int | None = None,
+    launcher_pid: int | None = None,
+    silence: float = 1.0,
+    updated_at: str | None = None,
+) -> JobRecord:
+    """A record as the file would have said it, without the file.
+
+    ``silence`` is how long ago the record was last written, in seconds before ``NOW`` — the
+    only clock reading any of this depends on.
+    """
+    return JobRecord(
+        job_id="separate-stems-abc123",
+        kind=KIND,
+        state=state,
+        session=session,
+        detached=detached,
+        pid=pid,
+        launcher_pid=launcher_pid,
+        started_at=(NOW - timedelta(seconds=silence)).isoformat(),
+        updated_at=updated_at or (NOW - timedelta(seconds=silence)).isoformat(),
+        step="separating four stems (50%)",
+        progress=0.5,
+    )
+
+
+TABLE = [
+    pytest.param(
+        _record(lifecycle.COMPLETED),
+        (),
+        Outcome.SETTLED,
+        id="a finished job is not judged at all",
+    ),
+    pytest.param(
+        _record(lifecycle.FAILED, detached=True, pid=WORKER, session="a-server-that-is-gone"),
+        (),
+        Outcome.SETTLED,
+        id="a finished detached job is not judged by its dead pid",
+    ),
+    pytest.param(
+        _record(lifecycle.COMPLETED, session="a-server-that-is-gone"),
+        (),
+        Outcome.SETTLED,
+        id="a finished job from a previous server is left alone",
+    ),
+    pytest.param(
+        _record(),
+        (),
+        Outcome.LIVE,
+        id="a running job of this session's is running",
+    ),
+    pytest.param(
+        _record(session="the-server-that-restarted"),
+        (),
+        Outcome.RESTARTED,
+        id="a running job of a dead session's died with it",
+    ),
+    pytest.param(
+        _record(detached=True, pid=WORKER),
+        (WORKER,),
+        Outcome.LIVE,
+        id="a detached job whose worker is alive is running",
+    ),
+    pytest.param(
+        _record(detached=True, pid=WORKER, session="the-server-that-launched-it"),
+        (WORKER,),
+        Outcome.LIVE,
+        id="a detached job outlives the session that launched it",
+    ),
+    pytest.param(
+        _record(detached=True, pid=WORKER),
+        (),
+        Outcome.WORKER_GONE,
+        id="a detached job whose worker exited is over",
+    ),
+    pytest.param(
+        _record(detached=True, pid=WORKER, silence=lifecycle.HEARTBEAT_CEILING - 1),
+        (WORKER,),
+        Outcome.LIVE,
+        id="a long separation is not closed for taking its time",
+    ),
+    pytest.param(
+        _record(detached=True, pid=WORKER, silence=lifecycle.HEARTBEAT_CEILING),
+        (WORKER,),
+        Outcome.LIVE,
+        id="silence exactly at the ceiling is still believed",
+    ),
+    pytest.param(
+        _record(detached=True, pid=WORKER, silence=lifecycle.HEARTBEAT_CEILING + 60),
+        (WORKER,),
+        Outcome.SILENT,
+        id="a live pid that has written nothing past the ceiling is a reissued number",
+    ),
+    pytest.param(
+        _record(detached=True, pid=WORKER, updated_at="not a timestamp"),
+        (WORKER,),
+        Outcome.LIVE,
+        id="a record whose timestamp cannot be read is not closed on the strength of it",
+    ),
+    pytest.param(
+        _record(detached=True, launcher_pid=LAUNCHER),
+        (LAUNCHER,),
+        Outcome.LIVE,
+        id="a launch in flight is a running job",
+    ),
+    pytest.param(
+        _record(detached=True, launcher_pid=None),
+        (),
+        Outcome.STALLED_LAUNCH,
+        id="a pid-less record naming no launcher is a launch that never happened",
+    ),
+    pytest.param(
+        _record(detached=True, launcher_pid=DEAD),
+        (WORKER,),
+        Outcome.STALLED_LAUNCH,
+        id="a launcher that is gone leaves a record nothing will ever write",
+    ),
+    pytest.param(
+        _record(detached=True, launcher_pid=LAUNCHER, silence=lifecycle.LAUNCH_WINDOW),
+        (LAUNCHER,),
+        Outcome.LIVE,
+        id="a launch exactly at the window is still in flight",
+    ),
+    pytest.param(
+        _record(detached=True, launcher_pid=LAUNCHER, silence=lifecycle.LAUNCH_WINDOW + 60),
+        (LAUNCHER,),
+        Outcome.STALLED_LAUNCH,
+        id="a live launcher pid that has produced no worker is recycled or idle",
+    ),
+    pytest.param(
+        _record(detached=True, launcher_pid=LAUNCHER, updated_at="not a timestamp"),
+        (LAUNCHER,),
+        Outcome.LIVE,
+        id="an unreadable timestamp does not stall a launch whose launcher is alive",
+    ),
+]
+
+
+@pytest.mark.parametrize(("record", "live", "expected"), TABLE)
+def test_the_verdict_truth_table(
+    record: JobRecord, live: tuple[int, ...], expected: Outcome
+) -> None:
+    """State, detached flag, session, the two pids and one clock reading decide all of it."""
+    assert verdict(record, NOW, Liveness(*live)).outcome is expected
+
+
+@pytest.mark.parametrize(("record", "live", "expected"), TABLE)
+def test_a_verdict_closes_the_job_exactly_when_nothing_is_running_it(
+    record: JobRecord, live: tuple[int, ...], expected: Outcome
+) -> None:
+    """``cause`` is the whole of what the store needs to write back, and it is set or it isn't."""
+    call = verdict(record, NOW, Liveness(*live))
+
+    assert call.closes is (expected not in (Outcome.SETTLED, Outcome.LIVE))
+    assert (call.cause is not None) is call.closes
+
+
+def test_a_settled_record_is_never_asked_about_a_pid() -> None:
+    """The first question ends it: a job that is over cannot be judged by anybody's liveness."""
+    asked = Liveness()
+    record = _record(lifecycle.COMPLETED, detached=True, pid=WORKER, launcher_pid=LAUNCHER)
+
+    verdict(record, NOW, asked)
+
+    assert asked.asked == []
+
+
+def test_a_detached_record_with_a_worker_pid_is_not_asked_about_its_launcher() -> None:
+    """The launcher answers for one window only — record written, worker not yet adopted."""
+    asked = Liveness(WORKER)
+    record = _record(detached=True, pid=WORKER, launcher_pid=LAUNCHER)
+
+    verdict(record, NOW, asked)
+
+    assert asked.asked == [WORKER]
+
+
+def test_the_verdict_leaves_the_record_exactly_as_it_found_it() -> None:
+    """Deciding is not writing: the store composes the two, and only the store writes."""
+    record = _record(session="the-server-that-restarted")
+    before = record.payload()
+
+    verdict(record, NOW, Liveness())
+
+    assert record.payload() == before
+
+
+def test_the_same_record_and_the_same_clock_reach_the_same_verdict() -> None:
+    """Nothing under here reads a clock of its own — ``now`` is the only one."""
+    record = _record(detached=True, pid=WORKER, silence=lifecycle.HEARTBEAT_CEILING + 60)
+
+    first = verdict(record, NOW, Liveness(WORKER))
+    second = verdict(record, NOW, Liveness(WORKER))
+
+    assert first == second
+
+
+@pytest.mark.parametrize(
+    ("record", "live", "phrase"),
+    [
+        pytest.param(
+            _record(session="the-server-that-restarted"),
+            (),
+            "The server restarted while separate_stems was running",
+            id="restarted",
+        ),
+        pytest.param(
+            _record(detached=True, pid=WORKER),
+            (),
+            f"exited before the job finished (pid {WORKER}).",
+            id="worker gone",
+        ),
+        pytest.param(
+            _record(detached=True, pid=WORKER, silence=lifecycle.HEARTBEAT_CEILING + 60),
+            (WORKER,),
+            f"so pid {WORKER} is a reissued number",
+            id="silent",
+        ),
+        pytest.param(
+            _record(detached=True, launcher_pid=DEAD),
+            (),
+            "exited before the worker was started",
+            id="launcher gone",
+        ),
+        pytest.param(
+            _record(detached=True, launcher_pid=LAUNCHER, silence=lifecycle.LAUNCH_WINDOW + 60),
+            (LAUNCHER,),
+            "never started one",
+            id="launch stalled",
+        ),
+    ],
+)
+def test_the_cause_says_which_way_the_job_died(
+    record: JobRecord, live: tuple[int, ...], phrase: str
+) -> None:
+    """What the agent reads on the failed record — one sentence per way a job stops running."""
+    call = verdict(record, NOW, Liveness(*live))
+
+    assert call.cause is not None
+    assert phrase in call.cause
+
+
+def test_a_stalled_launch_counts_the_silence_it_measured() -> None:
+    """The number in the cause is the record's own age, not a constant."""
+    record = _record(detached=True, launcher_pid=LAUNCHER, silence=LAUNCH_STALL)
+
+    call = verdict(record, NOW, Liveness(LAUNCHER))
+
+    assert call.cause is not None
+    assert f"{LAUNCH_STALL:.0f} seconds" in call.cause

--- a/tests/test_job_lifecycle.py
+++ b/tests/test_job_lifecycle.py
@@ -198,11 +198,15 @@ def test_the_verdict_truth_table(
 def test_a_verdict_closes_the_job_exactly_when_nothing_is_running_it(
     record: JobRecord, live: tuple[int, ...], expected: Outcome
 ) -> None:
-    """``cause`` is the whole of what the store needs to write back, and it is set or it isn't."""
+    """``cause`` is the whole of what the store needs to write back, and it is set or it isn't.
+
+    The store branches on ``cause is None`` alone, so the invariant it leans on is that a cause
+    is present for exactly the four outcomes that end a job and absent for the two that do not.
+    """
     call = verdict(record, NOW, Liveness(*live))
 
-    assert call.closes is (expected not in (Outcome.SETTLED, Outcome.LIVE))
-    assert (call.cause is not None) is call.closes
+    closes = expected not in (Outcome.SETTLED, Outcome.LIVE)
+    assert (call.cause is not None) is closes
 
 
 def test_a_settled_record_is_never_asked_about_a_pid() -> None:

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -15,7 +15,7 @@ import pytest
 
 from resolve_mcp.config import get_config
 from resolve_mcp.errors import JobNotFoundError
-from resolve_mcp.jobs import store
+from resolve_mcp.jobs import lifecycle, store
 
 SAVES = 300
 
@@ -152,7 +152,7 @@ def test_the_interruption_is_written_back_so_the_verdict_is_reached_once() -> No
 
     on_disk = json.loads(_record_path(record.job_id).read_text(encoding="utf-8"))
     assert on_disk["state"] == "failed"
-    assert on_disk["session"] == store.SESSION
+    assert on_disk["session"] == lifecycle.SESSION
 
 
 def test_a_finished_job_from_a_previous_server_is_left_alone() -> None:

--- a/tests/test_job_tools.py
+++ b/tests/test_job_tools.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from resolve_mcp.config import get_config
-from resolve_mcp.jobs import store
+from resolve_mcp.jobs import lifecycle
 from resolve_mcp.jobs.runner import JobOutput, Progress, start_job, wait_for
 from resolve_mcp.tools.jobs import get_job, list_jobs
 
@@ -111,7 +111,7 @@ def _rewrite_as_a_previous_server_left_it(job_id: str) -> None:
     raw = json.loads(path.read_text(encoding="utf-8"))
     raw.update(
         {
-            "state": store.RUNNING,
+            "state": lifecycle.RUNNING,
             "session": "a-server-that-has-since-exited",
             "result": None,
             "finished_at": None,


### PR DESCRIPTION
Closes #216.

## What changed

`jobs/lifecycle.py` (new) owns the job-lifecycle verdict: `verdict(record, now, alive)` is a total function of the record's state, detached flag, session, two pids and timestamps, with pid-liveness injected. It reads nothing and writes nothing. `store.load` is now read file → verdict → maybe write the failure back, and `store.py` drops from 967 to 808 lines.

The job states and `SESSION` move with the verdict — it asks both, and mypy strict forbids reaching them back through the store that imports them (`Module "store" does not explicitly export attribute "RUNNING"`). Every caller in `src/`, `tests/` and `gauntlet/` now names `lifecycle` for those.

Verdicts and cause strings are byte-identical: branch order, the `<=`/`>` boundaries at each ceiling, which pid is asked when, and both failure `detail` shapes. The only difference is that the clock is now read once in `store._recovered` rather than inside each age check — not observable.

**Test seam: fake tier.** `tests/test_job_lifecycle.py` is the truth table as 18 parametrised rows over records built in memory, plus the boundary case at each ceiling, the purity assertions (a settled record is never asked about a pid; the verdict leaves the record as it found it) and one row per cause string. No `store.save`/`store.load` round-trip to reach a decision; liveness is a stub object that records what it was asked. The six existing lifecycle tests in `test_job_store.py` and `test_detached_jobs.py` are unchanged apart from constant renames and now cover the store's *composition* — the write-back, the worker-log fold-in, the child-handle release.

Full fake tier 2160 passed, mypy strict clean, ruff clean.

## Review

Two axes, run as parallel sub-agents against `origin/main`.

**Standards — no hard violations; four judgement calls.**

1. *Implicit re-export, load-bearing off-CI.* Twelve `gauntlet/recon/*.py` scripts still read `store.RUNNING`, which resolved only through the store's import of `lifecycle` — the shape CLAUDE.md bans, in the one directory mypy does not read. **Fixed** in b7105e7: they name `lifecycle` too.
2. *Duplicated Code — the disk-backed twins in `test_detached_jobs.py` were renamed, not thinned.* **Kept, deliberately.** AC 2 asks that the existing lifecycle tests pass against the composition, which is the byte-identity proof; and what they now cover is what the pure test cannot reach — that the verdict is written back once, that a dead worker's last output is folded onto the record, that the launcher lets go of the child handle.
3. *Speculative Generality — `Verdict.closes` had no production caller.* **Fixed:** removed. `store._recovered` branches on `cause is None` because that is what narrows the type it passes to `_restarted`; the invariant the property stood for is stated on the dataclass and asserted in the truth table. The `Outcome` members that the store does not distinguish (`WORKER_GONE`, `SILENT`, `STALLED_LAUNCH`) are **kept**: they are the truth table's vocabulary — the ticket's four named verdicts — and the parametrised test asserts each one by name. Collapsing them would leave the table able to say only "closes / does not".
4. *Repeated Switches (mild) — two discriminators in `store._recovered`.* **Answered in place:** the middle branch now names the outcome it stands for in a comment; it stays a `cause is None` test because that is the one mypy narrows.
5. *`store.py` docstring said "Four things" over five bullets (pre-existing).* **Fixed.**

**Spec — all five acceptance criteria met; no missing requirements, nothing implemented wrong.**

The reviewer checked byte-identity directly against `origin/main`'s `_recovered`/`_recovered_detached`/`_running_or_silent`/`_stalled_launch`/`_age` and found branch order, boundaries, pid-asking order, all four cause strings and both `detail` shapes identical.

- *Scope creep:* `COMPLETED`, `FAILED` and `STATES` moved to `lifecycle` although `verdict` uses only `RUNNING` and `SESSION`, which is most of the diff's surface. **Kept:** they are one vocabulary, and splitting them would leave `STATES = (RUNNING, COMPLETED, FAILED)` in the store importing half of itself back from `lifecycle` — a worse seam for a smaller diff.
- *AC 4 (`pid_alive` is no longer a monkeypatch target) passes vacuously* — it was never monkeypatched on `main` either; the lifecycle tests reached liveness through real pids. The new tests inject a stub instead, which is the thing the AC was after.

Fix diff re-checked in a focused pass; no new findings.

Review: clean — Standards and Spec sub-agents, findings above either fixed in b7105e7 or answered.
