### PR TITLE
Split resolve/media: pool adapter vs media operations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -224,13 +224,13 @@ the record has no pid of its own, so a launcher can never overwrite a result.
 (**the seam**: lazy singleton, probe, one auto reconnect), `cut` (cut-file
 contract), `fusion` (Text+ node, text, opacity fade spline), `interchange`
 (timeline export/import), `loader` (import DaVinciResolveScript +
-direct-attach), `markers` (read/write, review-loop transport), `media`
-(the six media operations: import, list, inspect, metadata, organize,
-relink — all of them callers of `pool`), `pool` (**the media pool adapter**:
-reaching the pool, bin addressing, clip lookup, clip reading, frame bounds,
-offline and still handling — what `cut`, `build`, `apply`, `titles`,
-`audio/acquire` and `video/source` consume; import it from here, never
-through `media`), `mix` (where the master
+direct-attach), `markers` (read/write, review-loop transport), `media` (the
+six media operations: import, list, inspect, metadata, organize, relink —
+all of them callers of `pool`), `pool` (**the media pool adapter**: reaching
+the pool, bin addressing, clip lookup, clip reading, frame bounds, offline
+and still handling — what `cut`, `build`, `apply`, `titles`, `audio/acquire`
+and `video/source` consume; import it from here, never through `media`),
+`mix` (where the master
 mix sits under a timeline — the one axis a rebuild does not move; read by
 `build`'s marker carry and by `analysis/correlate`), `render` (render
 queue), `camera_sidecar` (camera model off the card's own XML, for media
@@ -293,7 +293,9 @@ Test files follow the module they cover, so the media pair splits the same way
 the source does: `test_media_pool.py` covers `resolve/pool` (bin addressing,
 clip lookup, clip reading, frame bounds, offline) and `test_media_tools.py`
 covers `resolve/media` (what the six operations do with what the adapter hands
-them). Both drive the fake seam through `tools/media`.
+them). Both drive the fake seam through `tools/media`, and both build their
+pools from `tests/mediapool.py` (`a_file`, `a_clip`, `a_shallow_copy_pool`) so
+the pair cannot drift on what a clip or a shadowed copy looks like.
 
 `tests/fakes/` is the fake Resolve API, one module per subsystem — open the
 module, not the package, and never the whole package at once:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -225,7 +225,12 @@ the record has no pid of its own, so a launcher can never overwrite a result.
 contract), `fusion` (Text+ node, text, opacity fade spline), `interchange`
 (timeline export/import), `loader` (import DaVinciResolveScript +
 direct-attach), `markers` (read/write, review-loop transport), `media`
-(media pool: import, list, inspect, bins, relink), `mix` (where the master
+(the six media operations: import, list, inspect, metadata, organize,
+relink — all of them callers of `pool`), `pool` (**the media pool adapter**:
+reaching the pool, bin addressing, clip lookup, clip reading, frame bounds,
+offline and still handling — what `cut`, `build`, `apply`, `titles`,
+`audio/acquire` and `video/source` consume; import it from here, never
+through `media`), `mix` (where the master
 mix sits under a timeline — the one axis a rebuild does not move; read by
 `build`'s marker carry and by `analysis/correlate`), `render` (render
 queue), `camera_sidecar` (camera model off the card's own XML, for media
@@ -283,6 +288,12 @@ out, and `analysis/correlate` joins the catalog on as `straddles_super`, #183),
 `source` (clip name → file path + the clip's own frame numbering).
 
 ## Test map — `tests/`
+
+Test files follow the module they cover, so the media pair splits the same way
+the source does: `test_media_pool.py` covers `resolve/pool` (bin addressing,
+clip lookup, clip reading, frame bounds, offline) and `test_media_tools.py`
+covers `resolve/media` (what the six operations do with what the adapter hands
+them). Both drive the fake seam through `tools/media`.
 
 `tests/fakes/` is the fake Resolve API, one module per subsystem — open the
 module, not the package, and never the whole package at once:

--- a/gauntlet/recon/live_probe.py
+++ b/gauntlet/recon/live_probe.py
@@ -197,7 +197,7 @@ def main() -> None:
 
     # --- media pool ------------------------------------------------------
     try:
-        from resolve_mcp.resolve import media as media_wrapper
+        from resolve_mcp.resolve import pool as media_wrapper
 
         connection = get_connection()
         pool = media_wrapper.media_pool(connection)

--- a/src/resolve_mcp/audio/acquire.py
+++ b/src/resolve_mcp/audio/acquire.py
@@ -42,7 +42,8 @@ from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, band, start_job
 from ..logging_config import get_logger
 from ..naming import keyed_name
-from ..resolve import media, render
+from ..resolve import pool as mediapool
+from ..resolve import render
 from ..resolve.connection import ResolveConnection
 from ..resolve.session import current_project
 from ..resolve.timeline import Reader, current_timeline, find_timeline, fingerprint, read_frames
@@ -490,20 +491,20 @@ def _locate_clip(
     connection: ResolveConnection,
     clip: str,
     bin: str | None,  # noqa: A002 - "bin" is the Resolve term the agent uses
-) -> tuple[media.LocatedClip, str]:
+) -> tuple[mediapool.LocatedClip, str]:
     """Find the clip and prove its audio is readable off its own file, or refuse."""
-    pool = media.media_pool(connection)
-    located = media.find_clip(pool, clip, bin)
-    reported = media.properties(located.clip)
-    source = reported.get(media.FILE_PATH, "")
-    if not source or media.is_offline(source):
+    pool = mediapool.media_pool(connection)
+    located = mediapool.find_clip(pool, clip, bin)
+    reported = mediapool.properties(located.clip)
+    source = reported.get(mediapool.FILE_PATH, "")
+    if not source or mediapool.is_offline(source):
         raise AudioExtractionError(
             cause=f"{clip!r} has no readable file on disk.",
             fix="relink_media points a clip back at its media; list_media shows what is offline.",
             detail={"clip": clip, "file_path": source},
         )
 
-    conflict = mapping_conflict(media.audio_mapping(located.clip), source)
+    conflict = mapping_conflict(mediapool.audio_mapping(located.clip), source)
     if conflict is not None:
         raise AudioMappingError(
             cause=f"{clip!r} does not carry its own audio: {conflict}",

--- a/src/resolve_mcp/resolve/apply.py
+++ b/src/resolve_mcp/resolve/apply.py
@@ -42,7 +42,8 @@ from ..timing import dual_time
 from ..titles.assets import Asset
 from ..titles.schema import TRACK_NAME
 from ..titles.validate import Event
-from . import fusion, media
+from . import fusion
+from . import pool as mediapool
 from . import timeline as timeline_read
 from . import titles as titles_read
 from .connection import ResolveConnection
@@ -118,7 +119,7 @@ def apply_titles(connection: ResolveConnection, titles_file: str) -> dict[str, A
     # No error means the document parsed, matched the schema and resolved against the
     # project — every reading below is one the rules have already been over.
     project, timeline = checked.project, checked.timeline
-    pool = media.media_pool(connection)
+    pool = mediapool.media_pool(connection)
 
     track = _own_track(timeline, timeline_read.name_of(timeline))
     # The switch comes first: ``GetIsTrackLocked`` answers ``False`` for every track of a
@@ -314,7 +315,7 @@ def _import_cards(
     pool: Pool,
     cards: dict[str, Asset],
     track: OwnedTrack,
-) -> dict[str, media.LocatedClip]:
+) -> dict[str, mediapool.LocatedClip]:
     """Every PNG card in the pool exactly once, with its duration unlocked.
 
     Deduplicated by the bin and the card's first frame: two events sharing one card share
@@ -323,8 +324,8 @@ def _import_cards(
     apply that imported afresh every time would grow the media pool by a copy of every
     card on every run, and the pool is the operator's, not this tool's.
     """
-    located: dict[str, media.LocatedClip] = {}
-    already: dict[tuple[str, str], media.LocatedClip] = {}
+    located: dict[str, mediapool.LocatedClip] = {}
+    already: dict[tuple[str, str], mediapool.LocatedClip] = {}
     for event_id, card in cards.items():
         key = (card.bin_path, card.first_frame())
         if key not in already:
@@ -335,12 +336,12 @@ def _import_cards(
     return located
 
 
-def _card_clip(pool: Pool, card: Asset, track: OwnedTrack) -> media.LocatedClip:
+def _card_clip(pool: Pool, card: Asset, track: OwnedTrack) -> mediapool.LocatedClip:
     """The pool clip for one card: the one already there, or a fresh import of it."""
-    target = media.ensure_bin(pool, card.bin_path)
-    standing = media.clip_at_path(pool, target.path, card.first_frame())
+    target = mediapool.ensure_bin(pool, card.bin_path)
+    standing = mediapool.clip_at_path(pool, target.path, card.first_frame())
     if standing is None:
-        imported = media.import_into(pool, [card.request()], target)
+        imported = mediapool.import_into(pool, [card.request()], target)
         if not imported:
             raise TitlesApplyFailedError(
                 cause=f"Resolve imported nothing for the card {card.declared!r} of "
@@ -350,7 +351,7 @@ def _card_clip(pool: Pool, card: Asset, track: OwnedTrack) -> media.LocatedClip:
                 "that the sequence is numbered without gaps, then apply again.",
                 detail=track.detail(id=card.event, asset=card.declared, bin=target.path),
             )
-        standing = media.LocatedClip(target.path, imported[0])
+        standing = mediapool.LocatedClip(target.path, imported[0])
         log.info("Imported the card %s into %r", card.declared, target.path or "the root")
     # The out point is written on every apply, not only on the import: a card put into the
     # pool by hand has never had one, and without it Resolve ignores ``endFrame`` outright
@@ -361,15 +362,15 @@ def _card_clip(pool: Pool, card: Asset, track: OwnedTrack) -> media.LocatedClip:
     # is what an HTML export writes — the ramps composite correctly untouched. The property
     # is settable if that ever stops being true; writing it now would only be a chance to
     # premultiply a card that was not.
-    media.apply_still_workaround(standing.clip, media.properties(standing.clip))
+    mediapool.apply_still_workaround(standing.clip, mediapool.properties(standing.clip))
     return standing
 
 
 def _place(
     pool: Pool,
     events: list[Event],
-    templates: dict[str, media.LocatedClip],
-    cards: dict[str, media.LocatedClip],
+    templates: dict[str, mediapool.LocatedClip],
+    cards: dict[str, mediapool.LocatedClip],
     track: OwnedTrack,
 ) -> None:
     """One call for the whole file, both routes in it. Its return value is counted,

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -60,7 +60,8 @@ from ..cut.validate import (
 from ..errors import BuildFailedError, CutInvalidError, TimelineNotFoundError
 from ..logging_config import get_logger
 from ..naming import latest_version, next_version_name, version_name
-from . import cut, markers, media, mix, takes
+from . import cut, markers, mix, takes
+from . import pool as mediapool
 from . import tail as tail_route
 from . import timeline as timeline_read
 from .connection import ResolveConnection
@@ -186,7 +187,7 @@ def build_timeline(
     doc: dict[str, Any] = checked.loaded.doc
 
     project = timeline_read.open_project(connection)
-    pool = media.media_pool(connection)
+    pool = mediapool.media_pool(connection)
     base = str(doc["timeline"]["name"])
     existing = timeline_read.timeline_names(project)
     # Read before the build, because creating the new version is what makes it the latest:
@@ -434,7 +435,7 @@ def _write_entry(marker: dict[str, Any], shift: int) -> dict[str, Any]:
 
 def _shots(
     doc: dict[str, Any],
-    clips: dict[str, media.LocatedClip],
+    clips: dict[str, mediapool.LocatedClip],
     start: int,
     stills: Stills,
 ) -> list[Shot]:
@@ -498,7 +499,7 @@ def _shots(
 def _shot(
     id: str,
     track: Track,
-    located: media.LocatedClip,
+    located: mediapool.LocatedClip,
     source_in: int,
     record: int,
     duration: int,
@@ -516,14 +517,14 @@ def _shot(
     )
 
 
-def _clip_name(located: media.LocatedClip) -> str:
+def _clip_name(located: mediapool.LocatedClip) -> str:
     """What to call the clip in a failure — read once, since a dead handle answers nothing."""
     return str(located.clip.GetName() or "")
 
 
 def _selectors(
     doc: dict[str, Any],
-    clips: dict[str, media.LocatedClip],
+    clips: dict[str, mediapool.LocatedClip],
     shots: list[Shot],
     shift: int = 0,
 ) -> list[takes.Selector]:
@@ -550,7 +551,7 @@ def _selectors(
     return found
 
 
-def _take(alternate: dict[str, Any], clips: dict[str, media.LocatedClip]) -> takes.Take:
+def _take(alternate: dict[str, Any], clips: dict[str, mediapool.LocatedClip]) -> takes.Take:
     source = str(alternate["source"])
     located = clips[source]
     return takes.Take(
@@ -661,7 +662,7 @@ def _handle(clip: Clip) -> int:
     return id(clip)
 
 
-def _prepare_sources(clips: dict[str, media.LocatedClip]) -> Stills:
+def _prepare_sources(clips: dict[str, mediapool.LocatedClip]) -> Stills:
     """Get every source clip ready to be appended, and answer with the stills among them.
 
     One pass, because each clip's properties are a round trip to Resolve and there is
@@ -684,18 +685,18 @@ def _prepare_sources(clips: dict[str, media.LocatedClip]) -> Stills:
         if _handle(located.clip) in seen:
             continue
         seen.add(_handle(located.clip))
-        reported = media.properties(located.clip)
-        start, _ = media.frame_bounds(reported)
+        reported = mediapool.properties(located.clip)
+        start, _ = mediapool.frame_bounds(reported)
         if start:
             log.info(
                 "%s counts its own frames from %d, not 0; source frames are read back per shot",
                 located.clip.GetName(),
                 start,
             )
-        if not media.is_still(reported):
+        if not mediapool.is_still(reported):
             continue
         stills.add(_handle(located.clip))
-        if media.apply_still_workaround(located.clip, reported):
+        if mediapool.apply_still_workaround(located.clip, reported):
             log.info("Unlocked exact durations on the still %s", located.clip.GetName())
     return frozenset(stills)
 

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -33,7 +33,7 @@ from ..document import LoadedDocument
 from ..findings import Finding, severity_of
 from ..logging_config import get_logger
 from ..timing import dual_time
-from . import media
+from . import pool as mediapool
 from .connection import ResolveConnection
 
 log = get_logger("cut")
@@ -71,7 +71,7 @@ class Source(NamedTuple):
     """
 
     facts: ClipFacts
-    located: media.LocatedClip
+    located: mediapool.LocatedClip
 
 
 class Preflight(NamedTuple):
@@ -127,7 +127,7 @@ def validate_cut(
     return _report(preflight(connection, cut_file, min_segment_frames))
 
 
-def clips_by_alias(checked: Preflight) -> dict[str, media.LocatedClip]:
+def clips_by_alias(checked: Preflight) -> dict[str, mediapool.LocatedClip]:
     """Alias -> the pool clip the rules resolved it to, ready to append.
 
     The alias is resolved by the same E4 rule the dry run uses, and the clip that comes
@@ -139,37 +139,37 @@ def clips_by_alias(checked: Preflight) -> dict[str, media.LocatedClip]:
     return {alias: handles[id(facts)] for alias, facts in resolved.items()}
 
 
-def _located(connection: ResolveConnection, doc: dict[str, Any]) -> list[media.LocatedClip]:
+def _located(connection: ResolveConnection, doc: dict[str, Any]) -> list[mediapool.LocatedClip]:
     """The pool clips this cut names, and nothing else.
 
     Only the aliased names are looked up: a concert pool holds thousands of clips, and a
     cut references a handful, so properties are read for the handful.
     """
-    pool = media.media_pool(connection)
+    pool = mediapool.media_pool(connection)
     wanted = {str(source["clip"]) for source in doc["sources"].values()}
-    located = media.clips_named(pool, wanted)
+    located = mediapool.clips_named(pool, wanted)
     log.info("Cut validation resolved %d of %d aliased clip names", len(located), len(wanted))
     return located
 
 
 def _facts(bin_path: str, clip: Clip, timeline_fps: float) -> ClipFacts:
     name = str(clip.GetName() or "")
-    reported = media.properties(clip)
+    reported = mediapool.properties(clip)
     # The timeline's rate is what the Duration fallback counts at: an audio-only clip
     # reports no Start/End/Frames and no rate of its own (#46), only a Duration timecode.
-    start, out = media.frame_bounds(reported, fps=timeline_fps)
+    start, out = mediapool.frame_bounds(reported, fps=timeline_fps)
     if start is None or out is None:
         # The condition W9 reports to the agent, said once here as well: the warning rides
         # in a result the agent may or may not read back, and a build that went wrong over a
         # range nothing checked is diagnosed from the log or not at all (#186).
         log.info("No usable media bounds on %s (%s-%s); E5 and E7 cannot check a range "
                  "against them", name, start, out)
-    channels = media.audio_channels(reported)
+    channels = mediapool.audio_channels(reported)
     if channels is None:
         # E7's has-audio leg reads an undocumented property key. If Resolve renames it
         # the rule silently passes everything, and no fake can catch that — so say so
         # here, where a live session's log is the only place it can be noticed.
-        log.info("No usable %r on %s; E7 cannot check for audio", media.AUDIO_CHANNELS, name)
+        log.info("No usable %r on %s; E7 cannot check for audio", mediapool.AUDIO_CHANNELS, name)
     return ClipFacts(
         name=name,
         bin_path=bin_path,
@@ -178,11 +178,11 @@ def _facts(bin_path: str, clip: Clip, timeline_fps: float) -> ClipFacts:
         # (the same fail-open stance has_audio takes below).
         start=start,
         end_exclusive=out,
-        fps=media.frame_rate(reported),
+        fps=mediapool.frame_rate(reported),
         # An unreported channel count must not fail a cut that is fine: E7 blocks the
         # build, and "Resolve did not say" is not evidence of silence.
         has_audio=channels is None or channels > 0,
-        is_still=media.is_still(reported),
+        is_still=mediapool.is_still(reported),
     )
 
 

--- a/src/resolve_mcp/resolve/interchange.py
+++ b/src/resolve_mcp/resolve/interchange.py
@@ -53,7 +53,7 @@ from ..errors import (
 from ..logging_config import get_logger
 from ..naming import write_target
 from .connection import ResolveConnection
-from .media import pool_of
+from .pool import pool_of
 from .timeline import (
     Reader,
     current_name,

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -1,16 +1,11 @@
-"""Media pool wrappers: import, list, inspect, metadata, bins, relink.
+"""The six media operations: import, list, inspect, metadata, organize, relink.
 
-Thin, testable, and MCP-free like the rest of this layer. Five things here are decisions
-rather than API calls, and are the reason this file exists at all:
+Thin, testable, and MCP-free like the rest of this layer — one function per media tool,
+each of them a caller of the pool adapter in :mod:`.pool`, which owns bin addressing, clip
+lookup and clip reading. Nothing outside this module should import a pool name *through*
+here; import it from :mod:`.pool` directly. Three things here are decisions rather than API
+calls, and are the reason this file exists at all:
 
-* **Bin paths are slash-separated from the media pool root** (``"Concert/Angles"``), the
-  root's own name optional as a first segment. Resolve's API has no bin path — only
-  ``GetSubFolderList()`` walks — and "current folder" state that every import depends on.
-* **Offline means the media is gone**, not that Resolve says so: there is no offline flag in
-  the scripting API. A clip is offline when nothing on disk stands behind its ``File Path``
-  — the path itself for ordinary media, the first frame for a sequence, whose path is only
-  a label (``shot_[0001-0024].png``, #85). A clip with no path at all (multicam, compound)
-  is not offline, it is pathless.
 * **Metadata fields route by what the clip itself reports.** The clip property key names are
   undocumented, so nothing is hard-coded: each clip is enumerated once with
   ``GetClipProperty()`` and a field whose key is in that dict is written as a clip property,
@@ -35,10 +30,6 @@ rather than API calls, and are the reason this file exists at all:
 
 from __future__ import annotations
 
-import json
-import re
-from collections import Counter
-from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -50,21 +41,39 @@ from ..errors import (
     ImportFailedError,
     InvalidRequestError,
     MediaOperationError,
-    MediaPoolUnavailableError,
-    NoProjectOpenError,
     RelinkFailedError,
 )
 from ..logging_config import get_logger
 from ..spill import spill
-from ..timing import dual_time, frames_from_timecode
+from ..timing import dual_time
 from .camera_sidecar import camera_model as recorded_camera_model
 from .connection import ResolveConnection
+from .pool import (
+    BIN_SEPARATOR,
+    FILE_PATH,
+    Clip,
+    LocatedBin,
+    Pool,
+    apply_still_workaround,
+    audio_mapping,
+    clips_under,
+    ensure_bin,
+    find_bin,
+    find_clip,
+    frame_bounds,
+    frame_count,
+    frame_rate,
+    import_into,
+    is_offline,
+    looks_like_image,
+    media_pool,
+    properties,
+    summarise,
+)
 
 log = get_logger("media")
 
-BIN_SEPARATOR = "/"
 DEFAULT_LIST_LIMIT = 200
-IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"})
 AUDIO_SUFFIXES = frozenset({".aac", ".aif", ".aiff", ".flac", ".m4a", ".mp3", ".ogg", ".wav"})
 GRAPHIC_SUFFIXES = frozenset({".ai", ".eps", ".psd", ".svg"})
 FOOTAGE_BIN = "02_Footage"
@@ -75,248 +84,9 @@ ASSETS_BIN = "04_Assets"
 # lives in "Camera TC Type" ("ILME-FX6V") while "Camera Type" holds the manufacturer
 # ("Sony"), so the model key must win or every camera bins as its make. Media that reports
 # no camera key at all — A7-series MP4 on an M4ROOT card — gets a second look in the
-# sidecar beside the clip (see :mod:`.sidecar`); only a camera unreadable both ways falls
-# back to the bare footage bin rather than guessing.
+# sidecar beside the clip (see :mod:`.camera_sidecar`); only a camera unreadable both ways
+# falls back to the bare footage bin rather than guessing.
 CAMERA_KEYS = ("Camera TC Type", "Camera Type")
-SEQUENCE_TOKEN = "%"
-# Resolve paths an imported image sequence by folding the index range into the name —
-# shot_[0001-0024].png — a label, not a file (#85, Resolve Studio 21.0.3.7).
-SEQUENCE_RANGE = re.compile(r"\[(\d+)-\d+\]")
-
-FILE_PATH = "File Path"
-DURATION = "Duration"
-FRAMES = "Frames"
-FPS = "FPS"
-START = "Start"
-END = "End"
-OUT = "Out"
-TYPE = "Type"
-RESOLUTION = "Resolution"
-AUDIO_CHANNELS = "Audio Ch"
-
-Clip = Any
-Folder = Any
-Pool = Any
-Project = Any
-
-
-class LocatedClip(NamedTuple):
-    """A clip and the bin it was found in — the pair every lookup hands back."""
-
-    bin_path: str
-    clip: Clip
-
-
-class LocatedBin(NamedTuple):
-    """A bin, the path walked to reach it, and whether that walk had to create it.
-
-    The path travels with the folder because it cannot be recovered from one: Resolve
-    hands out a fresh proxy object per call, so a folder cannot be recognised by identity
-    on a later walk, and the API has no path getter.
-    """
-
-    path: str
-    folder: Folder
-    created: bool
-
-
-# --- reaching the pool ------------------------------------------------------------------
-
-
-def media_pool(connection: ResolveConnection) -> Pool:
-    """The open project's media pool. Raises rather than returning a useless ``None``."""
-    manager = connection.handle().GetProjectManager()
-    project = manager.GetCurrentProject() if manager is not None else None
-    if project is None:
-        raise NoProjectOpenError(cause="No project is open, so there is no media pool to work in.")
-    return pool_of(project)
-
-
-def pool_of(project: Project) -> Pool:
-    """The pool of a project already in hand — the same walk, without repeating it.
-
-    A caller that has the project must not reach for it a second time: two walks are two
-    chances to land on different projects if the GUI switches between them, and the pool
-    would then not belong to the project the rest of the call is reading.
-    """
-    pool = project.GetMediaPool()
-    if pool is None:
-        raise MediaPoolUnavailableError(
-            cause=f"Resolve returned no media pool for the open project {project.GetName()!r}.",
-        )
-    return pool
-
-
-# --- bins -------------------------------------------------------------------------------
-
-
-def _segments(path: str | None, root: Folder) -> list[str]:
-    """Split a bin path into folder names, dropping a leading root name if it is one.
-
-    Resolve calls the root "Master" and the agent may write it or not. A real bin called
-    Master would otherwise become unaddressable, so the leading name is only treated as the
-    root when the root has no child by that name.
-    """
-    parts = [part.strip() for part in (path or "").split(BIN_SEPARATOR)]
-    parts = [part for part in parts if part]
-    root_name = str(root.GetName() or "")
-    if parts and root_name and parts[0] == root_name:
-        children = {str(sub.GetName() or "") for sub in _subfolders(root)}
-        if root_name not in children:
-            parts = parts[1:]
-    return parts
-
-
-def _root(pool: Pool) -> Folder:
-    root = pool.GetRootFolder()
-    if root is None:
-        raise MediaPoolUnavailableError(cause="Resolve returned no media pool root folder.")
-    return root
-
-
-def _subfolders(folder: Folder) -> list[Folder]:
-    return list(folder.GetSubFolderList() or [])
-
-
-def bin_paths(pool: Pool) -> list[str]:
-    """Every bin path in the pool, root excluded — what to offer when one is missing."""
-    found: list[str] = []
-    for path, _folder in _walk_bins(_root(pool)):
-        if path:
-            found.append(path)
-    return found
-
-
-def _walk_bins(folder: Folder, prefix: str = "") -> Iterator[tuple[str, Folder]]:
-    yield prefix, folder
-    for sub in _subfolders(folder):
-        name = str(sub.GetName() or "")
-        yield from _walk_bins(sub, f"{prefix}{BIN_SEPARATOR}{name}" if prefix else name)
-
-
-def find_bin(pool: Pool, path: str | None) -> LocatedBin:
-    """The bin at ``path``. ``None`` or ``""`` is the root."""
-    root = _root(pool)
-    folder = root
-    walked: list[str] = []
-    for segment in _segments(path, root):
-        matches = [sub for sub in _subfolders(folder) if str(sub.GetName() or "") == segment]
-        if not matches:
-            raise BinNotFoundError(str(path), bin_paths(pool))
-        folder = matches[0]
-        walked.append(segment)
-    return LocatedBin(BIN_SEPARATOR.join(walked), folder, created=False)
-
-
-def ensure_bin(pool: Pool, path: str | None) -> LocatedBin:
-    """The bin at ``path``, creating it and any missing parents."""
-    root = _root(pool)
-    folder = root
-    walked: list[str] = []
-    created = False
-    for segment in _segments(path, root):
-        matches = [sub for sub in _subfolders(folder) if str(sub.GetName() or "") == segment]
-        if matches:
-            folder = matches[0]
-        else:
-            made = pool.AddSubFolder(folder, segment)
-            if made is None:
-                raise MediaOperationError(cause=f"Resolve refused to create the bin {segment!r}.")
-            log.info("Created bin %s", segment)
-            folder = made
-            created = True
-        walked.append(segment)
-    return LocatedBin(BIN_SEPARATOR.join(walked), folder, created)
-
-
-# --- clips ------------------------------------------------------------------------------
-
-
-def _clips_under(where: LocatedBin, recursive: bool) -> Iterator[LocatedClip]:
-    base = where.path
-    if not recursive:
-        for clip in where.folder.GetClipList() or []:
-            yield LocatedClip(base, clip)
-        return
-    for suffix, sub in _walk_bins(where.folder):
-        path = f"{base}{BIN_SEPARATOR}{suffix}" if base and suffix else (base or suffix)
-        for clip in sub.GetClipList() or []:
-            yield LocatedClip(path, clip)
-
-
-def _searched_label(bin_path: str | None, where: LocatedBin, deep: bool) -> str:
-    """What a clip_not_found says it looked in — the caller's own words for a named bin.
-
-    A shallow search says ``alone`` so the refusal points at the flag: the clip may well
-    be one folder down, and dropping ``recursive`` is then the fix, not renaming anything.
-    """
-    if not where.path:
-        return "the media pool" if bin_path is None and deep else "the media pool root"
-    return f"the bin {bin_path!r}" if deep else f"the bin {bin_path!r} alone"
-
-
-def _addressing(bins: list[str]) -> tuple[list[str], list[str]]:
-    """Which bins holding a duplicated name reach one clip: passed alone, then passed shallow.
-
-    One entry per matching clip comes in, so a repeat means one bin holds two of the name —
-    no lookup singles those out, and neither list offers them. A bin whose subfolder holds
-    another copy has no address of its own either, because a named bin is searched right
-    through; it does hold exactly one clip itself, so ``recursive=False`` reaches that one
-    (#134). The root is never shadowed: ``""`` is the root folder alone (#122).
-    """
-    counted = Counter(bins)
-    alone = {path for path, times in counted.items() if times == 1}
-    shadowed = {
-        path
-        for path in alone
-        if path and any(other.startswith(f"{path}{BIN_SEPARATOR}") for other in bins)
-    }
-    return sorted(alone - shadowed), sorted(shadowed)
-
-
-def find_clip(
-    pool: Pool,
-    name: str,
-    bin_path: str | None = None,
-    recursive: bool | None = None,
-) -> LocatedClip:
-    """One clip by exact name.
-
-    ``None`` searches the whole pool. A named bin searches that bin and everything nested
-    inside it. ``""`` — or the root's own name — is the root folder *alone*, not the pool:
-    naming the root recursively would be the whole-pool search again, which left a root
-    clip whose name a bin also used with no expressible address at all (#122). The empty
-    string is what :func:`summarise` reports for a root clip, so the ``bin`` value a
-    listing gives back always reads the clip it described.
-
-    ``recursive=False`` stops the search descending, so the clips a bin holds *itself* are
-    all that is looked at — the address of a copy shadowed by another of the name filed
-    deeper (#134). With no bin it narrows to the root, the way :func:`list_media` does;
-    ``bin=""`` and the root's own name are already that search, so they are unaffected.
-
-    ``recursive=None`` is a caller with no such flag of its own to pass on — the video and
-    analysis tools, which resolve a clip by name but take no ``recursive``. It searches
-    deep like ``True``, and an ambiguity is not offered the shallow form, because a fix
-    naming an argument its caller cannot accept is the #122 defect one axis over.
-    """
-    where = find_bin(pool, bin_path)
-    the_root_itself = bin_path is not None and not where.path
-    deep = recursive is not False and not the_root_itself
-    searched = list(_clips_under(where, deep))
-    matches = [found for found in searched if str(found.clip.GetName() or "") == name]
-    if not matches:
-        available = sorted({str(found.clip.GetName() or "") for found in searched})
-        raise ClipNotFoundError(name, _searched_label(bin_path, where, deep), available)
-    if len(matches) > 1:
-        found_in = [found.bin_path for found in matches]
-        deep_address, shallow_address = _addressing(found_in)
-        raise AmbiguousClipError(
-            name,
-            found_in,
-            deep_address,
-            shallow_address if recursive is not None else [],
-        )
-    return matches[0]
 
 
 def _wants_recursion(item: dict[str, Any]) -> bool:
@@ -333,185 +103,6 @@ def _wants_recursion(item: dict[str, Any]) -> bool:
             fix='Pass a JSON boolean: "recursive": false to search the named bin alone.',
         )
     return wanted
-
-
-def clip_at_path(pool: Pool, bin_path: str, file_path: str) -> LocatedClip | None:
-    """The clip in ``bin_path`` that already stands for ``file_path``, if one does.
-
-    Identity is the first frame on disk rather than the reported path or the clip name,
-    because Resolve renames and re-paths an imported sequence into a folded label
-    (:func:`first_frame_of`). ``None`` — rather than a raise — because "not imported yet"
-    is the ordinary answer on a first run, not a failure.
-    """
-    wanted = Path(first_frame_of(file_path))
-    for found in _clips_under(find_bin(pool, bin_path), recursive=True):
-        standing = properties(found.clip).get(FILE_PATH, "")
-        if standing and Path(first_frame_of(standing)) == wanted:
-            return found
-    return None
-
-
-def clips_named(pool: Pool, names: Iterable[str]) -> list[LocatedClip]:
-    """Every clip anywhere in the pool whose name is one of ``names``.
-
-    Unlike :func:`find_clip` this reports the duplicates instead of raising on them: a
-    validation pass has to name every ambiguity at once, not stop at the first.
-    """
-    wanted = set(names)
-    return [
-        found
-        for found in _clips_under(find_bin(pool, None), recursive=True)
-        if str(found.clip.GetName() or "") in wanted
-    ]
-
-
-_logged_property_keys = False
-
-
-def properties(clip: Clip) -> dict[str, str]:
-    """Every clip property Resolve reports, enumerated — key names are never hard-coded.
-
-    The key names are undocumented, so the first enumeration of a session is logged: when a
-    reading comes back empty on a live machine, that line is what says whether the key was
-    renamed or the value really was blank.
-    """
-    reported = clip.GetClipProperty()
-    if not isinstance(reported, dict):
-        return {}
-    global _logged_property_keys
-    if not _logged_property_keys:
-        log.info("Clip properties Resolve reports: %s", sorted(str(key) for key in reported))
-        _logged_property_keys = True
-    return {str(key): "" if value is None else str(value) for key, value in reported.items()}
-
-
-def _number(reported: dict[str, str], key: str) -> int | None:
-    try:
-        return int(float(reported.get(key, "")))
-    except (TypeError, ValueError):
-        return None
-
-
-def frame_rate(reported: dict[str, str]) -> float | None:
-    """The clip's frame rate, or ``None`` when Resolve does not report one (audio, stills)."""
-    try:
-        return float(reported.get(FPS, ""))
-    except (TypeError, ValueError):
-        return None
-
-
-def frame_bounds(
-    reported: dict[str, str], fps: float | None = None
-) -> tuple[int | None, int | None]:
-    """Media bounds as half-open ``[start, out)``.
-
-    Resolve reports ``End`` as the last frame; every range in this server is half-open, so
-    the out point is that frame plus one. Frame count is the fallback when ``End`` is
-    missing. The rule lives here so bounds mean the same thing to a listing and to a cut.
-
-    Audio-only clips report ``Start``, ``End`` and ``Frames`` as empty strings (#46,
-    live-verified): only ``Duration`` carries the length, as timecode. So whenever the
-    out point is unreadable and ``Duration`` parses, the duration stands in — bounds are
-    ``[start, start + duration)`` with an unreported start read as 0 — counted at the
-    clip's own rate or, since audio reports no rate either, at the caller's ``fps`` (the
-    timeline's, for a cut). With no rate at all, or no parseable ``Duration``, the
-    unknowns stay ``None`` — unknown, never invented.
-    """
-    start = _number(reported, START)
-    end = _number(reported, END)
-    frames = _number(reported, FRAMES)
-    out = end + 1 if end is not None else (start + frames if start is not None and frames else None)
-    if out is None:
-        rate = frame_rate(reported) or fps
-        duration = frames_from_timecode(reported.get(DURATION, ""), rate) if rate else None
-        if duration is not None:
-            begin = start if start is not None else 0
-            log.debug(
-                "End/Frames unreported; bounds %d-%d read from %s %r at %s fps",
-                begin,
-                begin + duration,
-                DURATION,
-                reported.get(DURATION),
-                rate,
-            )
-            return begin, begin + duration
-        # The case a live session most needs to see: nothing reported and nothing to
-        # derive from, so every bounds-based check downstream silently fails open.
-        log.debug(
-            "End/Frames unreported and %s %r cannot stand in (rate %s); bounds unknown",
-            DURATION,
-            reported.get(DURATION),
-            rate,
-        )
-    return start, out
-
-
-def audio_channels(reported: dict[str, str]) -> int | None:
-    """How many audio channels the clip carries, or ``None`` when Resolve does not say."""
-    return _number(reported, AUDIO_CHANNELS)
-
-
-def is_still(reported: dict[str, str]) -> bool:
-    """Whether the clip is an image rather than moving footage.
-
-    Judged by file suffix: the ``Type`` property does not separate a still from a
-    sequence, and the suffix is what the still-duration workaround already keys off.
-    """
-    return _looks_like_image(reported.get(FILE_PATH, ""))
-
-
-def first_frame_of(file_path: str) -> str:
-    """The one file a clip's path really stands for, sequence labels unfolded.
-
-    Resolve reports an imported sequence as ``shot_[0001-0024].png`` (#85) — a label, not
-    a path — so the first frame is the only form of a sequence's address that is a real
-    file both before the import (where the caller has a ``%0Nd`` pattern) and after it.
-    That makes it the identity a re-run can recognise an already-imported card by.
-    Anything that is not a folded range comes back unchanged.
-    """
-    folded = SEQUENCE_RANGE.search(Path(file_path).name)
-    if folded is None:
-        return file_path
-    path = Path(file_path)
-    return str(path.with_name(SEQUENCE_RANGE.sub(folded.group(1), path.name, count=1)))
-
-
-def is_offline(file_path: str) -> bool:
-    """Whether the media behind a clip has moved away.
-
-    Resolve exposes no offline flag, so this is a disk check. A clip with no path at all
-    (multicam, compound) is pathless rather than offline. Sequence paths are never files on
-    disk, so they get judged by what stands behind them: a ``%0Nd`` pattern by its folder
-    (the range is unknown), a bracketed range — the form Resolve reports for an imported
-    sequence (#85) — by its first frame, which the range makes constructible.
-    """
-    if not file_path:
-        return False
-    path = Path(file_path)
-    if path.exists():
-        return False
-    if SEQUENCE_TOKEN in path.name:
-        return not path.parent.exists()
-    first = first_frame_of(file_path)
-    if first != file_path:
-        return not Path(first).exists()
-    return True
-
-
-def summarise(bin_path: str, clip: Clip, reported: dict[str, str] | None = None) -> dict[str, Any]:
-    """The one-line view of a clip that list and import both return."""
-    reported = reported if reported is not None else properties(clip)
-    file_path = reported.get(FILE_PATH, "")
-    return {
-        "name": str(clip.GetName() or ""),
-        "bin": bin_path,
-        "file_path": file_path,
-        "type": reported.get(TYPE, ""),
-        "frames": _number(reported, FRAMES),
-        "fps": frame_rate(reported),
-        "resolution": reported.get(RESOLUTION, ""),
-        "offline": is_offline(file_path),
-    }
 
 
 # --- import -----------------------------------------------------------------------------
@@ -551,45 +142,6 @@ def _requested_path(item: str | dict[str, Any]) -> str:
     return str(item["FilePath"]) if isinstance(item, dict) else str(item)
 
 
-def _looks_like_image(file_path: str) -> bool:
-    return Path(file_path).suffix.lower() in IMAGE_SUFFIXES
-
-
-def apply_still_workaround(clip: Clip, reported: dict[str, str]) -> bool:
-    """Write the out point once, so later ``endFrame`` values are honoured exactly.
-
-    Resolve ignores ``endFrame`` when appending a freshly imported still — every append
-    lands at the default still duration — until any out point has been written to the clip.
-    The value does not matter, only that the write happened.
-    """
-    if not is_still(reported):
-        return False
-    end = _number(reported, END)
-    if end is None:
-        frames = _number(reported, FRAMES)
-        end = max((frames or 1) - 1, 0)
-    if not clip.SetClipProperty(OUT, str(end)):
-        log.warning("Still-duration workaround refused on %s", clip.GetName())
-        return False
-    return True
-
-
-def import_into(pool: Pool, items: list[str | dict[str, Any]], target: LocatedBin) -> list[Clip]:
-    """``ImportMedia`` into one bin, and leave the pool where it was found.
-
-    Imports land in the media pool's *current* folder, so the current folder is moved for
-    the call and put back afterwards — a tool must not leave the GUI somewhere else. Every
-    route that imports goes through here so no route can forget the second half.
-    """
-    previous = pool.GetCurrentFolder()
-    pool.SetCurrentFolder(target.folder)
-    try:
-        return list(pool.ImportMedia(items) or [])
-    finally:
-        if previous is not None:
-            pool.SetCurrentFolder(previous)
-
-
 def import_media(
     connection: ResolveConnection,
     paths: list[str] | None = None,
@@ -599,7 +151,7 @@ def import_media(
     """Import media into ``bin_path``, creating the bin if needed.
 
     With no ``bin_path`` at all, every item gets a bin suggested by media type — the
-    module docstring's fifth decision (#57). An explicit bin, the root included, bypasses
+    module docstring's third decision (#57). An explicit bin, the root included, bypasses
     suggestion entirely.
     """
     pool = media_pool(connection)
@@ -652,13 +204,13 @@ def _import_suggested(pool: Pool, items: list[str | dict[str, Any]]) -> dict[str
 def _suggested_bin(item: str | dict[str, Any]) -> str:
     """Which #57 category an import request belongs to, judged before the import.
 
-    Suffix, not the ``Type`` property, for the same reason as :func:`is_still`: Resolve
+    Suffix, not the ``Type`` property, for the same reason as ``pool.is_still``: Resolve
     types a sequence and a movie both ``Video``. A sequence request (a dict) is image
     frames by construction.
     """
     if isinstance(item, dict):
         return ASSETS_BIN
-    if _looks_like_image(item):
+    if looks_like_image(item):
         return ASSETS_BIN
     suffix = Path(item).suffix.lower()
     if suffix in GRAPHIC_SUFFIXES:
@@ -810,7 +362,7 @@ def list_media(
     needle = (name_contains or "").lower()
 
     clips: list[dict[str, Any]] = []
-    for found in _clips_under(where, recursive):
+    for found in clips_under(where, recursive):
         summary = summarise(found.bin_path, found.clip)
         if needle and needle not in summary["name"].lower():
             continue
@@ -860,25 +412,6 @@ def _markers(clip: Clip) -> list[dict[str, Any]]:
     return sorted(markers, key=lambda marker: marker["frame"])
 
 
-def audio_mapping(clip: Clip) -> dict[str, Any] | None:
-    """``GetAudioMapping`` returns a JSON *string* — or nothing, on clips without audio."""
-    try:
-        reported = clip.GetAudioMapping()
-    except Exception:  # noqa: BLE001 - an unmapped clip is not a failed inspection
-        log.debug("Could not read the audio mapping", exc_info=True)
-        return None
-    if not reported:
-        return None
-    if isinstance(reported, dict):
-        return reported
-    try:
-        parsed = json.loads(str(reported))
-    except (TypeError, ValueError):
-        log.warning("Unparseable audio mapping: %r", reported)
-        return None
-    return parsed if isinstance(parsed, dict) else None
-
-
 def _bounds(clip: Clip, reported: dict[str, str]) -> dict[str, Any]:
     """Media bounds half-open ``[in, out)``, plus whatever mark in/out is set.
 
@@ -891,9 +424,7 @@ def _bounds(clip: Clip, reported: dict[str, str]) -> dict[str, Any]:
     # timeline to borrow a rate from, so its bounds stay unknown while a cut, which does,
     # can still derive them.
     start, out = frame_bounds(reported, fps=fps)
-    duration = (
-        out - start if out is not None and start is not None else _number(reported, FRAMES)
-    )
+    duration = out - start if out is not None and start is not None else frame_count(reported)
 
     marks: dict[str, Any] = {}
     try:

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -51,9 +51,7 @@ from .connection import ResolveConnection
 from .pool import (
     BIN_SEPARATOR,
     FILE_PATH,
-    Clip,
     LocatedBin,
-    Pool,
     apply_still_workaround,
     audio_mapping,
     clips_under,
@@ -72,6 +70,11 @@ from .pool import (
 )
 
 log = get_logger("media")
+
+# Declared here rather than imported from :mod:`.pool`, the way every other module in this
+# package declares them: they are untyped scripting-API handles, not a shared type.
+Clip = Any
+Pool = Any
 
 DEFAULT_LIST_LIMIT = 200
 AUDIO_SUFFIXES = frozenset({".aac", ".aif", ".aiff", ".flac", ".m4a", ".mp3", ".ogg", ".wav"})

--- a/src/resolve_mcp/resolve/pool.py
+++ b/src/resolve_mcp/resolve/pool.py
@@ -41,7 +41,10 @@ from ..logging_config import get_logger
 from ..timing import frames_from_timecode
 from .connection import ResolveConnection
 
-log = get_logger("media")
+# A child of the operations module's logger, so anything configured for "media" still
+# catches the adapter — but a bin creation or a still-workaround refusal says which half
+# of the old module it came from, which is the whole point of the line in a live failure.
+log = get_logger("media.pool")
 
 BIN_SEPARATOR = "/"
 IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"})

--- a/src/resolve_mcp/resolve/pool.py
+++ b/src/resolve_mcp/resolve/pool.py
@@ -1,0 +1,534 @@
+"""The media pool adapter: reaching the pool, addressing bins, locating and reading clips.
+
+Thin, testable, and MCP-free like the rest of this layer. This is the half of the old
+``media`` module that everything else consumes — the cut contract, audio acquisition,
+titles application, video source resolution — and that the six media operations in
+:mod:`.media` are themselves callers of. Two things here are decisions rather than API
+calls, and are the reason this file exists at all:
+
+* **Bin paths are slash-separated from the media pool root** (``"Concert/Angles"``), the
+  root's own name optional as a first segment. Resolve's API has no bin path — only
+  ``GetSubFolderList()`` walks — and "current folder" state that every import depends on.
+* **Offline means the media is gone**, not that Resolve says so: there is no offline flag in
+  the scripting API. A clip is offline when nothing on disk stands behind its ``File Path``
+  — the path itself for ordinary media, the first frame for a sequence, whose path is only
+  a label (``shot_[0001-0024].png``, #85). A clip with no path at all (multicam, compound)
+  is not offline, it is pathless.
+
+:func:`apply_still_workaround` sits here as a primitive rather than a policy: *when* a still
+gets its out point written is the import's decision (see :mod:`.media`), but *what* the
+write is stays with the clip reading that judges a still in the first place.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from ..errors import (
+    AmbiguousClipError,
+    BinNotFoundError,
+    ClipNotFoundError,
+    MediaOperationError,
+    MediaPoolUnavailableError,
+    NoProjectOpenError,
+)
+from ..logging_config import get_logger
+from ..timing import frames_from_timecode
+from .connection import ResolveConnection
+
+log = get_logger("media")
+
+BIN_SEPARATOR = "/"
+IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr", ".dpx", ".tga"})
+SEQUENCE_TOKEN = "%"
+# Resolve paths an imported image sequence by folding the index range into the name —
+# shot_[0001-0024].png — a label, not a file (#85, Resolve Studio 21.0.3.7).
+SEQUENCE_RANGE = re.compile(r"\[(\d+)-\d+\]")
+
+FILE_PATH = "File Path"
+DURATION = "Duration"
+FRAMES = "Frames"
+FPS = "FPS"
+START = "Start"
+END = "End"
+OUT = "Out"
+TYPE = "Type"
+RESOLUTION = "Resolution"
+AUDIO_CHANNELS = "Audio Ch"
+
+Clip = Any
+Folder = Any
+Pool = Any
+Project = Any
+
+
+class LocatedClip(NamedTuple):
+    """A clip and the bin it was found in — the pair every lookup hands back."""
+
+    bin_path: str
+    clip: Clip
+
+
+class LocatedBin(NamedTuple):
+    """A bin, the path walked to reach it, and whether that walk had to create it.
+
+    The path travels with the folder because it cannot be recovered from one: Resolve
+    hands out a fresh proxy object per call, so a folder cannot be recognised by identity
+    on a later walk, and the API has no path getter.
+    """
+
+    path: str
+    folder: Folder
+    created: bool
+
+
+# --- reaching the pool ------------------------------------------------------------------
+
+
+def media_pool(connection: ResolveConnection) -> Pool:
+    """The open project's media pool. Raises rather than returning a useless ``None``."""
+    manager = connection.handle().GetProjectManager()
+    project = manager.GetCurrentProject() if manager is not None else None
+    if project is None:
+        raise NoProjectOpenError(cause="No project is open, so there is no media pool to work in.")
+    return pool_of(project)
+
+
+def pool_of(project: Project) -> Pool:
+    """The pool of a project already in hand — the same walk, without repeating it.
+
+    A caller that has the project must not reach for it a second time: two walks are two
+    chances to land on different projects if the GUI switches between them, and the pool
+    would then not belong to the project the rest of the call is reading.
+    """
+    pool = project.GetMediaPool()
+    if pool is None:
+        raise MediaPoolUnavailableError(
+            cause=f"Resolve returned no media pool for the open project {project.GetName()!r}.",
+        )
+    return pool
+
+
+# --- bins -------------------------------------------------------------------------------
+
+
+def _segments(path: str | None, root: Folder) -> list[str]:
+    """Split a bin path into folder names, dropping a leading root name if it is one.
+
+    Resolve calls the root "Master" and the agent may write it or not. A real bin called
+    Master would otherwise become unaddressable, so the leading name is only treated as the
+    root when the root has no child by that name.
+    """
+    parts = [part.strip() for part in (path or "").split(BIN_SEPARATOR)]
+    parts = [part for part in parts if part]
+    root_name = str(root.GetName() or "")
+    if parts and root_name and parts[0] == root_name:
+        children = {str(sub.GetName() or "") for sub in _subfolders(root)}
+        if root_name not in children:
+            parts = parts[1:]
+    return parts
+
+
+def _root(pool: Pool) -> Folder:
+    root = pool.GetRootFolder()
+    if root is None:
+        raise MediaPoolUnavailableError(cause="Resolve returned no media pool root folder.")
+    return root
+
+
+def _subfolders(folder: Folder) -> list[Folder]:
+    return list(folder.GetSubFolderList() or [])
+
+
+def bin_paths(pool: Pool) -> list[str]:
+    """Every bin path in the pool, root excluded — what to offer when one is missing."""
+    found: list[str] = []
+    for path, _folder in _walk_bins(_root(pool)):
+        if path:
+            found.append(path)
+    return found
+
+
+def _walk_bins(folder: Folder, prefix: str = "") -> Iterator[tuple[str, Folder]]:
+    yield prefix, folder
+    for sub in _subfolders(folder):
+        name = str(sub.GetName() or "")
+        yield from _walk_bins(sub, f"{prefix}{BIN_SEPARATOR}{name}" if prefix else name)
+
+
+def find_bin(pool: Pool, path: str | None) -> LocatedBin:
+    """The bin at ``path``. ``None`` or ``""`` is the root."""
+    root = _root(pool)
+    folder = root
+    walked: list[str] = []
+    for segment in _segments(path, root):
+        matches = [sub for sub in _subfolders(folder) if str(sub.GetName() or "") == segment]
+        if not matches:
+            raise BinNotFoundError(str(path), bin_paths(pool))
+        folder = matches[0]
+        walked.append(segment)
+    return LocatedBin(BIN_SEPARATOR.join(walked), folder, created=False)
+
+
+def ensure_bin(pool: Pool, path: str | None) -> LocatedBin:
+    """The bin at ``path``, creating it and any missing parents."""
+    root = _root(pool)
+    folder = root
+    walked: list[str] = []
+    created = False
+    for segment in _segments(path, root):
+        matches = [sub for sub in _subfolders(folder) if str(sub.GetName() or "") == segment]
+        if matches:
+            folder = matches[0]
+        else:
+            made = pool.AddSubFolder(folder, segment)
+            if made is None:
+                raise MediaOperationError(cause=f"Resolve refused to create the bin {segment!r}.")
+            log.info("Created bin %s", segment)
+            folder = made
+            created = True
+        walked.append(segment)
+    return LocatedBin(BIN_SEPARATOR.join(walked), folder, created)
+
+
+# --- clips ------------------------------------------------------------------------------
+
+
+def clips_under(where: LocatedBin, recursive: bool) -> Iterator[LocatedClip]:
+    """Every clip in a located bin, each paired with the bin path that addresses it."""
+    base = where.path
+    if not recursive:
+        for clip in where.folder.GetClipList() or []:
+            yield LocatedClip(base, clip)
+        return
+    for suffix, sub in _walk_bins(where.folder):
+        path = f"{base}{BIN_SEPARATOR}{suffix}" if base and suffix else (base or suffix)
+        for clip in sub.GetClipList() or []:
+            yield LocatedClip(path, clip)
+
+
+def _searched_label(bin_path: str | None, where: LocatedBin, deep: bool) -> str:
+    """What a clip_not_found says it looked in — the caller's own words for a named bin.
+
+    A shallow search says ``alone`` so the refusal points at the flag: the clip may well
+    be one folder down, and dropping ``recursive`` is then the fix, not renaming anything.
+    """
+    if not where.path:
+        return "the media pool" if bin_path is None and deep else "the media pool root"
+    return f"the bin {bin_path!r}" if deep else f"the bin {bin_path!r} alone"
+
+
+def _addressing(bins: list[str]) -> tuple[list[str], list[str]]:
+    """Which bins holding a duplicated name reach one clip: passed alone, then passed shallow.
+
+    One entry per matching clip comes in, so a repeat means one bin holds two of the name —
+    no lookup singles those out, and neither list offers them. A bin whose subfolder holds
+    another copy has no address of its own either, because a named bin is searched right
+    through; it does hold exactly one clip itself, so ``recursive=False`` reaches that one
+    (#134). The root is never shadowed: ``""`` is the root folder alone (#122).
+    """
+    counted = Counter(bins)
+    alone = {path for path, times in counted.items() if times == 1}
+    shadowed = {
+        path
+        for path in alone
+        if path and any(other.startswith(f"{path}{BIN_SEPARATOR}") for other in bins)
+    }
+    return sorted(alone - shadowed), sorted(shadowed)
+
+
+def find_clip(
+    pool: Pool,
+    name: str,
+    bin_path: str | None = None,
+    recursive: bool | None = None,
+) -> LocatedClip:
+    """One clip by exact name.
+
+    ``None`` searches the whole pool. A named bin searches that bin and everything nested
+    inside it. ``""`` — or the root's own name — is the root folder *alone*, not the pool:
+    naming the root recursively would be the whole-pool search again, which left a root
+    clip whose name a bin also used with no expressible address at all (#122). The empty
+    string is what :func:`summarise` reports for a root clip, so the ``bin`` value a
+    listing gives back always reads the clip it described.
+
+    ``recursive=False`` stops the search descending, so the clips a bin holds *itself* are
+    all that is looked at — the address of a copy shadowed by another of the name filed
+    deeper (#134). With no bin it narrows to the root, the way ``list_media`` does;
+    ``bin=""`` and the root's own name are already that search, so they are unaffected.
+
+    ``recursive=None`` is a caller with no such flag of its own to pass on — the video and
+    analysis tools, which resolve a clip by name but take no ``recursive``. It searches
+    deep like ``True``, and an ambiguity is not offered the shallow form, because a fix
+    naming an argument its caller cannot accept is the #122 defect one axis over.
+    """
+    where = find_bin(pool, bin_path)
+    the_root_itself = bin_path is not None and not where.path
+    deep = recursive is not False and not the_root_itself
+    searched = list(clips_under(where, deep))
+    matches = [found for found in searched if str(found.clip.GetName() or "") == name]
+    if not matches:
+        available = sorted({str(found.clip.GetName() or "") for found in searched})
+        raise ClipNotFoundError(name, _searched_label(bin_path, where, deep), available)
+    if len(matches) > 1:
+        found_in = [found.bin_path for found in matches]
+        deep_address, shallow_address = _addressing(found_in)
+        raise AmbiguousClipError(
+            name,
+            found_in,
+            deep_address,
+            shallow_address if recursive is not None else [],
+        )
+    return matches[0]
+
+
+def clip_at_path(pool: Pool, bin_path: str, file_path: str) -> LocatedClip | None:
+    """The clip in ``bin_path`` that already stands for ``file_path``, if one does.
+
+    Identity is the first frame on disk rather than the reported path or the clip name,
+    because Resolve renames and re-paths an imported sequence into a folded label
+    (:func:`first_frame_of`). ``None`` — rather than a raise — because "not imported yet"
+    is the ordinary answer on a first run, not a failure.
+    """
+    wanted = Path(first_frame_of(file_path))
+    for found in clips_under(find_bin(pool, bin_path), recursive=True):
+        standing = properties(found.clip).get(FILE_PATH, "")
+        if standing and Path(first_frame_of(standing)) == wanted:
+            return found
+    return None
+
+
+def clips_named(pool: Pool, names: Iterable[str]) -> list[LocatedClip]:
+    """Every clip anywhere in the pool whose name is one of ``names``.
+
+    Unlike :func:`find_clip` this reports the duplicates instead of raising on them: a
+    validation pass has to name every ambiguity at once, not stop at the first.
+    """
+    wanted = set(names)
+    return [
+        found
+        for found in clips_under(find_bin(pool, None), recursive=True)
+        if str(found.clip.GetName() or "") in wanted
+    ]
+
+
+_logged_property_keys = False
+
+
+def properties(clip: Clip) -> dict[str, str]:
+    """Every clip property Resolve reports, enumerated — key names are never hard-coded.
+
+    The key names are undocumented, so the first enumeration of a session is logged: when a
+    reading comes back empty on a live machine, that line is what says whether the key was
+    renamed or the value really was blank.
+    """
+    reported = clip.GetClipProperty()
+    if not isinstance(reported, dict):
+        return {}
+    global _logged_property_keys
+    if not _logged_property_keys:
+        log.info("Clip properties Resolve reports: %s", sorted(str(key) for key in reported))
+        _logged_property_keys = True
+    return {str(key): "" if value is None else str(value) for key, value in reported.items()}
+
+
+def _number(reported: dict[str, str], key: str) -> int | None:
+    try:
+        return int(float(reported.get(key, "")))
+    except (TypeError, ValueError):
+        return None
+
+
+def frame_count(reported: dict[str, str]) -> int | None:
+    """How many frames Resolve says the clip holds, or ``None`` when it says nothing.
+
+    The raw ``Frames`` reading, unlike :func:`frame_bounds`, which derives bounds when the
+    count is missing — the fallback a duration a listing has no rate for cannot take.
+    """
+    return _number(reported, FRAMES)
+
+
+def frame_rate(reported: dict[str, str]) -> float | None:
+    """The clip's frame rate, or ``None`` when Resolve does not report one (audio, stills)."""
+    try:
+        return float(reported.get(FPS, ""))
+    except (TypeError, ValueError):
+        return None
+
+
+def frame_bounds(
+    reported: dict[str, str], fps: float | None = None
+) -> tuple[int | None, int | None]:
+    """Media bounds as half-open ``[start, out)``.
+
+    Resolve reports ``End`` as the last frame; every range in this server is half-open, so
+    the out point is that frame plus one. Frame count is the fallback when ``End`` is
+    missing. The rule lives here so bounds mean the same thing to a listing and to a cut.
+
+    Audio-only clips report ``Start``, ``End`` and ``Frames`` as empty strings (#46,
+    live-verified): only ``Duration`` carries the length, as timecode. So whenever the
+    out point is unreadable and ``Duration`` parses, the duration stands in — bounds are
+    ``[start, start + duration)`` with an unreported start read as 0 — counted at the
+    clip's own rate or, since audio reports no rate either, at the caller's ``fps`` (the
+    timeline's, for a cut). With no rate at all, or no parseable ``Duration``, the
+    unknowns stay ``None`` — unknown, never invented.
+    """
+    start = _number(reported, START)
+    end = _number(reported, END)
+    frames = _number(reported, FRAMES)
+    out = end + 1 if end is not None else (start + frames if start is not None and frames else None)
+    if out is None:
+        rate = frame_rate(reported) or fps
+        duration = frames_from_timecode(reported.get(DURATION, ""), rate) if rate else None
+        if duration is not None:
+            begin = start if start is not None else 0
+            log.debug(
+                "End/Frames unreported; bounds %d-%d read from %s %r at %s fps",
+                begin,
+                begin + duration,
+                DURATION,
+                reported.get(DURATION),
+                rate,
+            )
+            return begin, begin + duration
+        # The case a live session most needs to see: nothing reported and nothing to
+        # derive from, so every bounds-based check downstream silently fails open.
+        log.debug(
+            "End/Frames unreported and %s %r cannot stand in (rate %s); bounds unknown",
+            DURATION,
+            reported.get(DURATION),
+            rate,
+        )
+    return start, out
+
+
+def audio_channels(reported: dict[str, str]) -> int | None:
+    """How many audio channels the clip carries, or ``None`` when Resolve does not say."""
+    return _number(reported, AUDIO_CHANNELS)
+
+
+def audio_mapping(clip: Clip) -> dict[str, Any] | None:
+    """``GetAudioMapping`` returns a JSON *string* — or nothing, on clips without audio."""
+    try:
+        reported = clip.GetAudioMapping()
+    except Exception:  # noqa: BLE001 - an unmapped clip is not a failed inspection
+        log.debug("Could not read the audio mapping", exc_info=True)
+        return None
+    if not reported:
+        return None
+    if isinstance(reported, dict):
+        return reported
+    try:
+        parsed = json.loads(str(reported))
+    except (TypeError, ValueError):
+        log.warning("Unparseable audio mapping: %r", reported)
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def looks_like_image(file_path: str) -> bool:
+    """Whether a path names image media, judged by suffix alone — see :func:`is_still`."""
+    return Path(file_path).suffix.lower() in IMAGE_SUFFIXES
+
+
+def is_still(reported: dict[str, str]) -> bool:
+    """Whether the clip is an image rather than moving footage.
+
+    Judged by file suffix: the ``Type`` property does not separate a still from a
+    sequence, and the suffix is what the still-duration workaround already keys off.
+    """
+    return looks_like_image(reported.get(FILE_PATH, ""))
+
+
+def apply_still_workaround(clip: Clip, reported: dict[str, str]) -> bool:
+    """Write the out point once, so later ``endFrame`` values are honoured exactly.
+
+    Resolve ignores ``endFrame`` when appending a freshly imported still — every append
+    lands at the default still duration — until any out point has been written to the clip.
+    The value does not matter, only that the write happened.
+    """
+    if not is_still(reported):
+        return False
+    end = _number(reported, END)
+    if end is None:
+        frames = _number(reported, FRAMES)
+        end = max((frames or 1) - 1, 0)
+    if not clip.SetClipProperty(OUT, str(end)):
+        log.warning("Still-duration workaround refused on %s", clip.GetName())
+        return False
+    return True
+
+
+def first_frame_of(file_path: str) -> str:
+    """The one file a clip's path really stands for, sequence labels unfolded.
+
+    Resolve reports an imported sequence as ``shot_[0001-0024].png`` (#85) — a label, not
+    a path — so the first frame is the only form of a sequence's address that is a real
+    file both before the import (where the caller has a ``%0Nd`` pattern) and after it.
+    That makes it the identity a re-run can recognise an already-imported card by.
+    Anything that is not a folded range comes back unchanged.
+    """
+    folded = SEQUENCE_RANGE.search(Path(file_path).name)
+    if folded is None:
+        return file_path
+    path = Path(file_path)
+    return str(path.with_name(SEQUENCE_RANGE.sub(folded.group(1), path.name, count=1)))
+
+
+def is_offline(file_path: str) -> bool:
+    """Whether the media behind a clip has moved away.
+
+    Resolve exposes no offline flag, so this is a disk check. A clip with no path at all
+    (multicam, compound) is pathless rather than offline. Sequence paths are never files on
+    disk, so they get judged by what stands behind them: a ``%0Nd`` pattern by its folder
+    (the range is unknown), a bracketed range — the form Resolve reports for an imported
+    sequence (#85) — by its first frame, which the range makes constructible.
+    """
+    if not file_path:
+        return False
+    path = Path(file_path)
+    if path.exists():
+        return False
+    if SEQUENCE_TOKEN in path.name:
+        return not path.parent.exists()
+    first = first_frame_of(file_path)
+    if first != file_path:
+        return not Path(first).exists()
+    return True
+
+
+def summarise(bin_path: str, clip: Clip, reported: dict[str, str] | None = None) -> dict[str, Any]:
+    """The one-line view of a clip that list and import both return."""
+    reported = reported if reported is not None else properties(clip)
+    file_path = reported.get(FILE_PATH, "")
+    return {
+        "name": str(clip.GetName() or ""),
+        "bin": bin_path,
+        "file_path": file_path,
+        "type": reported.get(TYPE, ""),
+        "frames": frame_count(reported),
+        "fps": frame_rate(reported),
+        "resolution": reported.get(RESOLUTION, ""),
+        "offline": is_offline(file_path),
+    }
+
+
+def import_into(pool: Pool, items: list[str | dict[str, Any]], target: LocatedBin) -> list[Clip]:
+    """``ImportMedia`` into one bin, and leave the pool where it was found.
+
+    Imports land in the media pool's *current* folder, so the current folder is moved for
+    the call and put back afterwards — a tool must not leave the GUI somewhere else. Every
+    route that imports goes through here so no route can forget the second half.
+    """
+    previous = pool.GetCurrentFolder()
+    pool.SetCurrentFolder(target.folder)
+    try:
+        return list(pool.ImportMedia(items) or [])
+    finally:
+        if previous is not None:
+            pool.SetCurrentFolder(previous)

--- a/src/resolve_mcp/resolve/titles.py
+++ b/src/resolve_mcp/resolve/titles.py
@@ -36,7 +36,8 @@ from ..titles.validate import (
     validate_project,
     validate_structure,
 )
-from . import markers, media
+from . import markers
+from . import pool as mediapool
 from . import timeline as timeline_read
 from .connection import ResolveConnection
 from .session import frame_rate
@@ -75,7 +76,7 @@ class Preflight:
     project: Project | None = None
     timeline: Timeline | None = None
     fps: float | None = None
-    templates: dict[str, media.LocatedClip] = field(default_factory=dict)
+    templates: dict[str, mediapool.LocatedClip] = field(default_factory=dict)
     assets: dict[str, Asset] = field(default_factory=dict)
     events: list[Event] = field(default_factory=list)
 
@@ -109,7 +110,7 @@ def preflight(connection: ResolveConnection, titles_file: str) -> Preflight:
     project = timeline_read.open_project(connection)
     timeline = timeline_read.find_timeline(project, doc.get("timeline"))
     fps = frame_rate(project, timeline)
-    pool = media.media_pool(connection)
+    pool = mediapool.media_pool(connection)
 
     facts, located = _templates(pool, doc)
     anchors = markers.markers_by_name(connection, timeline, fps, ANCHOR_COLOR)
@@ -150,7 +151,7 @@ def _span(timeline: Timeline) -> tuple[int, int]:
 def _templates(
     pool: Pool,
     doc: dict[str, Any],
-) -> tuple[list[TemplateFacts], dict[str, media.LocatedClip]]:
+) -> tuple[list[TemplateFacts], dict[str, mediapool.LocatedClip]]:
     """Every declared template the file actually uses, resolved against the pool.
 
     Reported as facts rather than raised on, because T5 has to name every unusable
@@ -164,10 +165,10 @@ def _templates(
         if route_of(event) != PNG
     }
     declared = {name: one for name, one in doc.get("templates", {}).items() if name in used}
-    found = media.clips_named(pool, {str(one["clip"]) for one in declared.values()})
+    found = mediapool.clips_named(pool, {str(one["clip"]) for one in declared.values()})
 
     facts: list[TemplateFacts] = []
-    located: dict[str, media.LocatedClip] = {}
+    located: dict[str, mediapool.LocatedClip] = {}
     for name, template in declared.items():
         clip = str(template["clip"])
         bin_path = template.get("bin")
@@ -192,11 +193,11 @@ def _under(bin_path: str | None, declared: str) -> bool:
     """Whether a clip's bin is the declared one or nested inside it, as find_clip searches.
 
     ``declared`` is compared as written, so the one spelling this does not share with
-    :func:`media.find_clip` is the root's own name: ``Master`` reads as a bin called
+    :func:`mediapool.find_clip` is the root's own name: ``Master`` reads as a bin called
     Master here, where find_clip reads it as the root.
     """
     where = bin_path or ""
-    return where == declared or where.startswith(f"{declared}{media.BIN_SEPARATOR}")
+    return where == declared or where.startswith(f"{declared}{mediapool.BIN_SEPARATOR}")
 
 
 def validate_titles(connection: ResolveConnection, titles_file: str) -> dict[str, Any]:

--- a/src/resolve_mcp/titles/assets.py
+++ b/src/resolve_mcp/titles/assets.py
@@ -28,7 +28,7 @@ from .schema import ASSET_BIN
 
 SEQUENCE_TOKEN: Final = "%"
 BIN_SEPARATOR: Final = "/"
-# Both mirror ``resolve.media`` deliberately rather than importing it: this layer is the
+# Both mirror ``resolve.pool`` deliberately rather than importing it: this layer is the
 # pure one, and a titles file has to be judged on a machine with no Resolve on it.
 
 SEQUENCE_INDEX: Final = re.compile(r"%0?\d*d")

--- a/src/resolve_mcp/video/source.py
+++ b/src/resolve_mcp/video/source.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any, NamedTuple
 
 from ..errors import InvalidRequestError, ResolveMcpError
-from ..resolve import media
+from ..resolve import pool as mediapool
 from ..resolve.connection import ResolveConnection
 from ..timing import dual_time
 
@@ -73,21 +73,21 @@ def locate(
     and a scan that cannot find its media are the same problem to the director and different
     tools to the agent.
     """
-    pool = media.media_pool(connection)
-    located = media.find_clip(pool, clip, bin_path)
-    reported = media.properties(located.clip)
-    path = reported.get(media.FILE_PATH, "")
-    if not path or media.is_offline(path):
+    pool = mediapool.media_pool(connection)
+    located = mediapool.find_clip(pool, clip, bin_path)
+    reported = mediapool.properties(located.clip)
+    path = reported.get(mediapool.FILE_PATH, "")
+    if not path or mediapool.is_offline(path):
         raise failure(
             cause=f"{clip!r} has no readable file on disk.",
             fix=RELINK_FIX,
             detail={"clip": clip, "file_path": path},
         )
 
-    fps = media.frame_rate(reported)
+    fps = mediapool.frame_rate(reported)
     # The clip's own rate is the only one this seam has; it feeds the Duration fallback
     # so a grab sees the same bounds a listing and a cut do.
-    start, out = media.frame_bounds(reported, fps=fps)
+    start, out = mediapool.frame_bounds(reported, fps=fps)
     return Source(
         name=clip,
         path=path,

--- a/tests/fakes/media.py
+++ b/tests/fakes/media.py
@@ -149,7 +149,7 @@ def _import_one(item: str | dict[str, Any]) -> FakeMediaPoolItem | None:
 
     ``Type`` is ``Video``, live-verified twice (#85 body, #95 probe): Resolve does not
     separate a sequence from moving footage here, which is why
-    :func:`resolve_mcp.resolve.media.is_still` keys off the file suffix instead.
+    :func:`resolve_mcp.resolve.pool.is_still` keys off the file suffix instead.
     """
     if isinstance(item, dict):
         pattern = str(item.get("FilePath", ""))

--- a/tests/mediapool.py
+++ b/tests/mediapool.py
@@ -1,0 +1,34 @@
+"""Media pool builders the two media test files share.
+
+``test_media_pool.py`` and ``test_media_tools.py`` were one file until the module they
+cover split in two; these are the fixtures both halves still need, kept in one place so
+the pair cannot drift apart on what a clip or a shadowed copy looks like.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .fakes import FakeMediaPool, FakeMediaPoolItem, media_pool
+
+
+def a_file(tmp_path: Path, name: str, content: bytes = b"media") -> Path:
+    target = tmp_path / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return target
+
+
+def a_clip(path: Path | str, **properties: str) -> FakeMediaPoolItem:
+    return FakeMediaPoolItem(Path(path).name, str(path), properties)
+
+
+def a_shallow_copy_pool(tmp_path: Path) -> FakeMediaPool:
+    """The #134 shape: one clip name held by a bin *and* by a bin nested inside it."""
+    same = a_file(tmp_path, "C0012.mp4")
+    return media_pool(
+        bins={
+            "Angles": [a_clip(same, Description="in Angles")],
+            "Angles/Cam A": [a_clip(same, Description="nested")],
+        }
+    )

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -48,7 +48,7 @@ from resolve_mcp.jobs import cache
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.naming import timestamped_name
 from resolve_mcp.resolve.connection import get_connection
-from resolve_mcp.resolve.media import (
+from resolve_mcp.resolve.pool import (
     AUDIO_CHANNELS,
     apply_still_workaround,
     audio_channels,

--- a/tests/test_media_pool.py
+++ b/tests/test_media_pool.py
@@ -1,0 +1,498 @@
+"""The media pool adapter — bin addressing, clip lookup, clip reading — at the fake seam.
+
+The adapter half of what used to be one media test file. These tests are about
+:mod:`resolve_mcp.resolve.pool`: which clip an address reaches, what a refusal says it
+searched, and what a clip's properties are read as. They drive it through the thinnest
+media tool that reaches the behaviour, because the fake substitutes the Resolve singleton
+at the connection — so the envelope a refusal is shaped into is verified alongside the
+lookup that produced it. What the six operations themselves do lives in
+``test_media_tools.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from resolve_mcp.resolve.pool import frame_bounds
+from resolve_mcp.tools.media import (
+    import_media,
+    inspect_clip,
+    list_media,
+    organize_media,
+    relink_media,
+    set_clip_metadata,
+)
+
+from .conftest import Attach
+from .fakes import FakeMediaPool, FakeMediaPoolItem, media_pool, studio
+
+
+def a_file(tmp_path: Path, name: str, content: bytes = b"media") -> Path:
+    target = tmp_path / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return target
+
+
+def a_clip(path: Path | str, **properties: str) -> FakeMediaPoolItem:
+    return FakeMediaPoolItem(Path(path).name, str(path), properties)
+
+
+# --- offline and sequence identity -------------------------------------------------------
+
+
+def test_an_imported_sequence_whose_frames_are_on_disk_is_not_offline(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Resolve paths a sequence by its bracketed label (#85), which never exists on disk.
+
+    Offline must be judged by the frames behind the label, or every freshly imported
+    sequence reads offline and list_media(offline_only=True) sends a relink chase at
+    healthy media.
+    """
+    for index in range(1, 4):
+        a_file(tmp_path, f"seq/shot_{index:04d}.png")
+    attach(studio(pool=media_pool()))
+
+    result = import_media(
+        sequences=[
+            {"path": str(tmp_path / "seq" / "shot_%04d.png"), "start_index": 1, "end_index": 3}
+        ]
+    )
+
+    assert result["ok"] is True
+    assert result["imported"][0]["name"] == "shot_[0001-0003].png"
+    assert result["imported"][0]["offline"] is False
+    assert list_media(offline_only=True)["count"] == 0
+
+
+def test_a_sequence_whose_frames_moved_away_is_offline(attach: Attach, tmp_path: Path) -> None:
+    """The folder still exists — offline is judged by the first frame, not the folder."""
+    (tmp_path / "seq").mkdir()
+    clip = a_clip(tmp_path / "seq" / "shot_[0001-0003].png")
+    attach(studio(pool=media_pool(bins={"Stills": [clip]})))
+
+    assert [found["name"] for found in list_media(offline_only=True)["clips"]] == [
+        "shot_[0001-0003].png"
+    ]
+
+
+# --- bin addressing ----------------------------------------------------------------------
+
+
+def test_a_bin_really_named_master_is_still_addressable(attach: Attach, tmp_path: Path) -> None:
+    """The root is called Master, so a leading Master is only dropped when it is the root."""
+    pool = media_pool(bins={"Master": [a_clip(a_file(tmp_path, "C0012.mp4"))], "": []})
+    attach(studio(pool=pool))
+
+    result = list_media(bin="Master", recursive=False)
+
+    assert result["ok"] is True
+    assert result["bin"] == "Master"
+    assert [clip["name"] for clip in result["clips"]] == ["C0012.mp4"]
+
+
+def test_list_of_an_unknown_bin_names_the_bins_that_exist(attach: Attach) -> None:
+    attach(studio(pool=media_pool(bins={"Angles/Cam A": []})))
+
+    result = list_media(bin="angles")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "bin_not_found"
+    assert "Angles/Cam A" in result["error"]["fix"]
+
+
+# --- reaching the pool -------------------------------------------------------------------
+
+
+def test_media_tools_need_a_project(attach: Attach) -> None:
+    attach(studio(project=None))
+
+    result = list_media()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "no_project_open"
+    assert result["error"]["fix"]
+
+
+def test_a_media_pool_resolve_will_not_hand_over_is_reported(attach: Attach) -> None:
+    attach(studio(pool=None))
+
+    result = list_media()
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "media_pool_unavailable"
+    assert result["error"]["fix"]
+
+
+# --- clip lookup -------------------------------------------------------------------------
+
+
+def test_inspect_of_an_unknown_clip_says_what_is_there(attach: Attach, tmp_path: Path) -> None:
+    attach(studio(pool=media_pool(bins={"Angles": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
+
+    result = inspect_clip("C0013.mp4")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "clip_not_found"
+    assert result["error"]["fix"]
+
+
+def test_inspect_refuses_an_ambiguous_clip_name(attach: Attach, tmp_path: Path) -> None:
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(
+        studio(pool=media_pool(bins={"Angles": [a_clip(same)], "Broll": [a_clip(same)]}))
+    )
+
+    result = inspect_clip("C0012.mp4")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "ambiguous_clip"
+    assert "Angles" in result["error"]["fix"]
+    assert inspect_clip("C0012.mp4", bin="Broll")["ok"] is True
+
+
+def test_a_root_clip_is_reachable_when_its_name_is_also_used_in_a_bin(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """#122: bin="" is the root folder alone — the only way to name the root copy."""
+    same = a_file(tmp_path, "C0012.mp4")
+    root_copy = a_clip(same, Description="at the root")
+    binned_copy = a_clip(same, Description="filed away")
+    attach(studio(pool=media_pool(bins={"": [root_copy], "Angles/Cam A": [binned_copy]})))
+
+    at_root = inspect_clip("C0012.mp4", bin="")
+
+    assert at_root["ok"] is True
+    assert at_root["clip"]["bin"] == ""
+    assert at_root["properties"]["Description"] == "at the root"
+    binned = inspect_clip("C0012.mp4", bin="Angles/Cam A")
+    assert binned["clip"]["bin"] == "Angles/Cam A"
+    assert binned["properties"]["Description"] == "filed away"
+
+
+def test_a_duplicated_name_still_refuses_without_a_bin(attach: Attach, tmp_path: Path) -> None:
+    """Narrowing the root must not turn the whole-pool search into a first-match."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(studio(pool=media_pool(bins={"": [a_clip(same)], "Angles": [a_clip(same)]})))
+
+    result = inspect_clip("C0012.mp4")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "ambiguous_clip"
+    assert result["error"]["detail"]["bins"] == ["", "Angles"]
+    assert 'bin=""' in result["error"]["fix"]  # the root has to be expressible
+    assert 'bin="Angles"' in result["error"]["fix"]
+    assert inspect_clip("C0012.mp4", bin="")["ok"] is True  # and every value offered works
+    assert inspect_clip("C0012.mp4", bin="Angles")["ok"] is True
+
+
+def test_every_bin_a_listing_reports_reads_the_same_clip_back(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The bin value list_media reports round-trips verbatim, root included."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(
+        studio(
+            pool=media_pool(
+                bins={
+                    "": [a_clip(same)],
+                    "Angles": [a_clip(a_file(tmp_path, "C0013.mp4"))],
+                    "Angles/Cam A": [a_clip(same)],
+                }
+            )
+        )
+    )
+
+    listed = list_media()["clips"]
+
+    assert len(listed) == 3
+    for entry in listed:
+        read_back = inspect_clip(entry["name"], bin=entry["bin"])
+        assert read_back["ok"] is True, entry
+        assert read_back["clip"]["bin"] == entry["bin"]
+
+
+def test_a_named_bin_still_reaches_a_clip_in_its_subfolder(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Only the root narrows: a named bin keeps searching what is nested inside it."""
+    attach(studio(pool=media_pool(bins={"Angles/Cam A": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
+
+    result = inspect_clip("C0012.mp4", bin="Angles")
+
+    assert result["ok"] is True
+    assert result["clip"]["bin"] == "Angles/Cam A"
+
+
+def test_an_ambiguity_offers_only_the_bins_that_reach_one_clip(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A bin whose subfolder holds another copy is not an answer, so it is not offered."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(
+        studio(
+            pool=media_pool(bins={"Angles": [a_clip(same)], "Angles/Cam A": [a_clip(same)]})
+        )
+    )
+
+    result = inspect_clip("C0012.mp4", bin="Angles")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "ambiguous_clip"
+    assert result["error"]["fix"] == (
+        'Pass one of these to say which: bin="Angles/Cam A". Or bin="Angles" with '
+        "recursive=false for the copy in that bin itself."
+    )  # bin="Angles" alone reaches the nested copy too, so it is only offered shallow
+    assert inspect_clip("C0012.mp4", bin="Angles/Cam A")["ok"] is True
+
+
+def test_two_copies_in_one_bin_are_refused_with_advice_that_is_not_a_bin(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """When no bin can answer, the fix says so instead of naming a value that fails."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(studio(pool=media_pool(bins={"Angles": [a_clip(same), a_clip(same)]})))
+
+    result = inspect_clip("C0012.mp4", bin="Angles")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "ambiguous_clip"
+    assert "bin=" not in result["error"]["fix"]
+    assert "recursive" not in result["error"]["fix"]  # a shallow lookup cannot answer either
+    assert "Rename one in the Resolve GUI" in result["error"]["fix"]
+
+
+def test_naming_the_root_master_reaches_the_root_clip_only(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Master is the root's own name, so it narrows the same way the empty string does."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(
+        studio(
+            pool=media_pool(
+                bins={"": [a_clip(same, Description="at the root")], "Angles": [a_clip(same)]}
+            )
+        )
+    )
+
+    result = inspect_clip("C0012.mp4", bin="Master")
+
+    assert result["ok"] is True
+    assert result["clip"]["bin"] == ""
+    assert result["properties"]["Description"] == "at the root"
+
+
+def test_inspect_of_a_missing_root_clip_says_it_searched_the_root(
+    attach: Attach, tmp_path: Path
+) -> None:
+    attach(studio(pool=media_pool(bins={"Angles": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
+
+    result = inspect_clip("C0012.mp4", bin="")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "clip_not_found"
+    assert result["error"]["detail"]["searched"] == "the media pool root"
+
+
+# --- recursive -------------------------------------------------------------------------
+
+
+def a_shallow_copy_pool(tmp_path: Path) -> FakeMediaPool:
+    """The #134 shape: one clip name held by a bin *and* by a bin nested inside it."""
+    same = a_file(tmp_path, "C0012.mp4")
+    return media_pool(
+        bins={
+            "Angles": [a_clip(same, Description="in Angles")],
+            "Angles/Cam A": [a_clip(same, Description="nested")],
+        }
+    )
+
+
+def test_a_shallow_lookup_reaches_the_copy_held_by_the_named_bin_itself(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """#134: recursive=False says this bin alone, so the shadowed copy has an address."""
+    attach(studio(pool=a_shallow_copy_pool(tmp_path)))
+
+    result = inspect_clip("C0012.mp4", bin="Angles", recursive=False)
+
+    assert result["ok"] is True
+    assert result["clip"]["bin"] == "Angles"
+    assert result["properties"]["Description"] == "in Angles"
+
+
+def test_a_named_bin_stays_recursive_unless_recursive_is_passed(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The flag is opt-in: the default keeps searching what is nested inside the bin."""
+    attach(studio(pool=a_shallow_copy_pool(tmp_path)))
+
+    assert inspect_clip("C0012.mp4", bin="Angles")["error"]["code"] == "ambiguous_clip"
+    assert inspect_clip("C0012.mp4", bin="Angles/Cam A", recursive=False)["ok"] is True
+
+
+def test_an_ambiguity_offers_the_shallow_form_when_that_is_what_reaches_a_copy(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """Every value the fix names must work — including the one that needs recursive=false."""
+    attach(studio(pool=a_shallow_copy_pool(tmp_path)))
+
+    fix = inspect_clip("C0012.mp4", bin="Angles")["error"]["fix"]
+
+    assert 'bin="Angles/Cam A"' in fix
+    assert "recursive=false" in fix
+    assert inspect_clip("C0012.mp4", bin="Angles/Cam A")["ok"] is True
+    assert inspect_clip("C0012.mp4", bin="Angles", recursive=False)["ok"] is True
+
+
+def test_a_shallow_lookup_without_a_bin_stays_in_the_root(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """No bin means the root, and recursive=False narrows it the way list_media does."""
+    same = a_file(tmp_path, "C0012.mp4")
+    attach(
+        studio(
+            pool=media_pool(
+                bins={
+                    "": [a_clip(same, Description="at the root")],
+                    "Angles": [a_clip(same, Description="filed away")],
+                }
+            )
+        )
+    )
+
+    result = inspect_clip("C0012.mp4", recursive=False)
+
+    assert result["ok"] is True
+    assert result["clip"]["bin"] == ""
+    assert result["properties"]["Description"] == "at the root"
+
+
+def test_a_shallow_lookup_that_finds_nothing_says_it_did_not_descend(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The refusal names what was searched, so the fix is to drop the flag, not the bin."""
+    attach(studio(pool=media_pool(bins={"Angles/Cam A": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
+
+    result = inspect_clip("C0012.mp4", bin="Angles", recursive=False)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "clip_not_found"
+    assert result["error"]["detail"]["searched"] == "the bin 'Angles' alone"
+
+
+def test_metadata_writes_to_the_copy_a_shallow_item_names(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = a_shallow_copy_pool(tmp_path)
+    attach(studio(pool=pool))
+
+    result = set_clip_metadata(
+        [
+            {
+                "clip": "C0012.mp4",
+                "bin": "Angles",
+                "recursive": False,
+                "fields": {"Description": "the shallow copy"},
+            }
+        ]
+    )
+
+    assert result["results"][0]["ok"] is True
+    assert result["results"][0]["bin"] == "Angles"
+    angles = pool.GetRootFolder().GetSubFolderList()[0]
+    assert angles.GetClipList()[0].property_writes == [("Description", "the shallow copy")]
+    nested = angles.GetSubFolderList()[0].GetClipList()[0]
+    assert nested.property_writes == []
+    assert nested.metadata_writes == []
+
+
+def test_organize_moves_the_copy_a_shallow_from_bin_names(
+    attach: Attach, tmp_path: Path
+) -> None:
+    pool = a_shallow_copy_pool(tmp_path)
+    attach(studio(pool=pool))
+
+    result = organize_media(
+        [
+            {
+                "op": "move_clips",
+                "clips": ["C0012.mp4"],
+                "from_bin": "Angles",
+                "recursive": False,
+                "to_bin": "Broll",
+            }
+        ]
+    )
+
+    assert result["results"][0]["ok"] is True
+    root = pool.GetRootFolder()
+    angles = root.GetSubFolderList()[0]
+    broll = [sub for sub in root.GetSubFolderList() if sub.GetName() == "Broll"][0]
+    assert angles.GetClipList() == []  # the copy Angles held itself
+    assert [item.GetName() for item in broll.GetClipList()] == ["C0012.mp4"]
+    assert len(angles.GetSubFolderList()[0].GetClipList()) == 1  # the nested copy stayed
+
+
+def test_relink_takes_the_shallow_form_too(attach: Attach, tmp_path: Path) -> None:
+    moved = a_file(tmp_path, "new/C0012.mp4")
+    attach(
+        studio(
+            pool=media_pool(
+                bins={
+                    "Angles": [a_clip(tmp_path / "old" / "C0012.mp4")],
+                    "Angles/Cam A": [a_clip(tmp_path / "old" / "C0012.mp4")],
+                }
+            )
+        )
+    )
+
+    result = relink_media(["C0012.mp4"], str(moved.parent), bin="Angles", recursive=False)
+
+    assert result["ok"] is True
+    assert result["results"][0]["bin"] == "Angles"
+    assert result["results"][0]["offline"] is False
+    assert list_media(offline_only=True)["count"] == 1  # the nested copy is still offline
+
+
+# --- frame bounds -----------------------------------------------------------------------
+
+
+def test_frame_bounds_falls_back_to_duration_for_an_audio_only_clip() -> None:
+    """Audio-only clips report Start/End/Frames as empty strings (#46, live-verified);
+    Duration is the only length they carry, counted at the caller's rate because audio
+    reports no rate of its own either."""
+    reported = {
+        "Type": "Audio",
+        "FPS": "",
+        "Frames": "",
+        "Start": "",
+        "End": "",
+        "Duration": "01:26:38:09",
+        "Sample Rate": "48000",
+        "Audio Ch": "1",
+    }
+
+    assert frame_bounds(reported, fps=23.976) == (0, 124761)
+
+
+def test_frame_bounds_with_no_rate_at_all_stays_unknown() -> None:
+    reported = {"FPS": "", "Frames": "", "Start": "", "End": "", "Duration": "01:26:38:09"}
+
+    assert frame_bounds(reported) == (None, None)
+
+
+def test_the_duration_fallback_applies_whenever_the_out_point_is_unreadable() -> None:
+    """A reported Start does not disqualify the fallback: only End/Frames being blank
+    leaves the out point unknown, and Duration stands in from wherever start is."""
+    reported = {"FPS": "", "Frames": "", "Start": "0", "End": "", "Duration": "01:26:38:09"}
+
+    assert frame_bounds(reported, fps=23.976) == (0, 124761)
+
+
+def test_a_zero_frame_duration_is_empty_media_not_unknown_media() -> None:
+    """[0, 0) is a statement about the media; only an unparseable length is unknown."""
+    reported = {"FPS": "", "Frames": "", "Start": "", "End": "", "Duration": "00:00:00:00"}
+
+    assert frame_bounds(reported, fps=24.0) == (0, 0)

--- a/tests/test_media_pool.py
+++ b/tests/test_media_pool.py
@@ -24,19 +24,8 @@ from resolve_mcp.tools.media import (
 )
 
 from .conftest import Attach
-from .fakes import FakeMediaPool, FakeMediaPoolItem, media_pool, studio
-
-
-def a_file(tmp_path: Path, name: str, content: bytes = b"media") -> Path:
-    target = tmp_path / name
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_bytes(content)
-    return target
-
-
-def a_clip(path: Path | str, **properties: str) -> FakeMediaPoolItem:
-    return FakeMediaPoolItem(Path(path).name, str(path), properties)
-
+from .fakes import media_pool, studio
+from .mediapool import a_clip, a_file, a_shallow_copy_pool
 
 # --- offline and sequence identity -------------------------------------------------------
 
@@ -296,17 +285,6 @@ def test_inspect_of_a_missing_root_clip_says_it_searched_the_root(
 
 
 # --- recursive -------------------------------------------------------------------------
-
-
-def a_shallow_copy_pool(tmp_path: Path) -> FakeMediaPool:
-    """The #134 shape: one clip name held by a bin *and* by a bin nested inside it."""
-    same = a_file(tmp_path, "C0012.mp4")
-    return media_pool(
-        bins={
-            "Angles": [a_clip(same, Description="in Angles")],
-            "Angles/Cam A": [a_clip(same, Description="nested")],
-        }
-    )
 
 
 def test_a_shallow_lookup_reaches_the_copy_held_by_the_named_bin_itself(

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -1,4 +1,10 @@
-"""The media pool tools, called in-process against the fake Resolve seam."""
+"""The six media operations, called in-process against the fake Resolve seam.
+
+What each operation does with what the pool adapter hands it: import and its suggested
+bins, listing and its spill, the inspect envelope, metadata routing, bin operations and
+relink. The adapter's own behaviour — bin addressing, clip lookup, clip reading — is
+verified in ``test_media_pool.py``.
+"""
 
 from __future__ import annotations
 
@@ -7,7 +13,6 @@ from pathlib import Path
 
 import pytest
 
-from resolve_mcp.resolve.media import frame_bounds
 from resolve_mcp.tools.media import (
     import_media,
     inspect_clip,
@@ -98,42 +103,6 @@ def test_an_imported_sequence_reports_the_same_type_as_moving_footage(
     )
 
     assert [clip["type"] for clip in result["imported"]] == ["Video", "Video"]
-
-
-def test_an_imported_sequence_whose_frames_are_on_disk_is_not_offline(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """Resolve paths a sequence by its bracketed label (#85), which never exists on disk.
-
-    Offline must be judged by the frames behind the label, or every freshly imported
-    sequence reads offline and list_media(offline_only=True) sends a relink chase at
-    healthy media.
-    """
-    for index in range(1, 4):
-        a_file(tmp_path, f"seq/shot_{index:04d}.png")
-    attach(studio(pool=media_pool()))
-
-    result = import_media(
-        sequences=[
-            {"path": str(tmp_path / "seq" / "shot_%04d.png"), "start_index": 1, "end_index": 3}
-        ]
-    )
-
-    assert result["ok"] is True
-    assert result["imported"][0]["name"] == "shot_[0001-0003].png"
-    assert result["imported"][0]["offline"] is False
-    assert list_media(offline_only=True)["count"] == 0
-
-
-def test_a_sequence_whose_frames_moved_away_is_offline(attach: Attach, tmp_path: Path) -> None:
-    """The folder still exists — offline is judged by the first frame, not the folder."""
-    (tmp_path / "seq").mkdir()
-    clip = a_clip(tmp_path / "seq" / "shot_[0001-0003].png")
-    attach(studio(pool=media_pool(bins={"Stills": [clip]})))
-
-    assert [found["name"] for found in list_media(offline_only=True)["clips"]] == [
-        "shot_[0001-0003].png"
-    ]
 
 
 def test_import_applies_the_still_duration_workaround_to_image_media(
@@ -591,38 +560,6 @@ def test_list_spills_the_full_listing_to_disk_past_the_cap(attach: Attach, tmp_p
     assert len(json.loads(spilled.read_text(encoding="utf-8"))["clips"]) == 5
 
 
-def test_a_bin_really_named_master_is_still_addressable(attach: Attach, tmp_path: Path) -> None:
-    """The root is called Master, so a leading Master is only dropped when it is the root."""
-    pool = media_pool(bins={"Master": [a_clip(a_file(tmp_path, "C0012.mp4"))], "": []})
-    attach(studio(pool=pool))
-
-    result = list_media(bin="Master", recursive=False)
-
-    assert result["ok"] is True
-    assert result["bin"] == "Master"
-    assert [clip["name"] for clip in result["clips"]] == ["C0012.mp4"]
-
-
-def test_list_of_an_unknown_bin_names_the_bins_that_exist(attach: Attach) -> None:
-    attach(studio(pool=media_pool(bins={"Angles/Cam A": []})))
-
-    result = list_media(bin="angles")
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "bin_not_found"
-    assert "Angles/Cam A" in result["error"]["fix"]
-
-
-def test_media_tools_need_a_project(attach: Attach) -> None:
-    attach(studio(project=None))
-
-    result = list_media()
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "no_project_open"
-    assert result["error"]["fix"]
-
-
 # --- inspect ---------------------------------------------------------------------------
 
 
@@ -685,360 +622,6 @@ def test_inspect_survives_a_clip_with_no_audio_mapping_or_markers(
     assert result["clip"]["bin"] == ""
 
 
-def test_inspect_of_an_unknown_clip_says_what_is_there(attach: Attach, tmp_path: Path) -> None:
-    attach(studio(pool=media_pool(bins={"Angles": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
-
-    result = inspect_clip("C0013.mp4")
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "clip_not_found"
-    assert result["error"]["fix"]
-
-
-def test_inspect_refuses_an_ambiguous_clip_name(attach: Attach, tmp_path: Path) -> None:
-    same = a_file(tmp_path, "C0012.mp4")
-    attach(
-        studio(pool=media_pool(bins={"Angles": [a_clip(same)], "Broll": [a_clip(same)]}))
-    )
-
-    result = inspect_clip("C0012.mp4")
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "ambiguous_clip"
-    assert "Angles" in result["error"]["fix"]
-    assert inspect_clip("C0012.mp4", bin="Broll")["ok"] is True
-
-
-def test_a_root_clip_is_reachable_when_its_name_is_also_used_in_a_bin(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """#122: bin="" is the root folder alone — the only way to name the root copy."""
-    same = a_file(tmp_path, "C0012.mp4")
-    root_copy = a_clip(same, Description="at the root")
-    binned_copy = a_clip(same, Description="filed away")
-    attach(studio(pool=media_pool(bins={"": [root_copy], "Angles/Cam A": [binned_copy]})))
-
-    at_root = inspect_clip("C0012.mp4", bin="")
-
-    assert at_root["ok"] is True
-    assert at_root["clip"]["bin"] == ""
-    assert at_root["properties"]["Description"] == "at the root"
-    binned = inspect_clip("C0012.mp4", bin="Angles/Cam A")
-    assert binned["clip"]["bin"] == "Angles/Cam A"
-    assert binned["properties"]["Description"] == "filed away"
-
-
-def test_a_duplicated_name_still_refuses_without_a_bin(attach: Attach, tmp_path: Path) -> None:
-    """Narrowing the root must not turn the whole-pool search into a first-match."""
-    same = a_file(tmp_path, "C0012.mp4")
-    attach(studio(pool=media_pool(bins={"": [a_clip(same)], "Angles": [a_clip(same)]})))
-
-    result = inspect_clip("C0012.mp4")
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "ambiguous_clip"
-    assert result["error"]["detail"]["bins"] == ["", "Angles"]
-    assert 'bin=""' in result["error"]["fix"]  # the root has to be expressible
-    assert 'bin="Angles"' in result["error"]["fix"]
-    assert inspect_clip("C0012.mp4", bin="")["ok"] is True  # and every value offered works
-    assert inspect_clip("C0012.mp4", bin="Angles")["ok"] is True
-
-
-def test_every_bin_a_listing_reports_reads_the_same_clip_back(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """The bin value list_media reports round-trips verbatim, root included."""
-    same = a_file(tmp_path, "C0012.mp4")
-    attach(
-        studio(
-            pool=media_pool(
-                bins={
-                    "": [a_clip(same)],
-                    "Angles": [a_clip(a_file(tmp_path, "C0013.mp4"))],
-                    "Angles/Cam A": [a_clip(same)],
-                }
-            )
-        )
-    )
-
-    listed = list_media()["clips"]
-
-    assert len(listed) == 3
-    for entry in listed:
-        read_back = inspect_clip(entry["name"], bin=entry["bin"])
-        assert read_back["ok"] is True, entry
-        assert read_back["clip"]["bin"] == entry["bin"]
-
-
-def test_a_named_bin_still_reaches_a_clip_in_its_subfolder(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """Only the root narrows: a named bin keeps searching what is nested inside it."""
-    attach(studio(pool=media_pool(bins={"Angles/Cam A": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
-
-    result = inspect_clip("C0012.mp4", bin="Angles")
-
-    assert result["ok"] is True
-    assert result["clip"]["bin"] == "Angles/Cam A"
-
-
-def test_an_ambiguity_offers_only_the_bins_that_reach_one_clip(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """A bin whose subfolder holds another copy is not an answer, so it is not offered."""
-    same = a_file(tmp_path, "C0012.mp4")
-    attach(
-        studio(
-            pool=media_pool(bins={"Angles": [a_clip(same)], "Angles/Cam A": [a_clip(same)]})
-        )
-    )
-
-    result = inspect_clip("C0012.mp4", bin="Angles")
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "ambiguous_clip"
-    assert result["error"]["fix"] == (
-        'Pass one of these to say which: bin="Angles/Cam A". Or bin="Angles" with '
-        "recursive=false for the copy in that bin itself."
-    )  # bin="Angles" alone reaches the nested copy too, so it is only offered shallow
-    assert inspect_clip("C0012.mp4", bin="Angles/Cam A")["ok"] is True
-
-
-def test_two_copies_in_one_bin_are_refused_with_advice_that_is_not_a_bin(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """When no bin can answer, the fix says so instead of naming a value that fails."""
-    same = a_file(tmp_path, "C0012.mp4")
-    attach(studio(pool=media_pool(bins={"Angles": [a_clip(same), a_clip(same)]})))
-
-    result = inspect_clip("C0012.mp4", bin="Angles")
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "ambiguous_clip"
-    assert "bin=" not in result["error"]["fix"]
-    assert "recursive" not in result["error"]["fix"]  # a shallow lookup cannot answer either
-    assert "Rename one in the Resolve GUI" in result["error"]["fix"]
-
-
-def test_naming_the_root_master_reaches_the_root_clip_only(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """Master is the root's own name, so it narrows the same way the empty string does."""
-    same = a_file(tmp_path, "C0012.mp4")
-    attach(
-        studio(
-            pool=media_pool(
-                bins={"": [a_clip(same, Description="at the root")], "Angles": [a_clip(same)]}
-            )
-        )
-    )
-
-    result = inspect_clip("C0012.mp4", bin="Master")
-
-    assert result["ok"] is True
-    assert result["clip"]["bin"] == ""
-    assert result["properties"]["Description"] == "at the root"
-
-
-def test_inspect_of_a_missing_root_clip_says_it_searched_the_root(
-    attach: Attach, tmp_path: Path
-) -> None:
-    attach(studio(pool=media_pool(bins={"Angles": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
-
-    result = inspect_clip("C0012.mp4", bin="")
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "clip_not_found"
-    assert result["error"]["detail"]["searched"] == "the media pool root"
-
-
-# --- recursive -------------------------------------------------------------------------
-
-
-def a_shallow_copy_pool(tmp_path: Path) -> FakeMediaPool:
-    """The #134 shape: one clip name held by a bin *and* by a bin nested inside it."""
-    same = a_file(tmp_path, "C0012.mp4")
-    return media_pool(
-        bins={
-            "Angles": [a_clip(same, Description="in Angles")],
-            "Angles/Cam A": [a_clip(same, Description="nested")],
-        }
-    )
-
-
-def test_a_shallow_lookup_reaches_the_copy_held_by_the_named_bin_itself(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """#134: recursive=False says this bin alone, so the shadowed copy has an address."""
-    attach(studio(pool=a_shallow_copy_pool(tmp_path)))
-
-    result = inspect_clip("C0012.mp4", bin="Angles", recursive=False)
-
-    assert result["ok"] is True
-    assert result["clip"]["bin"] == "Angles"
-    assert result["properties"]["Description"] == "in Angles"
-
-
-def test_a_named_bin_stays_recursive_unless_recursive_is_passed(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """The flag is opt-in: the default keeps searching what is nested inside the bin."""
-    attach(studio(pool=a_shallow_copy_pool(tmp_path)))
-
-    assert inspect_clip("C0012.mp4", bin="Angles")["error"]["code"] == "ambiguous_clip"
-    assert inspect_clip("C0012.mp4", bin="Angles/Cam A", recursive=False)["ok"] is True
-
-
-def test_an_ambiguity_offers_the_shallow_form_when_that_is_what_reaches_a_copy(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """Every value the fix names must work — including the one that needs recursive=false."""
-    attach(studio(pool=a_shallow_copy_pool(tmp_path)))
-
-    fix = inspect_clip("C0012.mp4", bin="Angles")["error"]["fix"]
-
-    assert 'bin="Angles/Cam A"' in fix
-    assert "recursive=false" in fix
-    assert inspect_clip("C0012.mp4", bin="Angles/Cam A")["ok"] is True
-    assert inspect_clip("C0012.mp4", bin="Angles", recursive=False)["ok"] is True
-
-
-def test_a_shallow_lookup_without_a_bin_stays_in_the_root(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """No bin means the root, and recursive=False narrows it the way list_media does."""
-    same = a_file(tmp_path, "C0012.mp4")
-    attach(
-        studio(
-            pool=media_pool(
-                bins={
-                    "": [a_clip(same, Description="at the root")],
-                    "Angles": [a_clip(same, Description="filed away")],
-                }
-            )
-        )
-    )
-
-    result = inspect_clip("C0012.mp4", recursive=False)
-
-    assert result["ok"] is True
-    assert result["clip"]["bin"] == ""
-    assert result["properties"]["Description"] == "at the root"
-
-
-def test_a_shallow_lookup_that_finds_nothing_says_it_did_not_descend(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """The refusal names what was searched, so the fix is to drop the flag, not the bin."""
-    attach(studio(pool=media_pool(bins={"Angles/Cam A": [a_clip(a_file(tmp_path, "C0012.mp4"))]})))
-
-    result = inspect_clip("C0012.mp4", bin="Angles", recursive=False)
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "clip_not_found"
-    assert result["error"]["detail"]["searched"] == "the bin 'Angles' alone"
-
-
-def test_metadata_writes_to_the_copy_a_shallow_item_names(
-    attach: Attach, tmp_path: Path
-) -> None:
-    pool = a_shallow_copy_pool(tmp_path)
-    attach(studio(pool=pool))
-
-    result = set_clip_metadata(
-        [
-            {
-                "clip": "C0012.mp4",
-                "bin": "Angles",
-                "recursive": False,
-                "fields": {"Description": "the shallow copy"},
-            }
-        ]
-    )
-
-    assert result["results"][0]["ok"] is True
-    assert result["results"][0]["bin"] == "Angles"
-    angles = pool.GetRootFolder().GetSubFolderList()[0]
-    assert angles.GetClipList()[0].property_writes == [("Description", "the shallow copy")]
-    nested = angles.GetSubFolderList()[0].GetClipList()[0]
-    assert nested.property_writes == []
-    assert nested.metadata_writes == []
-
-
-def test_organize_moves_the_copy_a_shallow_from_bin_names(
-    attach: Attach, tmp_path: Path
-) -> None:
-    pool = a_shallow_copy_pool(tmp_path)
-    attach(studio(pool=pool))
-
-    result = organize_media(
-        [
-            {
-                "op": "move_clips",
-                "clips": ["C0012.mp4"],
-                "from_bin": "Angles",
-                "recursive": False,
-                "to_bin": "Broll",
-            }
-        ]
-    )
-
-    assert result["results"][0]["ok"] is True
-    root = pool.GetRootFolder()
-    angles = root.GetSubFolderList()[0]
-    broll = [sub for sub in root.GetSubFolderList() if sub.GetName() == "Broll"][0]
-    assert angles.GetClipList() == []  # the copy Angles held itself
-    assert [item.GetName() for item in broll.GetClipList()] == ["C0012.mp4"]
-    assert len(angles.GetSubFolderList()[0].GetClipList()) == 1  # the nested copy stayed
-
-
-def test_a_recursive_key_that_is_not_a_boolean_is_refused_not_coerced(
-    attach: Attach, tmp_path: Path
-) -> None:
-    """A JSON string reads as True under bool(), which would search the opposite way."""
-    pool = a_shallow_copy_pool(tmp_path)
-    attach(studio(pool=pool))
-
-    result = set_clip_metadata(
-        [
-            {
-                "clip": "C0012.mp4",
-                "bin": "Angles",
-                "recursive": "false",
-                "fields": {"Description": "no"},
-            },
-            {"clip": "C0012.mp4", "bin": "Angles/Cam A", "fields": {"Description": "yes"}},
-        ]
-    )
-
-    first, second = result["results"]
-    assert first["ok"] is False
-    assert first["error"]["code"] == "invalid_request"
-    assert second["ok"] is True  # one bad item never sinks the batch
-    assert pool.GetRootFolder().GetSubFolderList()[0].GetClipList()[0].property_writes == []
-
-
-def test_relink_takes_the_shallow_form_too(attach: Attach, tmp_path: Path) -> None:
-    moved = a_file(tmp_path, "new/C0012.mp4")
-    attach(
-        studio(
-            pool=media_pool(
-                bins={
-                    "Angles": [a_clip(tmp_path / "old" / "C0012.mp4")],
-                    "Angles/Cam A": [a_clip(tmp_path / "old" / "C0012.mp4")],
-                }
-            )
-        )
-    )
-
-    result = relink_media(["C0012.mp4"], str(moved.parent), bin="Angles", recursive=False)
-
-    assert result["ok"] is True
-    assert result["results"][0]["bin"] == "Angles"
-    assert result["results"][0]["offline"] is False
-    assert list_media(offline_only=True)["count"] == 1  # the nested copy is still offline
-
-
 # --- metadata --------------------------------------------------------------------------
 
 
@@ -1090,6 +673,38 @@ def test_metadata_batch_reports_per_item_failures_without_losing_the_batch(
     assert second["error"]["code"] == "clip_not_found"
     assert third["ok"] is True
     assert willing.metadata_writes == [("Description", "yes")]
+
+
+def test_a_recursive_key_that_is_not_a_boolean_is_refused_not_coerced(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """A JSON string reads as True under bool(), which would search the opposite way."""
+    same = a_file(tmp_path, "C0012.mp4")
+    pool = media_pool(
+        bins={
+            "Angles": [a_clip(same, Description="in Angles")],
+            "Angles/Cam A": [a_clip(same, Description="nested")],
+        }
+    )
+    attach(studio(pool=pool))
+
+    result = set_clip_metadata(
+        [
+            {
+                "clip": "C0012.mp4",
+                "bin": "Angles",
+                "recursive": "false",
+                "fields": {"Description": "no"},
+            },
+            {"clip": "C0012.mp4", "bin": "Angles/Cam A", "fields": {"Description": "yes"}},
+        ]
+    )
+
+    first, second = result["results"]
+    assert first["ok"] is False
+    assert first["error"]["code"] == "invalid_request"
+    assert second["ok"] is True  # one bad item never sinks the batch
+    assert pool.GetRootFolder().GetSubFolderList()[0].GetClipList()[0].property_writes == []
 
 
 # --- organize --------------------------------------------------------------------------
@@ -1261,55 +876,3 @@ def test_media_tools_survive_a_handle_that_dies_mid_call(attach: Attach, tmp_pat
 
     assert result["ok"] is True
     assert result["count"] == 1
-
-
-def test_a_media_pool_resolve_will_not_hand_over_is_reported(attach: Attach) -> None:
-    attach(studio(pool=None))
-
-    result = list_media()
-
-    assert result["ok"] is False
-    assert result["error"]["code"] == "media_pool_unavailable"
-    assert result["error"]["fix"]
-
-
-# --- frame bounds -----------------------------------------------------------------------
-
-
-def test_frame_bounds_falls_back_to_duration_for_an_audio_only_clip() -> None:
-    """Audio-only clips report Start/End/Frames as empty strings (#46, live-verified);
-    Duration is the only length they carry, counted at the caller's rate because audio
-    reports no rate of its own either."""
-    reported = {
-        "Type": "Audio",
-        "FPS": "",
-        "Frames": "",
-        "Start": "",
-        "End": "",
-        "Duration": "01:26:38:09",
-        "Sample Rate": "48000",
-        "Audio Ch": "1",
-    }
-
-    assert frame_bounds(reported, fps=23.976) == (0, 124761)
-
-
-def test_frame_bounds_with_no_rate_at_all_stays_unknown() -> None:
-    reported = {"FPS": "", "Frames": "", "Start": "", "End": "", "Duration": "01:26:38:09"}
-
-    assert frame_bounds(reported) == (None, None)
-
-
-def test_the_duration_fallback_applies_whenever_the_out_point_is_unreadable() -> None:
-    """A reported Start does not disqualify the fallback: only End/Frames being blank
-    leaves the out point unknown, and Duration stands in from wherever start is."""
-    reported = {"FPS": "", "Frames": "", "Start": "0", "End": "", "Duration": "01:26:38:09"}
-
-    assert frame_bounds(reported, fps=23.976) == (0, 124761)
-
-
-def test_a_zero_frame_duration_is_empty_media_not_unknown_media() -> None:
-    """[0, 0) is a statement about the media; only an unparseable length is unknown."""
-    reported = {"FPS": "", "Frames": "", "Start": "", "End": "", "Duration": "00:00:00:00"}
-
-    assert frame_bounds(reported, fps=24.0) == (0, 0)

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -24,6 +24,7 @@ from resolve_mcp.tools.media import (
 
 from .conftest import Attach
 from .fakes import FakeFolder, FakeMediaPool, FakeMediaPoolItem, media_pool, studio
+from .mediapool import a_clip, a_file, a_shallow_copy_pool
 
 AUDIO_MAPPING = json.dumps(
     {
@@ -32,17 +33,6 @@ AUDIO_MAPPING = json.dumps(
         "track_mapping": {"1": {"channel_idx": [1, 3], "mute": False, "type": "Stereo"}},
     }
 )
-
-
-def a_file(tmp_path: Path, name: str, content: bytes = b"media") -> Path:
-    target = tmp_path / name
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_bytes(content)
-    return target
-
-
-def a_clip(path: Path | str, **properties: str) -> FakeMediaPoolItem:
-    return FakeMediaPoolItem(Path(path).name, str(path), properties)
 
 
 # --- import ----------------------------------------------------------------------------
@@ -679,13 +669,7 @@ def test_a_recursive_key_that_is_not_a_boolean_is_refused_not_coerced(
     attach: Attach, tmp_path: Path
 ) -> None:
     """A JSON string reads as True under bool(), which would search the opposite way."""
-    same = a_file(tmp_path, "C0012.mp4")
-    pool = media_pool(
-        bins={
-            "Angles": [a_clip(same, Description="in Angles")],
-            "Angles/Cam A": [a_clip(same, Description="nested")],
-        }
-    )
+    pool = a_shallow_copy_pool(tmp_path)
     attach(studio(pool=pool))
 
     result = set_clip_metadata(

--- a/tests/text_plus_probe.py
+++ b/tests/text_plus_probe.py
@@ -45,7 +45,7 @@ from typing import Any, NamedTuple
 from resolve_mcp.logging_config import get_logger
 from resolve_mcp.naming import timestamped_name
 from resolve_mcp.resolve.connection import ResolveConnection
-from resolve_mcp.resolve.media import media_pool
+from resolve_mcp.resolve.pool import media_pool
 
 log = get_logger("probe.textplus")
 


### PR DESCRIPTION
Closes #227.

`resolve/media.py` fused two halves: the media pool adapter every other package
consumed (clip location, property reading, bin navigation, frame bounds,
offline/still handling) and the six tool-facing operations that are themselves
callers of it. The adapter moves to `resolve/pool.py`; `resolve/media.py` keeps
import, list, inspect, metadata, organize and relink.

External callers — `cut`, `build`, `apply`, `titles`, `interchange`,
`audio/acquire`, `video/source`, `gauntlet/recon/live_probe` — now import the
adapter directly as `mediapool`, never through the operations module. mypy
strict's no-implicit-reexport rule is what holds that line going forward, and it
is green.

Three helpers changed shape for the seam: `_clips_under` and `_looks_like_image`
become public (`clips_under`, `looks_like_image`), `_number` gains a named public
form (`frame_count`), and `_wants_recursion` moves to the operations side, where
both its callers live. Every other definition moved byte-identical.

The media test file splits the same way: `test_media_pool.py` takes the 28
bin-addressing, lookup, offline and frame-bounds tests; `test_media_tools.py`
keeps the 43 that are about what an operation does. All 71 survive, and the
sorted test-name lists on `main` and this branch are identical — nothing
renamed, dropped or added.

**Test seam:** fake tier. Both files drive `tools/media` against the fake Resolve
singleton, so a lookup and the envelope its refusal is shaped into are verified
together. No live AC — this is a refactor with no new attach behaviour.

`resolve/timeline.py` left alone, as the ticket requires.

## Review

`/code-review` against `origin/main` (two axes, parallel sub-agents).

**Standards** — no hard violations. Move fidelity verified definition by
definition against `origin/main:src/resolve_mcp/resolve/media.py`: every body
byte-identical apart from the intended renames and `_number(reported, FRAMES)` →
`frame_count(reported)`, which is that call verbatim. Four judgement calls, all
fixed in `84a49d1`:

- *Duplicated Code* — `a_file`/`a_clip` defined verbatim in both test files, and
  one test had its `a_shallow_copy_pool` call inlined during the move. All three
  helpers now live in `tests/mediapool.py`, the way `tests/cutfile.py` and
  `tests/otio.py` already hold shared fixtures.
- *Shared logger name* — `pool.py` kept `get_logger("media")`, leaving the new
  module indistinguishable in the log. Now `get_logger("media.pool")`: a child,
  so anything configured for `media` still catches it, but a live failure says
  which half it came from.
- Ragged CONTEXT.md line re-wrapped.

**Spec** — all three acceptance criteria met; no scope creep; `resolve/timeline.py`
untouched. Two notes:

- The ticket body says "a deep pool adapter (~12 names)". The adapter exports 24
  public names. That is what the callers actually need — every one of them has
  an external consumer or an operations consumer, and trimming would mean
  re-privatising and duplicating logic. The seam was **moved, not deepened**;
  the ACs did not ask for deepening, but the "deep adapter" claim should not be
  inherited untested.
- `_markers` and `_set_field` in `media.py` still call the Resolve item API
  directly (`GetMarkers`, `SetClipProperty`, `SetMetadata`), so the operations
  module is not purely a caller of the adapter. Both predate this split and are
  write/inspect-shaping paths the adapter never covered; left as they were.
- `media.py` imported the `Clip`/`Pool` aliases from `.pool` while every other
  module in the package declares its own. Fixed in `84a49d1`.

Fix diff re-checked on its own: helper extraction, one logger rename, one alias
declaration — no behaviour touched.

**Checks:** `uv run pytest -m 'not live'` → 2114 passed, 43 deselected. `uv run
mypy src tests` → Success, 196 files. `uv run ruff check .` → All checks passed.
Run in the worktree after `uv sync` (gotcha R2), pinned to `origin/main` (R1).

Review: clean

## Review — merge of `origin/main` (`5e88f14`)

`main` moved under the branch (#231, #214), so `origin/main` is merged in. One
conflict, in `resolve/build.py`'s import block: `main` added `settings` to
`from . import cut, markers, media, mix, takes` while this branch had removed
`media` from it. Resolved to both changes — `from . import cut, markers, mix,
settings, takes` plus `from . import pool as mediapool`. Grepped the whole tree
for `<<<<<<<` (CLAUDE.md's merge rule): none. Grepped for surviving `media.`
attribute access outside `tools/media.py`: none, so `main`'s new `build.py` code
introduced no call the rename missed.

Re-checked on the merged tree after `uv sync`: `pytest -m 'not live'` → 2161
passed, 44 deselected; `mypy src tests` → Success, 199 files; `ruff check .` →
All checks passed.

Review: clean — merge only, one import-block conflict resolved
