### PR TITLE
Extract the shot-rhythm reading and the bar-map join into their own modules (#215)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,7 +125,12 @@ model will not commit a meter to — folds a too-fast grid to the tactus, then
 scores every meter and phase against a per-beat accent reading and takes the
 widest lead over the runner-up, refusing rather than guessing when the accents
 say nothing. The accent reading is injected per ADR 0002 and defaults to RMS off
-the mix; a named stem reads that instead, #180), `beats` (grid + downbeats, model
+the mix; a named stem reads that instead, #180), `barmap` (a cut read against that
+map: nearest bar line with a signed offset — a cut just before a downbeat is a cut
+on the one — giving `map_bar`, `in_group` and `bar_offset` per cut and the
+`bar_groups`/`bar_offsets` blocks over them, ungated on the beat gate since the map
+exists for the grids that gate refuses whole; pure, read by `correlate`, #180/#215),
+`beats` (grid + downbeats, model
 injected per ADR 0002; `trust` says which beats the grid describes well enough
 to count, #112; `spacing` says how wide a beat is at each beat), `correlate`
 (measure a cut against its music — by default the *visible* edit,
@@ -133,20 +138,11 @@ every frame resolved to the topmost enabled video item with uncovered stretches
 as black shots, #142; `track=` measures one video track alone. Gates the beat
 statistics on `trust`, refuses as `stranded` a cut further from its beat than a
 beat is wide — the grid does not reach it, #160 — and leaves the transient ones
-ungated. Also reads the cutting itself: `shot_rhythm` bins the shot lengths,
-measures the longest strict A/B alternation run and the longest monotonic
-duration `ramp`, and says `reads_metronomic` with the heuristic that drew it,
-and its `gears` block splits the cut's span into loudness terciles off a 1 s
-RMS curve and reports cuts per minute in each, the loud/quiet `rate_ratio`,
-where the sub-2 s shots sit, `one_speed`, and `outside_shots` — shots past
-the analysed mix, counted apart rather than clamped into a tercile — plus
-`quiet_floor`, the passages the slow gear is held through, found by smoothing
-that curve rather than off the per-window tercile labels, each read for the
-spread its lone flashes are not holding up (#190) —
-warnings the report carries, never gates. Takes an optional **bar map**
-(`bars=`) and then reports `map_bar`, `in_group` and `bar_offset` per cut and
-a `bar_groups` histogram — ungated on the beat gate, since the map exists for
-the grids that gate refuses whole, #180),
+ungated. Composes the readings other modules own rather than computing them:
+`rhythm` for `shot_rhythm`, `barmap` for a cut's place in the form (`bars=`, the
+optional **bar map**), `subject` for `on_soloist`. What is left here is the join —
+reading the timeline, putting every shot on the music's clock, writing the file,
+#215),
 `cuda` (preloads
 the CUDA runtime the `analysis` extra ships, so CTranslate2 finds it on Windows;
 pure decisions, #128),
@@ -165,10 +161,24 @@ is a rule layer over, as `drums` is to `fills`), `music` (beats + energy + gist
 job; `beats_of`/`energy_of` are the shared entries other jobs read a grid or a
 loudness curve through, one measurement per piece of audio), `phrases` (phrase boundaries: where the soloist stops, which is the
 cut-placement unit #46 named, #143),
-`records` (sliceable record files), `silence` (RMS spans), `solos` (front
+`records` (sliceable record files), `rhythm` (how varied the cutting is, one entry
+`read(rows, levels)` over per-cut rows and a level curve: `shot_rhythm` bins the
+shot lengths, measures the longest strict A/B alternation run and the longest
+monotonic duration `ramp`, and says `reads_metronomic` with the heuristic that drew
+it; its `gears` block splits the cut's span into loudness terciles off a 1 s RMS
+curve and reports cuts per minute in each, the loud/quiet `rate_ratio`, where the
+sub-2 s shots sit, `one_speed`, and `outside_shots` — shots past the analysed mix,
+counted apart rather than clamped into a tercile — plus `quiet_floor`, the passages
+the slow gear is held through, found by smoothing that curve rather than off the
+per-window tercile labels, each read for the spread its lone flashes are not holding
+up (#190). Warnings the report carries, never gates; pure, read by `correlate`,
+#215), `silence` (RMS spans), `solos` (front
 of band changes: lead off the stem energy, timbre off one stem's brightness —
 with the third pass on disk the voices are `wind`/`comp` rather than `other`
-and timbre reads `wind`, #157), `structure` (tunes + solo changes job; both
+and timbre reads `wind`, #157), `stats` (the readings taken over a column of
+records — signed offsets with early and late counted apart, a histogram, and
+whether a column was measured at all — shared by `correlate` and the joins it
+composes so the rules have one copy, #215), `structure` (tunes + solo changes job; both
 halves read the shared beats half and the tune half the shared energy half; its
 stem loader is what reaches the third pass), `subject` (what a shot is framed
 on crossed with who is out front: the angle sidecar's subject read as

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -120,16 +120,17 @@ Top level:
 with no pulse under them, #133; every boundary then walks forward off the applause
 to where the loudness curve says the band comes in, and a mix the threshold finds
 no clapping in at all is read at its own scale instead, #179),
-`bars` (the **bar map**: a rule layer over the grid for the material the beat
+`barmap` (a cut read against the **bar map** `bars` writes: nearest bar line with a
+signed offset — a cut just before a downbeat is a cut on the one — giving `map_bar`,
+`in_group` and `bar_offset` per cut and the `bar_groups`/`bar_offsets` blocks over
+them, ungated on the beat gate since the map exists for the grids that gate refuses
+whole; pure, read by `correlate`, #180/#215),
+`bars` (the **bar map** itself: a rule layer over the grid for the material the beat
 model will not commit a meter to — folds a too-fast grid to the tactus, then
 scores every meter and phase against a per-beat accent reading and takes the
 widest lead over the runner-up, refusing rather than guessing when the accents
 say nothing. The accent reading is injected per ADR 0002 and defaults to RMS off
-the mix; a named stem reads that instead, #180), `barmap` (a cut read against that
-map: nearest bar line with a signed offset — a cut just before a downbeat is a cut
-on the one — giving `map_bar`, `in_group` and `bar_offset` per cut and the
-`bar_groups`/`bar_offsets` blocks over them, ungated on the beat gate since the map
-exists for the grids that gate refuses whole; pure, read by `correlate`, #180/#215),
+the mix; a named stem reads that instead, #180),
 `beats` (grid + downbeats, model
 injected per ADR 0002; `trust` says which beats the grid describes well enough
 to count, #112; `spacing` says how wide a beat is at each beat), `correlate`

--- a/gauntlet/recon/quiet_floor.py
+++ b/gauntlet/recon/quiet_floor.py
@@ -14,11 +14,12 @@ orphans:
   cv_less      pstdev/mean over the passage with the orphans dropped
   carried_by   cv - cv_less, how much of the raw spread one or two shots were holding up
 
-Every one of those readings is taken by importing `analysis.correlate`'s own functions rather
-than by reimplementing them here. That is deliberate: this file is the receipt behind the
+Every one of those readings is taken by importing the server's own functions rather
+than by reimplementing them here (`analysis.rhythm`, which the reading moved to in #215;
+`analysis.correlate` before that). That is deliberate: this file is the receipt behind the
 corpus row and the style bullet, and a second copy of the arithmetic would let the receipt go
 on describing a tool the server no longer has. The `server_check` block at the end is the same
-point made end to end - correlate's `gears.quiet_floor`, run over the deliverable's own level
+point made end to end - the report's `gears.quiet_floor`, run over the deliverable's own level
 curve and our cut file, so "the rule fires on the cut the ticket complains about" is a
 recorded result rather than an inference.
 
@@ -43,7 +44,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from resolve_mcp.analysis import correlate, decode, energy
+from resolve_mcp.analysis import decode, energy, rhythm
 
 ROOT = Path(__file__).resolve().parents[2]
 OUT = Path(__file__).with_name("quiet_floor.json")
@@ -110,7 +111,7 @@ def level_curve(path: Path) -> list[tuple[float, float]]:
         )
         if proc.returncode != 0:
             raise SystemExit(proc.stderr[-2000:])
-        curve = energy.rms_curve(decode.read(wav), correlate.GEAR_WINDOW_SECONDS)
+        curve = energy.rms_curve(decode.read(wav), rhythm.GEAR_WINDOW_SECONDS)
     return [(level.seconds, level.rms_dbfs) for level in curve]
 
 
@@ -133,7 +134,7 @@ def shots_from_cut_file(path: Path) -> tuple[list[tuple[float, float]], float]:
 
 
 def rows_of(spans: list[tuple[float, float]]) -> list[dict[str, Any]]:
-    """Shot spans as the rows correlate's own readers take."""
+    """Shot spans as the rows the server's own readers take."""
     return [{"t": round(a, 3), "seconds": round(b - a, 3)} for a, b in spans]
 
 
@@ -146,10 +147,10 @@ def measure(label: str, spans: list[tuple[float, float]], total: float) -> dict[
         lengths = [round(b - a, 3) for a, b in inside]
         if not lengths:
             continue
-        orphans = correlate._orphans(lengths)
+        orphans = rhythm._orphans(lengths)
         kept = [x for i, x in enumerate(lengths) if i not in orphans]
-        cv = correlate._cv(lengths)
-        cv_less = correlate._cv(kept)
+        cv = rhythm._cv(lengths)
+        cv_less = rhythm._cv(kept)
         rows.append(
             {
                 "section": name,
@@ -173,9 +174,9 @@ def measure(label: str, spans: list[tuple[float, float]], total: float) -> dict[
         )
     quiet = [row for row in rows if row["section"] in QUIET]
     quiet_lengths = [x for row in quiet for x in row["lengths"]]
-    quiet_orphans = correlate._orphans(quiet_lengths)
+    quiet_orphans = rhythm._orphans(quiet_lengths)
     quiet_kept = [x for i, x in enumerate(quiet_lengths) if i not in quiet_orphans]
-    # A section holding one shot has no within-section spread to average in. correlate._cv
+    # A section holding one shot has no within-section spread to average in. rhythm._cv
     # answers 0.0 there on purpose - for a *passage*, one hold running through is exactly the
     # locked reading - but a mean over sections is a different question, and folding that 0.0
     # in would report a stillness the section never had. His `ending` is one 21 s shot.
@@ -189,18 +190,18 @@ def measure(label: str, spans: list[tuple[float, float]], total: float) -> dict[
         "label": label,
         "duration_sec": total,
         "shots": len(spans),
-        "shot_cv": correlate._cv(lengths_all),
+        "shot_cv": rhythm._cv(lengths_all),
         "sections": rows,
         "quiet_band": {
             "sections": list(QUIET),
             "shots": len(quiet_lengths),
             "median_seconds": round(statistics.median(quiet_lengths), 2),
-            "pooled_cv": correlate._cv(quiet_lengths),
+            "pooled_cv": rhythm._cv(quiet_lengths),
             "mean_of_section_cvs": round(
                 statistics.fmean([r["cv"] for r in quiet if r["cv"] is not None]), 3
             ),
             "orphans": len(quiet_orphans),
-            "pooled_cv_less_orphans": correlate._cv(quiet_kept),
+            "pooled_cv_less_orphans": rhythm._cv(quiet_kept),
             "lengths": quiet_lengths,
         },
         "mean_within_section_cv": round(statistics.fmean(section_cvs), 3),
@@ -212,9 +213,9 @@ def measure(label: str, spans: list[tuple[float, float]], total: float) -> dict[
 def over_runs(
     spans: list[tuple[float, float]], runs: list[tuple[float, float]]
 ) -> list[dict[str, Any]]:
-    """correlate's own passage reading, over the runs correlate's own run-finder derived."""
+    """rhythm's own passage reading, over the runs its own run-finder derived."""
     rows = rows_of(spans)
-    return [correlate._passage(rows, lo, hi) for lo, hi in runs]
+    return [rhythm._passage(rows, lo, hi) for lo, hi in runs]
 
 
 def main() -> None:
@@ -227,13 +228,13 @@ def main() -> None:
     ours = measure("ours (P4R2)", ours_spans, ours_total)
 
     curve = level_curve(DELIVERABLE)
-    runs = correlate._quiet_runs(curve)
+    runs = rhythm._quiet_runs(curve)
     derived = {
-        "smoothing_windows": correlate.QUIET_SMOOTHING_WINDOWS,
-        "window_seconds": correlate.GEAR_WINDOW_SECONDS,
-        "min_run_seconds": correlate.QUIET_FLOOR_SECONDS,
-        "orphan_fraction": correlate.ORPHAN_FRACTION,
-        "cv_floor": correlate.FLOOR_CV_FLOOR,
+        "smoothing_windows": rhythm.QUIET_SMOOTHING_WINDOWS,
+        "window_seconds": rhythm.GEAR_WINDOW_SECONDS,
+        "min_run_seconds": rhythm.QUIET_FLOOR_SECONDS,
+        "orphan_fraction": rhythm.ORPHAN_FRACTION,
+        "cv_floor": rhythm.FLOOR_CV_FLOOR,
         "curve_windows": len(curve),
         "runs": [{"d_from": round(a, 2), "d_to": round(b, 2), "seconds": round(b - a, 2)}
                  for a, b in runs],
@@ -241,9 +242,9 @@ def main() -> None:
         "ours": over_runs(ours_spans, runs),
     }
 
-    # The whole block as correlate would report it on our cut: the ticket's own cut, the
+    # The whole block as the report would carry it on our cut: the ticket's own cut, the
     # server's own code, so the claim that the rule fires on it is recorded rather than argued.
-    server_check = correlate._quiet_floor(rows_of(ours_spans), curve)
+    server_check = rhythm._quiet_floor(rows_of(ours_spans), curve)
 
     report = {
         "kind": "quiet_floor",
@@ -256,14 +257,14 @@ def main() -> None:
             "the whole deliverable, shots between consecutive detected cuts; ours: the cut file's "
             "own segment lengths at 23.976 fps. Sections are full_gears.py's, a shot belongs to "
             "the section its head sits in. Every spread, orphan and passage reading is taken by "
-            "analysis.correlate's own functions, not by a copy of them living here."
+            "analysis.rhythm's own functions, not by a copy of them living here."
         ),
         "threshold": THRESHOLD,
         "human": human,
         "ours": ours,
         "derived_quiet_runs": derived,
         "server_check": {
-            "what": "analysis.correlate gears.quiet_floor over our P4R2 cut file",
+            "what": "analysis.rhythm gears.quiet_floor over our P4R2 cut file",
             "reads_locked": server_check["reads_locked"],
             "runs": server_check["runs"],
         },
@@ -297,8 +298,8 @@ def main() -> None:
 
     print(
         f"\n=== derived quiet runs "
-        f"(smoothed {correlate.QUIET_SMOOTHING_WINDOWS} x "
-        f"{correlate.GEAR_WINDOW_SECONDS} s) ==="
+        f"(smoothed {rhythm.QUIET_SMOOTHING_WINDOWS} x "
+        f"{rhythm.GEAR_WINDOW_SECONDS} s) ==="
     )
     for run in derived["runs"]:
         print(f"  d {run['d_from']:7.2f} -> {run['d_to']:7.2f}  ({run['seconds']:.1f} s)")

--- a/src/resolve_mcp/analysis/barmap.py
+++ b/src/resolve_mcp/analysis/barmap.py
@@ -1,0 +1,87 @@
+"""Where a cut sits in the form: the join onto the bar map (#180).
+
+``bars.py`` writes the bar map — one record per bar, each with its place in the four-bar
+group. This is the other half: reading a cut against it, so a shot has a bar of the form under
+it rather than only a pulse. The two are apart because they answer to different things — the
+map is a measurement of the music, this is a measurement of an edit against that measurement,
+and the second one exists precisely for the material where the first one had to be run.
+
+*Why a second bar column at all.* Every beat in the grid already carries a bar number, but only
+the one the beat model committed to; on material where it commits to nothing that column is a
+meter of one, and the whole reading collapses. The bar map is the second opinion that recovers
+a real bar line, so a report can carry both and say which is which — ``bar``/``in_bar`` from
+the grid, ``map_bar``/``in_group``/``bar_offset`` from here.
+
+*Nearest, not containing.* The bar line is read the way the beat is: nearest, with a signed
+offset, negative early. A cut twenty milliseconds *before* a downbeat is a cut on the one, and
+a rule that filed it under the bar it technically falls inside would misfile the commonest
+placement in this material every time.
+
+The interface mirrors ``subject``: ``reading`` for the columns one cut carries, ``summary`` for
+the list-free blocks taken over them. Neither touches a file or a Resolve handle — bar records
+in, dicts out.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .beats import nearest
+from .stats import histogram, measured, offsets, rounded
+
+COLUMNS = ("map_bar", "in_group", "bar_offset")
+"""The columns a record carries from this join, unmeasured as ``None`` on all three."""
+
+
+def times(bars: Sequence[Mapping[str, Any]] | None) -> list[float]:
+    """The bar lines as seconds, in the order the map wrote them — what ``reading`` searches."""
+    return [float(row["t"]) for row in (bars or ())]
+
+
+def reading(
+    bars: Sequence[Mapping[str, Any]] | None,
+    lines: Sequence[float],
+    seconds: float,
+) -> dict[str, Any]:
+    """One cut against the bar map: which bar of the form, where in the group, how far off.
+
+    All three columns are ``None`` together when no map was named — a cut with no bar map is a
+    cut nobody asked the question of, and a zero offset would read as a cut landing dead on a
+    line that was never measured.
+
+    ``lines`` is ``times(bars)``, hoisted by the caller because a measurement runs this once per
+    cut and rebuilding the list each time would be the same list several thousand times over.
+    """
+    found = None if not lines else nearest(lines, seconds)
+    line = None if found is None else (bars or ())[found]
+    if line is None:
+        return dict.fromkeys(COLUMNS)
+    return {
+        "map_bar": line.get("bar"),
+        "in_group": line.get("in_group"),
+        "bar_offset": rounded(seconds - float(line["t"])),
+    }
+
+
+def summary(
+    rows: Sequence[Mapping[str, Any]], cuts: Sequence[Mapping[str, Any]]
+) -> dict[str, Any]:
+    """The two list-free blocks: where in the group the cuts land, and how far off the line.
+
+    Deliberately not gated on ``in_grid``. The beat gate refuses beats the *grid* describes
+    badly, and a bar map exists precisely for the grids that get refused wholesale — gating
+    this on the grid's verdict would empty the one reading that still had something to say.
+
+    ``rows`` is every record and ``cuts`` the ones cut to music, and the two are different
+    questions: whether the column was measured at all is asked of the whole file, while an
+    opening is not a cut to the music and would drag a meaningless offset into the statistics.
+    """
+    return {
+        "bar_groups": (
+            histogram(row["in_group"] for row in cuts) if measured("in_group", rows) else None
+        ),
+        "bar_offsets": (
+            offsets([row["bar_offset"] for row in cuts]) if measured("bar_offset", rows) else None
+        ),
+    }

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -15,6 +15,13 @@ Markdown document Claude writes, never server code (#21). The same goes for the 
 angle sidecar is the agent's own document and no server path touches it (#45), so the labels
 arrive here as a mapping the caller already lifted out of it.
 
+*Composed, not computed here.* The readings a caller quotes are owned by modules of their own
+and this file joins them onto the shots: `subject.py` for what a shot is framed on (#181),
+`rhythm.py` for the `shot_rhythm` block and everything under it — `gears`, `quiet_floor`,
+`reads_metronomic` (#215) — and `barmap.py` for a cut's place in the form (#180). What is left
+here is the join: reading the timeline, putting every shot on the music's clock, and writing
+the file.
+
 *Measurement, not analysis.* The beat grid, the tunes and the solo changes are files another
 job already wrote; this joins them to the shots. The one thing it computes is the transient
 list, because onsets are the fourth-wall risk (#21: transients, not the beat grid) and no
@@ -33,8 +40,7 @@ from __future__ import annotations
 
 import json
 import statistics
-from bisect import bisect_left, bisect_right
-from collections import Counter
+from bisect import bisect_left
 from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
@@ -63,10 +69,11 @@ from ..resolve.timeline import (
     start_frame,
     track_enabled,
 )
-from ..timing import SECONDS_PRECISION, dual_time, to_frames
+from ..timing import dual_time, to_frames
 from ..video import supers
-from . import decode, energy, records, subject
+from . import barmap, decode, energy, records, rhythm, subject
 from .beats import GridTrust, nearest, spacing, trust
+from .stats import histogram, measured, offsets, rounded
 
 if TYPE_CHECKING:  # pragma: no cover - numpy and scipy load with this module, in the worker
     from ..video import picture
@@ -96,143 +103,6 @@ measurement, and refusing it would be trading one wrong answer for another.
 
 BLACK = "black"
 """Where the stretches nothing covers are counted — a known absence, not a missing label."""
-
-RHYTHM_BINS: tuple[tuple[str, float], ...] = (
-    ("<2", 2.0),
-    ("2-4", 4.0),
-    ("4-8", 8.0),
-    ("8-15", 15.0),
-    ("15-30", 30.0),
-    (">30", float("inf")),
-)
-"""The corpus shot-length bins, as label and upper edge, in seconds.
-
-Half-open on the upper edge: a shot of exactly 4 s counts in ``4-8``, and the last bin takes
-everything from 30 s up. The labels are the ones the corpus and the style profiles already
-speak, so a histogram from this report drops straight into a comparison against them; the
-edges are that vocabulary's, not a threshold this file tuned.
-"""
-
-ALTERNATION_MIN = 2
-"""How many cuts an A/B run needs before it is alternation rather than a cut.
-
-Two shots that differ are just a cut — the pattern only exists once the cut *returns*, so a
-run is counted from three shots (A B A) up. Without this floor every two-shot timeline reads
-as perfectly alternating, which is arithmetic rather than a fact about the edit.
-"""
-
-RAMP_MIN = 4
-"""How many cuts of one direction make a ramp rather than a coincidence.
-
-Three shots that happen to shorten are two cuts, and two cuts in a row go one way in any cut
-list long enough — the shape only exists once it keeps going. Counted from five shots (four
-cuts) up, which is where a run stops being what randomness hands you.
-"""
-
-ALTERNATION_FLOOR = 0.8
-ONE_BIN_FLOOR = 0.6
-CV_FLOOR = 0.35
-RAMP_FLOOR = 0.6
-"""The four numbers ``reads_metronomic`` is drawn at — see ``HEURISTIC``."""
-
-HEURISTIC = (
-    "reads_metronomic is true when the longest strict A/B alternation run covers more than "
-    f"{ALTERNATION_FLOOR} of the cuts and the lengths are mechanical with it: either one bin "
-    f"holds more than {ONE_BIN_FLOOR} of the shots, or the coefficient of variation of shot "
-    f"lengths is under {CV_FLOOR}, or the longest run of shots that only shorten or only "
-    f"lengthen covers more than {RAMP_FLOOR} of the cuts. It is a warning to look at, not a "
-    "verdict: a passage that genuinely wants a two-camera ping-pong scores the same as a cut "
-    "nobody varied, and only the director can tell them apart."
-)
-"""The heuristic in words, carried in the report so nobody has to read this file to check it."""
-
-GEAR_WINDOW_SECONDS = 1.0
-"""How coarse the loudness curve the gearing is read against is, in seconds per window.
-
-A second is a bar at slow rock tempo and half of one at anything faster: coarse enough that
-a snare hit does not move a window into the loud third, fine enough that the quiet verse and
-the last chorus land in different ones. Nothing here is a loudness measurement anybody
-publishes — the only question asked of it is which windows are louder than which.
-"""
-
-QUIET, MID, LOUD = "quiet", "mid", "loud"
-"""The three gears, named where the report names them."""
-
-SUB_TWO_SECONDS = RHYTHM_BINS[0][1]
-"""What counts as a short shot: the corpus's own ``<2`` edge, not a second threshold."""
-
-RATE_RATIO_FLOOR = 1.3
-GEAR_CV_FLOOR = 0.65
-"""The two numbers ``one_speed`` is drawn at — see ``GEAR_HEURISTIC``."""
-
-GEAR_HEURISTIC = (
-    "one_speed is true when the loud third of the music is cut less than "
-    f"{RATE_RATIO_FLOOR}x as fast as the quiet third (rate_ratio) and the coefficient of "
-    f"variation of shot lengths is under {GEAR_CV_FLOOR}. Terciles are thirds of the span by "
-    "level, not by time: the 1 s RMS windows inside the cut are ranked and split three ways, "
-    "and each shot is counted in the window its first frame lands in — a shot the curve does "
-    "not reach is counted in outside_shots and in no tercile. It is a warning to look "
-    "at, not a verdict — a ballad cut at one speed throughout is a real edit, and a passage "
-    "whose loudness never moves has no gears to change. What it catches is the build that cut "
-    "the guitar solo at the pace it cut the intro."
-)
-"""The gearing heuristic in words, carried in the report beside the numbers it was drawn from."""
-
-QUIET_SMOOTHING_WINDOWS = 15
-"""How many gear windows the level curve is smoothed over before quiet passages are found.
-
-The terciles above label one window at a time, and at that resolution a live room's level
-crosses the quiet edge and back inside a single bar — a snare hit, a shout, a chord. Labels
-that flicker are exactly what a *rate* wants, since the rate is over the music each label
-holds however scattered it is, but a passage is not scattered: it is a stretch you sit in.
-A centred moving median over fifteen windows is the coarsest reading that still separates
-this corpus's sections, which run from thirty seconds to a minute and a half.
-"""
-
-QUIET_FLOOR_SECONDS = 20.0
-"""How long a quiet stretch must run before its shot lengths are read as a passage.
-
-Shorter than this is a pocket, and a pocket holds two or three shots — too few for a spread
-to mean anything, and short enough that holding through it is a gesture rather than a stall.
-"""
-
-ORPHAN_FRACTION = 0.5
-"""How much shorter than the passage's median a shot must be to count as an orphan.
-
-Half is the line because it puts a flash on the other side of the passage's own scale rather
-than of a fixed threshold: in a floor of ten-second holds a four-second shot is a shorter
-shot, and a two-second one is a different device.
-"""
-
-FLOOR_CV_FLOOR = 0.65
-"""The number ``reads_locked`` is drawn at — see ``FLOOR_HEURISTIC``.
-
-The same value ``GEAR_CV_FLOOR`` holds, and written out rather than aliased to it: it is the
-same question asked of a smaller span — are these lengths varied enough to read as cutting —
-but it is not the same knob, and retuning what a whole cut is judged at should not silently
-retune what a passage inside one is. Measured on the one full song in the corpus, the
-director's own quiet passage runs a spread of 0.78 across 157 s and ours 0.56; the floor sits
-between them, on a gap of one song, which is all it is worth.
-"""
-
-FLOOR_HEURISTIC = (
-    "quiet_floor reads the passages a build holds the slow gear through: the 1 s levels are "
-    f"smoothed over {QUIET_SMOOTHING_WINDOWS} windows, the quiet third of the smoothed curve "
-    f"is taken, and its contiguous stretches of at least {QUIET_FLOOR_SECONDS} s are the "
-    "passages. reads_locked is true for a passage whose spread survives neither its orphans "
-    f"nor the floor: cv_less_orphans under {FLOOR_CV_FLOOR}. An orphan is a shot under "
-    f"{ORPHAN_FRACTION}x the passage median with both neighbours inside the passage at or "
-    "above it — a lone flash, as against a burst, which is short shots side by side and stays "
-    "in the spread. The reading exists because cv alone is carried by whatever is most "
-    "extreme: five long holds and one flash score a spread the holds do not have. A passage "
-    "no shot starts inside is held through by one, which reads locked on its own — "
-    "held_through_seconds is that shot's length, and there is no cut in the passage to take a "
-    "spread over. No passage "
-    "long enough to read is an empty runs list, which is not the same as passing. It is a "
-    "warning to look at, not a verdict — a passage held on a picture that develops is a real "
-    "edit, and this measures lengths, not what is inside the frame."
-)
-"""The floor heuristic in words, carried in the report beside the numbers it was drawn from."""
 
 READING = 11
 """What this measurement *is*; bumped whenever a rerun over unchanged inputs would differ.
@@ -1042,7 +912,7 @@ def measured_levels(path: Path) -> tuple[tuple[float, float], ...]:
     """
     return tuple(
         (float(point.seconds), float(point.rms_dbfs))
-        for point in energy.rms_curve(decode.read(path), GEAR_WINDOW_SECONDS)
+        for point in energy.rms_curve(decode.read(path), rhythm.GEAR_WINDOW_SECONDS)
     )
 
 
@@ -1078,7 +948,7 @@ def measure(
     times = [float(row["t"]) for row in music.beats]
     tune_times = [float(row["t"]) for row in (music.tunes or ())]
     solo_times = [float(row["t"]) for row in (music.solos or ())]
-    bar_times = [float(row["t"]) for row in (music.bars or ())]
+    bar_times = barmap.times(music.bars)
     roles = music.roles or {}
     subjects = music.subjects or {}
     voices = subject.voices(music.solos)
@@ -1102,12 +972,6 @@ def measure(
             and trusted[found]
             and _out_of_reach(seconds, times[found], widths[found])
         )
-        # The bar line is read the way the beat is — nearest, with a signed offset — and for
-        # the same reason: a cut twenty milliseconds *before* a downbeat is a cut on the one,
-        # and a rule that assigned it to the bar it technically falls inside would file the
-        # commonest placement in this material under the wrong bar every time.
-        line = None if not bar_times else nearest(bar_times, seconds)
-        bar_line = None if line is None else (music.bars or ())[line]
         rows.append(
             {
                 "cut": index,
@@ -1128,14 +992,14 @@ def measure(
                     black=shot.clip is None,
                 ),
                 "opening": _opens(index, shot, shots),
-                "t": _rounded(seconds),
+                "t": rounded(seconds),
                 # Dual time for the two timeline positions, because an outlier the agent
                 # flags is one the director then has to find in Resolve, and a bare frame
                 # number is the one form nobody can scrub to.
                 "in": dual_time(shot.record_in, clock.fps),
                 "out": dual_time(shot.record_out, clock.fps),
-                "seconds": _rounded(shot.duration / clock.fps),
-                "beat_offset": None if beat is None else _rounded(seconds - float(beat["t"])),
+                "seconds": rounded(shot.duration / clock.fps),
+                "beat_offset": None if beat is None else rounded(seconds - float(beat["t"])),
                 "beat": None if beat is None else beat.get("beat"),
                 "bar": None if beat is None else beat.get("bar"),
                 "in_bar": None if beat is None else beat.get("in_bar"),
@@ -1146,12 +1010,9 @@ def measure(
                 "in_grid": found is not None and trusted[found] and not stranded,
                 "stranded": stranded,
                 # From the bar map, when one was named: which bar of the form this cut is on,
-                # where that bar sits in the four-bar group, and how far off the line it is.
-                "map_bar": None if bar_line is None else bar_line.get("bar"),
-                "in_group": None if bar_line is None else bar_line.get("in_group"),
-                "bar_offset": (
-                    None if bar_line is None else _rounded(seconds - float(bar_line["t"]))
-                ),
+                # where that bar sits in the four-bar group, and how far off the line it is
+                # (``barmap``, #180).
+                **barmap.reading(music.bars, bar_times, seconds),
                 "transient_offset": _offset(transients, seconds),
                 "tune": _tune_at(music.tunes, tune_times, seconds),
                 "front": _front_at(music.solos, solo_times, seconds),
@@ -1344,7 +1205,7 @@ def _offset(times: Sequence[float] | None, seconds: float) -> float | None:
     if times is None:
         return None
     found = nearest(times, seconds)
-    return None if found is None else _rounded(seconds - times[found])
+    return None if found is None else rounded(seconds - times[found])
 
 
 def _tune_at(
@@ -1409,7 +1270,9 @@ def _summary(
 
     ``shot_rhythm`` is the one reading here that is about the cut rather than about the music
     — the metronome check a build cannot perform on itself by looking at its offsets, and the
-    gearing check that joins the two.
+    gearing check that joins the two. It is ``rhythm.read``'s, as ``bar_groups`` and
+    ``bar_offsets`` are ``barmap.summary``'s and ``on_soloist`` is ``subject.summary``'s: this
+    function decides which readings the report carries, not what any of them says.
     """
     cut_to_music = [row for row in rows if not row["opening"]]
     # The gate is applied here and nowhere else (#112). Transients need no grid, so they are
@@ -1418,7 +1281,7 @@ def _summary(
     in_grid = [row for row in cut_to_music if row["in_grid"]]
     stranded = sum(1 for row in cut_to_music if row["stranded"])
     transient_offsets = (
-        None if transients is None else _offsets([row["transient_offset"] for row in cut_to_music])
+        None if transients is None else offsets([row["transient_offset"] for row in cut_to_music])
     )
     return {
         "timeline_fps": clock.fps,
@@ -1440,27 +1303,15 @@ def _summary(
         "stranded": stranded,
         "grid_meter": trusted.meter,
         "grid_refused": trusted.reasons,
-        "beat_offsets": _offsets([row["beat_offset"] for row in in_grid]),
+        "beat_offsets": offsets([row["beat_offset"] for row in in_grid]),
         "transient_offsets": transient_offsets,
-        "bars": _histogram(row["in_bar"] for row in in_grid),
-        # The bar map's own histogram, and deliberately not gated on ``in_grid``: the beat
-        # gate refuses beats the *grid* describes badly, and a bar map exists precisely for
-        # the grids that get refused wholesale. Gating this on the grid's verdict would empty
-        # the one reading that still had something to say (#180).
-        "bar_groups": (
-            _histogram(row["in_group"] for row in cut_to_music)
-            if _measured("in_group", rows)
-            else None
-        ),
-        "bar_offsets": (
-            _offsets([row["bar_offset"] for row in cut_to_music])
-            if _measured("bar_offset", rows)
-            else None
-        ),
-        "tunes": _spread("tune", cut_to_music) if _measured("tune", rows) else None,
-        "solos": _spread("front", cut_to_music) if _measured("front", rows) else None,
+        "bars": histogram(row["in_bar"] for row in in_grid),
+        # ``bar_groups`` and ``bar_offsets``, from the join that owns them (``barmap``).
+        **barmap.summary(rows, cut_to_music),
+        "tunes": _spread("tune", cut_to_music) if measured("tune", rows) else None,
+        "solos": _spread("front", cut_to_music) if measured("front", rows) else None,
         "shot_seconds": _lengths([row["seconds"] for row in rows]),
-        "shot_rhythm": _rhythm(rows, levels),
+        "shot_rhythm": rhythm.read(rows, levels),
         # Keyed on whether a catalog was *named*, not on whether anything joined: a catalog
         # that lines up with nothing is the failure this block is here to make loud, and
         # answering None would report it as a call that never asked.
@@ -1470,8 +1321,8 @@ def _summary(
         # joins nothing, and a null here would report that as a call that never asked.
         "picture_quality": None if takes is None else _quality(rows, takes, floors),
         "clips": _usage(rows, "clip"),
-        "roles": _usage(rows, "role") if _measured("role", rows) else None,
-        "subjects": _usage(rows, "subject") if _measured("subject", rows) else None,
+        "roles": _usage(rows, "role") if measured("role", rows) else None,
+        "subjects": _usage(rows, "subject") if measured("subject", rows) else None,
         # Taken over every shot, openings included: the question is where the screen time
         # went, and a shot that starts the film is screen time like any other (#181).
         "on_soloist": subject.summary(rows),
@@ -1636,509 +1487,37 @@ def _outside(rows: Sequence[dict[str, Any]], grid: Sequence[float]) -> int:
     return sum(1 for row in rows if not grid[0] <= float(row["t"]) <= grid[-1])
 
 
-def _measured(field: str, rows: Sequence[dict[str, Any]]) -> bool:
-    """Whether a column was measured at all — an input nobody named reads as nothing, not zero."""
-    return any(row[field] is not None for row in rows)
-
-
-def _offsets(found: Sequence[float | None]) -> dict[str, Any] | None:
-    """How far off the cuts are, and which way — early and late counted apart."""
-    measured = [value for value in found if value is not None]
-    if not measured:
-        return None
-    sizes = [abs(value) for value in measured]
-    return {
-        "measured": len(measured),
-        "mean_abs": _rounded(statistics.fmean(sizes)),
-        "median_abs": _rounded(statistics.median(sizes)),
-        "max_abs": _rounded(max(sizes)),
-        "early": sum(1 for value in measured if value < 0),
-        "late": sum(1 for value in measured if value > 0),
-        "on": sum(1 for value in measured if value == 0),
-    }
 
 
 def _lengths(seconds: Sequence[float]) -> dict[str, Any]:
     if not seconds:
         return {"mean": None, "median": None, "min": None, "max": None}
     return {
-        "mean": _rounded(statistics.fmean(seconds)),
-        "median": _rounded(statistics.median(seconds)),
-        "min": _rounded(min(seconds)),
-        "max": _rounded(max(seconds)),
+        "mean": rounded(statistics.fmean(seconds)),
+        "median": rounded(statistics.median(seconds)),
+        "min": rounded(min(seconds)),
+        "max": rounded(max(seconds)),
     }
 
 
-def _rhythm(
-    rows: Sequence[dict[str, Any]],
-    levels: Sequence[tuple[float, float]] | None = None,
-) -> dict[str, Any]:
-    """How varied the cutting is, in the three shapes a metronomic cut shows up in.
-
-    A build reviews itself with this report, and the failure it cannot see from the inside is
-    the one every critic names first: two cameras traded back and forth on a fixed length. It
-    is invisible in the offsets — every cut can sit dead on its beat and still read as a
-    metronome — so it needs its own reading: how the shot lengths spread, how strictly the
-    angles alternate, how much of the cut sits in a single length bin, and how far it ramps.
-
-    The ramp is the same mechanism wearing a disguise. A two-camera trade whose lengths walk
-    steadily from ten seconds down to three varies every one of them, so the bin and the
-    spread both call it varied — and a panel called it a mechanical metronome anyway, because
-    a ladder is as countable a pattern as a fixed length (P3·R3: strict two-framing, 9.9 s to
-    2.9 s without a step back up). The run of one-way lengths is what catches it.
-
-    ``gears`` asks the other half of the same question. A cut can vary its lengths and still
-    run at one speed through the whole concert — the intro cut as fast as the solo — and no
-    reading over the shot list alone can see it, because the thing missing is the music's own
-    dynamics. So the level curve is split into thirds by loudness and the cutting rate is
-    reported per third: a build that changes gear shows it here, and one that does not is
-    told so before a critic says it.
-
-    Nothing here is a gate. ``reads_metronomic`` and ``one_speed`` are sentences the report
-    says out loud along with the numbers and the rules that drew them (``HEURISTIC``,
-    ``GEAR_HEURISTIC``), so a builder can disagree with them on the evidence rather than argue
-    with a threshold. Trading two cameras for four minutes is a real edit some music asks for;
-    the point is that the builder *decided* it.
-    """
-    lengths = [float(row["seconds"]) for row in rows]
-    # The angle on screen is what alternation is about, so black counts as one source rather
-    # than as a hole: cutting camera, black, camera, black is a pattern, not an absence.
-    sources = [BLACK if row["clip"] is None else str(row["clip"]) for row in rows]
-    histogram = _bins(lengths)
-    alternation = _alternation(sources)
-    uniformity = _uniformity(lengths, histogram)
-    ramp = _ramp(lengths)
-    return {
-        "shots": len(rows),
-        "lengths": {
-            "histogram": histogram,
-            # max/min over the shots as written; ``shot_seconds`` holds the two numbers it is
-            # taken from. None when the shortest shot rounds to zero and the ratio would not
-            # divide.
-            "spread_ratio": _ratio(lengths),
-            "mean": _rounded(statistics.fmean(lengths)) if lengths else None,
-            "median": _rounded(statistics.median(lengths)) if lengths else None,
-        },
-        "alternation": alternation,
-        "uniformity": uniformity,
-        "ramp": ramp,
-        "reads_metronomic": _metronomic(alternation, uniformity, ramp),
-        "gears": _gears(rows, levels, uniformity),
-        "heuristic": HEURISTIC,
-    }
-
-
-def _bins(lengths: Sequence[float]) -> dict[str, int]:
-    """The corpus histogram, every bin present — a zero is a reading, not a missing key."""
-    counted = dict.fromkeys((label for label, _ in RHYTHM_BINS), 0)
-    for length in lengths:
-        for label, edge in RHYTHM_BINS:
-            if length < edge:
-                counted[label] += 1
-                break
-    return counted
-
-
-def _ratio(lengths: Sequence[float]) -> float | None:
-    if not lengths or min(lengths) <= 0:
-        return None
-    return _rounded(max(lengths) / min(lengths))
-
-
-def _alternation(sources: Sequence[str]) -> dict[str, Any]:
-    """The longest strict A/B run in the sequence of angles, counted in cuts.
-
-    Strict means each shot returns to the one before last and differs from the one before it:
-    A B A B. A third angle ends the run, and so does the same angle twice — both are variety,
-    which is the thing being looked for. The run is measured in cuts rather than shots so its
-    fraction is of the same denominator the report counts cuts in.
-    """
-    cuts = max(len(sources) - 1, 0)
-    longest = 0
-    run = 0
-    for index in range(1, len(sources)):
-        if sources[index] == sources[index - 1]:
-            run = 0
-            continue
-        returns = index >= 2 and sources[index] == sources[index - 2]
-        run = run + 1 if returns and run else 1
-        longest = max(longest, run)
-    counted = longest if longest >= ALTERNATION_MIN else 0
-    return {
-        "cuts": cuts,
-        "longest_run": counted,
-        "fraction": _rounded(counted / cuts) if cuts else 0.0,
-    }
-
 
-def _uniformity(lengths: Sequence[float], histogram: Mapping[str, int]) -> dict[str, Any]:
-    """How much of the cut is one length: the fullest bin's share, and the spread around it.
-
-    Two readings because they miss different cuts. The bin catches shots clustered at one
-    length even when the numbers wobble inside it; the coefficient of variation catches a cut
-    whose lengths drift slowly across a boundary and so land in two bins while never varying.
-    """
-    if not lengths:
-        return {"bin": None, "one_bin": None, "cv": None}
-    fullest = max(RHYTHM_BINS, key=lambda one: histogram[one[0]])[0]
-    return {
-        "bin": fullest,
-        "one_bin": _rounded(histogram[fullest] / len(lengths)),
-        "cv": _cv(lengths),
-    }
-
-
-def _ramp(lengths: Sequence[float]) -> dict[str, Any]:
-    """The longest run of shots that only shorten, or only lengthen, counted in cuts.
-
-    A tightening ladder is a pattern the bin count and the spread are both blind to: every
-    length differs, so no bin holds the cut and the coefficient of variation reads as variety,
-    while what the audience sees is one rule applied over and over. Direction rather than
-    slope, because the shape is the *monotony*, not the rate — a ladder that steps 10, 8, 7,
-    3 is as mechanical as one that halves each time, and a single step back up ends both.
-
-    Equal neighbours end a run rather than continue one: a stretch of identical lengths is
-    already what ``uniformity`` reads, and letting it feed this one would count the same cut
-    twice. Measured in cuts, like ``_alternation``, so the two fractions share a denominator.
-    """
-    cuts = max(len(lengths) - 1, 0)
-    longest = 0
-    rising = falling = 0
-    for index in range(1, len(lengths)):
-        rising = rising + 1 if lengths[index] > lengths[index - 1] else 0
-        falling = falling + 1 if lengths[index] < lengths[index - 1] else 0
-        longest = max(longest, rising, falling)
-    counted = longest if longest >= RAMP_MIN else 0
-    return {
-        "cuts": cuts,
-        "longest_run": counted,
-        "fraction": _rounded(counted / cuts) if cuts else 0.0,
-    }
-
-
-def _metronomic(
-    alternation: Mapping[str, Any], uniformity: Mapping[str, Any], ramp: Mapping[str, Any]
-) -> bool:
-    """``HEURISTIC``, applied. A reading it cannot take is not a reading against the cut."""
-    one_bin = uniformity["one_bin"]
-    cv = uniformity["cv"]
-    uniform = (one_bin is not None and one_bin > ONE_BIN_FLOOR) or (
-        cv is not None and cv < CV_FLOOR
-    )
-    ramped = float(ramp["fraction"]) > RAMP_FLOOR
-    return float(alternation["fraction"]) > ALTERNATION_FLOOR and (uniform or ramped)
-
-
-def _gears(
-    rows: Sequence[dict[str, Any]],
-    levels: Sequence[tuple[float, float]] | None,
-    uniformity: Mapping[str, Any],
-) -> dict[str, Any] | None:
-    """How the cutting rate changes with the music's loudness — the one-speed read.
-
-    ``None`` when there is no level curve to read, or none of it covers the cut: not looking
-    and finding no gearing are different answers, and only one of them is about the edit.
-
-    The span the terciles are taken over is the cut's own, not the mix's. A four-minute song
-    inside a two-hour concert is quiet *in that concert* from end to end, and thirds taken
-    over the whole mix would drop every shot in it into one gear and report nothing.
-
-    Where the cut runs past the curve — a tail after the analysed mix ends, a cold open ahead
-    of its start — those shots are counted in ``outside_shots`` and left out of the terciles
-    and out of the sub-2 s numbers with them. Every rate here divides by the seconds of music
-    its tercile holds, so a shot placed where no window exists is a numerator with no
-    denominator, and the one it borrows is the wrong one.
-    """
-    if not rows or not levels:
-        return None
-    span_start = min(float(row["t"]) for row in rows)
-    span_end = max(float(row["t"]) + float(row["seconds"]) for row in rows)
-    windows = [
-        (start, level)
-        for start, level in levels
-        if start < span_end and start + GEAR_WINDOW_SECONDS > span_start
-    ]
-    if not windows:
-        return None
-
-    placed = _terciles(windows)
-    starts = [start for start, _ in windows]
-    held: dict[str, list[dict[str, Any]]] = {QUIET: [], MID: [], LOUD: []}
-    outside = 0
-    for row in rows:
-        window = _window_at(starts, float(row["t"]))
-        if window is None:
-            outside += 1
-            continue
-        held[placed[window]].append(row)
-
-    terciles = {
-        gear: _gear(
-            held[gear],
-            [level for index, (_, level) in enumerate(windows) if placed[index] == gear],
-        )
-        for gear in (QUIET, MID, LOUD)
-    }
-    ratio = _rate_ratio(terciles[LOUD]["cuts_per_minute"], terciles[QUIET]["cuts_per_minute"])
-    # The short shots are the ones a fast passage is made of, so where they sit is the
-    # gearing read in its bluntest form: a build that saves them for the loud third has
-    # changed gear even if the averages move less than the ratio floor.
-    counted = [row for gear in (QUIET, MID, LOUD) for row in held[gear]]
-    short = sum(1 for row in counted if float(row["seconds"]) < SUB_TWO_SECONDS)
-    in_loud = sum(1 for row in held[LOUD] if float(row["seconds"]) < SUB_TWO_SECONDS)
-    return {
-        "window_seconds": GEAR_WINDOW_SECONDS,
-        "terciles": terciles,
-        "outside_shots": outside,
-        "rate_ratio": ratio,
-        "sub2s_count": short,
-        "sub2s_in_loud": in_loud,
-        "sub2s_loud_fraction": _rounded(in_loud / short) if short else None,
-        "one_speed": _one_speed(ratio, uniformity["cv"]),
-        "quiet_floor": _quiet_floor(rows, windows),
-        "heuristic": GEAR_HEURISTIC,
-    }
-
-
-def _quiet_floor(
-    rows: Sequence[dict[str, Any]], windows: Sequence[tuple[float, float]]
-) -> dict[str, Any]:
-    """Whether the passages held in the slow gear breathe, or only hold.
-
-    The gear ratios say a quiet section was cut slower; they say nothing about what happens
-    inside it. A build can hit the quiet rate exactly and still park: five holds of much the
-    same length in a row is the rate the table asked for and a passage nobody is watching by
-    the end of. This is the reading of the inside — how much the lengths move, and how much of
-    that movement one shot is holding up.
-
-    The passages are found on a smoothed curve rather than on the tercile labels above,
-    because those labels are per window and a live room crosses the quiet edge and back inside
-    a bar. Smoothing is what makes a *passage* out of a curve; the rates keep the unsmoothed
-    labels, since a rate does not care whether the music it holds was contiguous.
-    """
-    runs = _quiet_runs(windows)
-    passages = [_passage(rows, start, end) for start, end in runs]
-    return {
-        "smoothing_windows": QUIET_SMOOTHING_WINDOWS,
-        "runs": passages,
-        "reads_locked": any(passage["reads_locked"] for passage in passages),
-        "heuristic": FLOOR_HEURISTIC,
-    }
-
-
-def _quiet_runs(windows: Sequence[tuple[float, float]]) -> list[tuple[float, float]]:
-    """The stretches of music long enough, and quiet enough, to be a passage.
-
-    Quiet is the bottom third of the *smoothed* curve — the same split ``_terciles`` takes,
-    run over a curve the outliers have been taken out of rather than the raw one, which is the
-    whole difference between a passage and a window. Runs shorter than ``QUIET_FLOOR_SECONDS``
-    are dropped rather than measured: they hold two or three shots, and a spread over three
-    shots is a number the report cannot mean anything by.
-    """
-    if not windows:
-        return []
-    levels = _smoothed([level for _, level in windows])
-    smoothed = [(start, level) for (start, _), level in zip(windows, levels, strict=True)]
-    quiet = [label == QUIET for label in _terciles(smoothed)]
-
-    runs: list[tuple[float, float]] = []
-    opened: int | None = None
-    for index, is_quiet in enumerate([*quiet, False]):
-        if is_quiet and opened is None:
-            opened = index
-        elif not is_quiet and opened is not None:
-            runs.append((windows[opened][0], windows[index - 1][0] + GEAR_WINDOW_SECONDS))
-            opened = None
-    return [(start, end) for start, end in runs if end - start >= QUIET_FLOOR_SECONDS]
-
-
-def _smoothed(levels: Sequence[float]) -> list[float]:
-    """A centred moving median over ``QUIET_SMOOTHING_WINDOWS`` windows.
-
-    Median rather than mean, because the thing being smoothed out is exactly the outlier — one
-    crash in a quiet passage pulls a mean over the edge and leaves the median where the music
-    is. At the ends the window shrinks rather than padding: a curve that starts quiet should
-    read quiet from its first window, not ease in from a value nobody measured.
-    """
-    half = QUIET_SMOOTHING_WINDOWS // 2
-    return [
-        statistics.median(levels[max(0, index - half) : min(len(levels), index + half + 1)])
-        for index in range(len(levels))
-    ]
-
-
-def _passage(
-    rows: Sequence[dict[str, Any]], start: float, end: float
-) -> dict[str, Any]:
-    """One quiet passage: how it was cut, and whether the spread is real or carried.
-
-    ``cv_less_orphans`` is the reading the flag is drawn on. A coefficient of variation is
-    dominated by whatever is furthest from the mean, so one 2.5 s flash among five holds of
-    ten to twenty seconds reports a spread that no part of the passage a viewer sits through
-    actually has. Dropping the orphans and asking again is the difference between a floor that
-    breathes and a floor with a hole punched in it.
-
-    A passage with no shot starting inside it is not an absent reading, it is the stillest one
-    there is: a single hold runs the whole way through and there is no cut in it to measure.
-    That is reported as ``held_through_seconds`` and reads locked on its own, because a
-    spread taken over the no lengths inside would otherwise let the most parked passage
-    possible past the flag.
-    """
-    lengths = [
-        float(row["seconds"]) for row in rows if start <= float(row["t"]) < end
-    ]
-    held_through = _held_through(rows, start, end) if not lengths else None
-    orphans = _orphans(lengths)
-    kept = [length for index, length in enumerate(lengths) if index not in orphans]
-    cv = _cv(lengths)
-    less = _cv(kept)
-    seconds = end - start
-    return {
-        "from": _rounded(start),
-        "to": _rounded(end),
-        "seconds": _rounded(seconds),
-        "shots": len(lengths),
-        "cuts_per_minute": _rounded(len(lengths) / (seconds / 60.0)) if seconds > 0 else None,
-        "median_seconds": _rounded(statistics.median(lengths)) if lengths else None,
-        "cv": cv,
-        "orphans": len(orphans),
-        "orphan_seconds": [_rounded(lengths[index]) for index in orphans],
-        "cv_less_orphans": less,
-        "held_through_seconds": held_through,
-        "reads_locked": held_through is not None or (less is not None and less < FLOOR_CV_FLOOR),
-    }
-
-
-def _held_through(
-    rows: Sequence[dict[str, Any]], start: float, end: float
-) -> float | None:
-    """The length of the shot that runs the whole passage without a cut in it, if there is one.
-
-    Not every passage with nothing starting inside it is held through: a cut that ends before
-    the passage does — or one the level curve outruns — has no film there at all, and a
-    stretch with no picture in it is not an edit anybody made. The shot has to cover the
-    passage end to end for the reading to be about a decision.
-    """
-    for row in rows:
-        opens = float(row["t"])
-        if opens <= start and opens + float(row["seconds"]) >= end:
-            return _rounded(float(row["seconds"]))
-    return None
-
-
-def _orphans(lengths: Sequence[float]) -> set[int]:
-    """Which shots are lone flashes: short against the passage, with nothing short beside them.
-
-    Neighbours are taken inside the passage only, so its first and last shot are judged against
-    the one neighbour they have — a passage that opens on a flash is still opening on one.
-
-    Two short shots side by side are not orphans, either of them. That is a burst, which is a
-    gesture a quiet passage is allowed to make and which the spread should keep, and the whole
-    point of the distinction is that a burst is something a viewer reads as cutting while a
-    single flash between long holds reads as a mistake or a stinger.
-    """
-    if len(lengths) < 2:
-        return set()
-    median = statistics.median(lengths)
-    found: set[int] = set()
-    for index, length in enumerate(lengths):
-        if length >= ORPHAN_FRACTION * median:
-            continue
-        beside = [lengths[near] for near in (index - 1, index + 1) if 0 <= near < len(lengths)]
-        if all(other >= median for other in beside):
-            found.add(index)
-    return found
-
-
-def _cv(lengths: Sequence[float]) -> float | None:
-    """Coefficient of variation, or ``None`` where there is nothing to take it over.
-
-    One shot is a spread of zero rather than no reading: a passage crossed by a single hold is
-    the most locked a passage can be, and answering ``None`` there would let the stillest case
-    of all fall through the flag. Nothing at all — a long shot that started before the passage
-    and covers it whole — is the reading that cannot be taken, because no length inside it is a
-    decision made about it.
-    """
-    if not lengths:
-        return None
-    mean = statistics.fmean(lengths)
-    return _rounded(statistics.pstdev(lengths) / mean) if mean > 0 else None
-
-
-def _terciles(windows: Sequence[tuple[float, float]]) -> list[str]:
-    """Which third of the loudness each window sits in, by rank rather than by level range.
-
-    Ranking, because the levels themselves are not a scale anything can be split evenly on:
-    a mix mastered hot spends most of its windows inside four decibels, and thirds of *that*
-    range would put the whole concert in one gear. Thirds of the windows always split the
-    span three ways, so the rate in each is a rate over comparable amounts of music.
-
-    Ties break by time, which matters only on a curve flat enough that the split is arbitrary
-    — and there the ratio it produces lands near one, which is exactly what a passage whose
-    loudness never moves should read as.
-    """
-    order = sorted(range(len(windows)), key=lambda index: (windows[index][1], windows[index][0]))
-    lower, upper = len(order) // 3, (2 * len(order)) // 3
-    placed = [MID] * len(windows)
-    for rank, index in enumerate(order):
-        placed[index] = QUIET if rank < lower else LOUD if rank >= upper else MID
-    return placed
-
-
-def _window_at(starts: Sequence[float], seconds: float) -> int | None:
-    """The window a shot's first frame lands in, or ``None`` when the curve does not reach it.
-
-    A shot is counted whole in the gear it was cut *into*: that is the decision the editor
-    made at that frame. Splitting a long shot across two gears would credit the loud third
-    with screen time nobody cut there.
-
-    Past the ends the answer is nothing rather than the nearest window. The rates are cuts
-    over the *music* each tercile holds, and a curve that stops before the cut does — or
-    starts after it, on a cold open — holds no music where those shots sit; clamping them
-    into the first or last window would add cuts to a numerator whose denominator never grew,
-    and a cut running a minute past the analysed mix would read as a gear change nobody made.
-    """
-    index = bisect_right(starts, seconds) - 1
-    if index < 0 or seconds >= starts[-1] + GEAR_WINDOW_SECONDS:
-        return None
-    return index
-
-
-def _gear(shots: Sequence[dict[str, Any]], levels: Sequence[float]) -> dict[str, Any]:
-    """One tercile: how much music it holds, how many shots were cut in it, and how fast.
-
-    ``seconds`` is counted in whole windows rather than in the shots' own lengths, because
-    the denominator has to be the music: a gear where one long shot runs over a minute of
-    loud music has a real cutting rate, and dividing by that shot's length would report the
-    rate of the shot instead.
-    """
-    lengths = [float(shot["seconds"]) for shot in shots]
-    seconds = len(levels) * GEAR_WINDOW_SECONDS
-    return {
-        "seconds": _rounded(seconds),
-        "shots": len(shots),
-        "cuts_per_minute": _rounded(len(shots) / (seconds / 60.0)) if seconds > 0 else None,
-        "median_seconds": _rounded(statistics.median(lengths)) if lengths else None,
-        "level_dbfs": _rounded(statistics.median(levels)) if levels else None,
-    }
-
-
-def _rate_ratio(loud: Any, quiet: Any) -> float | None:
-    """How much faster the loud third is cut than the quiet one.
-
-    ``None`` when nothing was cut in the quiet third: a ratio against zero is a number the
-    report cannot mean anything by, and inventing one there would read as a verdict.
-    """
-    if not isinstance(loud, int | float) or not isinstance(quiet, int | float) or not quiet:
-        return None
-    return _rounded(float(loud) / float(quiet))
-
-
-def _one_speed(ratio: float | None, cv: Any) -> bool:
-    """``GEAR_HEURISTIC``, applied. A reading it cannot take is not a reading against the cut."""
-    if ratio is None or not isinstance(cv, int | float):
-        return False
-    return ratio < RATE_RATIO_FLOOR and float(cv) < GEAR_CV_FLOOR
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 def _usage(rows: Sequence[dict[str, Any]], field: str) -> dict[str, dict[str, Any]]:
@@ -2162,8 +1541,8 @@ def _usage(rows: Sequence[dict[str, Any]], field: str) -> dict[str, dict[str, An
         entry["cuts"] += 1
         entry["seconds"] += float(row["seconds"])
     for entry in usage.values():
-        entry["share"] = _rounded(entry["seconds"] / total)
-        entry["seconds"] = _rounded(entry["seconds"])
+        entry["share"] = rounded(entry["seconds"] / total)
+        entry["seconds"] = rounded(entry["seconds"])
     return usage
 
 
@@ -2173,17 +1552,5 @@ def _spread(field: str, rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
     return {
         "covered": len(set(placed)),
         "outside": len(rows) - len(placed),
-        "cuts": _histogram(iter(placed)),
+        "cuts": histogram(iter(placed)),
     }
-
-
-def _histogram(values: Any) -> dict[str, int]:
-    """Counts keyed by value as a string — JSON has no integer keys to speak of."""
-    counted = Counter(value for value in values if value is not None)
-    return {str(key): count for key, count in sorted(counted.items(), key=lambda one: str(one[0]))}
-
-
-def _rounded(seconds: float) -> float:
-    return round(seconds, SECONDS_PRECISION)
-
-

--- a/src/resolve_mcp/analysis/rhythm.py
+++ b/src/resolve_mcp/analysis/rhythm.py
@@ -1,0 +1,633 @@
+"""How varied the cutting is, and whether the music's dynamics moved it.
+
+The failure a build cannot see from the inside is the one every critic names first: two
+cameras traded back and forth on a fixed length. It is invisible in the offsets — every cut
+can sit dead on its beat and still read as a metronome — so it needs a reading of its own,
+taken over the shot list rather than over the music: how the lengths spread, how strictly the
+angles alternate, how much of the cut sits in one length bin, how far it ramps.
+
+``gears`` asks the other half of the same question, and is the one reading here that needs the
+music. A cut can vary every length and still run at one speed all night — the intro cut at the
+pace of the solo — and no reading over the shot list alone can see that, because the thing
+missing is the dynamics. So the level curve is split into thirds by loudness and the rate is
+reported per third. ``quiet_floor`` then reads the inside of the slow gear: hitting the quiet
+rate and parking are the same number until the lengths inside a passage are looked at.
+
+*Nothing here decides.* ``reads_metronomic``, ``one_speed`` and ``reads_locked`` are sentences
+the report says out loud beside the numbers and the rules that drew them (``HEURISTIC``,
+``GEAR_HEURISTIC``, ``FLOOR_HEURISTIC``), so a builder can disagree on the evidence rather than
+argue with a threshold. Trading two cameras for four minutes is a real edit some music asks
+for; the point is that the builder *decided* it.
+
+The interface is one function. ``read(rows, levels)`` takes the per-cut records the report is
+built from — ``t``, ``seconds`` and ``clip`` are the only columns touched — and the loudness
+curve, and returns the ``shot_rhythm`` block. No Resolve handle, no files, no job record: the
+arithmetic is testable from a list of dicts written by hand.
+"""
+
+from __future__ import annotations
+
+import statistics
+from bisect import bisect_right
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .stats import rounded
+
+BLACK = "black"
+"""What a stretch nothing covers is called in the sequence of angles.
+
+Spelled the same as the report's own black line and named here rather than imported, for the
+reason ``subject.py`` names its own: this module reads a column, and a shared constant would
+tie its vocabulary to a caller it otherwise knows nothing about.
+"""
+
+RHYTHM_BINS: tuple[tuple[str, float], ...] = (
+    ("<2", 2.0),
+    ("2-4", 4.0),
+    ("4-8", 8.0),
+    ("8-15", 15.0),
+    ("15-30", 30.0),
+    (">30", float("inf")),
+)
+"""The corpus shot-length bins, as label and upper edge, in seconds.
+
+Half-open on the upper edge: a shot of exactly 4 s counts in ``4-8``, and the last bin takes
+everything from 30 s up. The labels are the ones the corpus and the style profiles already
+speak, so a histogram from this report drops straight into a comparison against them; the
+edges are that vocabulary's, not a threshold this file tuned.
+"""
+
+ALTERNATION_MIN = 2
+"""How many cuts an A/B run needs before it is alternation rather than a cut.
+
+Two shots that differ are just a cut — the pattern only exists once the cut *returns*, so a
+run is counted from three shots (A B A) up. Without this floor every two-shot timeline reads
+as perfectly alternating, which is arithmetic rather than a fact about the edit.
+"""
+
+RAMP_MIN = 4
+"""How many cuts of one direction make a ramp rather than a coincidence.
+
+Three shots that happen to shorten are two cuts, and two cuts in a row go one way in any cut
+list long enough — the shape only exists once it keeps going. Counted from five shots (four
+cuts) up, which is where a run stops being what randomness hands you.
+"""
+
+ALTERNATION_FLOOR = 0.8
+ONE_BIN_FLOOR = 0.6
+CV_FLOOR = 0.35
+RAMP_FLOOR = 0.6
+"""The four numbers ``reads_metronomic`` is drawn at — see ``HEURISTIC``."""
+
+HEURISTIC = (
+    "reads_metronomic is true when the longest strict A/B alternation run covers more than "
+    f"{ALTERNATION_FLOOR} of the cuts and the lengths are mechanical with it: either one bin "
+    f"holds more than {ONE_BIN_FLOOR} of the shots, or the coefficient of variation of shot "
+    f"lengths is under {CV_FLOOR}, or the longest run of shots that only shorten or only "
+    f"lengthen covers more than {RAMP_FLOOR} of the cuts. It is a warning to look at, not a "
+    "verdict: a passage that genuinely wants a two-camera ping-pong scores the same as a cut "
+    "nobody varied, and only the director can tell them apart."
+)
+"""The heuristic in words, carried in the report so nobody has to read this file to check it."""
+
+GEAR_WINDOW_SECONDS = 1.0
+"""How coarse the loudness curve the gearing is read against is, in seconds per window.
+
+A second is a bar at slow rock tempo and half of one at anything faster: coarse enough that
+a snare hit does not move a window into the loud third, fine enough that the quiet verse and
+the last chorus land in different ones. Nothing here is a loudness measurement anybody
+publishes — the only question asked of it is which windows are louder than which.
+"""
+
+QUIET, MID, LOUD = "quiet", "mid", "loud"
+"""The three gears, named where the report names them."""
+
+SUB_TWO_SECONDS = RHYTHM_BINS[0][1]
+"""What counts as a short shot: the corpus's own ``<2`` edge, not a second threshold."""
+
+RATE_RATIO_FLOOR = 1.3
+GEAR_CV_FLOOR = 0.65
+"""The two numbers ``one_speed`` is drawn at — see ``GEAR_HEURISTIC``."""
+
+GEAR_HEURISTIC = (
+    "one_speed is true when the loud third of the music is cut less than "
+    f"{RATE_RATIO_FLOOR}x as fast as the quiet third (rate_ratio) and the coefficient of "
+    f"variation of shot lengths is under {GEAR_CV_FLOOR}. Terciles are thirds of the span by "
+    "level, not by time: the 1 s RMS windows inside the cut are ranked and split three ways, "
+    "and each shot is counted in the window its first frame lands in — a shot the curve does "
+    "not reach is counted in outside_shots and in no tercile. It is a warning to look "
+    "at, not a verdict — a ballad cut at one speed throughout is a real edit, and a passage "
+    "whose loudness never moves has no gears to change. What it catches is the build that cut "
+    "the guitar solo at the pace it cut the intro."
+)
+"""The gearing heuristic in words, carried in the report beside the numbers it was drawn from."""
+
+QUIET_SMOOTHING_WINDOWS = 15
+"""How many gear windows the level curve is smoothed over before quiet passages are found.
+
+The terciles above label one window at a time, and at that resolution a live room's level
+crosses the quiet edge and back inside a single bar — a snare hit, a shout, a chord. Labels
+that flicker are exactly what a *rate* wants, since the rate is over the music each label
+holds however scattered it is, but a passage is not scattered: it is a stretch you sit in.
+A centred moving median over fifteen windows is the coarsest reading that still separates
+this corpus's sections, which run from thirty seconds to a minute and a half.
+"""
+
+QUIET_FLOOR_SECONDS = 20.0
+"""How long a quiet stretch must run before its shot lengths are read as a passage.
+
+Shorter than this is a pocket, and a pocket holds two or three shots — too few for a spread
+to mean anything, and short enough that holding through it is a gesture rather than a stall.
+"""
+
+ORPHAN_FRACTION = 0.5
+"""How much shorter than the passage's median a shot must be to count as an orphan.
+
+Half is the line because it puts a flash on the other side of the passage's own scale rather
+than of a fixed threshold: in a floor of ten-second holds a four-second shot is a shorter
+shot, and a two-second one is a different device.
+"""
+
+FLOOR_CV_FLOOR = 0.65
+"""The number ``reads_locked`` is drawn at — see ``FLOOR_HEURISTIC``.
+
+The same value ``GEAR_CV_FLOOR`` holds, and written out rather than aliased to it: it is the
+same question asked of a smaller span — are these lengths varied enough to read as cutting —
+but it is not the same knob, and retuning what a whole cut is judged at should not silently
+retune what a passage inside one is. Measured on the one full song in the corpus, the
+director's own quiet passage runs a spread of 0.78 across 157 s and ours 0.56; the floor sits
+between them, on a gap of one song, which is all it is worth.
+"""
+
+FLOOR_HEURISTIC = (
+    "quiet_floor reads the passages a build holds the slow gear through: the 1 s levels are "
+    f"smoothed over {QUIET_SMOOTHING_WINDOWS} windows, the quiet third of the smoothed curve "
+    f"is taken, and its contiguous stretches of at least {QUIET_FLOOR_SECONDS} s are the "
+    "passages. reads_locked is true for a passage whose spread survives neither its orphans "
+    f"nor the floor: cv_less_orphans under {FLOOR_CV_FLOOR}. An orphan is a shot under "
+    f"{ORPHAN_FRACTION}x the passage median with both neighbours inside the passage at or "
+    "above it — a lone flash, as against a burst, which is short shots side by side and stays "
+    "in the spread. The reading exists because cv alone is carried by whatever is most "
+    "extreme: five long holds and one flash score a spread the holds do not have. A passage "
+    "no shot starts inside is held through by one, which reads locked on its own — "
+    "held_through_seconds is that shot's length, and there is no cut in the passage to take a "
+    "spread over. No passage "
+    "long enough to read is an empty runs list, which is not the same as passing. It is a "
+    "warning to look at, not a verdict — a passage held on a picture that develops is a real "
+    "edit, and this measures lengths, not what is inside the frame."
+)
+"""The floor heuristic in words, carried in the report beside the numbers it was drawn from."""
+
+
+def read(
+    rows: Sequence[Mapping[str, Any]],
+    levels: Sequence[tuple[float, float]] | None = None,
+) -> dict[str, Any]:
+    """The ``shot_rhythm`` block: how varied the cutting is, in the shapes a metronome shows in.
+
+    ``rows`` are the per-cut records as the report writes them, openings included — where the
+    screen time went is the question, and the shot that starts the film is screen time like any
+    other. Three columns are read: ``seconds``, ``clip`` (``None`` for black), and ``t`` for the
+    gearing. ``levels`` is the loudness curve as ``(window start, RMS in dBFS)`` pairs; without
+    one, ``gears`` is ``None`` rather than a gearing nobody measured.
+
+    The ramp is the same mechanism wearing a disguise. A two-camera trade whose lengths walk
+    steadily from ten seconds down to three varies every one of them, so the bin and the spread
+    both call it varied — and a panel called it a mechanical metronome anyway, because a ladder
+    is as countable a pattern as a fixed length (P3·R3: strict two-framing, 9.9 s to 2.9 s
+    without a step back up). The run of one-way lengths is what catches it.
+    """
+    lengths = [float(row["seconds"]) for row in rows]
+    # The angle on screen is what alternation is about, so black counts as one source rather
+    # than as a hole: cutting camera, black, camera, black is a pattern, not an absence.
+    sources = [BLACK if row["clip"] is None else str(row["clip"]) for row in rows]
+    histogram = _bins(lengths)
+    alternation = _alternation(sources)
+    uniformity = _uniformity(lengths, histogram)
+    ramp = _ramp(lengths)
+    return {
+        "shots": len(rows),
+        "lengths": {
+            "histogram": histogram,
+            # max/min over the shots as written; ``shot_seconds`` holds the two numbers it is
+            # taken from. None when the shortest shot rounds to zero and the ratio would not
+            # divide.
+            "spread_ratio": _ratio(lengths),
+            "mean": rounded(statistics.fmean(lengths)) if lengths else None,
+            "median": rounded(statistics.median(lengths)) if lengths else None,
+        },
+        "alternation": alternation,
+        "uniformity": uniformity,
+        "ramp": ramp,
+        "reads_metronomic": _metronomic(alternation, uniformity, ramp),
+        "gears": _gears(rows, levels, uniformity),
+        "heuristic": HEURISTIC,
+    }
+
+
+def _bins(lengths: Sequence[float]) -> dict[str, int]:
+    """The corpus histogram, every bin present — a zero is a reading, not a missing key."""
+    counted = dict.fromkeys((label for label, _ in RHYTHM_BINS), 0)
+    for length in lengths:
+        for label, edge in RHYTHM_BINS:
+            if length < edge:
+                counted[label] += 1
+                break
+    return counted
+
+
+def _ratio(lengths: Sequence[float]) -> float | None:
+    if not lengths or min(lengths) <= 0:
+        return None
+    return rounded(max(lengths) / min(lengths))
+
+
+def _alternation(sources: Sequence[str]) -> dict[str, Any]:
+    """The longest strict A/B run in the sequence of angles, counted in cuts.
+
+    Strict means each shot returns to the one before last and differs from the one before it:
+    A B A B. A third angle ends the run, and so does the same angle twice — both are variety,
+    which is the thing being looked for. The run is measured in cuts rather than shots so its
+    fraction is of the same denominator the report counts cuts in.
+    """
+    cuts = max(len(sources) - 1, 0)
+    longest = 0
+    run = 0
+    for index in range(1, len(sources)):
+        if sources[index] == sources[index - 1]:
+            run = 0
+            continue
+        returns = index >= 2 and sources[index] == sources[index - 2]
+        run = run + 1 if returns and run else 1
+        longest = max(longest, run)
+    counted = longest if longest >= ALTERNATION_MIN else 0
+    return {
+        "cuts": cuts,
+        "longest_run": counted,
+        "fraction": rounded(counted / cuts) if cuts else 0.0,
+    }
+
+
+def _uniformity(lengths: Sequence[float], histogram: Mapping[str, int]) -> dict[str, Any]:
+    """How much of the cut is one length: the fullest bin's share, and the spread around it.
+
+    Two readings because they miss different cuts. The bin catches shots clustered at one
+    length even when the numbers wobble inside it; the coefficient of variation catches a cut
+    whose lengths drift slowly across a boundary and so land in two bins while never varying.
+    """
+    if not lengths:
+        return {"bin": None, "one_bin": None, "cv": None}
+    fullest = max(RHYTHM_BINS, key=lambda one: histogram[one[0]])[0]
+    return {
+        "bin": fullest,
+        "one_bin": rounded(histogram[fullest] / len(lengths)),
+        "cv": _cv(lengths),
+    }
+
+
+def _ramp(lengths: Sequence[float]) -> dict[str, Any]:
+    """The longest run of shots that only shorten, or only lengthen, counted in cuts.
+
+    A tightening ladder is a pattern the bin count and the spread are both blind to: every
+    length differs, so no bin holds the cut and the coefficient of variation reads as variety,
+    while what the audience sees is one rule applied over and over. Direction rather than
+    slope, because the shape is the *monotony*, not the rate — a ladder that steps 10, 8, 7,
+    3 is as mechanical as one that halves each time, and a single step back up ends both.
+
+    Equal neighbours end a run rather than continue one: a stretch of identical lengths is
+    already what ``_uniformity`` reads, and letting it feed this one would count the same cut
+    twice. Measured in cuts, like ``_alternation``, so the two fractions share a denominator.
+    """
+    cuts = max(len(lengths) - 1, 0)
+    longest = 0
+    rising = falling = 0
+    for index in range(1, len(lengths)):
+        rising = rising + 1 if lengths[index] > lengths[index - 1] else 0
+        falling = falling + 1 if lengths[index] < lengths[index - 1] else 0
+        longest = max(longest, rising, falling)
+    counted = longest if longest >= RAMP_MIN else 0
+    return {
+        "cuts": cuts,
+        "longest_run": counted,
+        "fraction": rounded(counted / cuts) if cuts else 0.0,
+    }
+
+
+def _metronomic(
+    alternation: Mapping[str, Any], uniformity: Mapping[str, Any], ramp: Mapping[str, Any]
+) -> bool:
+    """``HEURISTIC``, applied. A reading it cannot take is not a reading against the cut."""
+    one_bin = uniformity["one_bin"]
+    cv = uniformity["cv"]
+    uniform = (one_bin is not None and one_bin > ONE_BIN_FLOOR) or (
+        cv is not None and cv < CV_FLOOR
+    )
+    ramped = float(ramp["fraction"]) > RAMP_FLOOR
+    return float(alternation["fraction"]) > ALTERNATION_FLOOR and (uniform or ramped)
+
+
+def _gears(
+    rows: Sequence[Mapping[str, Any]],
+    levels: Sequence[tuple[float, float]] | None,
+    uniformity: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """How the cutting rate changes with the music's loudness — the one-speed read.
+
+    ``None`` when there is no level curve to read, or none of it covers the cut: not looking
+    and finding no gearing are different answers, and only one of them is about the edit.
+
+    The span the terciles are taken over is the cut's own, not the mix's. A four-minute song
+    inside a two-hour concert is quiet *in that concert* from end to end, and thirds taken
+    over the whole mix would drop every shot in it into one gear and report nothing.
+
+    Where the cut runs past the curve — a tail after the analysed mix ends, a cold open ahead
+    of its start — those shots are counted in ``outside_shots`` and left out of the terciles
+    and out of the sub-2 s numbers with them. Every rate here divides by the seconds of music
+    its tercile holds, so a shot placed where no window exists is a numerator with no
+    denominator, and the one it borrows is the wrong one.
+    """
+    if not rows or not levels:
+        return None
+    span_start = min(float(row["t"]) for row in rows)
+    span_end = max(float(row["t"]) + float(row["seconds"]) for row in rows)
+    windows = [
+        (start, level)
+        for start, level in levels
+        if start < span_end and start + GEAR_WINDOW_SECONDS > span_start
+    ]
+    if not windows:
+        return None
+
+    placed = _terciles(windows)
+    starts = [start for start, _ in windows]
+    held: dict[str, list[Mapping[str, Any]]] = {QUIET: [], MID: [], LOUD: []}
+    outside = 0
+    for row in rows:
+        window = _window_at(starts, float(row["t"]))
+        if window is None:
+            outside += 1
+            continue
+        held[placed[window]].append(row)
+
+    terciles = {
+        gear: _gear(
+            held[gear],
+            [level for index, (_, level) in enumerate(windows) if placed[index] == gear],
+        )
+        for gear in (QUIET, MID, LOUD)
+    }
+    ratio = _rate_ratio(terciles[LOUD]["cuts_per_minute"], terciles[QUIET]["cuts_per_minute"])
+    # The short shots are the ones a fast passage is made of, so where they sit is the
+    # gearing read in its bluntest form: a build that saves them for the loud third has
+    # changed gear even if the averages move less than the ratio floor.
+    counted = [row for gear in (QUIET, MID, LOUD) for row in held[gear]]
+    short = sum(1 for row in counted if float(row["seconds"]) < SUB_TWO_SECONDS)
+    in_loud = sum(1 for row in held[LOUD] if float(row["seconds"]) < SUB_TWO_SECONDS)
+    return {
+        "window_seconds": GEAR_WINDOW_SECONDS,
+        "terciles": terciles,
+        "outside_shots": outside,
+        "rate_ratio": ratio,
+        "sub2s_count": short,
+        "sub2s_in_loud": in_loud,
+        "sub2s_loud_fraction": rounded(in_loud / short) if short else None,
+        "one_speed": _one_speed(ratio, uniformity["cv"]),
+        "quiet_floor": _quiet_floor(rows, windows),
+        "heuristic": GEAR_HEURISTIC,
+    }
+
+
+def _quiet_floor(
+    rows: Sequence[Mapping[str, Any]], windows: Sequence[tuple[float, float]]
+) -> dict[str, Any]:
+    """Whether the passages held in the slow gear breathe, or only hold.
+
+    The gear ratios say a quiet section was cut slower; they say nothing about what happens
+    inside it. A build can hit the quiet rate exactly and still park: five holds of much the
+    same length in a row is the rate the table asked for and a passage nobody is watching by
+    the end of. This is the reading of the inside — how much the lengths move, and how much of
+    that movement one shot is holding up.
+
+    The passages are found on a smoothed curve rather than on the tercile labels above,
+    because those labels are per window and a live room crosses the quiet edge and back inside
+    a bar. Smoothing is what makes a *passage* out of a curve; the rates keep the unsmoothed
+    labels, since a rate does not care whether the music it holds was contiguous.
+    """
+    runs = _quiet_runs(windows)
+    passages = [_passage(rows, start, end) for start, end in runs]
+    return {
+        "smoothing_windows": QUIET_SMOOTHING_WINDOWS,
+        "runs": passages,
+        "reads_locked": any(passage["reads_locked"] for passage in passages),
+        "heuristic": FLOOR_HEURISTIC,
+    }
+
+
+def _quiet_runs(windows: Sequence[tuple[float, float]]) -> list[tuple[float, float]]:
+    """The stretches of music long enough, and quiet enough, to be a passage.
+
+    Quiet is the bottom third of the *smoothed* curve — the same split ``_terciles`` takes,
+    run over a curve the outliers have been taken out of rather than the raw one, which is the
+    whole difference between a passage and a window. Runs shorter than ``QUIET_FLOOR_SECONDS``
+    are dropped rather than measured: they hold two or three shots, and a spread over three
+    shots is a number the report cannot mean anything by.
+    """
+    if not windows:
+        return []
+    levels = _smoothed([level for _, level in windows])
+    smoothed = [(start, level) for (start, _), level in zip(windows, levels, strict=True)]
+    quiet = [label == QUIET for label in _terciles(smoothed)]
+
+    runs: list[tuple[float, float]] = []
+    opened: int | None = None
+    for index, is_quiet in enumerate([*quiet, False]):
+        if is_quiet and opened is None:
+            opened = index
+        elif not is_quiet and opened is not None:
+            runs.append((windows[opened][0], windows[index - 1][0] + GEAR_WINDOW_SECONDS))
+            opened = None
+    return [(start, end) for start, end in runs if end - start >= QUIET_FLOOR_SECONDS]
+
+
+def _smoothed(levels: Sequence[float]) -> list[float]:
+    """A centred moving median over ``QUIET_SMOOTHING_WINDOWS`` windows.
+
+    Median rather than mean, because the thing being smoothed out is exactly the outlier — one
+    crash in a quiet passage pulls a mean over the edge and leaves the median where the music
+    is. At the ends the window shrinks rather than padding: a curve that starts quiet should
+    read quiet from its first window, not ease in from a value nobody measured.
+    """
+    half = QUIET_SMOOTHING_WINDOWS // 2
+    return [
+        statistics.median(levels[max(0, index - half) : min(len(levels), index + half + 1)])
+        for index in range(len(levels))
+    ]
+
+
+def _passage(rows: Sequence[Mapping[str, Any]], start: float, end: float) -> dict[str, Any]:
+    """One quiet passage: how it was cut, and whether the spread is real or carried.
+
+    ``cv_less_orphans`` is the reading the flag is drawn on. A coefficient of variation is
+    dominated by whatever is furthest from the mean, so one 2.5 s flash among five holds of
+    ten to twenty seconds reports a spread that no part of the passage a viewer sits through
+    actually has. Dropping the orphans and asking again is the difference between a floor that
+    breathes and a floor with a hole punched in it.
+
+    A passage with no shot starting inside it is not an absent reading, it is the stillest one
+    there is: a single hold runs the whole way through and there is no cut in it to measure.
+    That is reported as ``held_through_seconds`` and reads locked on its own, because a
+    spread taken over the no lengths inside would otherwise let the most parked passage
+    possible past the flag.
+    """
+    lengths = [float(row["seconds"]) for row in rows if start <= float(row["t"]) < end]
+    held_through = _held_through(rows, start, end) if not lengths else None
+    orphans = _orphans(lengths)
+    kept = [length for index, length in enumerate(lengths) if index not in orphans]
+    cv = _cv(lengths)
+    less = _cv(kept)
+    seconds = end - start
+    return {
+        "from": rounded(start),
+        "to": rounded(end),
+        "seconds": rounded(seconds),
+        "shots": len(lengths),
+        "cuts_per_minute": rounded(len(lengths) / (seconds / 60.0)) if seconds > 0 else None,
+        "median_seconds": rounded(statistics.median(lengths)) if lengths else None,
+        "cv": cv,
+        "orphans": len(orphans),
+        "orphan_seconds": [rounded(lengths[index]) for index in orphans],
+        "cv_less_orphans": less,
+        "held_through_seconds": held_through,
+        "reads_locked": held_through is not None or (less is not None and less < FLOOR_CV_FLOOR),
+    }
+
+
+def _held_through(rows: Sequence[Mapping[str, Any]], start: float, end: float) -> float | None:
+    """The length of the shot that runs the whole passage without a cut in it, if there is one.
+
+    Not every passage with nothing starting inside it is held through: a cut that ends before
+    the passage does — or one the level curve outruns — has no film there at all, and a
+    stretch with no picture in it is not an edit anybody made. The shot has to cover the
+    passage end to end for the reading to be about a decision.
+    """
+    for row in rows:
+        opens = float(row["t"])
+        if opens <= start and opens + float(row["seconds"]) >= end:
+            return rounded(float(row["seconds"]))
+    return None
+
+
+def _orphans(lengths: Sequence[float]) -> set[int]:
+    """Which shots are lone flashes: short against the passage, with nothing short beside them.
+
+    Neighbours are taken inside the passage only, so its first and last shot are judged against
+    the one neighbour they have — a passage that opens on a flash is still opening on one.
+
+    Two short shots side by side are not orphans, either of them. That is a burst, which is a
+    gesture a quiet passage is allowed to make and which the spread should keep, and the whole
+    point of the distinction is that a burst is something a viewer reads as cutting while a
+    single flash between long holds reads as a mistake or a stinger.
+    """
+    if len(lengths) < 2:
+        return set()
+    median = statistics.median(lengths)
+    found: set[int] = set()
+    for index, length in enumerate(lengths):
+        if length >= ORPHAN_FRACTION * median:
+            continue
+        beside = [lengths[near] for near in (index - 1, index + 1) if 0 <= near < len(lengths)]
+        if all(other >= median for other in beside):
+            found.add(index)
+    return found
+
+
+def _cv(lengths: Sequence[float]) -> float | None:
+    """Coefficient of variation, or ``None`` where there is nothing to take it over.
+
+    One shot is a spread of zero rather than no reading: a passage crossed by a single hold is
+    the most locked a passage can be, and answering ``None`` there would let the stillest case
+    of all fall through the flag. Nothing at all — a long shot that started before the passage
+    and covers it whole — is the reading that cannot be taken, because no length inside it is a
+    decision made about it.
+    """
+    if not lengths:
+        return None
+    mean = statistics.fmean(lengths)
+    return rounded(statistics.pstdev(lengths) / mean) if mean > 0 else None
+
+
+def _terciles(windows: Sequence[tuple[float, float]]) -> list[str]:
+    """Which third of the loudness each window sits in, by rank rather than by level range.
+
+    Ranking, because the levels themselves are not a scale anything can be split evenly on:
+    a mix mastered hot spends most of its windows inside four decibels, and thirds of *that*
+    range would put the whole concert in one gear. Thirds of the windows always split the
+    span three ways, so the rate in each is a rate over comparable amounts of music.
+
+    Ties break by time, which matters only on a curve flat enough that the split is arbitrary
+    — and there the ratio it produces lands near one, which is exactly what a passage whose
+    loudness never moves should read as.
+    """
+    order = sorted(range(len(windows)), key=lambda index: (windows[index][1], windows[index][0]))
+    lower, upper = len(order) // 3, (2 * len(order)) // 3
+    placed = [MID] * len(windows)
+    for rank, index in enumerate(order):
+        placed[index] = QUIET if rank < lower else LOUD if rank >= upper else MID
+    return placed
+
+
+def _window_at(starts: Sequence[float], seconds: float) -> int | None:
+    """The window a shot's first frame lands in, or ``None`` when the curve does not reach it.
+
+    A shot is counted whole in the gear it was cut *into*: that is the decision the editor
+    made at that frame. Splitting a long shot across two gears would credit the loud third
+    with screen time nobody cut there.
+
+    Past the ends the answer is nothing rather than the nearest window. The rates are cuts
+    over the *music* each tercile holds, and a curve that stops before the cut does — or
+    starts after it, on a cold open — holds no music where those shots sit; clamping them
+    into the first or last window would add cuts to a numerator whose denominator never grew,
+    and a cut running a minute past the analysed mix would read as a gear change nobody made.
+    """
+    index = bisect_right(starts, seconds) - 1
+    if index < 0 or seconds >= starts[-1] + GEAR_WINDOW_SECONDS:
+        return None
+    return index
+
+
+def _gear(shots: Sequence[Mapping[str, Any]], levels: Sequence[float]) -> dict[str, Any]:
+    """One tercile: how much music it holds, how many shots were cut in it, and how fast.
+
+    ``seconds`` is counted in whole windows rather than in the shots' own lengths, because
+    the denominator has to be the music: a gear where one long shot runs over a minute of
+    loud music has a real cutting rate, and dividing by that shot's length would report the
+    rate of the shot instead.
+    """
+    lengths = [float(shot["seconds"]) for shot in shots]
+    seconds = len(levels) * GEAR_WINDOW_SECONDS
+    return {
+        "seconds": rounded(seconds),
+        "shots": len(shots),
+        "cuts_per_minute": rounded(len(shots) / (seconds / 60.0)) if seconds > 0 else None,
+        "median_seconds": rounded(statistics.median(lengths)) if lengths else None,
+        "level_dbfs": rounded(statistics.median(levels)) if levels else None,
+    }
+
+
+def _rate_ratio(loud: Any, quiet: Any) -> float | None:
+    """How much faster the loud third is cut than the quiet one.
+
+    ``None`` when nothing was cut in the quiet third: a ratio against zero is a number the
+    report cannot mean anything by, and inventing one there would read as a verdict.
+    """
+    if not isinstance(loud, int | float) or not isinstance(quiet, int | float) or not quiet:
+        return None
+    return rounded(float(loud) / float(quiet))
+
+
+def _one_speed(ratio: float | None, cv: Any) -> bool:
+    """``GEAR_HEURISTIC``, applied. A reading it cannot take is not a reading against the cut."""
+    if ratio is None or not isinstance(cv, int | float):
+        return False
+    return ratio < RATE_RATIO_FLOOR and float(cv) < GEAR_CV_FLOOR

--- a/src/resolve_mcp/analysis/rhythm.py
+++ b/src/resolve_mcp/analysis/rhythm.py
@@ -19,10 +19,17 @@ the report says out loud beside the numbers and the rules that drew them (``HEUR
 argue with a threshold. Trading two cameras for four minutes is a real edit some music asks
 for; the point is that the builder *decided* it.
 
-The interface is one function. ``read(rows, levels)`` takes the per-cut records the report is
-built from — ``t``, ``seconds`` and ``clip`` are the only columns touched — and the loudness
-curve, and returns the ``shot_rhythm`` block. No Resolve handle, no files, no job record: the
-arithmetic is testable from a list of dicts written by hand.
+The interface a caller uses is one function. ``read(rows, levels)`` takes the per-cut records
+the report is built from — ``t``, ``seconds`` and ``clip`` are the only columns touched — and
+the loudness curve, and returns the ``shot_rhythm`` block. No Resolve handle, no files, no job
+record: the arithmetic is testable from a list of dicts written by hand.
+
+One reader goes underneath it on purpose. ``gauntlet/recon/quiet_floor.py`` is the receipt
+behind #190's corpus row, and it reads a passage at a time against sections the report knows
+nothing about; it imports the private helpers rather than reimplementing them, so the receipt
+cannot go on describing arithmetic the server has changed. They stay private because that is
+what they are — a receipt is not a second caller to keep an interface stable for, and it lives
+in this repo where a rename reaches it.
 """
 
 from __future__ import annotations

--- a/src/resolve_mcp/analysis/stats.py
+++ b/src/resolve_mcp/analysis/stats.py
@@ -1,0 +1,51 @@
+"""The readings taken over a column of records, shared by everything that takes one.
+
+Small on purpose. Three of these — how far off a column of offsets is, how its values
+distribute, whether it was measured at all — are asked by the cut report and by every join
+that contributes a block to it, and a second copy of "early is negative" or of "a column
+nobody named reads as nothing, not zero" is a second rule waiting to disagree with the first.
+
+Nothing here knows what a cut is. A sequence of numbers in, a dict out.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ..timing import SECONDS_PRECISION
+
+
+def rounded(seconds: float) -> float:
+    """Seconds at the precision every time in a report is written to."""
+    return round(seconds, SECONDS_PRECISION)
+
+
+def measured(field: str, rows: Sequence[Mapping[str, Any]]) -> bool:
+    """Whether a column was measured at all — an input nobody named reads as nothing, not zero."""
+    return any(row[field] is not None for row in rows)
+
+
+def offsets(found: Sequence[float | None]) -> dict[str, Any] | None:
+    """How far off the cuts are, and which way — early and late counted apart."""
+    values = [value for value in found if value is not None]
+    if not values:
+        return None
+    sizes = [abs(value) for value in values]
+    return {
+        "measured": len(values),
+        "mean_abs": rounded(statistics.fmean(sizes)),
+        "median_abs": rounded(statistics.median(sizes)),
+        "max_abs": rounded(max(sizes)),
+        "early": sum(1 for value in values if value < 0),
+        "late": sum(1 for value in values if value > 0),
+        "on": sum(1 for value in values if value == 0),
+    }
+
+
+def histogram(values: Any) -> dict[str, int]:
+    """Counts keyed by value as a string — JSON has no integer keys to speak of."""
+    counted = Counter(value for value in values if value is not None)
+    return {str(key): count for key, count in sorted(counted.items(), key=lambda one: str(one[0]))}

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -297,6 +297,16 @@ def correlate_timeline(
     joined against the solo map, or asserted by a camera the sidecar says follows the front —
     and soloist_seconds_by_follow_camera is how much of the share is the second kind.
 
+    The inline reading also carries shot_rhythm, which is the one block about the cut rather
+    than about the music: how the shot lengths spread, how strictly the angles alternate, how
+    much of the cut sits in one length bin and how far it ramps, plus reads_metronomic. Inside
+    it, gears splits the music into thirds by loudness and reports the cutting rate in each
+    (rate_ratio, one_speed), and quiet_floor reads the passages held in the slow gear — whether
+    the lengths inside one breathe or only hold (reads_locked). Every one of those flags is a
+    sentence, not a gate, and each block carries the heuristic it was drawn at in words.
+    analysis/rhythm.py owns the shape and the thresholds; analysis/barmap.py owns the bar-map
+    columns and the bar_groups and bar_offsets blocks taken over them.
+
     Nothing here judges the edit. Two frames late is reported as two frames late; what
     counts as musical belongs in your style profile, not in this server.
     """

--- a/tests/test_bar_map_join.py
+++ b/tests/test_bar_map_join.py
@@ -65,7 +65,14 @@ def test_a_cut_past_the_end_of_the_map_is_read_against_its_last_bar() -> None:
 
 
 def test_no_map_leaves_all_three_columns_null_together() -> None:
-    assert barmap.reading(None, [], 4.0) == dict.fromkeys(barmap.COLUMNS)
+    # Spelled out rather than taken from ``COLUMNS``: this is the record's contract, and an
+    # assertion built from the same constant the implementation builds from would survive a
+    # column being renamed on both sides at once.
+    assert barmap.reading(None, [], 4.0) == {
+        "map_bar": None,
+        "in_group": None,
+        "bar_offset": None,
+    }
 
 
 def test_the_place_in_the_group_is_the_maps_own() -> None:
@@ -99,9 +106,12 @@ def test_a_call_that_named_no_bar_map_reads_null_rather_than_empty() -> None:
     assert barmap.summary(rows, rows) == {"bar_groups": None, "bar_offsets": None}
 
 
-def test_the_reading_survives_a_grid_the_beat_gate_refused_wholesale() -> None:
-    # in_grid false on every row: the beat gate refuses beats the *grid* describes badly, and a
-    # bar map exists precisely for those grids (#180).
+def test_the_join_reads_no_gate_column_at_all() -> None:
+    # A bar map exists precisely for the grids the #112 beat gate refuses wholesale (#180), so
+    # this join must not consult that verdict — here, rows carrying ``in_grid`` false still
+    # produce both blocks in full. That the *report* leaves the blocks ungated end to end is a
+    # fact about ``correlate._summary``, and is pinned there by
+    # ``test_the_group_histogram_is_not_gated_on_the_grid``.
     rows = [
         _cut(in_grid=False, in_group=2, bar_offset=0.05),
         _cut(in_grid=False, in_group=4, bar_offset=-0.05),

--- a/tests/test_bar_map_join.py
+++ b/tests/test_bar_map_join.py
@@ -1,0 +1,118 @@
+"""Reading a cut against the bar map: the columns, and the two blocks taken over them.
+
+Hand-written bar records in, dicts out — ``bars.py``'s own tests cover how a map is found, and
+these cover what an edit reads against one. The two cases worth their own test are the ones a
+whole-report run would hide: a cut that lands *before* a downbeat is a cut on the one, and a
+grid the beat gate refused wholesale is exactly when this reading has to keep working.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from resolve_mcp.analysis import barmap
+
+BARS: tuple[dict[str, Any], ...] = (
+    {"bar": 1, "t": 0.0, "in_group": 1},
+    {"bar": 2, "t": 2.0, "in_group": 2},
+    {"bar": 3, "t": 4.0, "in_group": 3},
+    {"bar": 4, "t": 6.0, "in_group": 4},
+    {"bar": 5, "t": 8.0, "in_group": 1},
+)
+"""Five two-second bars, the shape ``detect_bars`` writes."""
+
+
+def _cut(**columns: Any) -> dict[str, Any]:
+    """A record carrying only what this join reads back."""
+    return {"in_group": None, "bar_offset": None, **columns}
+
+
+# --- the columns ------------------------------------------------------------------------------
+
+
+def test_the_bar_lines_are_read_off_the_map_in_order() -> None:
+    assert barmap.times(BARS) == [0.0, 2.0, 4.0, 6.0, 8.0]
+
+
+def test_no_map_is_no_lines_rather_than_an_error() -> None:
+    assert barmap.times(None) == []
+
+
+def test_a_cut_on_a_downbeat_lands_on_that_bar_with_no_offset() -> None:
+    assert barmap.reading(BARS, barmap.times(BARS), 4.0) == {
+        "map_bar": 3,
+        "in_group": 3,
+        "bar_offset": 0.0,
+    }
+
+
+def test_a_cut_just_before_a_downbeat_is_a_cut_on_the_one_read_early() -> None:
+    read = barmap.reading(BARS, barmap.times(BARS), 3.98)
+    assert read["map_bar"] == 3
+    assert read["bar_offset"] == -0.02
+
+
+def test_a_cut_just_after_a_downbeat_is_read_late_against_the_same_bar() -> None:
+    read = barmap.reading(BARS, barmap.times(BARS), 4.02)
+    assert read["map_bar"] == 3
+    assert read["bar_offset"] == 0.02
+
+
+def test_a_cut_past_the_end_of_the_map_is_read_against_its_last_bar() -> None:
+    read = barmap.reading(BARS, barmap.times(BARS), 20.0)
+    assert read["map_bar"] == 5
+    assert read["bar_offset"] == 12.0
+
+
+def test_no_map_leaves_all_three_columns_null_together() -> None:
+    assert barmap.reading(None, [], 4.0) == dict.fromkeys(barmap.COLUMNS)
+
+
+def test_the_place_in_the_group_is_the_maps_own() -> None:
+    assert barmap.reading(BARS, barmap.times(BARS), 8.1)["in_group"] == 1
+
+
+# --- the blocks -------------------------------------------------------------------------------
+
+
+def test_the_group_histogram_and_offsets_are_taken_over_the_cuts_to_music() -> None:
+    rows = [
+        _cut(in_group=1, bar_offset=0.1),
+        _cut(in_group=1, bar_offset=-0.3),
+        _cut(in_group=3, bar_offset=0.0),
+    ]
+    read = barmap.summary(rows, rows[1:])
+    assert read["bar_groups"] == {"1": 1, "3": 1}
+    assert read["bar_offsets"] == {
+        "measured": 2,
+        "mean_abs": 0.15,
+        "median_abs": 0.15,
+        "max_abs": 0.3,
+        "early": 1,
+        "late": 0,
+        "on": 1,
+    }
+
+
+def test_a_call_that_named_no_bar_map_reads_null_rather_than_empty() -> None:
+    rows = [_cut(), _cut()]
+    assert barmap.summary(rows, rows) == {"bar_groups": None, "bar_offsets": None}
+
+
+def test_the_reading_survives_a_grid_the_beat_gate_refused_wholesale() -> None:
+    # in_grid false on every row: the beat gate refuses beats the *grid* describes badly, and a
+    # bar map exists precisely for those grids (#180).
+    rows = [
+        _cut(in_grid=False, in_group=2, bar_offset=0.05),
+        _cut(in_grid=False, in_group=4, bar_offset=-0.05),
+    ]
+    read = barmap.summary(rows, rows)
+    assert read["bar_groups"] == {"2": 1, "4": 1}
+    assert read["bar_offsets"]["measured"] == 2
+
+
+def test_an_opening_is_left_out_of_the_statistics_it_would_skew() -> None:
+    rows = [_cut(in_group=1, bar_offset=9.9), _cut(in_group=2, bar_offset=0.1)]
+    read = barmap.summary(rows, rows[1:])
+    assert read["bar_groups"] == {"2": 1}
+    assert read["bar_offsets"]["max_abs"] == 0.1

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -21,6 +21,7 @@ import pytest
 
 from resolve_mcp.analysis import beats as beats_module
 from resolve_mcp.analysis import correlate, energy, records
+from resolve_mcp.analysis import rhythm as rhythm_module
 from resolve_mcp.analysis.beats import BeatGrid
 from resolve_mcp.errors import InvalidRequestError
 from resolve_mcp.jobs.runner import wait_for
@@ -2147,9 +2148,9 @@ def test_the_rhythm_reading_carries_the_rule_it_applied(attach: Attach, tmp_path
 
     rhythm = _rhythm(_measured(tmp_path))
 
-    assert rhythm["heuristic"] == correlate.HEURISTIC
+    assert rhythm["heuristic"] == rhythm_module.HEURISTIC
     assert "warning" in rhythm["heuristic"]
-    assert str(correlate.ALTERNATION_FLOOR) in rhythm["heuristic"]
+    assert str(rhythm_module.ALTERNATION_FLOOR) in rhythm["heuristic"]
     assert set(rhythm) == {
         "shots",
         "lengths",
@@ -2340,7 +2341,7 @@ def test_a_cut_that_changes_gear_is_not_one_speed_though_its_lengths_barely_vary
     rhythm, gears = _rhythm(result), _gears(result)
 
     assert gears["rate_ratio"] == 1.5  # thirty cuts a minute against twenty
-    assert rhythm["uniformity"]["cv"] < correlate.GEAR_CV_FLOOR
+    assert rhythm["uniformity"]["cv"] < rhythm_module.GEAR_CV_FLOOR
     assert gears["one_speed"] is False
 
 
@@ -2361,7 +2362,7 @@ def test_a_cut_whose_lengths_vary_is_not_one_speed_though_its_rate_holds(
     rhythm, gears = _rhythm(result), _gears(result)
 
     assert gears["rate_ratio"] == 1.0
-    assert rhythm["uniformity"]["cv"] > correlate.GEAR_CV_FLOOR
+    assert rhythm["uniformity"]["cv"] > rhythm_module.GEAR_CV_FLOOR
     assert gears["one_speed"] is False
 
 
@@ -2387,10 +2388,10 @@ def test_the_gearing_reading_carries_the_rule_it_applied(attach: Attach, tmp_pat
 
     gears = _gears(_measured(tmp_path))
 
-    assert gears["heuristic"] == correlate.GEAR_HEURISTIC
+    assert gears["heuristic"] == rhythm_module.GEAR_HEURISTIC
     assert "warning" in gears["heuristic"]
-    assert str(correlate.RATE_RATIO_FLOOR) in gears["heuristic"]
-    assert str(correlate.GEAR_CV_FLOOR) in gears["heuristic"]
+    assert str(rhythm_module.RATE_RATIO_FLOOR) in gears["heuristic"]
+    assert str(rhythm_module.GEAR_CV_FLOOR) in gears["heuristic"]
     assert set(gears) == {
         "window_seconds",
         "terciles",
@@ -2668,12 +2669,12 @@ def test_the_quiet_floor_reading_carries_the_rule_it_applied(
 
     floor = _floor(_measured(tmp_path, loudness=_levels(_steps(*BLOCKS))))
 
-    assert floor["heuristic"] == correlate.FLOOR_HEURISTIC
+    assert floor["heuristic"] == rhythm_module.FLOOR_HEURISTIC
     assert "warning" in floor["heuristic"]
-    assert str(correlate.FLOOR_CV_FLOOR) in floor["heuristic"]
-    assert str(correlate.ORPHAN_FRACTION) in floor["heuristic"]
-    assert str(correlate.QUIET_FLOOR_SECONDS) in floor["heuristic"]
-    assert floor["smoothing_windows"] == correlate.QUIET_SMOOTHING_WINDOWS
+    assert str(rhythm_module.FLOOR_CV_FLOOR) in floor["heuristic"]
+    assert str(rhythm_module.ORPHAN_FRACTION) in floor["heuristic"]
+    assert str(rhythm_module.QUIET_FLOOR_SECONDS) in floor["heuristic"]
+    assert floor["smoothing_windows"] == rhythm_module.QUIET_SMOOTHING_WINDOWS
     assert set(floor) == {"smoothing_windows", "runs", "reads_locked", "heuristic"}
     assert set(floor["runs"][0]) == {
         "from",

--- a/tests/test_rhythm.py
+++ b/tests/test_rhythm.py
@@ -1,0 +1,315 @@
+"""How varied the cutting is, read straight from a list of dicts.
+
+Every case here is hand-written rows in and a dict out — no fake studio, no beats file, no job
+poll — because that is what the module is: arithmetic over three columns (``t``, ``seconds``,
+``clip``) and a loudness curve. The interesting cases are the ones a whole-report test cannot
+reach without building a concert to reach them: a ladder that varies every length and is still
+mechanical, a passage held through by one shot, a burst that is not two orphans.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from resolve_mcp.analysis import rhythm
+
+QUIET_DBFS, MID_DBFS, LOUD_DBFS = -40.0, -30.0, -20.0
+"""Three flat levels, thirty windows each: a curve whose terciles are known by construction."""
+
+
+def _curve() -> list[tuple[float, float]]:
+    """Ninety one-second windows — quiet for thirty, then mid, then loud."""
+    return [
+        (float(index), QUIET_DBFS if index < 30 else MID_DBFS if index < 60 else LOUD_DBFS)
+        for index in range(90)
+    ]
+
+
+def _rows(*shots: tuple[float, float], clips: str = "AB") -> list[dict[str, Any]]:
+    """Records from ``(start, length)`` pairs, angles cycling through ``clips``."""
+    return [
+        {"t": start, "seconds": length, "clip": clips[index % len(clips)]}
+        for index, (start, length) in enumerate(shots)
+    ]
+
+
+# --- the shot lengths -------------------------------------------------------------------------
+
+
+def test_the_bins_are_the_corpus_ones_and_half_open_on_the_upper_edge() -> None:
+    read = rhythm.read(_rows((0.0, 1.5), (2.0, 4.0), (6.0, 30.0)))
+    assert read["lengths"]["histogram"] == {
+        "<2": 1,
+        "2-4": 0,
+        "4-8": 1,
+        "8-15": 0,
+        "15-30": 0,
+        ">30": 1,
+    }
+
+
+def test_every_bin_is_present_even_when_it_holds_nothing() -> None:
+    assert set(rhythm.read(_rows((0.0, 3.0)))["lengths"]["histogram"]) == {
+        label for label, _ in rhythm.RHYTHM_BINS
+    }
+
+
+def test_the_spread_ratio_is_none_when_the_shortest_shot_rounds_to_zero() -> None:
+    assert rhythm.read(_rows((0.0, 0.0), (0.0, 8.0)))["lengths"]["spread_ratio"] is None
+
+
+def test_no_shots_reads_as_no_lengths_rather_than_as_zero() -> None:
+    read = rhythm.read([])
+    assert read["shots"] == 0
+    assert read["lengths"]["mean"] is None
+    assert read["uniformity"] == {"bin": None, "one_bin": None, "cv": None}
+    assert read["reads_metronomic"] is False
+
+
+# --- alternation ------------------------------------------------------------------------------
+
+
+def test_a_strict_ab_trade_is_counted_in_cuts() -> None:
+    read = rhythm.read(_rows((0.0, 2.0), (2.0, 2.0), (4.0, 2.0), (6.0, 2.0), (8.0, 2.0)))
+    assert read["alternation"] == {"cuts": 4, "longest_run": 4, "fraction": 1.0}
+
+
+def test_a_third_angle_ends_the_run() -> None:
+    rows = _rows((0.0, 2.0), (2.0, 2.0), (4.0, 2.0), (6.0, 2.0), (8.0, 2.0), clips="ABABC")
+    assert rhythm.read(rows)["alternation"]["longest_run"] == 3
+
+
+def test_the_same_angle_twice_ends_the_run() -> None:
+    rows = _rows((0.0, 2.0), (2.0, 2.0), (4.0, 2.0), (6.0, 2.0), clips="ABBA")
+    assert rhythm.read(rows)["alternation"]["longest_run"] == 0
+
+
+def test_two_shots_that_differ_are_a_cut_rather_than_alternation() -> None:
+    read = rhythm.read(_rows((0.0, 2.0), (2.0, 2.0)))
+    assert read["alternation"] == {"cuts": 1, "longest_run": 0, "fraction": 0.0}
+
+
+def test_black_is_an_angle_in_the_trade_rather_than_a_hole_in_it() -> None:
+    rows = _rows((0.0, 2.0), (2.0, 2.0), (4.0, 2.0), (6.0, 2.0))
+    for index in (1, 3):
+        rows[index]["clip"] = None
+    assert rhythm.read(rows)["alternation"]["longest_run"] == 3
+
+
+# --- uniformity and the ramp ------------------------------------------------------------------
+
+
+def test_one_bin_is_the_fullest_bins_share_of_the_shots() -> None:
+    read = rhythm.read(_rows((0.0, 3.0), (3.0, 3.0), (6.0, 3.0), (9.0, 20.0)))
+    assert read["uniformity"]["bin"] == "2-4"
+    assert read["uniformity"]["one_bin"] == 0.75
+
+
+def test_a_ladder_that_only_shortens_is_a_ramp() -> None:
+    read = rhythm.read(_rows((0.0, 10.0), (10.0, 8.0), (18.0, 7.0), (25.0, 5.0), (30.0, 3.0)))
+    assert read["ramp"] == {"cuts": 4, "longest_run": 4, "fraction": 1.0}
+
+
+def test_a_step_back_up_ends_the_ramp() -> None:
+    read = rhythm.read(_rows((0.0, 10.0), (10.0, 8.0), (18.0, 7.0), (25.0, 9.0), (34.0, 3.0)))
+    assert read["ramp"]["longest_run"] == 0
+
+
+def test_equal_neighbours_end_a_ramp_rather_than_continue_it() -> None:
+    read = rhythm.read(_rows((0.0, 5.0), (5.0, 5.0), (10.0, 5.0), (15.0, 5.0), (20.0, 5.0)))
+    assert read["ramp"]["longest_run"] == 0
+
+
+# --- the metronome verdict --------------------------------------------------------------------
+
+
+def test_a_two_camera_trade_on_one_length_reads_metronomic() -> None:
+    rows = _rows(*[(float(index * 3), 3.0) for index in range(12)])
+    read = rhythm.read(rows)
+    assert read["reads_metronomic"] is True
+
+
+def test_a_ladder_reads_metronomic_even_though_every_length_differs() -> None:
+    # P3·R3: strict two-framing, 9.9 s down to 2.9 s without a step back up. The bin and the
+    # spread both call this varied; the ramp is what catches it.
+    lengths = [9.9, 8.9, 7.9, 6.9, 5.9, 4.9, 3.9, 2.9]
+    start = 0.0
+    shots = []
+    for length in lengths:
+        shots.append((start, length))
+        start += length
+    read = rhythm.read(_rows(*shots))
+    assert read["uniformity"]["one_bin"] < rhythm.ONE_BIN_FLOOR
+    assert read["reads_metronomic"] is True
+
+
+def test_a_varied_cut_on_two_cameras_does_not_read_metronomic() -> None:
+    read = rhythm.read(_rows((0.0, 2.0), (2.0, 14.0), (16.0, 3.0), (19.0, 25.0), (44.0, 5.0)))
+    assert read["reads_metronomic"] is False
+
+
+def test_the_heuristic_is_carried_in_the_block_with_the_numbers_it_was_drawn_at() -> None:
+    read = rhythm.read(_rows((0.0, 3.0)))
+    assert read["heuristic"] == rhythm.HEURISTIC
+    assert str(rhythm.ALTERNATION_FLOOR) in read["heuristic"]
+
+
+# --- the gearing ------------------------------------------------------------------------------
+
+
+def test_no_level_curve_is_no_gearing_rather_than_a_flat_one() -> None:
+    assert rhythm.read(_rows((0.0, 3.0), (3.0, 3.0)))["gears"] is None
+
+
+def test_a_curve_that_does_not_reach_the_cut_is_no_gearing_either() -> None:
+    away = [(float(index) + 500.0, LOUD_DBFS) for index in range(30)]
+    assert rhythm.read(_rows((0.0, 3.0), (3.0, 3.0)), away)["gears"] is None
+
+
+def _geared() -> dict[str, Any]:
+    """Three holds in the quiet third, three in the mid, thirty one-second shots in the loud."""
+    shots = [(0.0, 10.0), (10.0, 10.0), (20.0, 10.0), (30.0, 10.0), (40.0, 10.0), (50.0, 10.0)]
+    shots += [(60.0 + index, 1.0) for index in range(30)]
+    return rhythm.read(_rows(*shots), _curve())
+
+
+def test_each_tercile_holds_a_third_of_the_music_and_its_own_rate() -> None:
+    gears = _geared()
+    assert gears is not None
+    terciles = gears["gears"]["terciles"]
+    assert [terciles[gear]["seconds"] for gear in (rhythm.QUIET, rhythm.MID, rhythm.LOUD)] == [
+        30.0,
+        30.0,
+        30.0,
+    ]
+    assert terciles[rhythm.QUIET]["cuts_per_minute"] == 6.0
+    assert terciles[rhythm.LOUD]["cuts_per_minute"] == 60.0
+    assert terciles[rhythm.LOUD]["level_dbfs"] == LOUD_DBFS
+
+
+def test_the_rate_ratio_is_the_loud_third_against_the_quiet_one() -> None:
+    assert _geared()["gears"]["rate_ratio"] == 10.0
+
+
+def test_a_cut_that_changes_gear_is_not_one_speed() -> None:
+    assert _geared()["gears"]["one_speed"] is False
+
+
+def test_the_short_shots_are_counted_where_they_sit() -> None:
+    gears = _geared()["gears"]
+    assert gears["sub2s_count"] == 30
+    assert gears["sub2s_in_loud"] == 30
+    assert gears["sub2s_loud_fraction"] == 1.0
+
+
+def test_a_shot_past_the_curve_is_counted_outside_rather_than_in_a_tercile() -> None:
+    shots = [(0.0, 10.0), (10.0, 10.0), (20.0, 10.0), (200.0, 4.0)]
+    gears = rhythm.read(_rows(*shots), _curve())["gears"]
+    assert gears["outside_shots"] == 1
+    assert sum(gears["terciles"][gear]["shots"] for gear in gears["terciles"]) == 3
+
+
+def test_one_speed_is_true_where_the_rate_barely_moves_and_the_lengths_do_not() -> None:
+    shots = [(float(index) * 3.0, 3.0) for index in range(30)]
+    gears = rhythm.read(_rows(*shots), _curve())["gears"]
+    assert gears["rate_ratio"] is not None
+    assert gears["rate_ratio"] < rhythm.RATE_RATIO_FLOOR
+    assert gears["one_speed"] is True
+
+
+def test_the_gear_heuristic_is_carried_beside_its_numbers() -> None:
+    gears = _geared()["gears"]
+    assert gears["heuristic"] == rhythm.GEAR_HEURISTIC
+    assert gears["window_seconds"] == rhythm.GEAR_WINDOW_SECONDS
+
+
+# --- the quiet floor --------------------------------------------------------------------------
+
+
+def _filler() -> list[tuple[float, float]]:
+    """Two-second shots from 30 s to the end of the curve.
+
+    The terciles are taken over the windows the *cut* spans, so a passage test whose shots all
+    sit in the first thirty seconds would be splitting a flat thirty-second curve three ways
+    rather than reading the quiet third of a ninety-second one. These carry the span out to the
+    end of the curve and start after the quiet passage, so they are outside every reading here.
+    """
+    return [(30.0 + index * 2.0, 2.0) for index in range(30)]
+
+
+def _floor(*shots: tuple[float, float]) -> dict[str, Any]:
+    """The ``quiet_floor`` block for shots read against the known curve."""
+    floor: dict[str, Any] = rhythm.read(_rows(*shots, *_filler()), _curve())["gears"][
+        "quiet_floor"
+    ]
+    return floor
+
+
+def test_the_quiet_passage_is_the_smoothed_bottom_third() -> None:
+    floor = _floor((0.0, 10.0), (10.0, 10.0), (20.0, 10.0))
+    assert len(floor["runs"]) == 1
+    passage = floor["runs"][0]
+    assert (passage["from"], passage["to"], passage["seconds"]) == (0.0, 30.0, 30.0)
+    assert passage["shots"] == 3
+    assert passage["cuts_per_minute"] == 6.0
+
+
+def test_holds_of_one_length_read_locked() -> None:
+    floor = _floor((0.0, 10.0), (10.0, 10.0), (20.0, 10.0))
+    assert floor["runs"][0]["cv"] == 0.0
+    assert floor["runs"][0]["reads_locked"] is True
+    assert floor["reads_locked"] is True
+
+
+def test_a_lone_flash_between_holds_is_an_orphan_and_does_not_buy_a_spread() -> None:
+    floor = _floor((0.0, 10.0), (10.0, 2.0), (12.0, 10.0), (22.0, 10.0))
+    passage = floor["runs"][0]
+    assert passage["orphans"] == 1
+    assert passage["orphan_seconds"] == [2.0]
+    assert passage["cv"] > passage["cv_less_orphans"] == 0.0
+    assert passage["reads_locked"] is True
+
+
+def test_two_short_shots_side_by_side_are_a_burst_and_stay_in_the_spread() -> None:
+    floor = _floor((0.0, 4.0), (4.0, 4.0), (8.0, 20.0), (28.0, 12.0))
+    passage = floor["runs"][0]
+    assert passage["orphans"] == 0
+    assert passage["cv_less_orphans"] == passage["cv"] > rhythm.FLOOR_CV_FLOOR
+    assert passage["reads_locked"] is False
+    assert floor["reads_locked"] is False
+
+
+def test_a_passage_crossed_by_one_hold_reads_locked_on_that_shot() -> None:
+    floor = _floor((-10.0, 60.0), (50.0, 4.0), (54.0, 4.0))
+    passage = floor["runs"][0]
+    assert passage["shots"] == 0
+    assert passage["held_through_seconds"] == 60.0
+    assert passage["reads_locked"] is True
+
+
+def test_a_passage_the_film_does_not_cover_is_not_held_through() -> None:
+    floor = _floor((-10.0, 5.0), (50.0, 4.0), (54.0, 4.0))
+    passage = floor["runs"][0]
+    assert passage["shots"] == 0
+    assert passage["held_through_seconds"] is None
+    assert passage["reads_locked"] is False
+
+
+def test_a_pocket_too_short_to_sit_in_is_no_passage() -> None:
+    # Three ten-second dips rather than one long one: the quiet third is the same size either
+    # way, and every run in it is under QUIET_FLOOR_SECONDS.
+    dips = {index for start in (10, 40, 70) for index in range(start, start + 10)}
+    curve = [
+        (float(index), QUIET_DBFS if index in dips else LOUD_DBFS + index * 0.01)
+        for index in range(90)
+    ]
+    rows = _rows(*[(float(index) * 3.0, 3.0) for index in range(30)])
+    floor = rhythm.read(rows, curve)["gears"]["quiet_floor"]
+    assert floor["runs"] == []
+    assert floor["reads_locked"] is False
+
+
+def test_the_floor_heuristic_is_carried_with_the_smoothing_it_was_read_at() -> None:
+    floor = _floor((0.0, 10.0), (10.0, 10.0), (20.0, 10.0))
+    assert floor["heuristic"] == rhythm.FLOOR_HEURISTIC
+    assert floor["smoothing_windows"] == rhythm.QUIET_SMOOTHING_WINDOWS


### PR DESCRIPTION
Closes #215.

The stats section of `analysis/correlate.py` was ~590 lines whose only inputs were rows, a level curve and the black sentinel — a module with a clean interface and no file. It now has one, on the pattern `subject.py` (#181) set in this exact spot.

- **`analysis/rhythm.py`** owns `shot_rhythm` and everything under it — `gears`, `quiet_floor`, `reads_metronomic`, `one_speed` and their heuristic constants — behind a single entry, `read(rows, levels)`. No Resolve handle, no files, no job record.
- **`analysis/barmap.py`** owns the bar-map join (#180): `reading()` for the `map_bar`/`in_group`/`bar_offset` columns, `summary()` for the `bar_groups` and `bar_offsets` blocks, mirroring `subject.reading`/`subject.summary`.
- **`analysis/stats.py`** holds the three readings both the report and the joins it composes take over a column of records — `offsets`, `histogram`, `measured`, plus `rounded`. `correlate` imports `barmap`, so the alternatives were a cross-import cycle or a second copy of "early is negative"; this is the minimum extraction the split forces.

`correlate` composes all three. `correlate.py` drops from 2,189 lines to 1,568.

**Report shape is unchanged**, so `READING` is not bumped: `_summary`'s key order is identical (`bar_groups`/`bar_offsets` land in the same slot via `**barmap.summary(...)`, with the same asymmetric gating — `measured(...)` over every row, values over the cuts to music), the per-cut columns keep their old position and order, and the "all three `None` together" path is preserved exactly. Existing correlate tests pass with an import change and nothing else.

## Test seam

Fake tier throughout — this is arithmetic over dicts, which is what the extraction is for. `tests/test_rhythm.py` (35 cases) and `tests/test_bar_map_join.py` (12) call the modules directly with hand-written rows: no fake studio, no beats file, no job poll. `tests/test_correlate_timeline.py` keeps every end-to-end assertion and only re-points its constants at `rhythm`. Full fake tier: 2162 passed, 43 deselected. mypy strict and ruff clean over `src` and `tests`. No live AC — nothing here touches a Resolve handle.

## Review

Two-axis review (Standards and Spec, parallel sub-agents) against `origin/main`, on the branch before this PR existed.

**Spec axis — no missing or wrong requirements.** Report shape verified against `git show origin/main:...correlate.py` key by key; existing tests confirmed changed by imports only; `rhythm.read` confirmed as the single public entry taking only rows and a level curve. `analysis/stats.py` was examined as possible scope creep and judged the minimum the spec's own instruction forces. One minor finding, fixed below.

**Standards axis — behaviour preservation clean.** Every top-level symbol AST-diffed against `origin/main` with the rename map applied: no symbol lost, no arithmetic changed; all body diffs reduce to the four `stats.*` renames, `_rhythm`→`rhythm.read`, a `Sequence[dict]`→`Sequence[Mapping]` widening, and prose. No hard violations. Four judgement calls, three fixed:

1. **CONTEXT.md ordering** — `barmap` was inserted after `bars`; the analysis list is alphabetical. Fixed in 65e7d96.
2. **A docstring the codebase contradicts** — `rhythm.py` asserted a one-function interface while `gauntlet/recon/quiet_floor.py` imports five of its private helpers (pre-existing: it did the same to `correlate`). Fixed: the module now says which reader goes underneath and why those helpers stay private.
3. **Tautological assertion** — the no-map test was built from `barmap.COLUMNS`, the same constant the implementation builds from, so a column renamed on both sides would survive it. Fixed: spelled out as a literal.
4. **A test naming a property it cannot check** — `barmap.summary` never reads `in_grid`, so a unit test could not show the block is ungated on the beat gate. Fixed: renamed to what it does show (the join consults no gate column), pointing at `test_the_group_histogram_is_not_gated_on_the_grid`, which pins the end-to-end fact at the `correlate` seam.
5. Not fixed, accepted as written: `rhythm.BLACK` duplicating `correlate.BLACK`, on the same rationale `subject.py` names its own — documented in place.

Fix diff re-checked (the two touched test files, ruff, mypy) rather than a second full pass.

Review: clean
