### PR TITLE
Give record files one reader, beside their writer

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -162,7 +162,10 @@ is a rule layer over, as `drums` is to `fills`), `music` (beats + energy + gist
 job; `beats_of`/`energy_of` are the shared entries other jobs read a grid or a
 loudness curve through, one measurement per piece of audio), `phrases` (phrase boundaries: where the soloist stops, which is the
 cut-placement unit #46 named, #143),
-`records` (sliceable record files), `rhythm` (how varied the cutting is, one entry
+`records` (sliceable record files — `write` and, beside it, the one strong reader
+`rows(path, field)` every caller shares: four refusals over a file that is not one of
+these, plus the numeric-`t` filter and the time-order sort that make the rest a
+timeline, #222), `rhythm` (how varied the cutting is, one entry
 `read(rows, levels)` over per-cut rows and a level curve: `shot_rhythm` bins the
 shot lengths, measures the longest strict A/B alternation run and the longest
 monotonic duration `ramp`, and says `reads_metronomic` with the heuristic that drew

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -165,7 +165,9 @@ cut-placement unit #46 named, #143),
 `records` (sliceable record files — `write` and, beside it, the one strong reader
 `rows(path, field)` every caller shares: four refusals over a file that is not one of
 these, plus the numeric-`t` filter and the time-order sort that make the rest a
-timeline, #222), `rhythm` (how varied the cutting is, one entry
+timeline. `allow_empty=` drops the empty-file refusal and is for the caller reading
+back a file it just wrote — nothing found is a wrong path only when an agent named
+the file, #222), `rhythm` (how varied the cutting is, one entry
 `read(rows, levels)` over per-cut rows and a level curve: `shot_rhythm` bins the
 shot lengths, measures the longest strict A/B alternation run and the longest
 monotonic duration `ramp`, and says `reads_metronomic` with the heuristic that drew

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -742,7 +742,7 @@ def _music(
 ) -> Music:
     """Every file the measurement joins — or a refusal naming the one that is not there."""
     return Music(
-        beats=_rows(_path(beats, "beat grid", "analyze_music writes it"), "beats"),
+        beats=records.rows(_path(beats, "beat grid", "analyze_music writes it"), "beats"),
         tunes=_optional_rows(tunes, "tune list", "tunes"),
         solos=_optional_rows(solos, "solo changes", "solos"),
         bars=_optional_rows(bars, "bar map", "bars", "detect_bars writes it"),
@@ -760,7 +760,7 @@ def _optional_rows(
 ) -> tuple[dict[str, Any], ...] | None:
     if file is None:
         return None
-    return _rows(_path(file, what, provenance), field)
+    return records.rows(_path(file, what, provenance), field)
 
 
 def _path(file: str, what: str, provenance: str) -> Path:
@@ -775,44 +775,6 @@ def _path(file: str, what: str, provenance: str) -> Path:
             detail={"file": str(path)},
         )
     return path
-
-
-def _rows(path: Path, field: str) -> tuple[dict[str, Any], ...]:
-    """One analysis file's records, in time order — the shape ``records.write`` leaves."""
-    try:
-        doc = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise InvalidRequestError(
-            cause=f"Could not read {path.name} as analysis JSON: {exc}.",
-            fix="Pass the path an analysis job returned, unedited.",
-            detail={"file": str(path), "field": field},
-        ) from exc
-
-    held = doc.get(field) if isinstance(doc, Mapping) else None
-    if not isinstance(held, list):
-        raise InvalidRequestError(
-            cause=f"{path.name} holds no {field!r} records.",
-            fix=f"That file is not the {field} analysis; pass the one whose kind is {field!r}.",
-            detail={"file": str(path), "field": field},
-        )
-    rows = [
-        dict(row)
-        for row in held
-        if isinstance(row, Mapping) and isinstance(row.get("t"), int | float)
-    ]
-    if not rows:
-        # A file that was named but says nothing must not read like a file nobody named:
-        # both would leave the column null, and only one of them is what the caller meant.
-        raise InvalidRequestError(
-            cause=f"{path.name} holds no {field} record with a time in it.",
-            fix=(
-                f"Pass the {field} file a finished analysis job wrote — its records each "
-                'carry a "t" in seconds. An analysis that found nothing is worth rerunning '
-                "rather than measuring against."
-            ),
-            detail={"file": str(path), "field": field},
-        )
-    return tuple(sorted(rows, key=lambda row: float(row["t"])))
 
 
 def _roles(angles: Mapping[str, Any] | None) -> dict[str, str] | None:

--- a/src/resolve_mcp/analysis/music.py
+++ b/src/resolve_mcp/analysis/music.py
@@ -18,7 +18,6 @@ master mix — no stems, no Resolve. Three consequences worth stating:
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -28,7 +27,7 @@ from ..errors import InvalidRequestError
 from ..jobs import cache
 from ..jobs.runner import JobOutput, Progress, start_job
 from . import beats as beats_module
-from . import device, halves
+from . import device, halves, records
 
 if TYPE_CHECKING:  # pragma: no cover - the worker imports these when it runs
     from .energy import Measurement
@@ -144,14 +143,13 @@ def numbered_beats(
     """The beat records themselves, from ``beats_of`` — computed or read back from disk.
 
     The document is the interchange format, so a caller that wants the grid rather than a
-    path reads it the way an agent would. Reading it here rather than at the caller keeps
-    the file's layout the business of the module that writes it. Drum-fill detection (#39)
-    reports against this grid and must not pay for the beat model a second time on audio
-    music analysis already ran over.
+    path reads it through ``records``, the module that wrote it — the file's layout, and
+    what a file that is not one of these gets refused for, stay in one place (#222).
+    Drum-fill detection (#39) reports against this grid and must not pay for the beat model
+    a second time on audio music analysis already ran over.
     """
     document = beats_of(source, described, identity, detector, refresh, config)
-    written = json.loads(Path(document["path"]).read_text(encoding="utf-8"))
-    return list(written[BEATS])
+    return list(records.rows(Path(document["path"]), BEATS))
 
 
 def energy_of(
@@ -190,12 +188,11 @@ def numbered_energy(
     """The energy records themselves, from ``energy_of`` — computed or read back from disk.
 
     The document is the interchange format, the same bargain ``numbered_beats`` makes: a
-    caller that wants the curve rather than a path reads it the way an agent would, and the
+    caller that wants the curve rather than a path reads it through ``records``, so the
     file's layout stays the business of the module that writes it.
     """
     document = energy_of(source, described, identity, shape, refresh, config)
-    written = json.loads(Path(document["path"]).read_text(encoding="utf-8"))
-    return list(written[ENERGY])
+    return list(records.rows(Path(document["path"]), ENERGY))
 
 
 def analyze(

--- a/src/resolve_mcp/analysis/music.py
+++ b/src/resolve_mcp/analysis/music.py
@@ -149,7 +149,7 @@ def numbered_beats(
     a second time on audio music analysis already ran over.
     """
     document = beats_of(source, described, identity, detector, refresh, config)
-    return list(records.rows(Path(document["path"]), BEATS))
+    return list(records.rows(Path(document["path"]), BEATS, allow_empty=True))
 
 
 def energy_of(
@@ -192,7 +192,7 @@ def numbered_energy(
     file's layout stays the business of the module that writes it.
     """
     document = energy_of(source, described, identity, shape, refresh, config)
-    return list(records.rows(Path(document["path"]), ENERGY))
+    return list(records.rows(Path(document["path"]), ENERGY, allow_empty=True))
 
 
 def analyze(

--- a/src/resolve_mcp/analysis/records.py
+++ b/src/resolve_mcp/analysis/records.py
@@ -15,6 +15,8 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from ..errors import InvalidRequestError
+
 INDENT = "  "
 
 
@@ -30,7 +32,7 @@ def write(
         "{",
         *(f"{INDENT}{json.dumps(key)}: {json.dumps(value)}," for key, value in header.items()),
         f"{INDENT}{json.dumps(field)}: [",
-        *_rows(rows),
+        *_lines(rows),
         f"{INDENT}]",
         "}",
     ]
@@ -48,7 +50,53 @@ def read(path: Path) -> dict[str, Any]:
     return loaded
 
 
-def _rows(rows: Sequence[Mapping[str, Any]]) -> list[str]:
+def rows(path: Path, field: str) -> tuple[dict[str, Any], ...]:
+    """One file's ``field`` records, in time order — the shape ``write`` leaves, read back.
+
+    The strong reader, and the reason it lives beside the writer: what a record file has to
+    be is this module's invariant, so every caller that reads one gets the same answer to a
+    file that is not one. Four refusals — unreadable, not JSON, holding no such field, and
+    holding no record with a time — cover the ways a path an agent typed can be the wrong
+    path, and the ``"t"`` filter with the sort is what makes the rest of them a timeline
+    rather than a list (#222).
+    """
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise InvalidRequestError(
+            cause=f"Could not read {path.name} as analysis JSON: {exc}.",
+            fix="Pass the path an analysis job returned, unedited.",
+            detail={"file": str(path), "field": field},
+        ) from exc
+
+    held = doc.get(field) if isinstance(doc, Mapping) else None
+    if not isinstance(held, list):
+        raise InvalidRequestError(
+            cause=f"{path.name} holds no {field!r} records.",
+            fix=f"That file is not the {field} analysis; pass the one whose kind is {field!r}.",
+            detail={"file": str(path), "field": field},
+        )
+    found = [
+        dict(row)
+        for row in held
+        if isinstance(row, Mapping) and isinstance(row.get("t"), int | float)
+    ]
+    if not found:
+        # A file that was named but says nothing must not read like a file nobody named:
+        # both would leave the column null, and only one of them is what the caller meant.
+        raise InvalidRequestError(
+            cause=f"{path.name} holds no {field} record with a time in it.",
+            fix=(
+                f"Pass the {field} file a finished analysis job wrote — its records each "
+                'carry a "t" in seconds. An analysis that found nothing is worth rerunning '
+                "rather than measuring against."
+            ),
+            detail={"file": str(path), "field": field},
+        )
+    return tuple(sorted(found, key=lambda row: float(row["t"])))
+
+
+def _lines(rows: Sequence[Mapping[str, Any]]) -> list[str]:
     """Each record on its own line, comma-separated the way JSON wants."""
     written = [json.dumps(dict(row)) for row in rows]
     return [line + "," for line in written[:-1]] + written[-1:]

--- a/src/resolve_mcp/analysis/records.py
+++ b/src/resolve_mcp/analysis/records.py
@@ -50,7 +50,7 @@ def read(path: Path) -> dict[str, Any]:
     return loaded
 
 
-def rows(path: Path, field: str) -> tuple[dict[str, Any], ...]:
+def rows(path: Path, field: str, allow_empty: bool = False) -> tuple[dict[str, Any], ...]:
     """One file's ``field`` records, in time order — the shape ``write`` leaves, read back.
 
     The strong reader, and the reason it lives beside the writer: what a record file has to
@@ -59,6 +59,11 @@ def rows(path: Path, field: str) -> tuple[dict[str, Any], ...]:
     holding no record with a time — cover the ways a path an agent typed can be the wrong
     path, and the ``"t"`` filter with the sort is what makes the rest of them a timeline
     rather than a list (#222).
+
+    ``allow_empty`` turns the last refusal off, and only a caller reading a file it wrote
+    itself moments ago should pass it: an analysis that found nothing is a wrong path when
+    an agent named the file and a real answer when the worker just produced it — a beat
+    model that hears nothing is a grid the bar map refuses on purpose, not a bad request.
     """
     try:
         doc = json.loads(path.read_text(encoding="utf-8"))
@@ -81,7 +86,7 @@ def rows(path: Path, field: str) -> tuple[dict[str, Any], ...]:
         for row in held
         if isinstance(row, Mapping) and isinstance(row.get("t"), int | float)
     ]
-    if not found:
+    if not found and not allow_empty:
         # A file that was named but says nothing must not read like a file nobody named:
         # both would leave the column null, and only one of them is what the caller meant.
         raise InvalidRequestError(

--- a/tests/test_music_analysis.py
+++ b/tests/test_music_analysis.py
@@ -17,8 +17,9 @@ from typing import Any
 import pytest
 
 from resolve_mcp.analysis import beats as beats_module
-from resolve_mcp.analysis import music
+from resolve_mcp.analysis import halves, music
 from resolve_mcp.analysis.beats import BeatGrid
+from resolve_mcp.audio import wav
 from resolve_mcp.config import get_config
 from resolve_mcp.jobs import cache, store
 from resolve_mcp.jobs.runner import wait_for
@@ -321,6 +322,35 @@ def test_a_detector_that_hears_nothing_is_an_empty_grid_not_a_crash(fixture_audi
     assert result["beats"]["count"] == 0
     assert result["beats"]["tempo_bpm"] is None
     assert Path(result["beats"]["path"]).exists()
+
+
+# --- reading the grid and the curve back ---------------------------------------------------
+
+
+def _read_back(audio: Path, grid: BeatGrid | None = None) -> list[dict[str, Any]]:
+    config = get_config()
+    return music.numbered_beats(
+        audio, wav.describe(audio), halves.identity(audio, config), _detector(grid), False, config
+    )
+
+
+def test_the_grid_reads_back_through_the_reader_that_wrote_it(fixture_audio: Path) -> None:
+    """``numbered_beats`` goes through ``records.rows`` now, so the records arrive in order."""
+    grid = _read_back(fixture_audio)
+
+    assert [beat["t"] for beat in grid][:3] == [0.0, 0.5, 1.0]
+    assert grid[0] == {"t": 0.0, "beat": 1, "bar": 1, "in_bar": 1, "downbeat": True}
+
+
+def test_a_grid_the_model_heard_nothing_in_reads_back_empty_rather_than_refusing(
+    fixture_audio: Path,
+) -> None:
+    """The bar map answers REFUSED on an empty grid, so the reader has to let it get there.
+
+    An empty analysis is a wrong path only when an agent named the file; here the worker
+    wrote it moments ago and nothing found is the real answer (#222).
+    """
+    assert _read_back(fixture_audio, BeatGrid((), ())) == []
 
 
 # --- progress and the tool seam ----------------------------------------------------------

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -118,3 +118,23 @@ def test_a_file_whose_records_all_lack_a_time_is_the_same_refusal(tmp_path: Path
         records.rows(path, "beats")
 
     assert "record with a time in it" in caught.value.payload()["cause"]
+
+
+def test_a_caller_reading_back_its_own_file_gets_the_empty_analysis_it_wrote(
+    tmp_path: Path,
+) -> None:
+    """A beat model that heard nothing wrote a real answer — only a named path is refused."""
+    path = _written(tmp_path / "beats.json", [])
+
+    assert records.rows(path, "beats", allow_empty=True) == ()
+
+
+def test_the_other_refusals_still_stand_for_a_caller_reading_its_own_file(
+    tmp_path: Path,
+) -> None:
+    """Empty is the one refusal ``allow_empty`` drops; a file that is not one still refuses."""
+    path = tmp_path / "beats.json"
+    path.write_text("not json at all", encoding="utf-8")
+
+    with pytest.raises(InvalidRequestError):
+        records.rows(path, "beats", allow_empty=True)

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,120 @@
+"""Record files: what ``write`` leaves, and what ``rows`` will and will not read back.
+
+The reader is the strong one — it refuses a file it cannot vouch for rather than handing
+its caller a half-file — so the refusals are tested here, once, at the interface every
+caller now shares (#222). A caller-side test would only be re-testing this one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from resolve_mcp.analysis import records
+from resolve_mcp.errors import InvalidRequestError
+
+
+def _written(path: Path, rows: list[dict[str, object]], field: str = "beats") -> Path:
+    return records.write(path, {"kind": field, "count": len(rows)}, field, rows)
+
+
+# --- what reads back -------------------------------------------------------------------
+
+
+def test_the_records_come_back_as_they_were_written(tmp_path: Path) -> None:
+    path = _written(tmp_path / "beats.json", [{"t": 0.0, "beat": 1}, {"t": 0.5, "beat": 2}])
+
+    assert records.rows(path, "beats") == ({"t": 0.0, "beat": 1}, {"t": 0.5, "beat": 2})
+
+
+def test_the_header_keys_are_not_records(tmp_path: Path) -> None:
+    """Only the named field's list is read — a header key beside it is not a row."""
+    path = _written(tmp_path / "beats.json", [{"t": 1.0}])
+
+    assert records.rows(path, "beats") == ({"t": 1.0},)
+    assert records.read(path)["kind"] == "beats"
+
+
+def test_records_come_back_in_time_order_whatever_order_they_sit_in(tmp_path: Path) -> None:
+    """A file the writer did not sort must not read as a curve that jumps backwards."""
+    path = _written(tmp_path / "energy.json", [{"t": 2.0}, {"t": 0.5}, {"t": 1.0}], "energy")
+
+    assert [row["t"] for row in records.rows(path, "energy")] == [0.5, 1.0, 2.0]
+
+
+def test_a_record_with_no_time_in_it_is_dropped_not_read_as_time_zero(tmp_path: Path) -> None:
+    path = _written(tmp_path / "beats.json", [{"t": 1.0}, {"beat": 2}, {"t": "late"}, {"t": 0.0}])
+
+    assert [row["t"] for row in records.rows(path, "beats")] == [0.0, 1.0]
+
+
+# --- what it refuses -------------------------------------------------------------------
+
+
+def test_a_file_that_is_not_there_is_refused_by_name(tmp_path: Path) -> None:
+    with pytest.raises(InvalidRequestError) as caught:
+        records.rows(tmp_path / "absent.json", "beats")
+
+    detail = caught.value.payload()["detail"]
+    assert detail == {"file": str(tmp_path / "absent.json"), "field": "beats"}
+
+
+def test_a_file_that_is_not_json_is_refused_rather_than_raised_through(tmp_path: Path) -> None:
+    path = tmp_path / "beats.json"
+    path.write_text("not json at all", encoding="utf-8")
+
+    with pytest.raises(InvalidRequestError) as caught:
+        records.rows(path, "beats")
+
+    assert "as analysis JSON" in caught.value.payload()["cause"]
+
+
+def test_a_file_holding_no_such_field_is_refused_by_field_name(tmp_path: Path) -> None:
+    path = _written(tmp_path / "tunes.json", [{"t": 0.0}], "tunes")
+
+    with pytest.raises(InvalidRequestError) as caught:
+        records.rows(path, "beats")
+
+    payload = caught.value.payload()
+    assert "holds no 'beats' records" in payload["cause"]
+    assert payload["detail"]["field"] == "beats"
+
+
+def test_a_field_that_is_not_a_list_is_refused_like_a_missing_one(tmp_path: Path) -> None:
+    path = tmp_path / "beats.json"
+    path.write_text(json.dumps({"beats": {"t": 0.0}}), encoding="utf-8")
+
+    with pytest.raises(InvalidRequestError):
+        records.rows(path, "beats")
+
+
+def test_json_that_is_not_a_document_at_all_is_refused(tmp_path: Path) -> None:
+    path = tmp_path / "beats.json"
+    path.write_text(json.dumps([{"t": 0.0}]), encoding="utf-8")
+
+    with pytest.raises(InvalidRequestError):
+        records.rows(path, "beats")
+
+
+def test_a_file_that_measured_nothing_is_refused_not_read_as_a_file_nobody_named(
+    tmp_path: Path,
+) -> None:
+    """Empty and absent would both leave the column null, and they are not the same call."""
+    path = tmp_path / "beats.json"
+    path.write_text(json.dumps({"beats": []}), encoding="utf-8")
+
+    with pytest.raises(InvalidRequestError) as caught:
+        records.rows(path, "beats")
+
+    assert "record with a time in it" in caught.value.payload()["cause"]
+
+
+def test_a_file_whose_records_all_lack_a_time_is_the_same_refusal(tmp_path: Path) -> None:
+    path = _written(tmp_path / "beats.json", [{"beat": 1}, {"beat": 2}])
+
+    with pytest.raises(InvalidRequestError) as caught:
+        records.rows(path, "beats")
+
+    assert "record with a time in it" in caught.value.payload()["cause"]


### PR DESCRIPTION
Reading a file `records.write` wrote was implemented three times. `records.rows(path, field)` is now the one reader, beside the writer, and `correlate` plus both music readers collapse onto it.

- `records.rows` is `correlate._rows` promoted verbatim — same four refusals (unreadable, not JSON, no such field, no record with a time), same numeric-`t` filter, same time-order sort. `correlate._rows` is gone; `_music` and `_optional_rows` call through.
- `music.numbered_beats`/`numbered_energy` are two lines each now, reading through `records`. `import json` leaves `music`.
- The private writer helper `_rows` becomes `_lines` — the name the public `rows` needed.
- `records.read` stays: the spec asked for the row reader to be promoted, not for the whole-dict reader to go (`analysis/virtual.py:332` still wants it).

**Seam:** fake tier. New `tests/test_records.py` covers each refusal mode once at the records interface; `tests/test_music_analysis.py` gains the first tests the music readers have ever had. No live AC.

## Review

Two-axis review (`/code-review`) against `origin/main`, before this PR existed.

**Spec — 2 findings.**

1. *(fixed, commit 2)* AC2 says callers' behaviour is unchanged "except that malformed files now refuse". An empty but well-formed file is not malformed, and both axes caught it independently: `numbered_beats` returned `[]` for `{"beats": []}` and now raised from inside a job worker. An empty beat grid is a modelled, supported state downstream — `bars.py:460` returns a `REFUSED` bar map on it, `fills.py:107` answers `None` — so audio the beat model heard nothing in went from a graceful refusal to a failed job, with no caller catching `InvalidRequestError`. Fixed with `allow_empty=`, which drops that one refusal for a caller reading back a file it wrote itself; the other three still stand there. Tests pin both halves: the refusal fires without the flag, and the empty grid reads back empty with it.
2. *(kept, justified)* AC3 asks that each refusal mode be tested "once, at the records interface, not per-caller", and three pre-existing tests in `test_correlate_timeline.py` (`:781`, `:1524`, `:1596`) overlap two modes. They are kept: what they assert is that a refusal reaches the MCP envelope as `ok: False` with the field named — correlate's error plumbing, which a records-level test cannot reach. The diff adds no new per-caller refusal test.

No scope creep found: the `_rows`→`_lines` rename is forced by the collision with the new public name, and the `CONTEXT.md` map edit is repo policy.

**Standards — 3 findings.**

1. *(fixed, commit 2)* The empty-grid regression above, plus the observation that nothing in `tests/` called `numbered_beats`/`numbered_energy` at all — the changed behaviour had no seam. Both readers now have one.
2. *(verified safe)* The stricter semantics at the other call sites: `beats.numbered()` and `energy._windows()` both emit ascending `t`, so the sort is a no-op, and both always emit a numeric `"t"`, so the filter drops nothing. `energy._windows` returns one window even for audio shorter than the window, so the energy curve is never empty.
3. *(accepted)* `write`'s `rows` parameter now shares a name with the module's public `rows` function. `bars`, `fills` and `phrases` each already have their own module-level `rows()` beside `records.write(..., rows(...))` calls, so the name is the repo's vocabulary for this thing; `write` never calls the function, so there is no shadowing bug.

Fix diff re-checked on its own; ruff, mypy strict and the full fake tier (2283 passed) green.

Closes #222

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
