### PR TITLE
Route bars, phrases and fills through halves.written

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -153,7 +153,12 @@ no silent CPU fallback, #202; the inventory and the stays-on-CPU corpus policy:
 `docs/reference/compute-device-inventory.md`), `drums` (hits per stem), `energy`
 (loudness curves; `rms_curve` is the cheap level-only pass, no K-weighting and
 no onsets), `fills` (drum-fill candidates), `halves` (shared
-identify/cache/write pattern, plus `collected`/`stem_named` — where a
+identify/cache/write pattern — `written` is the one door every analysis file
+goes through, so every one of them opens `kind`/`audio`/`duration_seconds`
+(#223, guarded across detectors by `tests/test_analysis_reports.py`;
+`correlate`'s join over cut rows is the documented exception), and where the
+naming rule lives: a header-stats builder is `gist`, a record builder is
+`rows` — plus `collected`/`stem_named` — where a
 separation's stems are and which one was asked for, shared by every detector
 that reads one: `phrases` off the line, `bars` off the pulse),
 `melody` (notes off one melodic stem —

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -331,6 +331,14 @@ them). Both drive the fake seam through `tools/media`, and both build their
 pools from `tests/mediapool.py` (`a_file`, `a_clip`, `a_shallow_copy_pool`) so
 the pair cannot drift on what a clip or a shadowed copy looks like.
 
+`test_analysis_reports.py` is the one test that spans detectors rather than
+following a module: it runs every half that writes an analysis file — beats,
+energy, tunes, solos, bars, phrases, fills — and asserts they all open
+`kind`/`audio`/`duration_seconds`, the header `analysis/halves.written`
+exists to keep (#223). It imports each detector's fakes from that detector's
+own test file, so the inputs have one home; what each file *says* stays with
+the per-detector tests.
+
 `tests/fakes/` is the fake Resolve API, one module per subsystem — open the
 module, not the package, and never the whole package at once:
 

--- a/src/resolve_mcp/analysis/applause.py
+++ b/src/resolve_mcp/analysis/applause.py
@@ -667,7 +667,7 @@ def sifted(
     return Calls(tuple(kept), tuple(dropped))
 
 
-def numbered(found: Sequence[Tune]) -> tuple[dict[str, Any], ...]:
+def rows(found: Sequence[Tune]) -> tuple[dict[str, Any], ...]:
     """One record per tune, numbered from one — the rows a songs.json author reads."""
     return tuple(
         {

--- a/src/resolve_mcp/analysis/bars.py
+++ b/src/resolve_mcp/analysis/bars.py
@@ -54,7 +54,7 @@ from ..jobs.runner import JobOutput, Progress, start_job
 from ..logging_config import get_logger
 from ..naming import slug
 from . import beats as beats_module
-from . import halves, music, records
+from . import halves, music
 
 log = get_logger("analysis")
 
@@ -555,7 +555,7 @@ def _inferred(
     """The bars a fold and a barring imply, back in the grid's own beat numbering.
 
     A phase past zero leaves beats in front of the first bar line; they are a pickup and get
-    bar one, which is what ``beats.numbered`` does with the beats before the model's first
+    bar one, which is what ``beats.rows`` does with the beats before the model's first
     downbeat. Numbering them zero, or dropping them, would leave the first real bar line
     somewhere other than the top of a group.
     """
@@ -878,7 +878,7 @@ def detect(
     progress(0.8, "looking for the bar line")
     floor = float(settings["minimum_confidence"])
     bar_map = mapped(grid, salience, floor)
-    summary = gist(bar_map, floor, label)
+    stats = gist(bar_map, floor, label)
     log.info(
         "Bar map over %s: %s, meter %s, %s bars (grid said meter %s at %s bpm)",
         source.name,
@@ -891,16 +891,18 @@ def detect(
 
     progress(0.9, "writing the bars")
     target = config.analysis_dir / f"{slug(source.stem, 'analysis')}-{key[:12]}-{BARS}.json"
-    header = {
-        "kind": BARS,
-        "audio": described["path"],
-        "duration_seconds": described["duration_seconds"],
-        "start_seconds": settings["start_seconds"],
-        "end_seconds": settings["end_seconds"],
-        "reasons": bar_map.reasons,
-        **summary,
-    }
-    records.write(target, header, BARS, rows(bar_map))
+    result = halves.written(
+        target,
+        BARS,
+        described,
+        stats,
+        rows(bar_map),
+        {
+            "start_seconds": settings["start_seconds"],
+            "end_seconds": settings["end_seconds"],
+            "reasons": bar_map.reasons,
+        },
+    )
 
     progress(0.95, "written")
-    return JobOutput({"path": str(target), **summary}, (target,))
+    return JobOutput(result, (target,))

--- a/src/resolve_mcp/analysis/beats.py
+++ b/src/resolve_mcp/analysis/beats.py
@@ -126,7 +126,7 @@ def _loaded() -> Any:
         ) from exc
 
 
-def numbered(grid: BeatGrid) -> tuple[dict[str, Any], ...]:
+def rows(grid: BeatGrid) -> tuple[dict[str, Any], ...]:
     """One record per beat: its time, its number, its bar, and where it sits in the bar.
 
     Bars are counted from the downbeats the model gave, so a tune in five and a tune in four

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -392,6 +392,12 @@ def correlate(
     )
 
     target = config.analysis_dir / keyed_name(name, key, ".correlate.json", "correlate")
+    # The one report that does not go through ``halves.written``, and the reason is the header
+    # below: this is a join over one timeline's cut rows rather than a measurement of one audio
+    # file, so it names a ``timeline`` where every half names an ``audio`` and carries the
+    # inputs it joined. Routing it through the shared writer would mean a header shape with a
+    # hole in it (#223).
+    #
     # "count", not "cuts": the records themselves are the file's ``cuts`` field, and a header
     # key of the same name would be a second one that only the last reader of the two sees.
     header: dict[str, Any] = {

--- a/src/resolve_mcp/analysis/fills.py
+++ b/src/resolve_mcp/analysis/fills.py
@@ -48,7 +48,7 @@ from ..jobs.runner import JobOutput, Progress, start_job
 from ..logging_config import get_logger
 from ..naming import slug
 from . import beats as beats_module
-from . import drums, halves, music, records
+from . import drums, halves, music
 
 log = get_logger("analysis")
 
@@ -167,7 +167,7 @@ def candidates(
 ) -> Detection:
     """Fill candidates over ``hits``, aligned to the numbered beat ``grid``.
 
-    ``grid`` is what ``beats.numbered`` produces and the beats half writes: one record per
+    ``grid`` is what ``beats.rows`` produces and the beats half writes: one record per
     beat carrying its time, bar and whether it starts one.
     """
     beats = list(grid)
@@ -605,19 +605,13 @@ def detect(
     progress(0.8, "looking for fills")
     floor = float(settings["minimum_confidence"])
     detection = candidates(hits, grid, floor)
-    summary = gist(detection, floor, sorted(stems), len(hits))
+    stats = gist(detection, floor, sorted(stems), len(hits))
 
     progress(0.9, "writing the candidates")
     target = config.analysis_dir / f"{slug(source.stem, 'analysis')}-{key[:12]}-{FILLS}.json"
-    header = {
-        "kind": FILLS,
-        "audio": described["path"],
-        "duration_seconds": described["duration_seconds"],
-        **summary,
-    }
-    records.write(target, header, FILLS, rows(detection))
+    result = halves.written(target, FILLS, described, stats, rows(detection))
 
     progress(0.95, "written")
-    return JobOutput({"path": str(target), **summary}, (target,))
+    return JobOutput(result, (target,))
 
 

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -201,12 +201,33 @@ def written(
 ) -> dict[str, Any]:
     """One file per half: a header of gist stats, then one record per line.
 
+    Every analysis file goes through here, so every one of them opens the same way — ``kind``,
+    the audio it read, how long that audio is — and an agent that greps the head of one knows
+    what the head of the next says. That is only true while this is the single writer: three
+    detectors hand-rolled the header instead and the promise was already false when #223
+    routed them back through it. The one report that stays out is ``correlate``'s, which is a
+    join over cut rows rather than a measurement of one audio file — it has no ``audio`` to
+    name and its own header shape, so it calls ``records.write`` directly and says so there.
+
     ``aside`` is written into the header but kept out of what comes back, which is the way
     a half records something too long for a tool result and too short for its own file —
     the calls the tune half rejected, say (#133). The gist rides home in the job record and
     stays stats; the aside stays on disk with the records it is about. It goes in under the
     gist rather than over it, so a name a half picks for an aside can never quietly replace
     a stat and leave the header saying something the returned dict does not.
+
+    The two names this takes are the two a detector builds, and they are the names to build
+    them under (#223, settling a drift where half the detectors used the other one):
+
+    * ``gist`` — the scalars a half returns inline and writes into its header. Every module
+      that builds one names the builder ``gist``. ``summary`` is the *cut* side's word —
+      ``barmap.summary``, ``subject.summary``, ``correlate._summary`` read a column of cut
+      rows, which is a different interface over different input, not a half's header.
+    * ``rows`` — the record builder: one flat dict per line under the file's record field.
+      ``numbered`` was the other half of the drift and is gone; it read as a distinction
+      (records that carry an index) that was never one, since bars and fills number theirs
+      too. ``music.numbered_beats`` and ``numbered_energy`` keep their names: they are half
+      *entries* — read me the numbered beats — rather than builders of anything.
     """
     header = {
         "kind": kind,

--- a/src/resolve_mcp/analysis/halves.py
+++ b/src/resolve_mcp/analysis/halves.py
@@ -201,28 +201,41 @@ def written(
 ) -> dict[str, Any]:
     """One file per half: a header of gist stats, then one record per line.
 
-    Every analysis file goes through here, so every one of them opens the same way — ``kind``,
-    the audio it read, how long that audio is — and an agent that greps the head of one knows
-    what the head of the next says. That is only true while this is the single writer: three
-    detectors hand-rolled the header instead and the promise was already false when #223
-    routed them back through it. The one report that stays out is ``correlate``'s, which is a
-    join over cut rows rather than a measurement of one audio file — it has no ``audio`` to
-    name and its own header shape, so it calls ``records.write`` directly and says so there.
+    Every *half* goes through here, so every one of their files opens the same way —
+    ``kind``, the audio it read, how long that audio is — and an agent that greps the head of
+    one knows what the head of the next says. That is only true while this is the single
+    writer: three detectors hand-rolled the header instead and the promise was already false
+    when #223 routed them back through it.
 
-    ``aside`` is written into the header but kept out of what comes back, which is the way
-    a half records something too long for a tool result and too short for its own file —
-    the calls the tune half rejected, say (#133). The gist rides home in the job record and
-    stays stats; the aside stays on disk with the records it is about. It goes in under the
-    gist rather than over it, so a name a half picks for an aside can never quietly replace
-    a stat and leave the header saying something the returned dict does not.
+    Two reports in ``analysis_dir`` are not halves and stay out, both because their shape is
+    genuinely different rather than because nobody got to them:
+
+    * ``correlate``'s, a join over one timeline's cut rows rather than a measurement of one
+      audio file. It has no ``audio`` to name — it names a ``timeline`` — so it calls
+      ``records.write`` with its own header, and says so at that call.
+    * the transcript, a schema-versioned document with three record lists in it (words,
+      silence, low-confidence spans) rather than one. ``transcript.write`` is its writer.
+
+    ``aside`` is header-only material: written into the file's head, kept out of what comes
+    back. That is how a half records something too long for a tool result and too short for
+    its own file — the calls the tune half rejected (#133) — and equally how it records the
+    settings the file was made under, like the span and the reasons a bar map carries. The
+    gist rides home in the job record and stays stats; the aside stays on disk with the
+    records it is about. It goes in under the gist rather than over it, so a name a half
+    picks for an aside can never quietly replace a stat and leave the header saying something
+    the returned dict does not.
 
     The two names this takes are the two a detector builds, and they are the names to build
     them under (#223, settling a drift where half the detectors used the other one):
 
     * ``gist`` — the scalars a half returns inline and writes into its header. Every module
-      that builds one names the builder ``gist``. ``summary`` is the *cut* side's word —
-      ``barmap.summary``, ``subject.summary``, ``correlate._summary`` read a column of cut
-      rows, which is a different interface over different input, not a half's header.
+      that builds one names the builder ``gist``, and nothing else in the package is called
+      that. ``summary`` is the word for a reading of something that is *not* a half:
+      ``barmap.summary`` and ``subject.summary`` read a column of cut rows for ``correlate``,
+      and a private ``_summary`` boils a single record down (``applause``). Neither shape
+      ever builds a half's header, which is the whole distinction. A worker holding the gist
+      it is about to write names the local ``gist`` (``structure``), or ``stats`` in the
+      three modules whose own ``gist`` function owns that name already.
     * ``rows`` — the record builder: one flat dict per line under the file's record field.
       ``numbered`` was the other half of the drift and is gone; it read as a distinction
       (records that carry an index) that was never one, since bars and fills number theirs

--- a/src/resolve_mcp/analysis/music.py
+++ b/src/resolve_mcp/analysis/music.py
@@ -247,7 +247,7 @@ def beats_half(
 ) -> dict[str, Any]:
     """The beat grid for this audio, written out. Shared with structure analysis."""
     grid = beats_module.detect(source, detector)
-    rows = beats_module.numbered(grid)
+    rows = beats_module.rows(grid)
     return halves.written(target, BEATS, described, beats_module.gist(grid, rows), list(rows))
 
 

--- a/src/resolve_mcp/analysis/phrases.py
+++ b/src/resolve_mcp/analysis/phrases.py
@@ -58,7 +58,7 @@ from ..jobs.runner import JobOutput, Progress, start_job
 from ..logging_config import get_logger
 from ..naming import slug
 from . import beats as beats_module
-from . import halves, melody, music, records, solos
+from . import halves, melody, music, solos
 
 log = get_logger("analysis")
 
@@ -160,7 +160,7 @@ def boundaries(
 ) -> Detection:
     """Phrase boundaries over ``notes``, placed against the numbered beat ``grid``.
 
-    ``grid`` is what ``beats.numbered`` produces and the beats half writes: one record per
+    ``grid`` is what ``beats.rows`` produces and the beats half writes: one record per
     beat carrying its time, bar and whether it starts one.
     """
     played = sorted(notes, key=lambda one: (one.seconds, one.end))
@@ -329,7 +329,7 @@ def _clamp(value: float) -> float:
 def rows(detection: Detection) -> tuple[dict[str, Any], ...]:
     """One flat record per boundary — both placements, so a cut can use either.
 
-    The record keys are ``solos.numbered``'s and not this module's field names: ``t`` for the
+    The record keys are ``solos.rows``'s and not this module's field names: ``t`` for the
     time an event is called on and ``measured_t`` for where it was seen is what every record
     file in this stack already says, and a boundary is the same kind of thing as a solo change.
     A reader who greps one analysis document should not have to learn a second vocabulary.
@@ -520,17 +520,11 @@ def detect(
     progress(0.8, "looking for phrase boundaries")
     floor = float(settings["minimum_confidence"])
     detection = boundaries(notes, grid, floor)
-    summary = gist(detection, floor, label, len(notes))
+    stats = gist(detection, floor, label, len(notes))
 
     progress(0.9, "writing the boundaries")
     target = config.analysis_dir / f"{slug(source.stem, 'analysis')}-{key[:12]}-{PHRASES}.json"
-    header = {
-        "kind": PHRASES,
-        "audio": described["path"],
-        "duration_seconds": described["duration_seconds"],
-        **summary,
-    }
-    records.write(target, header, PHRASES, rows(detection))
+    result = halves.written(target, PHRASES, described, stats, rows(detection))
 
     progress(0.95, "written")
-    return JobOutput({"path": str(target), **summary}, (target,))
+    return JobOutput(result, (target,))

--- a/src/resolve_mcp/analysis/solos.py
+++ b/src/resolve_mcp/analysis/solos.py
@@ -459,7 +459,7 @@ def snapped(
     return tuple(called)
 
 
-def numbered(found: Sequence[Change]) -> tuple[dict[str, Any], ...]:
+def rows(found: Sequence[Change]) -> tuple[dict[str, Any], ...]:
     """One record per change: when it is called, when it was seen, and what changed."""
     return tuple(
         {

--- a/src/resolve_mcp/analysis/structure.py
+++ b/src/resolve_mcp/analysis/structure.py
@@ -477,7 +477,7 @@ def _tunes(
         TUNES,
         described,
         gist,
-        applause_module.numbered(calls.kept),
+        applause_module.rows(calls.kept),
         {
             "dropped_calls": list(applause_module.dropped_calls(calls.dropped, floor)),
             "quiet_calls": list(applause_module.quiet_calls(played, margin_db, tune_seconds)),
@@ -640,7 +640,7 @@ def _solos(
         brightness_stem or "nothing",
         source.name,
     )
-    return halves.written(target, SOLOS, described, gist, solos_module.numbered(changes))
+    return halves.written(target, SOLOS, described, gist, solos_module.rows(changes))
 
 
 def _timbre(

--- a/tests/test_analysis_reports.py
+++ b/tests/test_analysis_reports.py
@@ -6,15 +6,18 @@ and that only works while every detector writes the same three keys in the same 
 enforced it: ``halves.written`` built the header for music and structure while bars, phrases
 and fills hand-rolled their own copy, and a copy is a thing that drifts (#223).
 
-So this file runs every detector that writes an analysis file, over the smallest fixtures each
+So this file runs every half that writes through the writer, over the smallest fixtures each
 one will accept, and compares the heads. It is deliberately the only test that knows about all
 of them at once: the per-detector tests own what each file *says*, and this one owns what they
 all say the same way. The fakes come from those tests rather than from copies here, so a
-detector whose inputs change breaks this in one place with the rest of its own suite.
+detector whose inputs change breaks this in one place with the rest of its own suite. The two
+stem layouts below are the exception, and only because their originals are pytest fixtures
+rather than callables: a fixture cannot be imported and called from another module's test.
 
-``correlate`` is not here on purpose. Its report is a join over cut rows rather than a
-measurement of one audio file — no ``audio`` to name — so it writes its own header through
-``records.write``, which is the exception ``halves.written`` documents.
+Two files in the analysis directory are not halves and are absent on purpose: ``correlate``'s
+report, a join over cut rows rather than a measurement of one audio file (no ``audio`` to
+name), and the transcript, a schema-versioned document with three record lists rather than
+one. Both are the exceptions ``halves.written`` documents, and both keep their own writers.
 """
 
 from __future__ import annotations
@@ -78,6 +81,11 @@ def _drum_stems(tmp_path: Path) -> dict[str, Path]:
     }
 
 
+def _master(tmp_path: Path, seconds: float) -> Path:
+    """The mix a bar map is read off — silent, since the accent reading is injected."""
+    return write_hits(tmp_path / "media" / "master.wav", [], seconds=seconds)
+
+
 def _every_report(tmp_path: Path) -> dict[str, dict[str, Any]]:
     """Run every detector that writes an analysis file, and read back what each one wrote."""
     written: dict[str, Path] = {}
@@ -128,7 +136,7 @@ def _every_report(tmp_path: Path) -> dict[str, dict[str, Any]]:
     grid = _onset_scale()
     bars = _result(
         bars_module.detect_bars(
-            _master_for(tmp_path, float(grid[-1]["t"]) + 1.0),
+            _master(tmp_path, float(grid[-1]["t"]) + 1.0),
             detector=_bar_detector(grid),
             accent=_accent_of(_accented(grid, every=8)),
         )
@@ -162,10 +170,6 @@ def _every_report(tmp_path: Path) -> dict[str, dict[str, Any]]:
     return {
         kind: json.loads(path.read_text(encoding="utf-8")) for kind, path in written.items()
     }
-
-
-def _master_for(tmp_path: Path, seconds: float) -> Path:
-    return write_hits(tmp_path / "media" / "master.wav", [], seconds=seconds)
 
 
 def test_every_analysis_file_opens_with_the_same_header_keys(tmp_path: Path) -> None:

--- a/tests/test_analysis_reports.py
+++ b/tests/test_analysis_reports.py
@@ -1,0 +1,191 @@
+"""The one thing every analysis file has in common: how it opens.
+
+An agent reads these files by grepping the head of one — ``kind`` says what the measurement
+is, ``audio`` says what it was taken off, ``duration_seconds`` says how much of it there was —
+and that only works while every detector writes the same three keys in the same order. Nothing
+enforced it: ``halves.written`` built the header for music and structure while bars, phrases
+and fills hand-rolled their own copy, and a copy is a thing that drifts (#223).
+
+So this file runs every detector that writes an analysis file, over the smallest fixtures each
+one will accept, and compares the heads. It is deliberately the only test that knows about all
+of them at once: the per-detector tests own what each file *says*, and this one owns what they
+all say the same way. The fakes come from those tests rather than from copies here, so a
+detector whose inputs change breaks this in one place with the rest of its own suite.
+
+``correlate`` is not here on purpose. Its report is a join over cut rows rather than a
+measurement of one audio file — no ``audio`` to name — so it writes its own header through
+``records.write``, which is the exception ``halves.written`` documents.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.analysis import bars as bars_module
+from resolve_mcp.analysis import fills as fills_module
+from resolve_mcp.analysis import music as music_module
+from resolve_mcp.analysis import phrases as phrases_module
+from resolve_mcp.analysis import structure as structure_module
+from resolve_mcp.audio.stems import DRUM_PASS, DRUM_STEMS, FOUR_STEMS, MIX_PASS
+from resolve_mcp.jobs.runner import wait_for
+
+from .fakes import write_clicks, write_hits, write_sections, write_wav
+from .test_bar_map import _accent_of, _accented, _onset_scale
+from .test_bar_map import _detector as _bar_detector
+from .test_drum_fills import _detector_for as _fill_detector
+from .test_drum_fills import _grid as _fill_grid
+from .test_drum_fills import _played
+from .test_music_analysis import _detector as _music_detector
+from .test_music_analysis import _grid as _music_grid
+from .test_music_structure import APPLAUSE_SECONDS, SAMPLE_RATE, TUNE_SECONDS, _heard
+from .test_music_structure import _detector as _structure_detector
+from .test_music_structure import _stems as _solo_stems
+from .test_phrases import _detector_for as _phrase_detector
+from .test_phrases import _grid as _phrase_grid
+from .test_phrases import _read, _two_phrases
+
+HEADER = ("kind", "audio", "duration_seconds")
+"""What every analysis file opens with, in this order. The contract this file exists for."""
+
+SOLO_SECONDS = 24.0
+
+
+def _result(started: Mapping[str, Any]) -> dict[str, Any]:
+    record = wait_for(str(started["job_id"]))
+    assert record.state == "completed", record.error
+    assert record.result is not None
+    return record.result
+
+
+def _mix_stems(tmp_path: Path) -> dict[str, Path]:
+    """A four-stem separation, the shape the separation job reports it in."""
+    directory = tmp_path / "stems" / "concert-abc123def456" / MIX_PASS
+    return {
+        label: write_hits(directory / f"concert_({label.title()})_model.wav", times=(1.0,))
+        for label in FOUR_STEMS
+    }
+
+
+def _drum_stems(tmp_path: Path) -> dict[str, Path]:
+    """The kit taken apart — what the fill job counts hits across."""
+    directory = tmp_path / "kit" / "concert-abc123def456" / DRUM_PASS
+    return {
+        label: write_hits(directory / f"concert_({label.title()})_model.wav", times=())
+        for label in DRUM_STEMS
+    }
+
+
+def _every_report(tmp_path: Path) -> dict[str, dict[str, Any]]:
+    """Run every detector that writes an analysis file, and read back what each one wrote."""
+    written: dict[str, Path] = {}
+
+    # music: both halves at once, off a click track.
+    clicks = write_clicks(tmp_path / "media" / "clicks.wav", seconds=8.0)
+    music = _result(
+        music_module.analyze_music(clicks, detector=_music_detector(_music_grid(seconds=8.0)))
+    )
+    written[music_module.BEATS] = Path(music[music_module.BEATS]["path"])
+    written[music_module.ENERGY] = Path(music[music_module.ENERGY]["path"])
+
+    # structure: the tune half off a set with applause in it, the solo half off the stems.
+    concert = write_sections(
+        tmp_path / "media" / "concert.wav",
+        (("tone", TUNE_SECONDS), ("noise", APPLAUSE_SECONDS), ("tone", TUNE_SECONDS)),
+        sample_rate=SAMPLE_RATE,
+    )
+    tunes = _result(
+        structure_module.analyze_structure(
+            concert,
+            burst_seconds=1.0,
+            gap_seconds=1.0,
+            tune_seconds=2.0,
+            settle_seconds=1.0,
+            tagger=_heard(),
+            detector=_structure_detector(),
+        )
+    )
+    written[structure_module.TUNES] = Path(tunes[structure_module.TUNES]["path"])
+
+    set_audio = write_wav(
+        tmp_path / "media" / "set.wav", seconds=SOLO_SECONDS, sample_rate=SAMPLE_RATE
+    )
+    solos = _result(
+        structure_module.analyze_structure(
+            set_audio,
+            tunes=False,
+            solos=True,
+            stems=_solo_stems(tmp_path, seconds=SOLO_SECONDS),
+            solo_seconds=SOLO_SECONDS / 4,
+            detector=_structure_detector(),
+        )
+    )
+    written[structure_module.SOLOS] = Path(solos[structure_module.SOLOS]["path"])
+
+    # bars: the G2 grid and an accent reading that puts the bar line every eight beats.
+    grid = _onset_scale()
+    bars = _result(
+        bars_module.detect_bars(
+            _master_for(tmp_path, float(grid[-1]["t"]) + 1.0),
+            detector=_bar_detector(grid),
+            accent=_accent_of(_accented(grid, every=8)),
+        )
+    )
+    written[bars_module.BARS] = Path(bars["path"])
+
+    # phrases: a line with a rest in it, off the residual stem.
+    phrase_grid = _phrase_grid()
+    phrases = _result(
+        phrases_module.detect_phrases(
+            _mix_stems(tmp_path),
+            write_clicks(tmp_path / "media" / "line.wav", seconds=16.0),
+            detector=_phrase_detector(phrase_grid),
+            reader=_read(_two_phrases()),
+        )
+    )
+    written[phrases_module.PHRASES] = Path(phrases["path"])
+
+    # fills: comping with a fill in it, off the kit.
+    fill_grid = _fill_grid()
+    fills = _result(
+        fills_module.detect_drum_fills(
+            _drum_stems(tmp_path),
+            write_clicks(tmp_path / "media" / "kit.wav", seconds=16.0),
+            detector=_fill_detector(fill_grid),
+            transcriber=_played(fill_grid),
+        )
+    )
+    written[fills_module.FILLS] = Path(fills["path"])
+
+    return {
+        kind: json.loads(path.read_text(encoding="utf-8")) for kind, path in written.items()
+    }
+
+
+def _master_for(tmp_path: Path, seconds: float) -> Path:
+    return write_hits(tmp_path / "media" / "master.wav", [], seconds=seconds)
+
+
+def test_every_analysis_file_opens_with_the_same_header_keys(tmp_path: Path) -> None:
+    """One header for every detector — the promise ``halves.written`` is there to keep."""
+    reports = _every_report(tmp_path)
+
+    assert set(reports) == {
+        music_module.BEATS,
+        music_module.ENERGY,
+        structure_module.TUNES,
+        structure_module.SOLOS,
+        bars_module.BARS,
+        phrases_module.PHRASES,
+        fills_module.FILLS,
+    }
+    assert {kind: tuple(list(document)[: len(HEADER)]) for kind, document in reports.items()} == {
+        kind: HEADER for kind in reports
+    }
+    # And the header is about the file it sits in: the kind names both the measurement and
+    # the field the records are under.
+    for kind, document in reports.items():
+        assert document["kind"] == kind
+        assert kind in document

--- a/tests/test_applause_spans.py
+++ b/tests/test_applause_spans.py
@@ -397,7 +397,7 @@ def test_an_unmeasured_call_is_never_dropped() -> None:
 
 def test_every_tune_is_one_record_with_its_own_number() -> None:
     curve = _concert((0.0, 30.0), (0.9, 4.0), (0.0, 30.0))
-    rows = applause.numbered(applause.tunes(_spans(curve), 64.0, minimum_seconds=10.0))
+    rows = applause.rows(applause.tunes(_spans(curve), 64.0, minimum_seconds=10.0))
 
     assert [row["tune"] for row in rows] == [1, 2]
     assert set(rows[0]) == {
@@ -417,14 +417,14 @@ def test_every_tune_is_one_record_with_its_own_number() -> None:
 
 def test_a_record_carries_the_density_it_was_kept_on() -> None:
     """What the filter measured, on the row, so a songs.json author can see the evidence."""
-    rows = applause.numbered(applause.counted(_called((0.0, 10.0)), _beats(0.0, 10.0, 2.0)))
+    rows = applause.rows(applause.counted(_called((0.0, 10.0)), _beats(0.0, 10.0, 2.0)))
 
     assert rows[0]["beats"] == 20
     assert rows[0]["beats_per_second"] == 2.0
 
 
 def test_a_record_written_without_a_grid_says_so_rather_than_claiming_zero() -> None:
-    rows = applause.numbered(_called((0.0, 10.0)))
+    rows = applause.rows(_called((0.0, 10.0)))
 
     assert rows[0]["beats"] is None
     assert rows[0]["beats_per_second"] is None

--- a/tests/test_bar_map.py
+++ b/tests/test_bar_map.py
@@ -17,7 +17,7 @@ import pytest
 
 from resolve_mcp.analysis import bars as bars_module
 from resolve_mcp.analysis import music
-from resolve_mcp.analysis.beats import BeatGrid, Detector, numbered
+from resolve_mcp.analysis.beats import BeatGrid, Detector, rows
 from resolve_mcp.errors import InvalidRequestError
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.tools import analysis as analysis_tools
@@ -29,7 +29,7 @@ TEMPO = 107.0
 
 
 def _rows(beats: Sequence[float], downbeats: Sequence[float]) -> tuple[dict[str, Any], ...]:
-    return numbered(BeatGrid(beats=tuple(beats), downbeats=tuple(downbeats)))
+    return rows(BeatGrid(beats=tuple(beats), downbeats=tuple(downbeats)))
 
 
 def _times(count: int, step: float, first: float = 0.0) -> tuple[float, ...]:
@@ -43,13 +43,13 @@ def _onset_scale(bars: int = 8, meter: int = 4, tempo: float = TEMPO) -> tuple[d
     the grid a bar map has to make something of.
     """
     times = _times(bars * meter * 2, 60.0 / tempo / 2)
-    return numbered(BeatGrid(beats=times, downbeats=times))
+    return rows(BeatGrid(beats=times, downbeats=times))
 
 
 def _committed(bars: int = 8, meter: int = 4, tempo: float = TEMPO) -> tuple[dict[str, Any], ...]:
     """A grid the model did commit to: the tactus, with a downbeat every ``meter`` beats."""
     times = _times(bars * meter, 60.0 / tempo)
-    return numbered(BeatGrid(beats=times, downbeats=times[::meter]))
+    return rows(BeatGrid(beats=times, downbeats=times[::meter]))
 
 
 def _accented(
@@ -367,7 +367,7 @@ def test_the_floor_gates_the_model_path_too() -> None:
     times = _times(40, 60.0 / TEMPO)
     # Nine bars of four and one of three: the model held its meter for most of the tune.
     downbeats = times[:36:4] + (times[36],) + (times[39],)
-    grid = numbered(BeatGrid(beats=times, downbeats=downbeats))
+    grid = rows(BeatGrid(beats=times, downbeats=downbeats))
 
     lenient = bars_module.mapped(grid, [0.5] * len(grid), minimum_confidence=0.5)
     strict = bars_module.mapped(grid, [0.5] * len(grid), minimum_confidence=0.95)
@@ -384,7 +384,7 @@ def test_a_model_grid_that_only_half_commits_falls_through_to_inference() -> Non
     # Downbeats every four for the first half, then every beat — the shape a tracker gives
     # when it loses the form partway through a set.
     downbeats = times[:32:4] + times[32:]
-    grid = numbered(BeatGrid(beats=times, downbeats=downbeats))
+    grid = rows(BeatGrid(beats=times, downbeats=downbeats))
     mapped = bars_module.mapped(grid, _accented(grid, every=4, fold=1))
     assert mapped.source == "inferred"
     assert mapped.meter == 4

--- a/tests/test_bar_map.py
+++ b/tests/test_bar_map.py
@@ -16,8 +16,9 @@ from typing import Any
 import pytest
 
 from resolve_mcp.analysis import bars as bars_module
+from resolve_mcp.analysis import beats as beats_module
 from resolve_mcp.analysis import music
-from resolve_mcp.analysis.beats import BeatGrid, Detector, rows
+from resolve_mcp.analysis.beats import BeatGrid, Detector
 from resolve_mcp.errors import InvalidRequestError
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.tools import analysis as analysis_tools
@@ -29,7 +30,7 @@ TEMPO = 107.0
 
 
 def _rows(beats: Sequence[float], downbeats: Sequence[float]) -> tuple[dict[str, Any], ...]:
-    return rows(BeatGrid(beats=tuple(beats), downbeats=tuple(downbeats)))
+    return beats_module.rows(BeatGrid(beats=tuple(beats), downbeats=tuple(downbeats)))
 
 
 def _times(count: int, step: float, first: float = 0.0) -> tuple[float, ...]:
@@ -43,13 +44,13 @@ def _onset_scale(bars: int = 8, meter: int = 4, tempo: float = TEMPO) -> tuple[d
     the grid a bar map has to make something of.
     """
     times = _times(bars * meter * 2, 60.0 / tempo / 2)
-    return rows(BeatGrid(beats=times, downbeats=times))
+    return beats_module.rows(BeatGrid(beats=times, downbeats=times))
 
 
 def _committed(bars: int = 8, meter: int = 4, tempo: float = TEMPO) -> tuple[dict[str, Any], ...]:
     """A grid the model did commit to: the tactus, with a downbeat every ``meter`` beats."""
     times = _times(bars * meter, 60.0 / tempo)
-    return rows(BeatGrid(beats=times, downbeats=times[::meter]))
+    return beats_module.rows(BeatGrid(beats=times, downbeats=times[::meter]))
 
 
 def _accented(
@@ -367,7 +368,7 @@ def test_the_floor_gates_the_model_path_too() -> None:
     times = _times(40, 60.0 / TEMPO)
     # Nine bars of four and one of three: the model held its meter for most of the tune.
     downbeats = times[:36:4] + (times[36],) + (times[39],)
-    grid = rows(BeatGrid(beats=times, downbeats=downbeats))
+    grid = beats_module.rows(BeatGrid(beats=times, downbeats=downbeats))
 
     lenient = bars_module.mapped(grid, [0.5] * len(grid), minimum_confidence=0.5)
     strict = bars_module.mapped(grid, [0.5] * len(grid), minimum_confidence=0.95)
@@ -384,7 +385,7 @@ def test_a_model_grid_that_only_half_commits_falls_through_to_inference() -> Non
     # Downbeats every four for the first half, then every beat — the shape a tracker gives
     # when it loses the form partway through a set.
     downbeats = times[:32:4] + times[32:]
-    grid = rows(BeatGrid(beats=times, downbeats=downbeats))
+    grid = beats_module.rows(BeatGrid(beats=times, downbeats=downbeats))
     mapped = bars_module.mapped(grid, _accented(grid, every=4, fold=1))
     assert mapped.source == "inferred"
     assert mapped.meter == 4

--- a/tests/test_beat_grid.py
+++ b/tests/test_beat_grid.py
@@ -24,14 +24,14 @@ def _steady(count: int, step: float = 0.5, every: int = 4, first: int = 0) -> Be
 
 
 def test_bars_are_counted_from_the_downbeats_the_model_gave() -> None:
-    records = beats.numbered(_steady(9))
+    records = beats.rows(_steady(9))
 
     assert [record["bar"] for record in records] == [1, 1, 1, 1, 2, 2, 2, 2, 3]
     assert [record["in_bar"] for record in records] == [1, 2, 3, 4, 1, 2, 3, 4, 1]
 
 
 def test_a_tune_in_five_numbers_in_five() -> None:
-    records = beats.numbered(_steady(11, every=5))
+    records = beats.rows(_steady(11, every=5))
 
     assert [record["in_bar"] for record in records] == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1]
     assert beats.gist(_steady(11, every=5), records)["meter"] == 5
@@ -39,7 +39,7 @@ def test_a_tune_in_five_numbers_in_five() -> None:
 
 def test_a_pickup_before_the_first_downbeat_counts_as_bar_one() -> None:
     """Counting a horn's two pickup notes as bar zero would offset every bar after them."""
-    records = beats.numbered(_steady(10, first=2))
+    records = beats.rows(_steady(10, first=2))
 
     assert [record["bar"] for record in records][:4] == [1, 1, 2, 2]
     assert records[0]["downbeat"] is False
@@ -51,7 +51,7 @@ def test_a_downbeat_a_hair_off_its_beat_still_marks_that_beat() -> None:
     """The model reports the two separately; float equality would silently drop the mark."""
     grid = BeatGrid(beats=(0.0, 0.5, 1.0, 1.5), downbeats=(0.0, 1.0009))
 
-    records = beats.numbered(grid)
+    records = beats.rows(grid)
 
     assert [record["downbeat"] for record in records] == [True, False, True, False]
 
@@ -59,13 +59,13 @@ def test_a_downbeat_a_hair_off_its_beat_still_marks_that_beat() -> None:
 def test_a_downbeat_nowhere_near_a_beat_marks_nothing() -> None:
     grid = BeatGrid(beats=(0.0, 0.5, 1.0, 1.5), downbeats=(0.0, 1.2))
 
-    assert [record["downbeat"] for record in beats.numbered(grid)] == [True, False, False, False]
+    assert [record["downbeat"] for record in beats.rows(grid)] == [True, False, False, False]
 
 
 def test_the_gist_reports_tempo_from_the_intervals() -> None:
     grid = _steady(9)
 
-    found = beats.gist(grid, beats.numbered(grid))
+    found = beats.gist(grid, beats.rows(grid))
 
     assert found["tempo_bpm"] == pytest.approx(120.0)
     assert found["tempo_min_bpm"] == pytest.approx(120.0)
@@ -78,7 +78,7 @@ def test_the_gist_reports_tempo_from_the_intervals() -> None:
 def test_the_gist_of_an_empty_grid_says_nothing_rather_than_dividing_by_zero() -> None:
     grid = BeatGrid((), ())
 
-    found = beats.gist(grid, beats.numbered(grid))
+    found = beats.gist(grid, beats.rows(grid))
 
     assert found["count"] == 0
     assert found["tempo_bpm"] is None
@@ -89,7 +89,7 @@ def test_the_gist_of_an_empty_grid_says_nothing_rather_than_dividing_by_zero() -
 def test_a_grid_that_arrives_out_of_order_is_sorted_before_it_is_numbered() -> None:
     grid = BeatGrid(beats=(1.0, 0.0, 0.5), downbeats=(0.5,))
 
-    records = beats.numbered(beats.detect(Path("unused.wav"), lambda path: grid))
+    records = beats.rows(beats.detect(Path("unused.wav"), lambda path: grid))
 
     assert [record["t"] for record in records] == [0.0, 0.5, 1.0]
     assert [record["downbeat"] for record in records] == [False, True, False]
@@ -124,7 +124,7 @@ def test_a_structured_failure_from_a_detector_is_passed_through_unchanged() -> N
 
 
 def test_the_top_of_a_four_bar_group_is_the_strongest_placement() -> None:
-    records = beats.numbered(_steady(20))
+    records = beats.rows(_steady(20))
     tops = [
         record for record in records if record["downbeat"] and record["bar"] in (1, 5)
     ]
@@ -133,7 +133,7 @@ def test_the_top_of_a_four_bar_group_is_the_strongest_placement() -> None:
 
 
 def test_an_ordinary_bar_line_reads_weaker_than_the_top_of_the_group() -> None:
-    records = beats.numbered(_steady(20))
+    records = beats.rows(_steady(20))
     (second_bar,) = [record for record in records if record["bar"] == 2 and record["downbeat"]]
 
     assert beats.bar_line_strength(second_bar) == beats.AT_BAR_LINE
@@ -141,7 +141,7 @@ def test_an_ordinary_bar_line_reads_weaker_than_the_top_of_the_group() -> None:
 
 
 def test_a_beat_inside_a_bar_is_the_weakest_placement() -> None:
-    records = beats.numbered(_steady(20))
+    records = beats.rows(_steady(20))
     inside = next(record for record in records if not record["downbeat"])
 
     assert beats.bar_line_strength(inside) == beats.MID_BAR
@@ -166,7 +166,7 @@ def _rubato(steady: int = 12, free: Sequence[float] = (0.9, 1.4, 0.7, 1.3)) -> B
 
 def test_a_grid_that_keeps_time_in_four_is_trusted_end_to_end() -> None:
     """The gate has to be inert on the timelines whose grids are already sound."""
-    found = beats.trust(beats.numbered(_steady(13)))
+    found = beats.trust(beats.rows(_steady(13)))
 
     assert found.meter == 4
     assert all(found.trusted)
@@ -180,7 +180,7 @@ def test_a_bar_position_the_meter_cannot_hold_is_not_trusted() -> None:
         downbeats=(0.0, 3.0, 5.0, 7.0),
     )
 
-    found = beats.trust(beats.numbered(grid))
+    found = beats.trust(beats.rows(grid))
 
     assert found.meter == 4
     # The opening bar runs to six beats, so its fifth and sixth are positions 4/4 cannot hold.
@@ -191,7 +191,7 @@ def test_a_bar_position_the_meter_cannot_hold_is_not_trusted() -> None:
 
 def test_beats_either_side_of_an_out_of_time_stretch_are_not_trusted() -> None:
     """Rubato carries perfectly legal bar positions, so only the timing gives it away."""
-    found = beats.trust(beats.numbered(_rubato()))
+    found = beats.trust(beats.rows(_rubato()))
 
     assert found.trusted[:10] == (True,) * 10
     assert not all(found.trusted[11:])
@@ -204,7 +204,7 @@ def test_a_steady_grid_that_changes_tempo_once_is_not_gated_wholesale() -> None:
     fast = [round(slow[-1] + (index + 1) * 0.35, 6) for index in range(12)]
     grid = BeatGrid(beats=tuple(slow + fast), downbeats=tuple((slow + fast)[::4]))
 
-    found = beats.trust(beats.numbered(grid))
+    found = beats.trust(beats.rows(grid))
 
     assert all(found.trusted[:9])
     assert all(found.trusted[-9:])
@@ -212,7 +212,7 @@ def test_a_steady_grid_that_changes_tempo_once_is_not_gated_wholesale() -> None:
 
 def test_a_grid_too_short_to_judge_is_left_alone_rather_than_gated_blind() -> None:
     """Two beats give one interval and no local reference; refusing them all would invent a gate."""
-    found = beats.trust(beats.numbered(BeatGrid(beats=(0.0, 0.5), downbeats=(0.0,))))
+    found = beats.trust(beats.rows(BeatGrid(beats=(0.0, 0.5), downbeats=(0.0,))))
 
     assert all(found.trusted)
 
@@ -225,7 +225,7 @@ def test_a_grid_that_calls_every_beat_a_downbeat_describes_no_bar_position_at_al
     is not a gate finding a skew, it is a gate manufacturing one, so the grid is refused whole.
     """
     times = tuple(round(index * 0.5, 6) for index in range(16))
-    found = beats.trust(beats.numbered(BeatGrid(beats=times, downbeats=times)))
+    found = beats.trust(beats.rows(BeatGrid(beats=times, downbeats=times)))
 
     assert found.meter == 1
     assert not any(found.trusted)
@@ -233,7 +233,7 @@ def test_a_grid_that_calls_every_beat_a_downbeat_describes_no_bar_position_at_al
 
 
 def test_an_empty_grid_has_nothing_to_trust_and_no_meter() -> None:
-    found = beats.trust(beats.numbered(BeatGrid((), ())))
+    found = beats.trust(beats.rows(BeatGrid((), ())))
 
     assert found.trusted == ()
     assert found.meter is None

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -148,7 +148,7 @@ def beats_file(
         target,
         {"kind": "beats", "audio": "concert.wav", "duration_seconds": 6.0},
         "beats",
-        beats_module.numbered(grid),
+        beats_module.rows(grid),
     )
 
 

--- a/tests/test_drum_fills.py
+++ b/tests/test_drum_fills.py
@@ -18,8 +18,9 @@ from typing import Any
 
 import pytest
 
+from resolve_mcp.analysis import beats as beats_module
 from resolve_mcp.analysis import drums, fills, music
-from resolve_mcp.analysis.beats import BeatGrid, Detector, rows
+from resolve_mcp.analysis.beats import BeatGrid, Detector
 from resolve_mcp.analysis.drums import Hit
 from resolve_mcp.audio.stems import DRUM_PASS, DRUM_STEMS, MIX_PASS
 from resolve_mcp.config import get_config
@@ -68,7 +69,7 @@ def _grid(bars: int = 8, tempo: float = 120.0, meter: int = 4) -> tuple[dict[str
     step = 60.0 / tempo
     beats = tuple(round(index * step, 6) for index in range(bars * meter))
     downbeats = tuple(beats[index] for index in range(0, len(beats), meter))
-    return rows(BeatGrid(beats=beats, downbeats=downbeats))
+    return beats_module.rows(BeatGrid(beats=beats, downbeats=downbeats))
 
 
 def _comping(rows: Sequence[Mapping[str, Any]]) -> list[Hit]:

--- a/tests/test_drum_fills.py
+++ b/tests/test_drum_fills.py
@@ -19,7 +19,7 @@ from typing import Any
 import pytest
 
 from resolve_mcp.analysis import drums, fills, music
-from resolve_mcp.analysis.beats import BeatGrid, Detector, numbered
+from resolve_mcp.analysis.beats import BeatGrid, Detector, rows
 from resolve_mcp.analysis.drums import Hit
 from resolve_mcp.audio.stems import DRUM_PASS, DRUM_STEMS, MIX_PASS
 from resolve_mcp.config import get_config
@@ -64,11 +64,11 @@ def stems(separation: Path) -> dict[str, Path]:
 
 
 def _grid(bars: int = 8, tempo: float = 120.0, meter: int = 4) -> tuple[dict[str, Any], ...]:
-    """``numbered`` rows for a steady grid — the same shape the beats half writes."""
+    """``beats.rows`` for a steady grid — the same shape the beats half writes."""
     step = 60.0 / tempo
     beats = tuple(round(index * step, 6) for index in range(bars * meter))
     downbeats = tuple(beats[index] for index in range(0, len(beats), meter))
-    return numbered(BeatGrid(beats=beats, downbeats=downbeats))
+    return rows(BeatGrid(beats=beats, downbeats=downbeats))
 
 
 def _comping(rows: Sequence[Mapping[str, Any]]) -> list[Hit]:

--- a/tests/test_live_analysis.py
+++ b/tests/test_live_analysis.py
@@ -40,7 +40,7 @@ def test_the_installed_beat_model_hears_a_click_track(tmp_path: Path) -> None:
     path = write_clicks(tmp_path / "clicks.wav", beats_per_minute=CLICK_BPM, seconds=CLICK_SECONDS)
 
     grid = beats.detect(path)
-    found = beats.gist(grid, beats.numbered(grid))
+    found = beats.gist(grid, beats.rows(grid))
 
     # Times in seconds, not frames or samples: the unit is what a wrong call gets wrong.
     assert all(0.0 <= one <= CLICK_SECONDS for one in grid.beats)
@@ -74,7 +74,7 @@ def test_a_bar_map_over_the_real_model_and_the_real_accents_finds_the_downbeat(
         accents=[1.0 if index % BAR_METER == 0 else 0.3 for index in range(len(times))],
     )
 
-    grid = beats.numbered(beats.detect(path))
+    grid = beats.rows(beats.detect(path))
     salience = bars.accents(path, [float(row["t"]) for row in grid])
     found = bars.mapped(grid, salience)
 

--- a/tests/test_phrases.py
+++ b/tests/test_phrases.py
@@ -21,8 +21,9 @@ from typing import Any
 
 import pytest
 
+from resolve_mcp.analysis import beats as beats_module
 from resolve_mcp.analysis import melody, music, phrases
-from resolve_mcp.analysis.beats import BeatGrid, Detector, rows
+from resolve_mcp.analysis.beats import BeatGrid, Detector
 from resolve_mcp.analysis.melody import Note
 from resolve_mcp.audio.stems import DRUM_PASS, DRUM_STEMS, FOUR_STEMS, MIX_PASS
 from resolve_mcp.config import get_config
@@ -72,7 +73,7 @@ def _grid(bars: int = 8, tempo: float = TEMPO, meter: int = 4) -> tuple[dict[str
     step = 60.0 / tempo
     beats = tuple(round(index * step, 6) for index in range(bars * meter))
     downbeats = tuple(beats[index] for index in range(0, len(beats), meter))
-    return rows(BeatGrid(beats=beats, downbeats=downbeats))
+    return beats_module.rows(BeatGrid(beats=beats, downbeats=downbeats))
 
 
 def _line(
@@ -230,7 +231,7 @@ def test_a_line_of_one_note_reads_nothing() -> None:
 
 def test_a_grid_with_no_tempo_in_it_reads_nothing() -> None:
     """No beat to measure a rest in. Better nothing than a rest measured against zero."""
-    flat = rows(BeatGrid(beats=(0.0, 0.0, 0.0), downbeats=(0.0,)))
+    flat = beats_module.rows(BeatGrid(beats=(0.0, 0.0, 0.0), downbeats=(0.0,)))
 
     assert phrases.boundaries(_running(8), flat).boundaries == ()
 

--- a/tests/test_phrases.py
+++ b/tests/test_phrases.py
@@ -22,7 +22,7 @@ from typing import Any
 import pytest
 
 from resolve_mcp.analysis import melody, music, phrases
-from resolve_mcp.analysis.beats import BeatGrid, Detector, numbered
+from resolve_mcp.analysis.beats import BeatGrid, Detector, rows
 from resolve_mcp.analysis.melody import Note
 from resolve_mcp.audio.stems import DRUM_PASS, DRUM_STEMS, FOUR_STEMS, MIX_PASS
 from resolve_mcp.config import get_config
@@ -68,11 +68,11 @@ def stems(separation: Path) -> dict[str, Path]:
 
 
 def _grid(bars: int = 8, tempo: float = TEMPO, meter: int = 4) -> tuple[dict[str, Any], ...]:
-    """``numbered`` rows for a steady grid — the same shape the beats half writes."""
+    """``beats.rows`` for a steady grid — the same shape the beats half writes."""
     step = 60.0 / tempo
     beats = tuple(round(index * step, 6) for index in range(bars * meter))
     downbeats = tuple(beats[index] for index in range(0, len(beats), meter))
-    return numbered(BeatGrid(beats=beats, downbeats=downbeats))
+    return rows(BeatGrid(beats=beats, downbeats=downbeats))
 
 
 def _line(
@@ -230,7 +230,7 @@ def test_a_line_of_one_note_reads_nothing() -> None:
 
 def test_a_grid_with_no_tempo_in_it_reads_nothing() -> None:
     """No beat to measure a rest in. Better nothing than a rest measured against zero."""
-    flat = numbered(BeatGrid(beats=(0.0, 0.0, 0.0), downbeats=(0.0,)))
+    flat = rows(BeatGrid(beats=(0.0, 0.0, 0.0), downbeats=(0.0,)))
 
     assert phrases.boundaries(_running(8), flat).boundaries == ()
 

--- a/tests/test_solo_changes.py
+++ b/tests/test_solo_changes.py
@@ -291,7 +291,7 @@ def test_change_records_name_what_left_and_what_took_over() -> None:
         _voice("other", (-18.0, 12.0), (-30.0, 12.0)),
         _voice("vocals", (-30.0, 12.0), (-18.0, 12.0)),
     )
-    rows = solos.numbered(solos.snapped(solos.changes(runs, ()), (11.6,), tolerance=2.0))
+    rows = solos.rows(solos.snapped(solos.changes(runs, ()), (11.6,), tolerance=2.0))
 
     assert rows[0]["change"] == 1
     assert rows[0]["from"] == "other"


### PR DESCRIPTION
Closes #223.

## What changed

`halves.written` builds the standard analysis-file header and gist reply, but only music and structure went through it — bars, phrases and fills hand-rolled the same header and called `records.write` directly, so "every analysis file has the same header" was enforced nowhere. All three now write through the shared writer. The bar map's `start_seconds`/`end_seconds`/`reasons` become the `aside` the writer already has a slot for, which is what they always were: header-only material, kept out of the reply.

Headers land byte-identical in key order and content, and each job returns the same dict it did before, so no cache version moves.

The naming drift is settled in the same pass, stated where `written` is documented:

- **`gist`** — the builder of a half's header stats. `summary` is the word for a reading of something that is not a half (`barmap.summary`, `subject.summary` for `correlate`; a private `_summary` boiling one record down).
- **`rows`** — the record builder. `applause`, `beats` and `solos` rename from `numbered`, which read as a distinction (records carrying an index) that was never one, since bars and fills number theirs too.

`correlate`'s report and the transcript stay outside the writer, both because their shape is genuinely different — a join over cut rows with no `audio` to name, and a schema-versioned document with three record lists. Both are named at the writer and at their own call sites.

## Test seam

Fake tier, per the ACs. `tests/test_analysis_reports.py` is the new cross-detector guard: it runs all seven halves that write a file (beats, energy, tunes, solos, bars, phrases, fills) and asserts they open `kind`/`audio`/`duration_seconds`. It was verified to fail — re-drifting fills' header made it red, and reverting made it green again. Each detector's fakes are imported from that detector's own test file, so the inputs keep one home.

Full fake tier 2269 passed, mypy strict clean over 209 files, ruff clean. No live ACs on this ticket.

## Review

Two-axis `/code-review` against `origin/main`, run on the branch before this PR existed.

**Standards — 5 findings, all addressed.**

1. *CONTEXT.md map updated in the analysis paragraph but not in the `## Test map — tests/` section, which is where "which test file covers Y" is answered.* Fixed — the new test has an entry there.
2. *The naming rule enumerated every `summary` in the tree and the enumeration was already wrong: `applause._summary` is a `summary` inside a half module.* Fixed — the rule now says what the word is for instead of listing instances.
3. *The rename lands a bare `rows` in test modules that use `rows` as a local everywhere; `src/` avoids this by qualifying.* Fixed — the three test modules import `beats_module` and call `beats_module.rows`.
4. *The new file re-rolls two stem layouts while importing every other helper, without saying why.* Fixed — the docstring says why (the originals are pytest fixtures, which cannot be called from another module).
5. *`_master_for` was the only helper without a docstring and sat below its caller.* Fixed — renamed `_master`, documented, moved above.

**Spec — 3 findings, 2 addressed, 1 verified as already correct.**

1. *The transcript (`transcript.write`) is a third report in `analysis_dir` that bypasses both writers, so "the one report that stays out is correlate's" overclaims, in the writer's docstring and the test's.* Fixed — both name it, and the test's claim narrows from "every detector" to "every half".
2. *`applause._summary` contradicts the rule as shipped.* Same fix as Standards #2.
3. *bars passes its span and reasons as `aside`, whose documented meaning ("too long for a tool result, too short for its own file") is stretched by it.* The behaviour was already right — `aside` is operationally "written to the head, kept out of the reply", which is exactly what those three keys were doing before this PR. Fixed the description rather than the code: `aside` is now documented by what it does, with both cases named.

Spec also verified AC3 independently: bars' old `kind, audio, duration_seconds, start_seconds, end_seconds, reasons, **summary` and the new `kind, audio, duration_seconds, **aside, **gist` are the same key order with the same collision precedence, fills and phrases are unchanged, and all three return the same dict.

Fix diff re-checked (ruff, mypy strict, and the affected tests) rather than re-reviewed whole, per CLAUDE.md step 3.

Review: clean — findings above resolved; two-axis review against origin/main, fix diff re-checked.



---

**Merge with `origin/main` (83aebbc):** one conflict, the `halves` entry in `CONTEXT.md` — keeps this branch's `written` paragraph and takes main's `collected`/`stem_named` wording (#220). `correlate`/`halves`/`music`/`phrases`/`structure` auto-merged. ruff / mypy strict / fake tier (2303 passed) green.

Review: clean — merge resolution, one prose hunk
