### PR TITLE
Split the tail: pure OTIO surgery vs the Resolve round trip

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -225,7 +225,8 @@ no Resolve import: `inject` cuts the dissolve and the audio fade into an
 exported OTIO document and reports what did *not* get one, `transitions` reads
 them back, and the span/rate arithmetic under both counts every track in the
 *timeline's* rate rather than each clip's own; `resolve/tail` is the only
-caller, #221). A `segments` entry is a shot or a **gap**
+caller, #221 — not `tests/otio.py`, which hand-builds documents for the live
+tier). A `segments` entry is a shot or a **gap**
 (`{"id", "gap": <frames>}`, literal black); `is_gap`/`entry_duration`/
 `overlay_track` are the `layout` accessors every walker of that array shares.
 
@@ -273,9 +274,11 @@ which needs `useCustomSettings` first and is judged by the read-back, never by
 the return value — #187), `tail` (**the tail's round trip**: the export/import
 `build` takes when a tail has a transition to cut in — a hard out that fades
 nothing builds directly — because the scripting API cannot cut a transition at
-all; the document edit itself is `cut/otio`. Returns a `Landed` — the imported
-cut plus `release`/`refuse` — so the staging timeline outlives the import until
-the caller has read the shots back on it, #221), `takes`
+all; the document edit itself is `cut/otio`. Takes one `Staging` — the project,
+pool, timeline and name the shots are on until the import lands — and returns a
+`Landed`: the imported cut plus `release`/`refuse`, so the staging timeline
+outlives the import until the caller has read the shots back on it, #221),
+`takes`
 (take selectors + in-place swap), `timeline` (timeline read wrappers),
 `titles` (titles file against a project + dry run).
 
@@ -395,7 +398,8 @@ interesting failures are the disagreements between them. `test_cut_tail.py` is t
 tail is one device across `cut/tail`, `cut/validate`, `resolve/tail` and
 `resolve/build`, and a dissolve that did not land looks exactly like a cut that
 never asked for one. (`test_cut_otio.py` is its pure half, split out with the
-module in #221: documents in, documents out, plain dicts and no fakes.) `test_hardware_decode.py` (#202) is the fourth: NVDEC is
+module in #221: documents in, documents out, plain dicts and no fakes.)
+`test_hardware_decode.py` (#202) is the fourth: NVDEC is
 one decision across `ffmpeg` (the probe), `video/ffmpeg` (flags, fallback,
 report) and the three video routes that carry the report, and the failure worth
 testing is a decode that ran one way and reported another. `test_cut_resolution.py`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -220,7 +220,12 @@ not run*, where Resolve named no media bounds for E5 or E7 to check a range
 against, #186; E11 is the exception it cannot answer, raised in
 `resolve/build` where a live locked track can be observed), `tail` (the optional
 **tail** device: one reading of `{type, duration_frames, audio_fade_frames}` for
-both the rules and the build). A `segments` entry is a shot or a **gap**
+both the rules and the build), `otio` (**the tail's document surgery** — pure,
+no Resolve import: `inject` cuts the dissolve and the audio fade into an
+exported OTIO document and reports what did *not* get one, `transitions` reads
+them back, and the span/rate arithmetic under both counts every track in the
+*timeline's* rate rather than each clip's own; `resolve/tail` is the only
+caller, #221). A `segments` entry is a shot or a **gap**
 (`{"id", "gap": <frames>}`, literal black); `is_gap`/`entry_duration`/
 `overlay_track` are the `layout` accessors every walker of that array shares.
 
@@ -265,10 +270,12 @@ Resolve reports no camera metadata for — #94; not an **angle sidecar**),
 (session/project wrappers), `settings` (the timeline settings the server
 *writes*, through the string-typed `GetSetting`/`SetSetting` pair: resolution,
 which needs `useCustomSettings` first and is judged by the read-back, never by
-the return value — #187), `tail` (materialising a cut's tail: the OTIO
-document edit + the export/import round trip `build` takes when a tail has
-a transition to cut in — a hard out that fades nothing builds directly —
-because the scripting API cannot cut a transition at all), `takes`
+the return value — #187), `tail` (**the tail's round trip**: the export/import
+`build` takes when a tail has a transition to cut in — a hard out that fades
+nothing builds directly — because the scripting API cannot cut a transition at
+all; the document edit itself is `cut/otio`. Returns a `Landed` — the imported
+cut plus `release`/`refuse` — so the staging timeline outlives the import until
+the caller has read the shots back on it, #221), `takes`
 (take selectors + in-place swap), `timeline` (timeline read wrappers),
 `titles` (titles file against a project + dry run).
 
@@ -387,7 +394,8 @@ same reason: gaps and overlay tracks are one device each across `cut/layout`,
 interesting failures are the disagreements between them. `test_cut_tail.py` is the third: the
 tail is one device across `cut/tail`, `cut/validate`, `resolve/tail` and
 `resolve/build`, and a dissolve that did not land looks exactly like a cut that
-never asked for one. `test_hardware_decode.py` (#202) is the fourth: NVDEC is
+never asked for one. (`test_cut_otio.py` is its pure half, split out with the
+module in #221: documents in, documents out, plain dicts and no fakes.) `test_hardware_decode.py` (#202) is the fourth: NVDEC is
 one decision across `ffmpeg` (the probe), `video/ffmpeg` (flags, fallback,
 report) and the three video routes that carry the report, and the failure worth
 testing is a decode that ran one way and reported another. `test_cut_resolution.py`

--- a/src/resolve_mcp/cut/otio.py
+++ b/src/resolve_mcp/cut/otio.py
@@ -1,0 +1,325 @@
+"""The tail as document surgery: cutting a fade into an exported OTIO, and reading it back.
+
+Nothing here talks to Resolve. An OTIO document is a dict of dicts, so every decision this
+module makes — which track the picture ends on, whether the last shot is long enough to
+fade, what a transition is in frames — is answerable with a document alone, and the tests
+for it are plain dicts rather than fakes. The half that owns the export/import round trip
+is :mod:`resolve_mcp.resolve.tail`; it calls :func:`inject` before the import and
+:func:`transitions` after it, and those two are compared to each other by track name.
+
+Two things are decisions rather than mechanics, and both are about where the picture
+actually stops:
+
+* **The fade goes after the last shot, not after the last child.** Resolve pads every
+  exported track with a trailing ``Gap`` out to the length of the *timeline*, so a concert
+  cut — whose mix is authored to outlive the picture, as all five surveyed deliverables do
+  — exports a V1 that ends in black (verified live, 21.0.3: a 480-frame picture under a
+  520-frame mix exported V1 as three clips and a 40-frame gap). A transition appended to
+  the end of that track would dissolve black into black. Nothing is appended *after* the
+  picture either: black at the end of a cut is the cut file's own gap, subject to W8 like
+  any other, and adding one here would be this module inventing record time.
+* **Every frame count is read in the timeline's rate.** A tail counts in the rate the cut
+  file counts in; OTIO stamps each clip in its own *media* rate. On the ordinary
+  mixed-rate concert kit those are not the same number of frames, and comparing them raw
+  measures two layers in two units.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from .tail import Tail
+
+Document = dict[str, Any]
+Track = dict[str, Any]
+Item = dict[str, Any]
+
+DISSOLVE: Final = "SMPTE_Dissolve"
+"""The only transition type in play: a fade to black is a dissolve into nothing."""
+
+
+def inject(document: Document, tail: Tail) -> dict[str, Any]:
+    """Edit ``tail`` into an exported OTIO document. Returns what was put where.
+
+    The dissolve goes on every video track that reaches the end of the cut, which on an
+    ordinary concert build is V1 alone: an overlay that stopped earlier has nothing to do
+    with how the picture leaves, and fading it would be a second device nobody asked for.
+    The audio fade goes on every audio track's last clip, because the master mix is the only
+    thing this pillar puts there.
+
+    Also returned is what did *not* get one where one was needed — ``unfaded_video`` and
+    ``unfaded_audio``. A per-track refusal is invisible in the totals: a document where V1
+    faded and an opaque V2 did not still reports a dissolve, and the picture then pops back
+    out of black the frame the overlay ends. The caller refuses on either list rather than
+    delivering half a device.
+    """
+    video: list[str] = []
+    audio: list[str] = []
+    unfaded_video: list[str] = []
+    unfaded_audio: list[str] = []
+    rate = _timeline_rate(document)
+    if tail.dissolves:
+        ending = _tracks(document, "Video", last_only=True, rate=rate)
+        for track in ending:
+            placed = video if _append_transition(track, rate, tail.frames) else unfaded_video
+            placed.append(_name(track))
+        unfaded_video.extend(_name(track) for track in _inside(document, tail, ending, rate))
+    if tail.fades_audio:
+        for track in _tracks(document, "Audio", last_only=False, rate=rate):
+            placed = audio if _append_transition(track, rate, tail.audio_frames) else unfaded_audio
+            placed.append(_name(track))
+    return {
+        "video_tracks": video,
+        "audio_tracks": audio,
+        "unfaded_video": unfaded_video,
+        "unfaded_audio": unfaded_audio,
+    }
+
+
+def _name(track: Track) -> str:
+    """What a track is called on *both* sides of the round trip — one vocabulary, not two.
+
+    An OTIO track need not carry a name, and :func:`inject` and :func:`transitions` are
+    compared to each other, by name, by the round trip's own read-back. A fallback invented
+    separately on each side is therefore not a cosmetic difference: an unnamed track would
+    have its dissolve recorded under one word and read back under another, so every such
+    build would refuse a tail that landed perfectly — and take a correct import down with it
+    on the way out.
+    """
+    return str(track.get("name") or "") or str(track.get("kind") or "").lower()
+
+
+def _inside(document: Document, tail: Tail, ending: list[Track], rate: float) -> list[Track]:
+    """Video tracks whose picture stops *inside* the dissolve, which nothing here fades.
+
+    Such a track is opaque over part of the ramp and then ends, so the picture underneath
+    comes back partway through a fade to black — a visible second ending. It is not a track
+    to fade either: the dissolve reaches back into the shot that ends the cut, and one
+    starting where an overlay happens to stop would be a device nobody asked for. So it is
+    reported, and the build refuses rather than delivering a tail with a hole in it.
+    """
+    others = [
+        track
+        for track in _tracks(document, "Video", last_only=False, rate=rate)
+        if not any(track is one for one in ending)
+    ]
+    furthest = max((_span(track, rate) for track in ending), default=0)
+    return [track for track in others if furthest - tail.frames < _span(track, rate) < furthest]
+
+
+def _tracks(document: Document, kind: str, last_only: bool, rate: float) -> list[Track]:
+    """The tracks of one kind a transition belongs on, in document order.
+
+    ``last_only`` keeps the video dissolve to the layer the cut actually ends on. Ties are
+    kept, not broken: two video tracks both running to the last frame are both the end of
+    the picture, and fading one of them would leave the other opaque over black.
+    """
+    found = [
+        track
+        for track in ((document.get("tracks") or {}).get("children") or [])
+        if track.get("kind") == kind and _clips(track)
+    ]
+    if not last_only or not found:
+        return found
+    furthest = max(_span(track, rate) for track in found)
+    return [track for track in found if _span(track, rate) == furthest]
+
+
+def _clips(track: Track) -> list[Item]:
+    return [item for item in (track.get("children") or []) if _is_clip(item)]
+
+
+def _last_clip(track: Track) -> int:
+    """Where the last clip on this track sits among its children, or -1 if there is none.
+
+    Not simply the last child. Resolve pads every track it exports with a trailing ``Gap``
+    out to the length of the *timeline*, so a concert cut — whose mix is authored to outlive
+    the picture, as all five surveyed deliverables do — exports a V1 that ends in black
+    rather than in a shot (verified live, 21.0.3). A fade appended after that gap would
+    dissolve black into black.
+    """
+    children = list(track.get("children") or [])
+    for index in range(len(children) - 1, -1, -1):
+        if _is_clip(children[index]):
+            return index
+    return -1
+
+
+def _span(track: Track, rate: float) -> int:
+    """Where the *picture* on this track stops — trailing black is not part of the answer.
+
+    Measured to the end of the last clip rather than to the end of the track, for the same
+    reason: Resolve pads every track out to the timeline's length, so track length is the
+    one number that cannot tell the layer the cut ends on from a layer that stopped early.
+
+    In *timeline* frames, which is what makes the answer comparable across tracks at all: a
+    mixed-rate multicam stack carries a different media rate per clip, and summing the raw
+    numbers would measure two layers in two units and call the shorter one the end.
+
+    Summed unrounded and rounded once, because this is a sum and the comparison it feeds is
+    an equality. Rounding per clip spends up to half a frame each time, so a forty-shot V1
+    can come out two frames short of an overlay that ends on the very same frame — which
+    drops V1 out of the ending layers, straight into the window ``_inside`` refuses, and the
+    build then fails a correct mixed-rate cut with the shots already on a staging timeline.
+    """
+    children = list(track.get("children") or [])
+    last = _last_clip(track)
+    return round(
+        sum(
+            _exact(_duration(item), rate)
+            for item in children[: last + 1]
+            if not _is_transition(item)
+        )
+    )
+
+
+def _append_transition(track: Track, rate: float, frames: int) -> bool:
+    """Put a fade at the end of the track's picture, or answer False and leave it alone.
+
+    The transition goes immediately after the last clip, which is a clip→gap boundary
+    whenever something outlives the picture — reaching ``frames`` back into the shot and
+    nothing forward, so it lands on black on the shot's own last frame.
+
+    Refused rather than trimmed when that clip is too short: the length was validated (E12)
+    against the cut file, so a document that cannot carry it means the built timeline
+    disagrees with the cut, and quietly shortening the device would hide that.
+
+    Both numbers are timeline frames. ``frames`` comes from the cut file, which counts in
+    the timeline's rate; the clip's own duration is stamped in its *media* rate, so on a
+    mixed-rate multicam the raw comparison asks whether a 23.976 count fits inside a 25
+    one — and answers "the shot is too short to fade" about a shot that is not.
+    """
+    children = list(track.get("children") or [])
+    index = _last_clip(track)
+    if index < 0 or _frames(children[index], rate) <= frames:
+        return False
+    children.insert(index + 1, _transition(rate or _rate(children[index]), frames))
+    track["children"] = children
+    return True
+
+
+def _transition(rate: float, frames: int) -> Item:
+    """A dissolve reaching ``frames`` back into what precedes it and nothing forward.
+
+    ``out_offset`` of zero is what makes it a fade *out* rather than a cross: there is
+    nothing after it to reach into, and black is the absence of the frames it gives up.
+    """
+    return {
+        "OTIO_SCHEMA": "Transition.1",
+        "name": "Fade to Black",
+        "metadata": {},
+        "transition_type": DISSOLVE,
+        "in_offset": _rational(rate, frames),
+        "out_offset": _rational(rate, 0),
+    }
+
+
+def transitions(document: Document) -> list[dict[str, Any]]:
+    """Every transition in a document, as ``{track, kind, in_offset}`` — the read-back.
+
+    ``track`` is named by the same helper :func:`inject` records with, and ``in_offset`` is
+    in timeline frames, because both are compared against what ``inject`` asked for.
+    """
+    rate = _timeline_rate(document)
+    found = []
+    for track in (document.get("tracks") or {}).get("children") or []:
+        for item in track.get("children") or []:
+            if _is_transition(item):
+                found.append(
+                    {
+                        "track": _name(track),
+                        "kind": str(track.get("kind") or ""),
+                        "name": str(item.get("name") or ""),
+                        "in_offset": _at_rate(item.get("in_offset"), rate),
+                    }
+                )
+    return found
+
+
+def _rational(rate: float, value: int) -> dict[str, Any]:
+    return {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": value}
+
+
+def _is_clip(item: Item) -> bool:
+    return str(item.get("OTIO_SCHEMA", "")).startswith("Clip.")
+
+
+def _is_transition(item: Item) -> bool:
+    return str(item.get("OTIO_SCHEMA", "")).startswith("Transition.")
+
+
+def _duration(item: Item) -> dict[str, Any]:
+    duration: dict[str, Any] = ((item.get("source_range") or {}).get("duration")) or {}
+    return duration
+
+
+def _frames(item: Item, rate: float) -> int:
+    """One item's duration in whole timeline frames."""
+    return _at_rate(_duration(item), rate)
+
+
+def _rate(item: Item) -> float:
+    try:
+        return float(_duration(item).get("rate") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _timeline_rate(document: Document) -> float:
+    """The rate the *timeline* counts in, or 0.0 when the document does not say.
+
+    Every frame count a tail carries — ``duration_frames``, ``audio_fade_frames`` — is in
+    the timeline's rate, because that is the rate the cut file counts in and the rate E12
+    validated them against. OTIO stamps each clip's ``source_range`` in its own *media*
+    rate instead, so on a mixed-rate multicam (an FX6 at 23.976 beside an A7IV at another
+    rate, the ordinary concert kit) the two units are not the same number of frames.
+
+    ``global_start_time`` is the OTIO timeline's own ``RationalTime``, and its rate is the
+    timeline's — the one number in the document that is not somebody's media. **Not yet
+    confirmed against a live mixed-rate export**; every rate in the documents seen so far is
+    the same rate, which is exactly why this cannot be told apart by looking at them.
+
+    Zero — a document that carries no start time — means "do not convert" rather than a
+    guess: the arithmetic then runs on the items' own numbers, as it did before it could ask.
+    """
+    time = document.get("global_start_time")
+    if not isinstance(time, dict):
+        return 0.0
+    try:
+        rate = float(time.get("rate") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+    return rate if rate > 0 else 0.0
+
+
+def _at_rate(time: Any, rate: float) -> int:
+    """A ``RationalTime`` as a whole number of frames at ``rate``, its own rate if that is 0."""
+    return round(_exact(time, rate))
+
+
+def _exact(time: Any, rate: float) -> float:
+    """The same reading, unrounded — what a sum has to be built out of. See :func:`_span`.
+
+    A rate this cannot read is not a reason to measure the item as nothing. Only ``value``
+    decides how long something is; the rate decides what unit that is in, and an unreadable
+    one means the value is taken as it comes — which is what this module did before it
+    converted between rates at all. Reading the two in one ``try`` would instead turn a
+    stray rate into a zero-length clip, a track measuring zero, and every fade on it
+    refused.
+    """
+    if not isinstance(time, dict):
+        return 0.0
+    try:
+        value = float(time.get("value") or 0)
+    except (TypeError, ValueError):
+        return 0.0
+    if rate <= 0:
+        return value
+    try:
+        own = float(time.get("rate") or 0.0)
+    except (TypeError, ValueError):
+        return value
+    return value * rate / own if own > 0 and own != rate else value
+
+
+__all__ = ["DISSOLVE", "Document", "Item", "Track", "inject", "transitions"]

--- a/src/resolve_mcp/cut/otio.py
+++ b/src/resolve_mcp/cut/otio.py
@@ -322,4 +322,4 @@ def _exact(time: Any, rate: float) -> float:
     return value * rate / own if own > 0 and own != rate else value
 
 
-__all__ = ["DISSOLVE", "Document", "Item", "Track", "inject", "transitions"]
+__all__ = ["Document", "inject", "transitions"]

--- a/src/resolve_mcp/cut/validate.py
+++ b/src/resolve_mcp/cut/validate.py
@@ -793,7 +793,7 @@ def _dissolve_errors(doc: dict[str, Any], tail: Tail, declared: dict[str, Any]) 
 def _overlay_dissolve_errors(doc: dict[str, Any], tail: Tail) -> list[Finding]:
     """The layers the dissolve has to agree with — the injector's own precondition, as a rule.
 
-    :mod:`resolve_mcp.resolve.tail` fades *every* video track whose picture reaches the end
+    :mod:`resolve_mcp.cut.otio` fades *every* video track whose picture reaches the end
     of the cut, and refuses outright when a track stops somewhere inside the dissolve: it is
     opaque over part of the ramp and then gone, so the picture underneath comes back partway
     through a fade to black. Both of those are answerable from the cut file, and so they are
@@ -852,7 +852,7 @@ def _overlay_dissolve_errors(doc: dict[str, Any], tail: Tail) -> list[Finding]:
 def _video_ends(doc: dict[str, Any]) -> dict[int, tuple[int, str, int]]:
     """Each video track to ``(where its picture stops, what ends it, how long that runs)``.
 
-    The same measurement :mod:`resolve_mcp.resolve.tail` makes on the exported document, made
+    The same measurement :mod:`resolve_mcp.cut.otio` makes on the exported document, made
     here on the cut file instead: a track's picture stops at the end of its last *clip*, so
     the trailing black Resolve pads every exported track with is not part of the answer —
     and neither is a gap the cut file itself authored at the end of V1.

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -233,16 +233,19 @@ def build_timeline(
         # staging one would be alternates for a cut that is about to be deleted. ``_verify``
         # goes with it: the timeline checked above is the staging one, and the cut that
         # ships is the one the import made out of it.
-        built, applied = tail_route.materialise(
-            connection,
-            project,
-            pool,
-            built,
-            writing,
-            name,
-            tail,
-            verify=lambda landed: _verify(reader, landed, shots, name, origin),
+        landed = tail_route.materialise(
+            connection, tail_route.Staging(project, pool, built, writing), name, tail
         )
+        # The import is checked here, by the same read-back the staging cut got, and the
+        # staging timeline is released only once it passes. Until ``release`` is called the
+        # fallback is still standing, which is what makes a refusal survivable: the shots
+        # stay somewhere a human can find them.
+        try:
+            _verify(reader, landed.timeline, shots, name, origin)
+        except BuildFailedError as exc:
+            raise landed.refuse(f"the round trip moved the shots: {exc.cause}") from exc
+        landed.release()
+        built, applied = landed.timeline, landed.applied
         if stated is not None:
             # The import is a different timeline and Resolve creates it at the project's
             # default like any other, so the staging timeline's setting does not travel with

--- a/src/resolve_mcp/resolve/tail.py
+++ b/src/resolve_mcp/resolve/tail.py
@@ -1,13 +1,15 @@
-"""Materialising a cut's tail: the dissolve to black and the fade under it.
+"""The tail's round trip: export the built cut, edit it, import it back, keep the fallback.
 
 The scripting API cannot cut a transition. That is not a gap in this server's knowledge of
 it — it was probed live on Resolve 21.0.3 and there is nothing: ``Timeline`` has no
 transition call at all, ``TimelineItem`` exposes ``SetProperty`` for a *static* ``Opacity``
 and nothing whatsoever for audio level. So the tail is built the only way it can be, on the
 route :mod:`resolve_mcp.resolve.interchange` exists for — export the built cut as OTIO,
-edit the transitions into the document, import it back.
+edit the transitions into the document, import it back. The edit itself is document surgery
+with no Resolve in it and lives in :mod:`resolve_mcp.cut.otio`; this module owns everything
+that touches the project.
 
-Three things are decisions rather than mechanics:
+Two things are decisions rather than mechanics:
 
 * **The document is edited, and then the cut is read back to see whether the edit took.**
   An OTIO transition is not an item with a duration; it sits *between* two children of a
@@ -17,26 +19,24 @@ Three things are decisions rather than mechanics:
   deleted. Resolve renames what it accepts (``Fade to Black`` comes back as
   ``Cross Dissolve`` on video and ``Cross Fade 0 dB`` on audio), so the check counts
   transitions and never trusts a name.
-* **The fade goes after the last shot, not after the last child.** Resolve pads every
-  exported track with a trailing ``Gap`` out to the length of the *timeline*, so a concert
-  cut — whose mix is authored to outlive the picture, as all five surveyed deliverables do
-  — exports a V1 that ends in black (verified live, 21.0.3: a 480-frame picture under a
-  520-frame mix exported V1 as three clips and a 40-frame gap). A transition appended to
-  the end of that track would dissolve black into black. Nothing is appended *after* the
-  picture either: black at the end of a cut is the cut file's own gap, subject to W8 like
-  any other, and adding one here would be this module inventing record time.
-* **The staging timeline is deleted only once the import has landed.** Until then it is the
-  only copy of the cut, and a build that loses the round trip has to leave the shots
-  somewhere a human can find them.
+* **The staging timeline is deleted only once the import has landed *and* the caller is
+  satisfied with it.** Until then it is the only copy of the cut, and a build that loses
+  the round trip has to leave the shots somewhere a human can find them. That is why
+  :func:`materialise` hands back a :class:`Landed` rather than a bare timeline: it is the
+  imported cut *plus* the two things that can still be done about it — released, once the
+  caller has checked it, or refused, which takes the import down and leaves staging
+  standing. The caller cannot get the cut without also holding the choice.
 """
 
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Final
 
+from ..cut.otio import Document, inject, transitions
 from ..cut.tail import Tail
 from ..errors import (
     BuildFailedError,
@@ -51,15 +51,9 @@ from .timeline import find_timeline, next_free_name
 
 log = get_logger("build")
 
-Document = dict[str, Any]
-Track = dict[str, Any]
-Item = dict[str, Any]
 Pool = Any
 Project = Any
 Timeline = Any
-
-DISSOLVE: Final = "SMPTE_Dissolve"
-"""The only transition type in play: a fade to black is a dissolve into nothing."""
 
 STAGING_SUFFIX: Final = " (tail staging)"
 """What the pre-transition timeline is called, so a lost round trip leaves a named cut."""
@@ -81,317 +75,69 @@ def staging_name(name: str, existing: Iterable[str] = ()) -> str:
     return next_free_name(f"{name}{STAGING_SUFFIX}", set(existing))
 
 
-# --- the document edit ----------------------------------------------------------------------
+@dataclass(frozen=True)
+class Staging:
+    """Where the shots are until the round trip lands: one cut, and how to reach it again.
 
-
-def inject(document: Document, tail: Tail) -> dict[str, Any]:
-    """Edit ``tail`` into an exported OTIO document. Returns what was put where.
-
-    The dissolve goes on every video track that reaches the end of the cut, which on an
-    ordinary concert build is V1 alone: an overlay that stopped earlier has nothing to do
-    with how the picture leaves, and fading it would be a second device nobody asked for.
-    The audio fade goes on every audio track's last clip, because the master mix is the only
-    thing this pillar puts there.
-
-    Also returned is what did *not* get one where one was needed — ``unfaded_video`` and
-    ``unfaded_audio``. A per-track refusal is invisible in the totals: a document where V1
-    faded and an opaque V2 did not still reports a dissolve, and the picture then pops back
-    out of black the frame the overlay ends. The caller refuses on either list rather than
-    delivering half a device.
+    Carried as one value rather than four parameters because they are one fact — the
+    fallback — and every failure in this module says the same thing about it: the cut is
+    still there, under this name, in this project.
     """
-    video: list[str] = []
-    audio: list[str] = []
-    unfaded_video: list[str] = []
-    unfaded_audio: list[str] = []
-    rate = _timeline_rate(document)
-    if tail.dissolves:
-        ending = _tracks(document, "Video", last_only=True, rate=rate)
-        for track in ending:
-            placed = video if _append_transition(track, rate, tail.frames) else unfaded_video
-            placed.append(_name(track))
-        unfaded_video.extend(_name(track) for track in _inside(document, tail, ending, rate))
-    if tail.fades_audio:
-        for track in _tracks(document, "Audio", last_only=False, rate=rate):
-            placed = audio if _append_transition(track, rate, tail.audio_frames) else unfaded_audio
-            placed.append(_name(track))
-    return {
-        "video_tracks": video,
-        "audio_tracks": audio,
-        "unfaded_video": unfaded_video,
-        "unfaded_audio": unfaded_audio,
-    }
+
+    project: Project
+    pool: Pool
+    timeline: Timeline
+    name: str
 
 
-def _name(track: Track) -> str:
-    """What a track is called on *both* sides of the round trip — one vocabulary, not two.
+@dataclass(frozen=True)
+class Landed:
+    """The imported cut, with the staging timeline still standing behind it.
 
-    An OTIO track need not carry a name, and :func:`inject` and :func:`transitions` are
-    compared to each other, by name, in ``_confirm``. A fallback invented separately on each
-    side is therefore not a cosmetic difference: an unnamed track would have its dissolve
-    recorded under one word and read back under another, so every such build would refuse a
-    tail that landed perfectly — and take a correct import down with it on the way out.
+    The invariant this type exists to carry is *check before delete*: the cut the round trip
+    delivers is a different timeline from the one the build appended to and checked, so the
+    one that ships is the one nobody has looked at yet. Until somebody does, staging is the
+    only copy worth keeping.
+
+    So this is not a timeline — it is a timeline plus the two things still to be done about
+    it. :meth:`release` says the caller has read the import back and is keeping it, and
+    drops staging. :meth:`refuse` says the caller found something wrong, and takes the
+    import down instead. Doing neither leaves both timelines in the project, which is the
+    safe end of the failure and not silently the wrong one.
     """
-    return str(track.get("name") or "") or str(track.get("kind") or "").lower()
 
+    timeline: Timeline
+    applied: dict[str, Any]
+    staging: Staging
+    name: str
 
-def _inside(document: Document, tail: Tail, ending: list[Track], rate: float) -> list[Track]:
-    """Video tracks whose picture stops *inside* the dissolve, which nothing here fades.
+    def release(self) -> None:
+        """Keep the import: drop the staging timeline. Best effort — see :func:`_delete_staging`."""
+        _delete_staging(self.staging)
 
-    Such a track is opaque over part of the ramp and then ends, so the picture underneath
-    comes back partway through a fade to black — a visible second ending. It is not a track
-    to fade either: the dissolve reaches back into the shot that ends the cut, and one
-    starting where an overlay happens to stop would be a device nobody asked for. So it is
-    reported, and the build refuses rather than delivering a tail with a hole in it.
-    """
-    others = [
-        track
-        for track in _tracks(document, "Video", last_only=False, rate=rate)
-        if not any(track is one for one in ending)
-    ]
-    furthest = max((_span(track, rate) for track in ending), default=0)
-    return [track for track in others if furthest - tail.frames < _span(track, rate) < furthest]
+    def refuse(self, why: str) -> BuildFailedError:
+        """Reject the import: take it down if Resolve will, and return the build's refusal.
 
-
-def _tracks(document: Document, kind: str, last_only: bool, rate: float) -> list[Track]:
-    """The tracks of one kind a transition belongs on, in document order.
-
-    ``last_only`` keeps the video dissolve to the layer the cut actually ends on. Ties are
-    kept, not broken: two video tracks both running to the last frame are both the end of
-    the picture, and fading one of them would leave the other opaque over black.
-    """
-    found = [
-        track
-        for track in ((document.get("tracks") or {}).get("children") or [])
-        if track.get("kind") == kind and _clips(track)
-    ]
-    if not last_only or not found:
-        return found
-    furthest = max(_span(track, rate) for track in found)
-    return [track for track in found if _span(track, rate) == furthest]
-
-
-def _clips(track: Track) -> list[Item]:
-    return [item for item in (track.get("children") or []) if _is_clip(item)]
-
-
-def _last_clip(track: Track) -> int:
-    """Where the last clip on this track sits among its children, or -1 if there is none.
-
-    Not simply the last child. Resolve pads every track it exports with a trailing ``Gap``
-    out to the length of the *timeline*, so a concert cut — whose mix is authored to outlive
-    the picture, as all five surveyed deliverables do — exports a V1 that ends in black
-    rather than in a shot (verified live, 21.0.3). A fade appended after that gap would
-    dissolve black into black.
-    """
-    children = list(track.get("children") or [])
-    for index in range(len(children) - 1, -1, -1):
-        if _is_clip(children[index]):
-            return index
-    return -1
-
-
-def _span(track: Track, rate: float) -> int:
-    """Where the *picture* on this track stops — trailing black is not part of the answer.
-
-    Measured to the end of the last clip rather than to the end of the track, for the same
-    reason: Resolve pads every track out to the timeline's length, so track length is the
-    one number that cannot tell the layer the cut ends on from a layer that stopped early.
-
-    In *timeline* frames, which is what makes the answer comparable across tracks at all: a
-    mixed-rate multicam stack carries a different media rate per clip, and summing the raw
-    numbers would measure two layers in two units and call the shorter one the end.
-
-    Summed unrounded and rounded once, because this is a sum and the comparison it feeds is
-    an equality. Rounding per clip spends up to half a frame each time, so a forty-shot V1
-    can come out two frames short of an overlay that ends on the very same frame — which
-    drops V1 out of the ending layers, straight into the window ``_inside`` refuses, and the
-    build then fails a correct mixed-rate cut with the shots already on a staging timeline.
-    """
-    children = list(track.get("children") or [])
-    last = _last_clip(track)
-    return round(
-        sum(
-            _exact(_duration(item), rate)
-            for item in children[: last + 1]
-            if not _is_transition(item)
-        )
-    )
-
-
-def _append_transition(track: Track, rate: float, frames: int) -> bool:
-    """Put a fade at the end of the track's picture, or answer False and leave it alone.
-
-    The transition goes immediately after the last clip, which is a clip→gap boundary
-    whenever something outlives the picture — reaching ``frames`` back into the shot and
-    nothing forward, so it lands on black on the shot's own last frame.
-
-    Refused rather than trimmed when that clip is too short: the length was validated (E12)
-    against the cut file, so a document that cannot carry it means the built timeline
-    disagrees with the cut, and quietly shortening the device would hide that.
-
-    Both numbers are timeline frames. ``frames`` comes from the cut file, which counts in
-    the timeline's rate; the clip's own duration is stamped in its *media* rate, so on a
-    mixed-rate multicam the raw comparison asks whether a 23.976 count fits inside a 25
-    one — and answers "the shot is too short to fade" about a shot that is not.
-    """
-    children = list(track.get("children") or [])
-    index = _last_clip(track)
-    if index < 0 or _frames(children[index], rate) <= frames:
-        return False
-    children.insert(index + 1, _transition(rate or _rate(children[index]), frames))
-    track["children"] = children
-    return True
-
-
-def _transition(rate: float, frames: int) -> Item:
-    """A dissolve reaching ``frames`` back into what precedes it and nothing forward.
-
-    ``out_offset`` of zero is what makes it a fade *out* rather than a cross: there is
-    nothing after it to reach into, and black is the absence of the frames it gives up.
-    """
-    return {
-        "OTIO_SCHEMA": "Transition.1",
-        "name": "Fade to Black",
-        "metadata": {},
-        "transition_type": DISSOLVE,
-        "in_offset": _rational(rate, frames),
-        "out_offset": _rational(rate, 0),
-    }
-
-
-def transitions(document: Document) -> list[dict[str, Any]]:
-    """Every transition in a document, as ``{track, kind, in_offset}`` — the read-back.
-
-    ``track`` is named by the same helper :func:`inject` records with, and ``in_offset`` is
-    in timeline frames, because both are compared against what ``inject`` asked for.
-    """
-    rate = _timeline_rate(document)
-    found = []
-    for track in (document.get("tracks") or {}).get("children") or []:
-        for item in track.get("children") or []:
-            if _is_transition(item):
-                found.append(
-                    {
-                        "track": _name(track),
-                        "kind": str(track.get("kind") or ""),
-                        "name": str(item.get("name") or ""),
-                        "in_offset": _at_rate(item.get("in_offset"), rate),
-                    }
-                )
-    return found
-
-
-def _rational(rate: float, value: int) -> dict[str, Any]:
-    return {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": value}
-
-
-def _is_clip(item: Item) -> bool:
-    return str(item.get("OTIO_SCHEMA", "")).startswith("Clip.")
-
-
-def _is_transition(item: Item) -> bool:
-    return str(item.get("OTIO_SCHEMA", "")).startswith("Transition.")
-
-
-def _duration(item: Item) -> dict[str, Any]:
-    duration: dict[str, Any] = ((item.get("source_range") or {}).get("duration")) or {}
-    return duration
-
-
-def _frames(item: Item, rate: float) -> int:
-    """One item's duration in whole timeline frames."""
-    return _at_rate(_duration(item), rate)
-
-
-def _rate(item: Item) -> float:
-    try:
-        return float(_duration(item).get("rate") or 0.0)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def _timeline_rate(document: Document) -> float:
-    """The rate the *timeline* counts in, or 0.0 when the document does not say.
-
-    Every frame count a tail carries — ``duration_frames``, ``audio_fade_frames`` — is in
-    the timeline's rate, because that is the rate the cut file counts in and the rate E12
-    validated them against. OTIO stamps each clip's ``source_range`` in its own *media*
-    rate instead, so on a mixed-rate multicam (an FX6 at 23.976 beside an A7IV at another
-    rate, the ordinary concert kit) the two units are not the same number of frames.
-
-    ``global_start_time`` is the OTIO timeline's own ``RationalTime``, and its rate is the
-    timeline's — the one number in the document that is not somebody's media. **Not yet
-    confirmed against a live mixed-rate export**; every rate in the documents seen so far is
-    the same rate, which is exactly why this cannot be told apart by looking at them.
-
-    Zero — a document that carries no start time — means "do not convert" rather than a
-    guess: the arithmetic then runs on the items' own numbers, as it did before it could ask.
-    """
-    time = document.get("global_start_time")
-    if not isinstance(time, dict):
-        return 0.0
-    try:
-        rate = float(time.get("rate") or 0.0)
-    except (TypeError, ValueError):
-        return 0.0
-    return rate if rate > 0 else 0.0
-
-
-def _at_rate(time: Any, rate: float) -> int:
-    """A ``RationalTime`` as a whole number of frames at ``rate``, its own rate if that is 0."""
-    return round(_exact(time, rate))
-
-
-def _exact(time: Any, rate: float) -> float:
-    """The same reading, unrounded — what a sum has to be built out of. See :func:`_span`.
-
-    A rate this cannot read is not a reason to measure the item as nothing. Only ``value``
-    decides how long something is; the rate decides what unit that is in, and an unreadable
-    one means the value is taken as it comes — which is what this module did before it
-    converted between rates at all. Reading the two in one ``try`` would instead turn a
-    stray rate into a zero-length clip, a track measuring zero, and every fade on it
-    refused.
-    """
-    if not isinstance(time, dict):
-        return 0.0
-    try:
-        value = float(time.get("value") or 0)
-    except (TypeError, ValueError):
-        return 0.0
-    if rate <= 0:
-        return value
-    try:
-        own = float(time.get("rate") or 0.0)
-    except (TypeError, ValueError):
-        return value
-    return value * rate / own if own > 0 and own != rate else value
-
-
-# --- the round trip -------------------------------------------------------------------------
+        Returned rather than raised so the caller raises it from its own ``except`` and keeps
+        the original failure as the cause.
+        """
+        return _failed_import(self.staging, self.name, self.name, why)
 
 
 def materialise(
     connection: ResolveConnection,
-    project: Project,
-    pool: Pool,
-    staging: Timeline,
-    staging_timeline: str,
+    staging: Staging,
     name: str,
     tail: Tail,
-    verify: Callable[[Timeline], None] | None = None,
-) -> tuple[Timeline, dict[str, Any]]:
-    """Round-trip ``staging_timeline`` into ``name`` with the tail edited in.
+) -> Landed:
+    """Round-trip ``staging`` into ``name`` with the tail edited in.
 
-    Returns the timeline the rest of the build works on — the imported one — and what
-    landed. Every failure here is a :class:`BuildFailedError` naming the staging timeline,
-    because the shots are on it and a caller told only "the export failed" has no way to
-    know its cut still exists — and, once the import has landed, naming the imported one
-    too unless Resolve let it be deleted.
-
-    ``verify`` is the caller's own read-back of where the shots are, run here rather than
-    by the caller so it happens on the *imported* timeline while the staging one is still
-    the fallback: the cut the build checked and the cut it delivers are two different
-    timelines, and the one nobody checked is the one that ships.
+    Returns the imported cut and what landed, as a :class:`Landed` the caller has to
+    release or refuse — staging is untouched until it does. Every failure here is a
+    :class:`BuildFailedError` naming the staging timeline, because the shots are on it and a
+    caller told only "the export failed" has no way to know its cut still exists — and,
+    once the import has landed, naming the imported one too unless Resolve let it be
+    deleted.
     """
     # No path: the export lands, timestamped, in the interchange directory every other
     # export goes to. Two reasons it is not a temp file. Resolve holds what it exported open
@@ -400,31 +146,29 @@ def materialise(
     # the evidence for what a tail did, so it belongs where a human already looks for
     # exports rather than in a temp directory nobody would think to open.
     try:
-        exported = export_timeline(connection, name=staging_timeline, export_format="otio")
+        exported = export_timeline(connection, name=staging.name, export_format="otio")
     except (TimelineExportFailedError, TimelineImportFailedError) as exc:
-        raise _lost(
-            staging_timeline, name, f"it could not be exported as OTIO: {exc.cause}"
-        ) from exc
+        raise _lost(staging, name, f"it could not be exported as OTIO: {exc.cause}") from exc
 
-    document = _load(Path(exported["path"]), staging_timeline, name)
+    document = _load(Path(exported["path"]), staging, name)
     placed = inject(document, tail)
     if tail.dissolves and not placed["video_tracks"]:
         raise _lost(
-            staging_timeline,
+            staging,
             name,
             f"no video track in the exported document ends on a shot longer than the "
             f"{tail.frames}-frame dissolve",
         )
     if tail.fades_audio and not placed["audio_tracks"]:
         raise _lost(
-            staging_timeline,
+            staging,
             name,
             f"no audio track in the exported document ends on a clip longer than the "
             f"{tail.audio_frames}-frame fade",
         )
     if placed["unfaded_video"]:
         raise _lost(
-            staging_timeline,
+            staging,
             name,
             f"{_listed(placed['unfaded_video'])} would stay opaque over part of the "
             f"{tail.frames}-frame dissolve, so the picture would come back out of black "
@@ -432,7 +176,7 @@ def materialise(
         )
     if placed["unfaded_audio"]:
         raise _lost(
-            staging_timeline,
+            staging,
             name,
             f"{_listed(placed['unfaded_audio'])} took no fade while "
             f"{_listed(placed['audio_tracks'])} did, so the mix would end on a cut",
@@ -446,15 +190,13 @@ def materialise(
         edited.write_text(json.dumps(document, indent=1), encoding="utf-8")
     except OSError as exc:
         raise _lost(
-            staging_timeline, name, f"the edited document could not be written to {edited}: {exc}"
+            staging, name, f"the edited document could not be written to {edited}: {exc}"
         ) from exc
 
     try:
         imported = import_timeline(connection, path=str(edited), name=name)
     except (TimelineExportFailedError, TimelineImportFailedError) as exc:
-        raise _lost(
-            staging_timeline, name, f"the edited document would not import: {exc.cause}"
-        ) from exc
+        raise _lost(staging, name, f"the edited document would not import: {exc.cause}") from exc
 
     landed = str(imported["timeline"]["name"])
     if landed != name:
@@ -463,10 +205,7 @@ def materialise(
         # holds ``name`` gets the dodge rather than a collision. Either way the cut under a
         # name nobody asked for is not the delivery, and it is not left standing.
         raise _failed_import(
-            pool,
-            project,
             staging,
-            staging_timeline,
             name,
             landed,
             f"the import landed as {landed!r} rather than {name!r} — either the project "
@@ -474,35 +213,21 @@ def materialise(
         )
 
     try:
-        built = find_timeline(project, landed)
+        built = find_timeline(staging.project, landed)
     except TimelineNotFoundError as exc:
         raise _lost(
-            staging_timeline,
+            staging,
             name,
             f"Resolve reported importing {landed!r} and the project holds no timeline of "
             "that name",
         ) from exc
-    project.SetCurrentTimeline(built)
-    # Both checks run before the staging timeline is deleted, because until the tail is
-    # confirmed and the shots are re-read on the imported cut, the staging one is still the
-    # only copy worth keeping.
+    staging.project.SetCurrentTimeline(built)
+    # This module's own check, on its own device, before it hands anything back. The
+    # caller's check of where the shots landed is the other half, and it runs on the value
+    # returned here — with staging still standing, because nothing below deletes it.
     confirmed, refused = _confirm(connection, landed, placed, tail)
     if refused is not None:
-        raise _failed_import(pool, project, staging, staging_timeline, name, landed, refused)
-    if verify is not None:
-        try:
-            verify(built)
-        except BuildFailedError as exc:
-            raise _failed_import(
-                pool,
-                project,
-                staging,
-                staging_timeline,
-                name,
-                landed,
-                f"the round trip moved the shots: {exc.cause}",
-            ) from exc
-    _delete_staging(pool, project, staging, staging_timeline)
+        raise _failed_import(staging, name, landed, refused)
     log.info(
         "Tail on %s: %s dissolve over %s, audio fade over %s",
         landed,
@@ -510,14 +235,19 @@ def materialise(
         ", ".join(placed["video_tracks"]) or "nothing",
         ", ".join(placed["audio_tracks"]) or "nothing",
     )
-    return built, {
-        **tail.as_dict(),
-        "video_tracks": placed["video_tracks"],
-        "audio_tracks": placed["audio_tracks"],
-        "route": "otio_round_trip",
-        "document": str(edited),
-        "confirmed": confirmed,
-    }
+    return Landed(
+        timeline=built,
+        applied={
+            **tail.as_dict(),
+            "video_tracks": placed["video_tracks"],
+            "audio_tracks": placed["audio_tracks"],
+            "route": "otio_round_trip",
+            "document": str(edited),
+            "confirmed": confirmed,
+        },
+        staging=staging,
+        name=name,
+    )
 
 
 def _listed(names: list[str]) -> str:
@@ -598,10 +328,7 @@ def _confirm(
 
 
 def _failed_import(
-    pool: Pool,
-    project: Project,
-    staging: Timeline,
-    staging_timeline: str,
+    staging: Staging,
     name: str,
     landed: str,
     why: str,
@@ -613,11 +340,11 @@ def _failed_import(
     with a failed import sitting there under that very name. When Resolve refuses the
     delete, the error names both timelines instead, because then renaming is not the advice.
     """
-    kept = None if _discard_import(pool, project, staging, landed) else landed
-    return _lost(staging_timeline, name, why, orphan=kept)
+    kept = None if _discard_import(staging, landed) else landed
+    return _lost(staging, name, why, orphan=kept)
 
 
-def _discard_import(pool: Pool, project: Project, staging: Timeline, landed: str) -> bool:
+def _discard_import(staging: Staging, landed: str) -> bool:
     """Best effort: the failure being reported must not be replaced by one from cleaning up.
 
     The current timeline is moved back to the staging cut first. Resolve will not delete the
@@ -625,8 +352,8 @@ def _discard_import(pool: Pool, project: Project, staging: Timeline, landed: str
     discarded is the one this build just switched to.
     """
     try:
-        project.SetCurrentTimeline(staging)
-        deleted = bool(pool.DeleteTimelines([find_timeline(project, landed)]))
+        staging.project.SetCurrentTimeline(staging.timeline)
+        deleted = bool(staging.pool.DeleteTimelines([find_timeline(staging.project, landed)]))
     except Exception:  # noqa: BLE001 - a refusal here only changes what the error says
         log.warning("Deleting the failed import %s raised", landed, exc_info=True)
         return False
@@ -637,41 +364,39 @@ def _discard_import(pool: Pool, project: Project, staging: Timeline, landed: str
     return deleted
 
 
-def _load(path: Path, staging_timeline: str, name: str) -> Document:
+def _load(path: Path, staging: Staging, name: str) -> Document:
     try:
         document: Document = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
-        raise _lost(
-            staging_timeline, name, f"its OTIO export could not be read back: {exc}"
-        ) from exc
+        raise _lost(staging, name, f"its OTIO export could not be read back: {exc}") from exc
     if not isinstance(document, dict):
-        raise _lost(staging_timeline, name, "its OTIO export is not a document")
+        raise _lost(staging, name, "its OTIO export is not a document")
     return document
 
 
-def _delete_staging(pool: Pool, project: Project, staging: Timeline, staging_timeline: str) -> None:
+def _delete_staging(staging: Staging) -> None:
     """Best effort, and after the import: a staging timeline left behind is a tidiness bug.
 
     A build that has its cut under the right name has succeeded; failing it over a timeline
     Resolve would not delete would throw away a good build to report housekeeping.
     """
     try:
-        deleted = bool(pool.DeleteTimelines([staging]))
+        deleted = bool(staging.pool.DeleteTimelines([staging.timeline]))
     except Exception:  # noqa: BLE001 - a refusal here must not fail a landed build
-        log.warning("Deleting the staging timeline %s raised", staging_timeline, exc_info=True)
+        log.warning("Deleting the staging timeline %s raised", staging.name, exc_info=True)
         return
     if deleted:
-        log.info("Deleted the staging timeline %s", staging_timeline)
+        log.info("Deleted the staging timeline %s", staging.name)
     else:
         log.warning(
             "Resolve would not delete the staging timeline %s; it is still in %s",
-            staging_timeline,
-            project.GetName(),
+            staging.name,
+            staging.project.GetName(),
         )
 
 
 def _lost(
-    staging_timeline: str,
+    staging: Staging,
     name: str,
     why: str,
     orphan: str | None = None,
@@ -686,18 +411,18 @@ def _lost(
         return BuildFailedError(
             cause=(
                 f"The cut was built but its tail could not be placed, because {why}. Two "
-                f"timelines are left: {staging_timeline!r}, which holds the whole cut with "
+                f"timelines are left: {staging.name!r}, which holds the whole cut with "
                 f"a hard cut where its tail should be, and {orphan!r}, the import that "
                 f"could not be used and that Resolve would not delete. Nothing was "
                 f"delivered as {name!r}."
             ),
             fix=(
-                f"Delete {orphan!r} by hand, then either rename {staging_timeline!r} into "
+                f"Delete {orphan!r} by hand, then either rename {staging.name!r} into "
                 f"{name!r} if a hard out will do, or delete it and build again."
             ),
             detail={
                 "timeline": name,
-                "staging_timeline": staging_timeline,
+                "staging_timeline": staging.name,
                 "imported_timeline": orphan,
             },
         )
@@ -707,12 +432,12 @@ def _lost(
             f"was delivered as {name!r}."
         ),
         fix=(
-            f"The shots are on {staging_timeline!r}, which holds the whole cut with a hard "
+            f"The shots are on {staging.name!r}, which holds the whole cut with a hard "
             f"cut where its tail should be. Rename it by hand if that will do, or delete it "
             f"and build again."
         ),
-        detail={"timeline": name, "staging_timeline": staging_timeline},
+        detail={"timeline": name, "staging_timeline": staging.name},
     )
 
 
-__all__ = ["inject", "materialise", "staging_name", "transitions"]
+__all__ = ["Landed", "Staging", "materialise", "staging_name"]

--- a/src/resolve_mcp/resolve/tail.py
+++ b/src/resolve_mcp/resolve/tail.py
@@ -112,7 +112,12 @@ class Landed:
     name: str
 
     def release(self) -> None:
-        """Keep the import: drop the staging timeline. Best effort — see :func:`_delete_staging`."""
+        """Keep the import: drop the staging timeline. Best effort — see :func:`_delete_staging`.
+
+        The line it logs is the one that says a tail *landed*, because this is the moment the
+        cut stopped having a fallback. Everything before it is provisional.
+        """
+        log.info("Kept %s: its caller read the shots back on the cut the import made", self.name)
         _delete_staging(self.staging)
 
     def refuse(self, why: str) -> BuildFailedError:
@@ -228,8 +233,14 @@ def materialise(
     confirmed, refused = _confirm(connection, landed, placed, tail)
     if refused is not None:
         raise _failed_import(staging, name, landed, refused)
+    # "Written", not "landed": the caller has still to read its shots back on this timeline,
+    # and it may yet refuse it. A line claiming the tail here would leave a log where a
+    # failed build reads as a successful one right up to the refusal two lines later — and a
+    # live failure outside this session is diagnosed from the log or not at all. What the
+    # build committed to is recorded by ``_delete_staging`` when the caller releases.
     log.info(
-        "Tail on %s: %s dissolve over %s, audio fade over %s",
+        "Tail written into %s, pending its caller's check: %s dissolve over %s, audio fade "
+        "over %s",
         landed,
         tail.kind,
         ", ".join(placed["video_tracks"]) or "nothing",

--- a/tests/test_cut_otio.py
+++ b/tests/test_cut_otio.py
@@ -1,0 +1,275 @@
+"""The document edit: what a tail puts into an exported OTIO, and what it reads back.
+
+Plain dicts, no fakes and no Resolve. :mod:`resolve_mcp.cut.otio` is pure document surgery
+— which track the picture ends on, whether the last shot is long enough to fade, what a
+transition is in frames — so every decision it makes is answerable with a document alone.
+The round trip that carries these documents to Resolve and back is the other half, and its
+tests are in ``test_cut_tail.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from resolve_mcp.cut import otio as cut_otio
+from resolve_mcp.cut import tail as tail_device
+
+
+def document(*tracks: dict[str, Any], rate: float | None = None) -> dict[str, Any]:
+    """An exported cut. ``rate`` is the timeline's own, where Resolve puts it: the start time."""
+    doc: dict[str, Any] = {"OTIO_SCHEMA": "Timeline.1", "tracks": {"children": list(tracks)}}
+    if rate is not None:
+        doc["global_start_time"] = {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": 0}
+    return doc
+
+
+def track(kind: str, name: str, *frames: int, rate: float = 24.0) -> dict[str, Any]:
+    """One track. ``rate`` is the *media* rate its clips are stamped in, as OTIO stamps them."""
+    return {
+        "OTIO_SCHEMA": "Track.1",
+        "kind": kind,
+        "name": name,
+        "children": [
+            {
+                "OTIO_SCHEMA": "Clip.2",
+                "name": f"{name}-{index}",
+                "source_range": {
+                    "duration": {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": length}
+                },
+            }
+            for index, length in enumerate(frames)
+        ],
+    }
+
+
+def unnamed(one: dict[str, Any]) -> dict[str, Any]:
+    """A track OTIO left without a name — nothing in the format promises one."""
+    one.pop("name", None)
+    return one
+
+
+def pad(one: dict[str, Any], frames: int) -> dict[str, Any]:
+    """The trailing black Resolve pads a short track with, out to the timeline's length."""
+    one["children"].append(
+        {
+            "OTIO_SCHEMA": "Gap.1",
+            "name": "",
+            "source_range": {
+                "duration": {"OTIO_SCHEMA": "RationalTime.1", "rate": 24.0, "value": frames}
+            },
+        }
+    )
+    return one
+
+
+def kinds(doc: dict[str, Any]) -> list[tuple[str, int]]:
+    return [(item["kind"], item["in_offset"]) for item in cut_otio.transitions(doc)]
+
+
+def test_the_dissolve_goes_on_the_video_track_and_the_fade_on_the_audio() -> None:
+    doc = document(track("Video", "Video 1", 100, 80), track("Audio", "Audio 1", 180))
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 40, 30))
+
+    assert placed == {
+        "video_tracks": ["Video 1"],
+        "audio_tracks": ["Audio 1"],
+        "unfaded_video": [],
+        "unfaded_audio": [],
+    }
+    assert kinds(doc) == [("Video", 40), ("Audio", 30)]
+
+
+def test_the_transition_ends_the_track_and_appends_no_black_after_it() -> None:
+    """A trailing gap is the cut file's own device, and Resolve drops one on import anyway."""
+    doc = document(track("Video", "Video 1", 100))
+
+    cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
+
+    children = doc["tracks"]["children"][0]["children"]
+    assert [child["OTIO_SCHEMA"] for child in children] == ["Clip.2", "Transition.1"]
+
+
+def test_an_overlay_that_stopped_earlier_keeps_its_own_ending() -> None:
+    """V2 covering a seam in the middle has nothing to do with how the picture leaves."""
+    doc = document(track("Video", "Video 1", 100, 80), track("Video", "Video 2", 30))
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
+
+    assert placed["video_tracks"] == ["Video 1"]
+
+
+def test_a_hard_out_fades_only_the_mix() -> None:
+    doc = document(track("Video", "Video 1", 100), track("Audio", "Audio 1", 100))
+
+    placed = cut_otio.inject(doc, tail_device.Tail("hard_to_black", 0, 30))
+
+    assert placed == {
+        "video_tracks": [],
+        "audio_tracks": ["Audio 1"],
+        "unfaded_video": [],
+        "unfaded_audio": [],
+    }
+    assert kinds(doc) == [("Audio", 30)]
+
+
+def test_the_fade_goes_before_the_black_a_longer_mix_pads_in() -> None:
+    """The corpus shape: the mix outlives the picture, so Resolve exports V1 ending on a gap.
+
+    A transition appended to the end of *that* track would dissolve black into black — the
+    failure this case was found by, live, on the first build of the real ending.
+    """
+    doc = document(pad(track("Video", "Video 1", 120, 200), 40), track("Audio", "Audio 1", 360))
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 142, 0))
+
+    assert placed["video_tracks"] == ["Video 1"]
+    children = doc["tracks"]["children"][0]["children"]
+    assert [child["OTIO_SCHEMA"] for child in children] == [
+        "Clip.2",
+        "Clip.2",
+        "Transition.1",
+        "Gap.1",
+    ]
+
+
+def test_the_pad_does_not_make_a_short_overlay_look_like_the_end_of_the_picture() -> None:
+    """Every track is padded to the same length, so track length cannot pick the layer."""
+    doc = document(
+        pad(track("Video", "Video 1", 120, 200), 40),
+        pad(track("Video", "Video 2", 60), 300),
+    )
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 142, 0))
+
+    assert placed["video_tracks"] == ["Video 1"]
+
+
+def test_a_last_clip_too_short_takes_no_transition() -> None:
+    """Refused, never trimmed: a shortened device is a device the report would lie about."""
+    doc = document(track("Video", "Video 1", 100, 40))
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
+
+    assert placed["video_tracks"] == []
+    assert cut_otio.transitions(doc) == []
+
+
+def test_an_overlay_ending_inside_the_dissolve_is_reported_unfaded() -> None:
+    """Opaque over part of the ramp, so the picture under it comes back mid-fade."""
+    doc = document(track("Video", "Video 1", 100, 80), track("Video", "Video 2", 160))
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
+
+    assert placed["video_tracks"] == ["Video 1"]
+    assert placed["unfaded_video"] == ["Video 2"]
+
+
+def test_an_overlay_ending_before_the_dissolve_starts_is_not_reported() -> None:
+    """The device covers the frames it covers: a layer that is gone by then is not in it."""
+    doc = document(track("Video", "Video 1", 100, 80), track("Video", "Video 2", 100))
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
+
+    assert placed["unfaded_video"] == []
+
+
+def test_an_unnamed_track_is_recorded_and_read_back_under_the_same_name() -> None:
+    """One vocabulary for both sides, because ``_confirm`` matches them to each other by string.
+
+    A fallback invented separately in each direction is not cosmetic: the dissolve would be
+    recorded on ``'video'`` and read back on ``''``, so a tail that landed perfectly reads as
+    a fade on the wrong track — and the refusal deletes the correct import on its way out.
+    """
+    doc = document(unnamed(track("Video", "", 100, 80)), unnamed(track("Audio", "", 180)))
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 40, 30))
+
+    assert placed["video_tracks"] == ["video"]
+    assert placed["audio_tracks"] == ["audio"]
+    assert [one["track"] for one in cut_otio.transitions(doc)] == ["video", "audio"]
+
+
+def test_a_shot_at_another_media_rate_is_long_enough_for_the_dissolve() -> None:
+    """The cut counts in timeline frames; OTIO stamps each clip in its own media rate.
+
+    A mixed-rate multicam is the ordinary concert kit, and a 60-frame dissolve under an
+    80-frame shot is a legal cut — but the shot's own stamp says 40, so the raw comparison
+    refuses a build that is fine, after the shots are already on a staging timeline.
+    """
+    doc = document(track("Video", "Video 1", 50, 40, rate=12.0), rate=24.0)
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 60, 0))
+
+    assert placed["video_tracks"] == ["Video 1"]
+    assert placed["unfaded_video"] == []
+    # Stamped in the timeline's rate, so the number the read-back compares is the number
+    # the cut file asked for rather than the same count in a rate nobody asked about.
+    transition = doc["tracks"]["children"][0]["children"][2]
+    assert transition["in_offset"] == {"OTIO_SCHEMA": "RationalTime.1", "rate": 24.0, "value": 60}
+    assert kinds(doc) == [("Video", 60)]
+
+
+def test_the_layer_the_cut_ends_on_is_picked_in_timeline_frames() -> None:
+    """Two layers stamped in two rates are two units, and the raw numbers pick the wrong one."""
+    doc = document(
+        track("Video", "Video 1", 50, 40, rate=12.0),
+        pad(track("Video", "Video 2", 120, rate=24.0), 60),
+        rate=24.0,
+    )
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
+
+    # V1 runs 180 timeline frames and V2 120, so V1 ends the picture — even though V1's raw
+    # stamps sum to 90 and V2's to 120.
+    assert placed["video_tracks"] == ["Video 1"]
+    assert placed["unfaded_video"] == []
+
+
+def test_many_short_clips_at_another_rate_still_end_where_the_overlay_over_them_ends() -> None:
+    """A span is a sum, so it is rounded once — half a frame per clip is frames per song.
+
+    Twenty shots stamped at a rate the timeline does not count in come to 1008 frames
+    exactly; rounded one clip at a time they come to 1000, which is far enough back to drop
+    V1 out of the ending layers and into the window ``_inside`` refuses. The overlay ending
+    on the same frame is then the only layer left to fade, and the build refuses a correct
+    cut after the shots are already on a staging timeline.
+    """
+    doc = document(
+        track("Video", "Video 1", *([21] * 20), rate=10.0),
+        track("Video", "Video 2", 908, 100, rate=24.0),
+        rate=24.0,
+    )
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
+
+    assert placed["video_tracks"] == ["Video 1", "Video 2"]
+    assert placed["unfaded_video"] == []
+
+
+def test_a_rate_this_cannot_read_measures_the_clip_by_its_value() -> None:
+    """Only ``value`` says how long something is; an unreadable rate is not a zero-length clip.
+
+    Reading value and rate under one guard turns a stray rate into a track measuring nothing,
+    and then every fade on it is refused for a reason that is not true of the cut.
+    """
+    doc = document(track("Video", "Video 1", 100, 80), rate=24.0)
+    for child in doc["tracks"]["children"][0]["children"]:
+        child["source_range"]["duration"]["rate"] = "twenty-four"
+
+    placed = cut_otio.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
+
+    assert placed["video_tracks"] == ["Video 1"]
+    assert placed["unfaded_video"] == []
+    assert kinds(doc) == [("Video", 40)]
+
+
+def test_an_audio_track_that_took_no_fade_while_another_did_is_reported() -> None:
+    """Half a fade is a mix that ends on a cut, which is the thing the tail exists to avoid."""
+    doc = document(track("Audio", "Audio 1", 100), track("Audio", "Audio 2", 20))
+
+    placed = cut_otio.inject(doc, tail_device.Tail("hard_to_black", 0, 30))
+
+    assert placed["audio_tracks"] == ["Audio 1"]
+    assert placed["unfaded_audio"] == ["Audio 2"]
+

--- a/tests/test_cut_tail.py
+++ b/tests/test_cut_tail.py
@@ -1,9 +1,10 @@
-"""The tail device: what the rules refuse, what lands in the document, what the build does.
+"""The tail device: what the rules refuse, what the round trip does, what the build delivers.
 
 Three seams, one device. The rules decide whether a tail can be placed at all (E1 shape,
-E12 lengths); :mod:`resolve_mcp.resolve.tail` decides what goes into the exported OTIO;
-and the build decides that a cut with a tail is round-tripped rather than delivered with a
-hard edge where its tail should be.
+E12 lengths); :mod:`resolve_mcp.resolve.tail` carries the cut out to OTIO and back and
+decides what happens to the staging timeline; and the build decides that a cut with a tail
+is round-tripped rather than delivered with a hard edge where its tail should be. The
+document edit itself has no Resolve in it and is tested in ``test_cut_otio.py``.
 
 The last of those is the one worth being explicit about. A dissolve that did not land and a
 cut that never asked for one produce the *same* timeline, so nothing downstream can tell
@@ -19,9 +20,14 @@ from typing import Any
 
 import pytest
 
+from resolve_mcp.cut import otio as cut_otio
 from resolve_mcp.cut import tail as tail_device
 from resolve_mcp.cut.validate import validate_structure
+from resolve_mcp.errors import BuildFailedError
+from resolve_mcp.resolve import pool as mediapool
 from resolve_mcp.resolve import tail as tail_route
+from resolve_mcp.resolve import timeline as timeline_read
+from resolve_mcp.resolve.connection import get_connection
 from resolve_mcp.tools.cut import build_timeline, validate_cut
 
 from .conftest import Attach
@@ -241,269 +247,12 @@ def test_the_dry_run_reports_a_bad_tail_before_resolve_is_touched(
     assert [error["rule"] for error in result["errors"]] == ["E12"]
 
 
-# --- the document edit ----------------------------------------------------------------------
-
-
-def document(*tracks: dict[str, Any], rate: float | None = None) -> dict[str, Any]:
-    """An exported cut. ``rate`` is the timeline's own, where Resolve puts it: the start time."""
-    doc: dict[str, Any] = {"OTIO_SCHEMA": "Timeline.1", "tracks": {"children": list(tracks)}}
-    if rate is not None:
-        doc["global_start_time"] = {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": 0}
-    return doc
-
-
-def track(kind: str, name: str, *frames: int, rate: float = 24.0) -> dict[str, Any]:
-    """One track. ``rate`` is the *media* rate its clips are stamped in, as OTIO stamps them."""
-    return {
-        "OTIO_SCHEMA": "Track.1",
-        "kind": kind,
-        "name": name,
-        "children": [
-            {
-                "OTIO_SCHEMA": "Clip.2",
-                "name": f"{name}-{index}",
-                "source_range": {
-                    "duration": {"OTIO_SCHEMA": "RationalTime.1", "rate": rate, "value": length}
-                },
-            }
-            for index, length in enumerate(frames)
-        ],
-    }
-
-
-def unnamed(one: dict[str, Any]) -> dict[str, Any]:
-    """A track OTIO left without a name — nothing in the format promises one."""
-    one.pop("name", None)
-    return one
-
-
-def pad(one: dict[str, Any], frames: int) -> dict[str, Any]:
-    """The trailing black Resolve pads a short track with, out to the timeline's length."""
-    one["children"].append(
-        {
-            "OTIO_SCHEMA": "Gap.1",
-            "name": "",
-            "source_range": {
-                "duration": {"OTIO_SCHEMA": "RationalTime.1", "rate": 24.0, "value": frames}
-            },
-        }
-    )
-    return one
+# --- the build ------------------------------------------------------------------------------
 
 
 def kinds(doc: dict[str, Any]) -> list[tuple[str, int]]:
-    return [(item["kind"], item["in_offset"]) for item in tail_route.transitions(doc)]
-
-
-def test_the_dissolve_goes_on_the_video_track_and_the_fade_on_the_audio() -> None:
-    doc = document(track("Video", "Video 1", 100, 80), track("Audio", "Audio 1", 180))
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 40, 30))
-
-    assert placed == {
-        "video_tracks": ["Video 1"],
-        "audio_tracks": ["Audio 1"],
-        "unfaded_video": [],
-        "unfaded_audio": [],
-    }
-    assert kinds(doc) == [("Video", 40), ("Audio", 30)]
-
-
-def test_the_transition_ends_the_track_and_appends_no_black_after_it() -> None:
-    """A trailing gap is the cut file's own device, and Resolve drops one on import anyway."""
-    doc = document(track("Video", "Video 1", 100))
-
-    tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
-
-    children = doc["tracks"]["children"][0]["children"]
-    assert [child["OTIO_SCHEMA"] for child in children] == ["Clip.2", "Transition.1"]
-
-
-def test_an_overlay_that_stopped_earlier_keeps_its_own_ending() -> None:
-    """V2 covering a seam in the middle has nothing to do with how the picture leaves."""
-    doc = document(track("Video", "Video 1", 100, 80), track("Video", "Video 2", 30))
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
-
-    assert placed["video_tracks"] == ["Video 1"]
-
-
-def test_a_hard_out_fades_only_the_mix() -> None:
-    doc = document(track("Video", "Video 1", 100), track("Audio", "Audio 1", 100))
-
-    placed = tail_route.inject(doc, tail_device.Tail("hard_to_black", 0, 30))
-
-    assert placed == {
-        "video_tracks": [],
-        "audio_tracks": ["Audio 1"],
-        "unfaded_video": [],
-        "unfaded_audio": [],
-    }
-    assert kinds(doc) == [("Audio", 30)]
-
-
-def test_the_fade_goes_before_the_black_a_longer_mix_pads_in() -> None:
-    """The corpus shape: the mix outlives the picture, so Resolve exports V1 ending on a gap.
-
-    A transition appended to the end of *that* track would dissolve black into black — the
-    failure this case was found by, live, on the first build of the real ending.
-    """
-    doc = document(pad(track("Video", "Video 1", 120, 200), 40), track("Audio", "Audio 1", 360))
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 142, 0))
-
-    assert placed["video_tracks"] == ["Video 1"]
-    children = doc["tracks"]["children"][0]["children"]
-    assert [child["OTIO_SCHEMA"] for child in children] == [
-        "Clip.2",
-        "Clip.2",
-        "Transition.1",
-        "Gap.1",
-    ]
-
-
-def test_the_pad_does_not_make_a_short_overlay_look_like_the_end_of_the_picture() -> None:
-    """Every track is padded to the same length, so track length cannot pick the layer."""
-    doc = document(
-        pad(track("Video", "Video 1", 120, 200), 40),
-        pad(track("Video", "Video 2", 60), 300),
-    )
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 142, 0))
-
-    assert placed["video_tracks"] == ["Video 1"]
-
-
-def test_a_last_clip_too_short_takes_no_transition() -> None:
-    """Refused, never trimmed: a shortened device is a device the report would lie about."""
-    doc = document(track("Video", "Video 1", 100, 40))
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
-
-    assert placed["video_tracks"] == []
-    assert tail_route.transitions(doc) == []
-
-
-def test_an_overlay_ending_inside_the_dissolve_is_reported_unfaded() -> None:
-    """Opaque over part of the ramp, so the picture under it comes back mid-fade."""
-    doc = document(track("Video", "Video 1", 100, 80), track("Video", "Video 2", 160))
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
-
-    assert placed["video_tracks"] == ["Video 1"]
-    assert placed["unfaded_video"] == ["Video 2"]
-
-
-def test_an_overlay_ending_before_the_dissolve_starts_is_not_reported() -> None:
-    """The device covers the frames it covers: a layer that is gone by then is not in it."""
-    doc = document(track("Video", "Video 1", 100, 80), track("Video", "Video 2", 100))
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
-
-    assert placed["unfaded_video"] == []
-
-
-def test_an_unnamed_track_is_recorded_and_read_back_under_the_same_name() -> None:
-    """One vocabulary for both sides, because ``_confirm`` matches them to each other by string.
-
-    A fallback invented separately in each direction is not cosmetic: the dissolve would be
-    recorded on ``'video'`` and read back on ``''``, so a tail that landed perfectly reads as
-    a fade on the wrong track — and the refusal deletes the correct import on its way out.
-    """
-    doc = document(unnamed(track("Video", "", 100, 80)), unnamed(track("Audio", "", 180)))
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 40, 30))
-
-    assert placed["video_tracks"] == ["video"]
-    assert placed["audio_tracks"] == ["audio"]
-    assert [one["track"] for one in tail_route.transitions(doc)] == ["video", "audio"]
-
-
-def test_a_shot_at_another_media_rate_is_long_enough_for_the_dissolve() -> None:
-    """The cut counts in timeline frames; OTIO stamps each clip in its own media rate.
-
-    A mixed-rate multicam is the ordinary concert kit, and a 60-frame dissolve under an
-    80-frame shot is a legal cut — but the shot's own stamp says 40, so the raw comparison
-    refuses a build that is fine, after the shots are already on a staging timeline.
-    """
-    doc = document(track("Video", "Video 1", 50, 40, rate=12.0), rate=24.0)
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 60, 0))
-
-    assert placed["video_tracks"] == ["Video 1"]
-    assert placed["unfaded_video"] == []
-    # Stamped in the timeline's rate, so the number the read-back compares is the number
-    # the cut file asked for rather than the same count in a rate nobody asked about.
-    transition = doc["tracks"]["children"][0]["children"][2]
-    assert transition["in_offset"] == {"OTIO_SCHEMA": "RationalTime.1", "rate": 24.0, "value": 60}
-    assert kinds(doc) == [("Video", 60)]
-
-
-def test_the_layer_the_cut_ends_on_is_picked_in_timeline_frames() -> None:
-    """Two layers stamped in two rates are two units, and the raw numbers pick the wrong one."""
-    doc = document(
-        track("Video", "Video 1", 50, 40, rate=12.0),
-        pad(track("Video", "Video 2", 120, rate=24.0), 60),
-        rate=24.0,
-    )
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
-
-    # V1 runs 180 timeline frames and V2 120, so V1 ends the picture — even though V1's raw
-    # stamps sum to 90 and V2's to 120.
-    assert placed["video_tracks"] == ["Video 1"]
-    assert placed["unfaded_video"] == []
-
-
-def test_many_short_clips_at_another_rate_still_end_where_the_overlay_over_them_ends() -> None:
-    """A span is a sum, so it is rounded once — half a frame per clip is frames per song.
-
-    Twenty shots stamped at a rate the timeline does not count in come to 1008 frames
-    exactly; rounded one clip at a time they come to 1000, which is far enough back to drop
-    V1 out of the ending layers and into the window ``_inside`` refuses. The overlay ending
-    on the same frame is then the only layer left to fade, and the build refuses a correct
-    cut after the shots are already on a staging timeline.
-    """
-    doc = document(
-        track("Video", "Video 1", *([21] * 20), rate=10.0),
-        track("Video", "Video 2", 908, 100, rate=24.0),
-        rate=24.0,
-    )
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
-
-    assert placed["video_tracks"] == ["Video 1", "Video 2"]
-    assert placed["unfaded_video"] == []
-
-
-def test_a_rate_this_cannot_read_measures_the_clip_by_its_value() -> None:
-    """Only ``value`` says how long something is; an unreadable rate is not a zero-length clip.
-
-    Reading value and rate under one guard turns a stray rate into a track measuring nothing,
-    and then every fade on it is refused for a reason that is not true of the cut.
-    """
-    doc = document(track("Video", "Video 1", 100, 80), rate=24.0)
-    for child in doc["tracks"]["children"][0]["children"]:
-        child["source_range"]["duration"]["rate"] = "twenty-four"
-
-    placed = tail_route.inject(doc, tail_device.Tail("dissolve_to_black", 40, 0))
-
-    assert placed["video_tracks"] == ["Video 1"]
-    assert placed["unfaded_video"] == []
-    assert kinds(doc) == [("Video", 40)]
-
-
-def test_an_audio_track_that_took_no_fade_while_another_did_is_reported() -> None:
-    """Half a fade is a mix that ends on a cut, which is the thing the tail exists to avoid."""
-    doc = document(track("Audio", "Audio 1", 100), track("Audio", "Audio 2", 20))
-
-    placed = tail_route.inject(doc, tail_device.Tail("hard_to_black", 0, 30))
-
-    assert placed["audio_tracks"] == ["Audio 1"]
-    assert placed["unfaded_audio"] == ["Audio 2"]
-
-
-# --- the build ------------------------------------------------------------------------------
+    """Every transition in a document Resolve handed back, as ``(kind, length in frames)``."""
+    return [(item["kind"], item["in_offset"]) for item in cut_otio.transitions(doc)]
 
 
 def test_a_tailed_cut_lands_under_its_version_name(attach: Attach, tmp_path: Path) -> None:
@@ -921,3 +670,60 @@ def test_a_retry_after_a_failed_round_trip_stages_under_a_free_name(
     assert result["ok"] is True, result.get("error")
     assert pool.created_timelines[-1] == "sunset-set v1 (tail staging) v2"
     assert timeline_names(resolve) == ["sunset-set v1 (tail staging)", "sunset-set v1"]
+
+
+# --- the landed cut's contract ----------------------------------------------------------------
+
+
+def a_staging_cut(resolve: Any, tmp_path: Path) -> tail_route.Staging:
+    """A built cut with no tail on it, stood up as the staging timeline for a round trip.
+
+    The shots are real (fake-tier real): the round trip exports this timeline, so a hand-made
+    stub would export as a document with nothing in it to fade.
+    """
+    assert build_timeline(a_cut(tmp_path, valid_doc()))["ok"] is True
+    connection = get_connection()
+    project = timeline_read.open_project(connection)
+    return tail_route.Staging(
+        project, mediapool.media_pool(connection), built(resolve, "sunset-set v1"), "sunset-set v1"
+    )
+
+
+def test_the_round_trip_leaves_staging_standing_for_the_caller_to_release(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The cut that ships is one nobody has checked yet, so the fallback outlives the import."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+    staging = a_staging_cut(resolve, tmp_path)
+
+    landed = tail_route.materialise(
+        get_connection(), staging, "sunset-set v2", tail_device.Tail("dissolve_to_black", 40, 0)
+    )
+
+    assert timeline_names(resolve) == ["sunset-set v1", "sunset-set v2"]
+    assert landed.timeline.GetName() == "sunset-set v2"
+    assert landed.applied["route"] == "otio_round_trip"
+
+    landed.release()
+
+    assert timeline_names(resolve) == ["sunset-set v2"]
+
+
+def test_a_caller_that_refuses_the_import_still_has_its_shots_on_staging(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The whole point of holding the delete: a refusal leaves the cut somewhere findable."""
+    resolve = empty_project(a_pool())
+    attach(resolve)
+    staging = a_staging_cut(resolve, tmp_path)
+    landed = tail_route.materialise(
+        get_connection(), staging, "sunset-set v2", tail_device.Tail("dissolve_to_black", 40, 0)
+    )
+
+    error = landed.refuse("the round trip moved the shots")
+
+    assert isinstance(error, BuildFailedError)
+    assert "the round trip moved the shots" in error.cause
+    assert error.detail["staging_timeline"] == "sunset-set v1"
+    assert timeline_names(resolve) == ["sunset-set v1"]


### PR DESCRIPTION
Closes #221.

`resolve/tail.py` fused two things behind the largest function in the repo: pure OTIO document surgery, which needs no Resolve at all, and the export/import round trip, which is nothing but Resolve. The seam between them was a `verify` callback the build filled with a lambda over its own private read-back — so the callee called back into its caller's privates mid-round-trip, and the caller had to know the callback's exception contract *and* that staging was deleted only once verify passed.

**After.** The surgery is `cut/otio.py` — `inject`, `transitions`, and the span and rate arithmetic under both — with no Resolve import and tests that are plain dicts rather than fakes. `materialise` keeps the round trip and loses the callback: its five context parameters become one `Staging`, and it returns a `Landed` — the imported cut plus the two things still to be done about it. The build runs its own read-back on `landed.timeline` and then calls `release()`, or calls `refuse(why)` and raises what comes back. Check-before-delete is now the returned object's contract rather than a callback protocol, and a caller that does neither leaves both timelines standing, which is the safe end of the failure.

## Test seams

Fake tier for everything except the attach, which no seam covers. `test_cut_otio.py` (15 tests, documents only, no fakes) verifies the surgery; `test_cut_tail.py` keeps the round trip and the build, with two new tests for the `Landed` contract — that `materialise` leaves staging standing for the caller to release, and that `refuse` drops the import and leaves the shots on staging. Every one of the 61 tests on `main` is preserved: the old→new set-diff of test names is empty.

- Fake tier: **2271 passed**, 44 deselected.
- mypy strict: clean (210 files). ruff check: clean.
- Live smoke (this box, Resolve Studio 21.0.3 up, python.org interpreter): `-m live -k "resolution or dissolve"` → **2 passed**, not skipped — `test_a_real_build_delivers_the_resolution_the_cut_asked_for` (which builds a cut carrying a 12-frame `dissolve_to_black` tail and asserts `route == "otio_round_trip"`) and `test_a_hand_injected_dissolve_imports_as_a_transition`. That is AC 4.

## Review

Two axes, both as parallel sub-agents against `origin/main...HEAD`.

**Spec — clean.** All five ACs met. Verified rather than taken on trust: `cut/otio.py` imports only `typing` and `.tail` and is transitively Resolve-free; `_delete_staging` is reachable only from `Landed.release`; the moved OTIO block is byte-identical to `main` apart from one docstring reword; no test was deleted rather than moved. Two findings, both fixed in 84c8a76:

- *The success log fired before the caller's verify.* On `main` the "Tail on %s" line fired only after verify passed and staging was gone; in the split it fired inside `materialise`, so a build that then refused the import logged a landed tail immediately followed by a refusal. Given that a live failure outside a session is diagnosed from the log or not at all, that is a real diagnostic regression. `materialise` now logs that the tail was *written* and is pending its caller's check; the line that says a tail landed moved to `release`, which is the moment the cut stopped having a fallback.
- *CONTEXT.md named `Landed` but not `Staging`.* Both are named now.

The one flagged scope question — `Staging` is a public type the ticket never named — is kept deliberately: the ticket's own complaint is "8 parameters, five of them caller context", and bundling them is what sheds the five.

**Standards — no hard violations.** The map is updated in the same PR, there is no implicit re-export (`resolve/tail` takes `Document`/`inject`/`transitions` from `cut.otio`, `cut/otio` takes `Tail` from `cut.tail`), and the docstrings keep the house habit of arguing decisions with live-probed evidence. Six judgement calls; three fixed, three declined with reasons:

- Fixed: `cut/otio.__all__` exported `DISSOLVE`, `Track`, `Item` with no callers; CONTEXT.md did not distinguish `cut/otio` from the live tier's `tests/otio.py`; one CONTEXT.md line was left at 128 columns.
- Declined — *`inject`'s return dict is a data clump.* True, and the same argument that produced `Staging` and `Landed` applies to it. It is also unchanged from `main`, crosses one boundary, and turning it into a type rewrites ~15 assertions in a diff that is already a move. Worth its own ticket, not this one.
- Declined — *four near-identical refusal blocks in `materialise`.* Each raises a differently-worded refusal naming a different frame count; the shape repeats, the sentences do not. Unchanged from `main`.
- Declined — *`kinds()` is defined in both test files.* Two lines, and the alternative is a cross-test-module import.

Review: clean — spec clean, two findings fixed in 84c8a76; standards no hard violations, three of six judgement calls fixed and three declined with reasons above.
