### PR TITLE
One definition of a truncated reply (#224)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,7 +24,9 @@ timelines. The server measures; Claude decides.
 - **envelope** — the shared tool-result shape every MCP tool returns
   (`tools/envelope.py`).
 - **spill** — oversized results written to disk for the agent to grep
-  instead of truncating.
+  instead of truncating. Every listing that can outgrow a reply is capped by
+  `spill.capped`, so `truncated` and `spilled_to` mean one thing everywhere and
+  a spilled file is the same reply carrying all of it (#224).
 - **bin path** — a media pool folder, slash-separated from the root. To a
   tool addressing one clip by name: omitted is the whole pool, a name is
   that bin and everything nested inside it, `""` is the root folder alone
@@ -112,7 +114,7 @@ Top level:
 | `logging_config.py` | stderr-only logging (stdout belongs to MCP transport) |
 | `naming.py` | names for written files and `<base> v<N>` timelines |
 | `server.py` | FastMCP app + tool registration; no logic |
-| `spill.py` | oversized results → disk |
+| `spill.py` | oversized results → disk; `capped` is the one definition of a truncated reply |
 | `timing.py` | frames authoritative; seconds/timecode/fps derived |
 
 `analysis/` — compute jobs that read audio and write findings to disk:

--- a/src/resolve_mcp/analysis/virtual.py
+++ b/src/resolve_mcp/analysis/virtual.py
@@ -30,13 +30,13 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final
 
-from ..config import Config, get_config
+from ..config import Config
 from ..cut.document import read_cut_file
 from ..cut.layout import is_gap, overlay_positions, positions, total_frames
 from ..document import LoadedDocument
 from ..errors import InvalidRequestError
 from ..findings import Finding, ordered
-from ..spill import spill
+from ..spill import capped
 from ..timing import IN_POINT, OUT_POINT, SECONDS_PRECISION, dual_time, frames_from_seconds
 from . import records
 from .transcript import DEFAULT_LOW_CONFIDENCE
@@ -166,26 +166,25 @@ def _result(
         "jump_cuts": sum(1 for seam in seams if seam["jump_cut"]),
         "uncovered": sum(1 for seam in seams if seam["jump_cut"] and seam["covered_by"] is None),
     }
-    result: dict[str, Any] = {
-        "cut_file": str(loaded.path),
-        "content_hash": loaded.content_hash,
-        "timeline": {"name": _name(doc), "fps": fps},
-        "total": dual_time(total, fps),
-        "text": " ".join(read["text"] for read in read_back if read["text"]),
-        "segments": read_back,
-        "words": rows[:INLINE_WORDS],
-        "truncated": len(rows) > INLINE_WORDS,
-        "spilled_to": None,
-        "seams": seams,
-        "counts": counts,
-        "warnings": [finding.as_dict() for finding in findings],
-    }
-    if result["truncated"]:
-        full = {**result, "words": rows, "truncated": False, "spilled_to": None}
-        result["spilled_to"] = spill(
-            f"{_name(doc)} virtual transcript", full, config or get_config(), fallback="cut"
-        )
-    return result
+    return capped(
+        {
+            "cut_file": str(loaded.path),
+            "content_hash": loaded.content_hash,
+            "timeline": {"name": _name(doc), "fps": fps},
+            "total": dual_time(total, fps),
+            "text": " ".join(read["text"] for read in read_back if read["text"]),
+            "segments": read_back,
+            "seams": seams,
+            "counts": counts,
+            "warnings": [finding.as_dict() for finding in findings],
+        },
+        key="words",
+        whole=rows,
+        limit=INLINE_WORDS,
+        label=f"{_name(doc)} virtual transcript",
+        fallback="cut",
+        config=config,
+    )
 
 
 def _read(

--- a/src/resolve_mcp/jobs/store.py
+++ b/src/resolve_mcp/jobs/store.py
@@ -441,8 +441,8 @@ def load_all(state: str | None = None, config: Config | None = None) -> list[Job
     """Every job this cache directory knows about, newest first.
 
     A state that is not one is refused here rather than at the tool: what the states are is
-    this module's fact, and a caller asking for a filter no record can ever match wants to
-    hear so (#224).
+    the job layer's own fact (``lifecycle.STATES``), and a caller asking for a filter no
+    record can ever match wants to hear so (#224).
     """
     if state is not None and state not in STATES:
         raise InvalidRequestError(

--- a/src/resolve_mcp/jobs/store.py
+++ b/src/resolve_mcp/jobs/store.py
@@ -42,10 +42,10 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from ..config import Config, get_config
-from ..errors import JobInterruptedError, JobNotFoundError
+from ..errors import InvalidRequestError, JobInterruptedError, JobNotFoundError
 from ..logging_config import get_logger
 from ..naming import slug
-from .lifecycle import COMPLETED, FAILED, RUNNING, SESSION, Outcome, verdict
+from .lifecycle import COMPLETED, FAILED, RUNNING, SESSION, STATES, Outcome, verdict
 
 log = get_logger("jobs")
 
@@ -438,7 +438,18 @@ def load(job_id: str, config: Config | None = None) -> JobRecord:
 
 
 def load_all(state: str | None = None, config: Config | None = None) -> list[JobRecord]:
-    """Every job this cache directory knows about, newest first."""
+    """Every job this cache directory knows about, newest first.
+
+    A state that is not one is refused here rather than at the tool: what the states are is
+    this module's fact, and a caller asking for a filter no record can ever match wants to
+    hear so (#224).
+    """
+    if state is not None and state not in STATES:
+        raise InvalidRequestError(
+            cause=f"{state!r} is not a job state.",
+            fix=f"Use one of {', '.join(STATES)}, or leave state out for all of them.",
+            detail={"requested": state, "states": list(STATES)},
+        )
     config = config or get_config()
     records = [_read(path) for path in sorted(config.job_dir.glob("*.json"))]
     found = [_recovered(one, config, sweep=False) for one in records if one is not None]

--- a/src/resolve_mcp/resolve/markers.py
+++ b/src/resolve_mcp/resolve/markers.py
@@ -30,10 +30,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..config import Config, get_config
+from ..config import Config
 from ..errors import InvalidRequestError, ResolveMcpError, TimelineOperationError
 from ..logging_config import get_logger
-from ..spill import spill
+from ..spill import capped
 from ..timing import dual_time, to_frames
 from .connection import ResolveConnection
 from .session import frame_rate
@@ -185,27 +185,24 @@ def list_markers(
     window = frame_window(start, end, clock.fps)
     wanted = [marker for marker in markers if _matches(marker, color) and _touches(marker, window)]
 
-    cap = max(int(limit), 0)
-    truncated = len(wanted) > cap
-    result: dict[str, Any] = {
-        "timeline": {
-            "name": clock.name,
-            "fps": clock.fps,
-            "start": dual_time(clock.start, clock.fps),
-            "end": dual_time(clock.end, clock.fps),
+    return capped(
+        {
+            "timeline": {
+                "name": clock.name,
+                "fps": clock.fps,
+                "start": dual_time(clock.start, clock.fps),
+                "end": dual_time(clock.end, clock.fps),
+            },
+            "count": len(wanted),
+            "colors": _colors(wanted),
         },
-        "count": len(wanted),
-        "markers": wanted[:cap] if truncated else wanted,
-        "colors": _colors(wanted),
-        "truncated": truncated,
-        "spilled_to": None,
-    }
-    if truncated:
-        full = {**result, "markers": wanted, "truncated": False, "spilled_to": None}
-        result["spilled_to"] = spill(
-            f"{clock.name} markers", full, config or get_config(), fallback="markers"
-        )
-    return result
+        key="markers",
+        whole=wanted,
+        limit=limit,
+        label=f"{clock.name} markers",
+        fallback="markers",
+        config=config,
+    )
 
 
 def _touches(marker: dict[str, Any], window: tuple[int | None, int | None]) -> bool:

--- a/src/resolve_mcp/resolve/media.py
+++ b/src/resolve_mcp/resolve/media.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, NamedTuple
 
-from ..config import Config, get_config
+from ..config import Config
 from ..errors import (
     AmbiguousClipError,
     BinNotFoundError,
@@ -44,7 +44,7 @@ from ..errors import (
     RelinkFailedError,
 )
 from ..logging_config import get_logger
-from ..spill import spill
+from ..spill import capped
 from ..timing import dual_time
 from .camera_sidecar import camera_model as recorded_camera_model
 from .connection import ResolveConnection
@@ -373,23 +373,15 @@ def list_media(
             continue
         clips.append(summary)
 
-    cap = max(int(limit), 0)
-    truncated = len(clips) > cap
-    result: dict[str, Any] = {
-        "bin": where.path,
-        "count": len(clips),
-        "clips": clips[:cap] if truncated else clips,
-        "truncated": truncated,
-        "spilled_to": None,
-    }
-    if truncated:
-        result["spilled_to"] = spill(
-            result["bin"],
-            {"bin": result["bin"], "count": len(clips), "clips": clips},
-            config or get_config(),
-            fallback="media-pool",
-        )
-    return result
+    return capped(
+        {"bin": where.path, "count": len(clips)},
+        key="clips",
+        whole=clips,
+        limit=limit,
+        label=where.path,
+        fallback="media-pool",
+        config=config,
+    )
 
 
 # --- inspect ----------------------------------------------------------------------------

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -32,14 +32,14 @@ import re
 from collections.abc import Iterator
 from typing import Any, Final, NamedTuple
 
-from ..config import Config, get_config
+from ..config import Config
 from ..errors import (
     InvalidRequestError,
     NoTimelineOpenError,
     TimelineNotFoundError,
 )
 from ..logging_config import get_logger
-from ..spill import spill
+from ..spill import capped, untruncated
 from ..timing import dual_time, to_frames
 from .connection import ResolveConnection
 from .session import current_project, frame_rate
@@ -412,20 +412,19 @@ def list_timelines(
     held = timelines_of(project)
     timelines = [summarise(reader, timeline, project, current) for timeline in held]
 
-    cap = max(int(limit), 0)
-    truncated = len(timelines) > cap
-    result: dict[str, Any] = {
-        "count": len(timelines),
-        "current": current,
-        "timelines": timelines[:cap] if truncated else timelines,
-        "latest_versions": _latest_versions(timelines),
-        "truncated": truncated,
-        "spilled_to": None,
-    }
-    if truncated:
-        full = {**result, "timelines": timelines, "truncated": False, "spilled_to": None}
-        result["spilled_to"] = spill("timelines", full, config or get_config(), fallback="timeline")
-    return result
+    return capped(
+        {
+            "count": len(timelines),
+            "current": current,
+            "latest_versions": _latest_versions(timelines),
+        },
+        key="timelines",
+        whole=timelines,
+        limit=limit,
+        label="timelines",
+        fallback="timeline",
+        config=config,
+    )
 
 
 def _latest_versions(timelines: list[dict[str, Any]]) -> dict[str, str]:
@@ -508,21 +507,21 @@ def inspect_timeline(
         "tracks": None if detail == "summary" else [_without_items(track) for track in tracks],
         "item_count": item_count,
         "currency": currency,
-        "truncated": False,
-        "spilled_to": None,
     }
     if not with_items:
-        return result
+        return untruncated(result)
 
-    cap = max(int(limit), 0)
-    result["tracks"] = _capped(tracks, cap)
-    if item_count > cap:
-        result["truncated"] = True
-        full = {**result, "tracks": tracks, "truncated": False, "spilled_to": None}
-        result["spilled_to"] = spill(
-            heading["name"], full, config or get_config(), fallback="timeline"
-        )
-    return result
+    return capped(
+        result,
+        key="tracks",
+        whole=tracks,
+        limit=limit,
+        counted=item_count,
+        share=_shared,
+        label=heading["name"],
+        fallback="timeline",
+        config=config,
+    )
 
 
 UNKNOWN_OFF_CURRENT: Final = ("enabled", "locked", "takes")
@@ -659,7 +658,7 @@ def _without_items(track: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in track.items() if key != "items"}
 
 
-def _capped(tracks: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
+def _shared(tracks: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
     """Share ``cap`` shots across the stack, a round at a time.
 
     Filling track by track would spend the whole budget on a busy V1 and hand back a

--- a/src/resolve_mcp/spill.py
+++ b/src/resolve_mcp/spill.py
@@ -3,18 +3,61 @@
 The client caps a tool result at roughly 25k tokens, and a concert media pool or timeline
 is far past that. Rather than truncate silently, a listing over its cap comes back capped
 *and* says where the whole thing landed — the locked hybrid inline/disk return shape.
+
+``capped`` is the one place that shape is decided. Every listing that can outgrow a reply
+goes through it, so ``truncated`` and ``spilled_to`` mean the same thing in every reply and
+the file on disk is the same reply carrying all of it. The hand-written copies drifted
+before this existed: the media listing's spilled file was missing the truncation keys every
+other spilled file carried, and the job listing capped with a vocabulary of its own and
+never spilled at all (#224).
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import Any
 
-from .config import Config
+from .config import Config, get_config
 from .logging_config import get_logger
 from .naming import timestamped_name
 
 log = get_logger("spill")
+
+
+def capped(
+    reply: dict[str, Any],
+    *,
+    key: str,
+    whole: list[Any],
+    limit: int,
+    label: str,
+    fallback: str,
+    config: Config | None = None,
+    counted: int | None = None,
+    share: Callable[[list[Any], int], list[Any]] | None = None,
+) -> dict[str, Any]:
+    """``reply`` with ``key`` capped at ``limit``, and the whole of it on disk if it did not fit.
+
+    ``counted`` is what the cap is measured against when that is not the length of ``whole``
+    — a stack of tracks is capped on the shots inside it, not on how many tracks there are.
+    ``share`` is how the budget is spent when a plain head slice is the wrong answer, for the
+    same reason: filling one track before the next would hand back a stacked reference with
+    every angle below the first one empty.
+    """
+    cap = max(int(limit), 0)
+    against = len(whole) if counted is None else counted
+    if against <= cap:
+        return untruncated({**reply, key: whole})
+
+    shown = (share or _head)(whole, cap)
+    spilled = spill(label, untruncated({**reply, key: whole}), config or get_config(), fallback)
+    return {**reply, key: shown, "truncated": True, "spilled_to": spilled}
+
+
+def untruncated(reply: dict[str, Any]) -> dict[str, Any]:
+    """A reply with nothing to cap: the same two keys, both saying so."""
+    return {**reply, "truncated": False, "spilled_to": None}
 
 
 def spill(label: str, payload: dict[str, Any], config: Config, fallback: str) -> str:
@@ -24,3 +67,7 @@ def spill(label: str, payload: dict[str, Any], config: Config, fallback: str) ->
     target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     log.info("Spilled the full %s reading to %s", fallback, target)
     return str(target)
+
+
+def _head(items: list[Any], cap: int) -> list[Any]:
+    return items[:cap]

--- a/src/resolve_mcp/spill.py
+++ b/src/resolve_mcp/spill.py
@@ -5,11 +5,12 @@ is far past that. Rather than truncate silently, a listing over its cap comes ba
 *and* says where the whole thing landed — the locked hybrid inline/disk return shape.
 
 ``capped`` is the one place that shape is decided. Every listing that can outgrow a reply
-goes through it, so ``truncated`` and ``spilled_to`` mean the same thing in every reply and
-the file on disk is the same reply carrying all of it. The hand-written copies drifted
-before this existed: the media listing's spilled file was missing the truncation keys every
-other spilled file carried, and the job listing capped with a vocabulary of its own and
-never spilled at all (#224).
+goes through it, so across the listings ``truncated`` and ``spilled_to`` mean one thing and
+the file on disk is the same reply carrying all of it. (A ``truncated`` outside the listings
+is a different word: ``resolve/scripting`` clips a long *string* under the same name.) The
+hand-written copies drifted before this existed: the media listing's spilled file was
+missing the truncation keys every other spilled file carried, and the job listing capped
+with a vocabulary of its own and never spilled at all (#224).
 """
 
 from __future__ import annotations
@@ -47,11 +48,12 @@ def capped(
     """
     cap = max(int(limit), 0)
     against = len(whole) if counted is None else counted
+    all_of_it = untruncated({**reply, key: whole})
     if against <= cap:
-        return untruncated({**reply, key: whole})
+        return all_of_it
 
     shown = (share or _head)(whole, cap)
-    spilled = spill(label, untruncated({**reply, key: whole}), config or get_config(), fallback)
+    spilled = spill(label, all_of_it, config or get_config(), fallback)
     return {**reply, key: shown, "truncated": True, "spilled_to": spilled}
 
 

--- a/src/resolve_mcp/tools/jobs.py
+++ b/src/resolve_mcp/tools/jobs.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..errors import InvalidRequestError
-from ..jobs import lifecycle, store
+from ..jobs import store
+from ..spill import capped
 from .envelope import tool
 
 DEFAULT_JOB_LIMIT = 50
@@ -36,21 +36,19 @@ def list_jobs(state: str | None = None, limit: int = DEFAULT_JOB_LIMIT) -> dict[
     state filters to running, completed or failed. Jobs survive a server restart because
     their records live in the cache directory; one that was still running when the server
     went down comes back failed with code job_interrupted, which means start it again —
-    finished work is already in the result cache and is not paid for twice.
+    finished work is already in the result cache and is not paid for twice. count is how
+    many there are, not how many came back: past limit the reply is capped and the whole
+    listing spills to disk (spilled_to).
     """
-    if state is not None and state not in lifecycle.STATES:
-        raise InvalidRequestError(
-            cause=f"{state!r} is not a job state.",
-            fix=f"Use one of {', '.join(lifecycle.STATES)}, or leave state out for all of them.",
-            detail={"requested": state, "states": list(lifecycle.STATES)},
-        )
-    found = store.load_all(state=state)
-    shown = found[:limit]
-    return {
-        "jobs": [one.payload() for one in shown],
-        "count": len(shown),
-        "total": len(found),
-    }
+    found = [one.payload() for one in store.load_all(state=state)]
+    return capped(
+        {"count": len(found)},
+        key="jobs",
+        whole=found,
+        limit=limit,
+        label="jobs",
+        fallback="jobs",
+    )
 
 
 TOOLS: tuple[Any, ...] = (

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -122,7 +122,7 @@ def test_jobs_come_back_newest_first_and_filter_by_state() -> None:
 
 
 def test_a_state_that_is_not_one_is_refused_by_the_listing_itself() -> None:
-    """What the states are is the store's fact, so the refusal is the store's too (#224)."""
+    """What the states are is the job layer's fact, so the refusal is the listing's (#224)."""
     with pytest.raises(InvalidRequestError) as raised:
         store.load_all(state="finished")
 

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 from resolve_mcp.config import get_config
-from resolve_mcp.errors import JobNotFoundError
+from resolve_mcp.errors import InvalidRequestError, JobNotFoundError
 from resolve_mcp.jobs import lifecycle, store
 
 SAVES = 300
@@ -119,6 +119,19 @@ def test_jobs_come_back_newest_first_and_filter_by_state() -> None:
     assert [one.job_id for one in listed] == [second.job_id, first.job_id]
     assert [one.job_id for one in store.load_all(state="completed")] == [first.job_id]
     assert [one.job_id for one in store.load_all(state="running")] == [second.job_id]
+
+
+def test_a_state_that_is_not_one_is_refused_by_the_listing_itself() -> None:
+    """What the states are is the store's fact, so the refusal is the store's too (#224)."""
+    with pytest.raises(InvalidRequestError) as raised:
+        store.load_all(state="finished")
+
+    assert raised.value.cause == "'finished' is not a job state."
+    assert "running" in raised.value.fix
+    assert raised.value.detail == {
+        "requested": "finished",
+        "states": ["running", "completed", "failed"],
+    }
 
 
 def test_two_jobs_started_in_the_same_clock_tick_still_list_in_order() -> None:

--- a/tests/test_job_tools.py
+++ b/tests/test_job_tools.py
@@ -52,7 +52,9 @@ def test_listing_shows_the_newest_job_first(attach: Attach) -> None:
     reply = list_jobs()
 
     assert [one["job_id"] for one in reply["jobs"]] == [second["job_id"], first["job_id"]]
-    assert reply["total"] == 2
+    assert reply["count"] == 2
+    assert reply["truncated"] is False
+    assert reply["spilled_to"] is None
 
 
 def test_listing_filters_by_state_and_rejects_a_state_that_is_not_one(attach: Attach) -> None:
@@ -69,17 +71,25 @@ def test_listing_filters_by_state_and_rejects_a_state_that_is_not_one(attach: At
     assert "running" in refused["error"]["fix"]
 
 
-def test_the_listing_caps_at_the_limit_but_still_says_how_many_there_are(
+def test_the_listing_caps_at_the_limit_and_spills_the_rest_like_every_other_listing(
     attach: Attach,
 ) -> None:
+    """count is how many there are, not how many came back — the vocabulary #224 unified."""
     attach(None)
     for _ in range(3):
         wait_for(start_job("extract_audio", {}, _produces({}))["job_id"])
 
     reply = list_jobs(limit=2)
 
-    assert reply["count"] == 2
-    assert reply["total"] == 3
+    assert len(reply["jobs"]) == 2
+    assert reply["count"] == 3
+    assert reply["truncated"] is True
+    spilled = Path(reply["spilled_to"])
+    assert spilled.exists()
+    written = json.loads(spilled.read_text(encoding="utf-8"))
+    assert len(written["jobs"]) == 3
+    assert written["truncated"] is False
+    assert written["spilled_to"] is None
 
 
 def test_a_job_the_previous_server_left_running_comes_back_interrupted(attach: Attach) -> None:

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -547,7 +547,13 @@ def test_list_spills_the_full_listing_to_disk_past_the_cap(attach: Attach, tmp_p
     assert len(result["clips"]) == 2
     spilled = Path(result["spilled_to"])
     assert spilled.exists()
-    assert len(json.loads(spilled.read_text(encoding="utf-8"))["clips"]) == 5
+    written = json.loads(spilled.read_text(encoding="utf-8"))
+    assert len(written["clips"]) == 5
+    # The spilled file is the same reply carrying all of it — the media copy used to be
+    # hand-built and dropped the two keys every other spilled file has (#224).
+    assert written["truncated"] is False
+    assert written["spilled_to"] is None
+    assert written["count"] == 5
 
 
 # --- inspect ---------------------------------------------------------------------------

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -1,7 +1,7 @@
 """One definition of a truncated reply — the cap, the two flags, and the file on disk.
 
 Every listing that can outgrow a reply goes through ``capped``. These tests are about the
-helper itself rather than any one listing: the five call sites each assert their own
+helper itself rather than any one listing: every call site asserts its own
 vocabulary, but what a truncated reply *means* is decided here and nowhere else (#224).
 """
 

--- a/tests/test_spill.py
+++ b/tests/test_spill.py
@@ -1,0 +1,146 @@
+"""One definition of a truncated reply — the cap, the two flags, and the file on disk.
+
+Every listing that can outgrow a reply goes through ``capped``. These tests are about the
+helper itself rather than any one listing: the five call sites each assert their own
+vocabulary, but what a truncated reply *means* is decided here and nowhere else (#224).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from resolve_mcp.spill import capped, untruncated
+
+
+def test_a_listing_inside_the_cap_stays_inline() -> None:
+    reply = capped(
+        {"bin": "Master"},
+        key="clips",
+        whole=[1, 2, 3],
+        limit=10,
+        label="Master",
+        fallback="media-pool",
+    )
+
+    assert reply["clips"] == [1, 2, 3]
+    assert reply["truncated"] is False
+    assert reply["spilled_to"] is None
+    assert reply["bin"] == "Master"
+
+
+def test_a_listing_past_the_cap_is_capped_and_the_whole_of_it_goes_to_disk() -> None:
+    reply = capped(
+        {"bin": "Master", "count": 5},
+        key="clips",
+        whole=[1, 2, 3, 4, 5],
+        limit=2,
+        label="Master",
+        fallback="media-pool",
+    )
+
+    assert reply["clips"] == [1, 2]
+    assert reply["truncated"] is True
+    assert reply["spilled_to"] is not None
+    assert Path(reply["spilled_to"]).exists()
+
+
+def test_the_spilled_file_is_the_same_reply_carrying_all_of_it() -> None:
+    """The file is not a different shape: same keys, whole list, both flags saying so."""
+    reply = capped(
+        {"bin": "Master", "count": 5},
+        key="clips",
+        whole=[1, 2, 3, 4, 5],
+        limit=2,
+        label="Master",
+        fallback="media-pool",
+    )
+
+    written = _read(reply["spilled_to"])
+
+    assert written["clips"] == [1, 2, 3, 4, 5]
+    assert written["truncated"] is False
+    assert written["spilled_to"] is None
+    assert written["bin"] == "Master"
+    assert written["count"] == 5
+
+
+def test_a_cap_of_zero_keeps_nothing_inline_and_still_spills() -> None:
+    reply = capped(
+        {}, key="items", whole=[1, 2], limit=0, label="none", fallback="listing"
+    )
+
+    assert reply["items"] == []
+    assert reply["truncated"] is True
+    assert _read(reply["spilled_to"])["items"] == [1, 2]
+
+
+def test_a_negative_limit_reads_as_no_room_at_all() -> None:
+    reply = capped(
+        {}, key="items", whole=[1], limit=-5, label="none", fallback="listing"
+    )
+
+    assert reply["items"] == []
+    assert reply["truncated"] is True
+
+
+def test_an_empty_listing_is_never_truncated() -> None:
+    reply = capped({}, key="items", whole=[], limit=0, label="none", fallback="listing")
+
+    assert reply["items"] == []
+    assert reply["truncated"] is False
+    assert reply["spilled_to"] is None
+
+
+def test_a_reply_can_cap_on_a_count_the_items_do_not_carry() -> None:
+    """A stack of tracks is capped on the shots inside it, not on how many tracks there are."""
+    tracks = [{"items": [1, 2, 3]}, {"items": [4, 5, 6]}]
+
+    reply = capped(
+        {},
+        key="tracks",
+        whole=tracks,
+        limit=4,
+        counted=6,
+        label="stack",
+        fallback="timeline",
+    )
+
+    assert reply["truncated"] is True
+    assert _read(reply["spilled_to"])["tracks"] == tracks
+
+
+def test_a_reply_can_share_the_cap_its_own_way() -> None:
+    reply = capped(
+        {},
+        key="items",
+        whole=[1, 2, 3, 4],
+        limit=2,
+        share=lambda items, cap: items[-cap:],
+        label="tail",
+        fallback="listing",
+    )
+
+    assert reply["items"] == [3, 4]
+
+
+def test_capping_leaves_the_reply_it_was_handed_alone() -> None:
+    given: dict[str, Any] = {"count": 3}
+
+    capped(given, key="items", whole=[1, 2, 3], limit=1, label="x", fallback="listing")
+
+    assert given == {"count": 3}
+
+
+def test_untruncated_says_a_reply_had_nothing_to_cap() -> None:
+    assert untruncated({"detail": "summary"}) == {
+        "detail": "summary",
+        "truncated": False,
+        "spilled_to": None,
+    }
+
+
+def _read(path: str) -> dict[str, Any]:
+    loaded: dict[str, Any] = json.loads(Path(path).read_text(encoding="utf-8"))
+    return loaded


### PR DESCRIPTION
Closes #224.

## What changed

`spill.capped` is now the one place that decides a cap, the two truncation
flags and the spill to disk. The idiom was written out five times — the
timeline listing and inspection, markers, media, the virtual transcript —
and one copy had already drifted: `list_media` hand-built its spilled
payload and so wrote a file missing the `truncated`/`spilled_to` keys every
other spilled file carries. `list_jobs` capped with a vocabulary of its own
and never spilled at all.

All six sites now reply through the helper. After this, `"truncated"` and
`"spilled_to"` appear as literal keys in exactly one module.

Two knobs carry the awkward site, `inspect_timeline`: `counted`, because a
stack of tracks is capped on the shots inside it rather than on its own
length, and `share`, for the round-robin that keeps every angle visible
instead of spending the whole budget on V1. `spill.untruncated` stamps the
same two keys on a reply that had nothing to cap — the summary path.

`list_jobs` joins the family: `count` is now how many there *are*, matching
every sibling listing, `total` is gone, and the reply spills past the limit.
Its body is delegation only; the state check moved to `store.load_all`,
where the states are defined, and raises the same error the tool raised.

**Reply-shape note for AC4:** shapes are unchanged *other than* the
`list_jobs` vocabulary the ticket asked to unify. That is a breaking change
to that one reply — `total` is gone and `count` changed meaning from "how
many came back" to "how many there are". Nothing in `src/`, `tests/` or
`docs/` read `total`.

## Test seam

Fake tier throughout — every acceptance criterion on #224 is marked
`(fake tier)` and none of this touches the attach. New `tests/test_spill.py`
covers the helper directly: the cap decision, both flags, the spilled file's
contents, a zero and a negative limit, the `counted` and `share` hooks, and
that the caller's dict is left alone. The media and job listings gained
assertions that the spilled file carries the truncation keys, and a store
test proves the refusal now lives in `load_all`.

Fake tier 2279 passed / 0 failed, mypy strict clean, ruff clean.

## Review

Two-axis review (`/code-review`) run on the branch against `origin/main`
before this PR existed.

**Spec axis — no findings.** All four ACs met; no missing requirements, no
scope creep, no wrong implementation. It judged the `count`/`total`
unification a faithful reading of the ticket (preserving `total` would have
forced `capped` to emit a key no other listing uses, keeping the third
vocabulary alive) and asked that the breaking reply change be recorded in
this body rather than left implicit in AC4 — done above.

**Standards axis — no hard violations, four judgement calls. Three fixed in
05abaa2:**

1. The module docstring claimed `truncated`/`spilled_to` "mean the same
   thing in every reply". Overreach: `resolve/scripting` returns a
   `truncated` of its own for a clipped string. Scoped the claim to the
   listings and named the exception.
2. The test module said "the five call sites"; there are six now that
   `list_jobs` joined. Says "every call site", which cannot rot.
3. `capped` built `untruncated({**reply, key: whole})` once per branch. One
   binding, named `all_of_it`, covers both and makes the docstring's
   sentence literally the code.

**Declined:** bundling `label`/`fallback`/`config` into a `Spill` value type
(possible Data Clumps). Three parameters sharing a destination are not yet a
concept, and the ticket asked for one definition of a truncated reply rather
than a new type to carry it.

Also corrected a fact of my own in the same commit: `load_all`'s docstring
said the states were "this module's fact", but `STATES` is defined in
`lifecycle`, not `store`.

The fix diff was re-checked (focused pass over what changed) — pytest, ruff
and mypy all clean.

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
