### PR TITLE
One lease module for cross-process claims (#217)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,9 +109,11 @@ Top level:
 | `ffmpeg.py` | the one place the server shells out to ffmpeg (argv lists) |
 | `findings.py` | shared finding shape `{rule, id, message, fix_hint}` |
 | `interpreter.py` | guard on which interpreters may attach to fusionscript (ADR 0001) |
+| `lease.py` | is the owner of this claim still alive — `SESSION`, `liveness`, `claim`/`holder` (#217) |
 | `logging_config.py` | stderr-only logging (stdout belongs to MCP transport) |
 | `naming.py` | names for written files and `<base> v<N>` timelines |
 | `server.py` | FastMCP app + tool registration; no logic |
+| `sharing.py` | the Windows retry for a file another handle holds (#217) |
 | `spill.py` | oversized results → disk |
 | `timing.py` | frames authoritative; seconds/timecode/fps derived |
 
@@ -202,7 +204,9 @@ mix into four, then the drum stem into the kit — plus an opt-in third,
 accompaniment, never a piano stem. A directory is judged pass by pass and
 only the passes it owes are run, so turning the third one on costs that pass
 alone — but a missing first pass redoes all three, since the later two are cut
-from what it wrote, #192), `wav` (header facts + the one
+from what it wrote, #192. `claimed` is the policy over `lease.claim` — how long
+a claim may go quiet, how long a run waits for the separation already under
+way, and what the agent is told when it is refused — #217), `wav` (header facts + the one
 unreadable-WAV error).
 
 `cut/` — cut-file schema v1: `document` (read off disk), `resolution` (the
@@ -229,10 +233,12 @@ wherever the file sits, read off a `known_hash` note remembered against a
 stat, except under `audio_dir` where it is always read for real;
 `fingerprint` is path+size+mtime and stays the identity for video sources
 and stems — ADR 0007, ADR 0003), `runner` (start heavy work without
-stalling stdio), `lifecycle` (the job states, this server's `SESSION`, and
+stalling stdio), `lifecycle` (the job states and
 `verdict(record, now, alive)` — whether anything is still running a job and
 the sentence for it if not, decided from the record alone with liveness
-injected, so the truth table is testable in memory), `store` (one JSON record
+injected, so the truth table is testable in memory; the pid/session/silence
+reading inside it is `lease.liveness`, shared with the stems claim, and the
+process identity `SESSION` is `lease`'s too — #217), `store` (one JSON record
 per job on disk; `load` is read file → verdict → maybe write the failure
 back), `detached` (hand a job to a process that outlives this one — flags,
 command, environment), `worker` (that process's entry point: `python -m
@@ -325,6 +331,13 @@ covers `resolve/media` (what the six operations do with what the adapter hands
 them). Both drive the fake seam through `tools/media`, and both build their
 pools from `tests/mediapool.py` (`a_file`, `a_clip`, `a_shallow_copy_pool`) so
 the pair cannot drift on what a clip or a shadowed copy looks like.
+
+`test_lease.py` covers `lease` — the liveness truth table in memory, then the
+claim protocol with both the liveness answer and the read injected, so a dead
+process, a recycled pid and a refused read are arrangements rather than
+monkeypatches. `test_detached_jobs.py` keeps what is stems-shaped over it (the
+refusals' wording, the claim held across the passes and dropped after them) and
+`test_sharing.py` pins the retry both files depend on (#217).
 
 `tests/fakes/` is the fake Resolve API, one module per subsystem — open the
 module, not the package, and never the whole package at once:

--- a/src/resolve_mcp/audio/stems.py
+++ b/src/resolve_mcp/audio/stems.py
@@ -43,28 +43,20 @@ Four decisions worth knowing:
 
 from __future__ import annotations
 
-import json
-import os
-import threading
 import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from .. import lease
 from ..config import Config, get_config
 from ..errors import InternalError, InvalidRequestError, SeparationInProgressError
 from ..ffmpeg import Runner
 from ..jobs import cache
 from ..jobs import runner as job_runner
-from ..jobs.lifecycle import SESSION
 from ..jobs.runner import Detached, JobOutput, Progress, start_job
-
-# ``_sharing`` is the store's, and is reached for by its private name deliberately: a claim file
-# and a job record are the same Windows problem — another handle holding the file for the
-# microsecond of a poll — and a second copy of the retry here would be a second policy to keep in
-# step with that one.
-from ..jobs.store import JobRecord, _sharing, pid_alive
+from ..jobs.store import JobRecord, pid_alive
 from ..logging_config import get_logger
 from ..naming import slug
 from ..resolve.connection import ResolveConnection
@@ -334,12 +326,16 @@ under an hour, so six of them can only be a claim whose process is gone in a way
 check could not see — the pid recycled onto a live, unrelated process. Without a ceiling
 that directory is locked out for the life of the machine.
 
-Only a claim nobody is working on ages: a running separation refreshes its own (see
-``_touch``), so what this measures is silence rather than runtime.
+Only a claim nobody is working on ages: a running separation refreshes its own (the callable
+``claimed`` yields), so what this measures is silence rather than runtime.
 """
 
 CLAIM_REFRESH = 60.0
-"""How often a running separation rewrites its claim, in seconds. See ``_keeping_the_claim``."""
+"""How often a running separation rewrites its claim, in seconds.
+
+The bar it is hung off moves several times a second while the claim only has to stay younger
+than a ceiling measured in hours, so the lease throttles to this. See ``_keeping_the_claim``.
+"""
 
 CLAIM_WAIT = 2 * 60 * 60
 """How long a run waits for the separation already under way to finish, in seconds.
@@ -356,28 +352,8 @@ well inside ``CLAIM_CEILING``, so giving up still comes long before the claim wo
 CLAIM_POLL = 5.0
 """How often a waiting run looks at the claim again, in seconds — one small read of one file."""
 
-UNREADABLE = b""
-"""What ``_claim_bytes`` gives back for a claim that is there but could not be read.
-
-Not the same answer as ``None``, which is no claim at all: a claim nothing can read is still
-somebody's until it ages out, while a missing one is free for the taking. Empty bytes rather than
-a sentinel of its own because a claim file with nothing in it — the window the fallback create
-leaves open — is unreadable in exactly that way and wants exactly that answer.
-"""
-
-Waiting = Callable[[int | None], None]
+Waiting = lease.Waiting
 """Told, each time round, which process is being waited for. See ``claimed``."""
-
-_claims: dict[str, threading.Lock] = {}
-_claims_lock = threading.Lock()
-"""One lock per stems directory, for the threads of *this* process. See ``claimed``."""
-
-
-def _local_lock(directory: Path) -> threading.Lock:
-    """The lock this process uses for that directory, made once and kept."""
-    key = os.path.normcase(str(directory.resolve()))
-    with _claims_lock:
-        return _claims.setdefault(key, threading.Lock())
 
 
 @contextmanager
@@ -395,20 +371,12 @@ def claimed(
     writing the same files interleave into stems that are neither run's: half the tracks from
     each, all of them looking complete to the reuse check that reads them next.
 
-    Two locks, because there are two kinds of rival. A file for the other *processes*: since
-    G4 a separation runs in a detached worker, and disk is the only thing those share — the
-    same reason the job record itself is a file. The claim is written under a name of this
-    process's own and then *linked* into place, so the winner is the one whose link the
-    filesystem accepted rather than whoever read an empty directory last — and what appears
-    under the claim's name is a complete claim, never the empty file an exclusive create
-    publishes before its content lands. And a plain in-process lock for the other *threads*,
-    which the file cannot separate at all: they share a pid, so each would read the other's
-    claim as its own and both would walk straight in.
-
-    A claim whose process is gone is a crashed run rather than an owner, and is taken over
-    instead of waited on: nobody is left locked out by a worker that died at the 50% mark. A
-    claim that is merely unreadable is not that — it is waited on, because the one thing that
-    reliably makes a claim unreadable is being read at the moment it is written.
+    All of the protocol is ``lease``'s — the file, the in-process lock, who may take a claim
+    over and when a wait has gone on too long — because a stems directory and a detached job
+    record are the same claim asked the same question: is the process that wrote this still
+    working? What is here is the policy: how long a claim may go quiet (``CLAIM_CEILING``),
+    how long a run waits for the separation already under way (``CLAIM_WAIT``), how often the
+    claim is rewritten (``CLAIM_REFRESH``), and what the agent is told when the answer is no.
 
     A rival that is genuinely working is **waited out** rather than refused, whenever the caller
     passes ``waiting`` — the callback that says the wait is still going, so a job with a progress
@@ -421,431 +389,74 @@ def claimed(
 
     Yields the callable that keeps the claim young: a separation runs for as long as an hour,
     the ceiling that reads a claim as abandoned is measured from when it was written, and a
-    claim nobody touches is eventually stolen out from under a run that is still going.
+    claim nobody touches is eventually stolen out from under a run that is still going. It is
+    yielded already wrapped, so a separation that has lost its directory hears about it in this
+    module's words at the moment it reports, rather than as a lease error at the end.
     """
-    directory.mkdir(parents=True, exist_ok=True)
     marker = directory / CLAIM
-    lock = _local_lock(directory)
-    deadline = time.monotonic() + (CLAIM_WAIT if budget is None else budget)
-    pause = CLAIM_POLL if poll is None else poll
-    _hold_locally(lock, directory, waiting, deadline, pause, sleep)
     try:
-        _take(marker, waiting, deadline, pause, sleep)
+        with lease.claim(
+            marker,
+            ceiling=CLAIM_CEILING,
+            refresh=CLAIM_REFRESH,
+            alive=pid_alive,
+            waiting=waiting,
+            budget=CLAIM_WAIT if budget is None else budget,
+            poll=CLAIM_POLL if poll is None else poll,
+            sleep=sleep,
+        ) as beat:
+            yield _reporting(directory, beat)
+    except lease.LeaseHeld as held:
+        raise _in_progress(directory, held) from held
+
+
+def _reporting(directory: Path, beat: Callable[[], None]) -> Callable[[], None]:
+    """The lease's refresh, saying who has the directory in the words the agent reads."""
+
+    def refresh() -> None:
         try:
-            yield lambda: _touch(marker)
-        finally:
-            _release(marker)
-    finally:
-        lock.release()
+            beat()
+        except lease.LeaseHeld as held:
+            raise _in_progress(directory, held) from held
+
+    return refresh
 
 
-def _hold_locally(
-    lock: threading.Lock,
-    directory: Path,
-    waiting: Waiting | None,
-    deadline: float,
-    poll: float,
-    sleep: Callable[[float], None],
-) -> None:
-    """Take this process's own lock on the directory, waiting out the thread that holds it.
+def _in_progress(directory: Path, held: lease.LeaseHeld) -> SeparationInProgressError:
+    """Who has the directory, said the way the agent reads it.
 
-    The claim file cannot separate two threads of one server — they share a pid, so each reads
-    the other's claim as its own and both walk in — and two jobs over the same mix land on one
-    directory by design. Waited out on the same terms as another process's claim, and for the
-    same reason: the thread ahead is making the stems this one is about to ask for.
+    Three refusals, because they are three different things to be told: the rival that already
+    had it, a thread of this very server that has it (the claim file cannot separate those —
+    they share a pid), and the one that arrives mid-separation, where the directory this run is
+    *writing* has become somebody else's. That last one stops the separation rather than
+    carrying on quietly, because what carrying on produces is a set of stems from two runs that
+    looks complete to the reuse check reading it next.
     """
-    if lock.acquire(blocking=False):
-        return
-    if waiting is not None:
-        log.info(
-            "Waiting for another thread of pid %s to finish separating into %s",
-            os.getpid(),
-            directory,
-        )
-        while time.monotonic() < deadline:
-            waiting(os.getpid())
-            sleep(poll)
-            if lock.acquire(blocking=False):
-                log.info("Took %s over from the thread that was separating into it", directory)
-                return
-        log.warning("Gave up waiting for this process's own thread to release %s", directory)
-    raise SeparationInProgressError(
-        cause=(
-            f"Another thread of this process (pid {os.getpid()}) is already separating "
+    return SeparationInProgressError(
+        cause=_refusal(directory, held),
+        detail={"directory": str(directory), "pid": held.pid},
+    )
+
+
+def _refusal(directory: Path, held: lease.LeaseHeld) -> str:
+    """The sentence for this refusal, chosen by what the lease said was in the way."""
+    if held.reason is lease.Reason.THREAD:
+        return (
+            f"Another thread of this process (pid {held.pid}) is already separating "
             f"into {directory}."
-        ),
-        detail={"directory": str(directory), "pid": os.getpid()},
-    )
-
-
-class _Held(NamedTuple):
-    """What the claim on disk says, as ``_take`` needs to hear it."""
-
-    held: bool
-    """Somebody is separating into this directory right now — wait rather than take over."""
-    pid: int | None
-    """Which process, when the claim names one legibly."""
-    judged: bytes | None
-    """The exact bytes this verdict was reached on, so a stale claim is cleared by identity."""
-
-
-def _take(
-    marker: Path,
-    waiting: Waiting | None = None,
-    deadline: float | None = None,
-    poll: float = CLAIM_POLL,
-    sleep: Callable[[float], None] = time.sleep,
-) -> None:
-    """Win the claim, or say who holds it — waiting the holder out where there is a way to wait.
-
-    A rival that is genuinely working is not on its own a reason to fail: the directory is keyed
-    by the audio and the models, so what that rival is producing is what this run came for, and
-    a caller that can report progress waits for it rather than refusing. Without ``waiting``
-    there is nowhere to say a wait is happening, so the refusal is immediate — and it names the
-    holder either way, at the start or after the budget has gone.
-    """
-    verdict = _one_turn(marker)
-    if verdict is None:
-        return
-    if waiting is None or deadline is None:
-        raise _in_progress(marker, verdict)
-    log.info(
-        "Waiting for pid %s to finish separating into %s before taking the directory",
-        verdict.pid,
-        marker.parent,
-    )
-    while time.monotonic() < deadline:
-        waiting(verdict.pid)
-        sleep(poll)
-        again = _one_turn(marker)
-        if again is None:
-            log.info("Took the claim on %s after waiting for pid %s", marker.parent, verdict.pid)
-            return
-        verdict = again
-    log.warning(
-        "Gave up waiting for pid %s to finish separating into %s", verdict.pid, marker.parent
-    )
-    raise _in_progress(marker, verdict)
-
-
-def _one_turn(marker: Path) -> _Held | None:
-    """One go at the claim: ``None`` once it is this run's, or what holds it if it is not.
-
-    Reading first and writing after is two separations both finding an empty directory and
-    both proceeding; the link is what makes the answer the filesystem's. A link that is
-    refused is not yet a refusal to run: the claim on disk may be one nothing is holding, and
-    then it is cleared and the link tried once more. Only once more per go — a second loser is
-    a live rival, not a stale file, and a caller that means to wait comes back round anyway.
-    """
-    if _create(marker):
-        return None
-    verdict = _holder(marker)
-    if not verdict.held:
-        _discard(marker, verdict.judged)
-        if _create(marker):
-            return None
-        verdict = _holder(marker)
-    return verdict
-
-
-def _in_progress(marker: Path, verdict: _Held) -> SeparationInProgressError:
-    """Who has the directory, said the way the agent reads it."""
-    directory = marker.parent
-    cause = (
-        f"Another process (pid {verdict.pid}) is already separating into {directory}."
-        if verdict.pid is not None
+        )
+    if held.reason is lease.Reason.LOST:
+        return (
+            f"Another process (pid {held.pid}) has taken the claim on {directory} while this "
+            "separation was writing into it."
+            if held.pid is not None
+            else f"The claim this separation was holding on {directory} is gone."
+        )
+    return (
+        f"Another process (pid {held.pid}) is already separating into {directory}."
+        if held.pid is not None
         else f"Another process claimed {directory} at the same moment this one tried to."
     )
-    return SeparationInProgressError(
-        cause=cause,
-        detail={"directory": str(directory), "pid": verdict.pid},
-    )
-
-
-def _content() -> bytes:
-    """The claim this process would write, as the bytes that go on disk."""
-    return json.dumps({"pid": os.getpid(), "session": SESSION, "claimed_at": time.time()}).encode()
-
-
-def _create(marker: Path) -> bool:
-    """Publish this process's claim only if nobody else has one; ``False`` means somebody does.
-
-    Written under a name of this process's own and hard-linked into place, rather than created
-    exclusively and then filled in. Both refuse a second winner, but an exclusive create
-    publishes the claim's *name* before its content: a rival reading in that instant finds an
-    empty file, reads it as unreadable, and the recovery for an unreadable claim — whatever it
-    is — is being run against the winner's live claim rather than against a stale one. A link
-    makes the name and the content appear together, so there is no such instant to read.
-
-    A filesystem that refuses hard links altogether (a cache directory on exFAT) falls back to
-    the exclusive create, which is still correct about who won; the empty-file window is then
-    covered by ``_holder`` reading an unreadable claim as held rather than adoptable.
-    """
-    scratch = marker.with_name(f"{marker.name}.{os.getpid()}")
-    payload = _content()
-    try:
-        scratch.write_bytes(payload)
-        try:
-            os.link(scratch, marker)
-        except FileExistsError:
-            return False
-        except OSError as exc:
-            log.warning(
-                "This filesystem will not link a stems claim into place (%s); falling back to "
-                "an exclusive create at %s",
-                exc,
-                marker,
-            )
-            return _create_exclusively(marker, payload)
-    finally:
-        scratch.unlink(missing_ok=True)
-    log.info("Claimed the stems directory %s for pid %s", marker.parent, os.getpid())
-    return True
-
-
-def _create_exclusively(marker: Path, payload: bytes) -> bool:
-    """The fallback for a filesystem with no hard links: create, then fill in."""
-    try:
-        handle = os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-    except FileExistsError:
-        return False
-    with os.fdopen(handle, "wb") as sink:
-        sink.write(payload)
-    log.info("Claimed the stems directory %s for pid %s", marker.parent, os.getpid())
-    return True
-
-
-def _touch(marker: Path) -> None:
-    """Say the claim is still being worked on, so the ceiling measures staleness not runtime.
-
-    ``CLAIM_CEILING`` exists for a claim whose process is gone in a way the pid check cannot
-    see, and it can only mean that if a claim that *is* being worked on stays young. Without
-    this a separation long enough to pass the ceiling — the whole case the ceiling is written
-    for — has its own claim read as abandoned and a second separator walks into the directory
-    it is still writing. Rewritten rather than ``utime``d because the age is read out of the
-    claim's content, and only while the claim is still this process's to rewrite.
-
-    Finding the claim is somebody else's stops the separation rather than skipping the
-    refresh. The claim is what says who may write these files, so a run that has lost it is a
-    run writing stems into a directory another separator now owns — the interleaving the claim
-    exists to prevent, arrived at from the inside. Carrying on quietly would produce exactly
-    the half-and-half set that looks complete to the reuse check reading it next, so the run
-    is failed here instead, naming whoever holds the directory now.
-
-    A refresh that cannot be *written* is only a claim left to age, so that stays a warning:
-    the directory is still ours and the pass still running, and the next reading of the bar
-    tries again. A refresh whose claim cannot be *read* is the same warning for the same
-    reason. Finding somebody else's claim is evidence; finding no answer at all is not, and
-    reading it as a loss ended half an hour of GPU work every time the filesystem refused one
-    read — which on Windows is a routine thing for it to do, and is why the read retries first.
-    """
-    raw = _claim_bytes(marker)
-    if raw == UNREADABLE:
-        log.warning(
-            "Could not read the stems claim at %s to refresh it; the claim is this run's until "
-            "something legible says otherwise, so the separation carries on",
-            marker,
-        )
-        return
-    held = None if raw is None else _parse_claim(marker, raw)
-    if held is None or held.get("session") != SESSION or held.get("pid") != os.getpid():
-        raise _lost_the_claim(marker, held)
-    scratch = marker.with_name(f"{marker.name}.{os.getpid()}")
-    try:
-        scratch.write_bytes(_content())
-        os.replace(scratch, marker)
-    except OSError:
-        log.warning("Could not refresh the stems claim at %s", marker)
-        # Guarded in its own right: this runs on the path where writing that very file already
-        # failed, and on Windows a scratch file another handle still holds refuses the unlink
-        # too. Letting that out would end a running separation over a leftover file nothing
-        # reads — the scratch name carries this process's pid, so no other run reads it as a
-        # claim.
-        try:
-            scratch.unlink(missing_ok=True)
-        except OSError:  # pragma: no cover - a scratch claim left behind is read by nothing
-            log.debug("Could not clear the scratch claim at %s", scratch)
-
-
-def _lost_the_claim(marker: Path, raw: dict[str, Any] | None) -> SeparationInProgressError:
-    """Why a separation stops mid-pass: the directory it is writing is not its own any more."""
-    holder = raw.get("pid") if raw is not None else None
-    pid = holder if isinstance(holder, int) else None
-    log.warning("The claim at %s is no longer this process's; stopping the separation", marker)
-    cause = (
-        f"Another process (pid {pid}) has taken the claim on {marker.parent} while this "
-        "separation was writing into it."
-        if pid is not None
-        else f"The claim this separation was holding on {marker.parent} is gone."
-    )
-    return SeparationInProgressError(
-        cause=cause,
-        detail={"directory": str(marker.parent), "pid": pid},
-    )
-
-
-def _read_claim(marker: Path) -> dict[str, Any] | None:
-    """What the claim file says, or ``None`` if there is nothing legible there."""
-    raw = _claim_bytes(marker)
-    return None if raw is None else _parse_claim(marker, raw)
-
-
-def _claim_bytes(marker: Path) -> bytes | None:
-    """The claim exactly as it is on disk, ``None`` for no claim, ``UNREADABLE`` for no answer.
-
-    Retried the way ``store`` retries a record read, and for the same reason: Windows refuses
-    the read that lands while another handle holds the file, and a claim has two handles on it
-    whenever anything is looking — a rival deciding whether to wait, the run holding it
-    refreshing once a minute. The window is microseconds wide and a short retry closes it.
-    Believing one refusal is expensive at both ends: to a rival an unreadable claim reads as
-    held, so a directory whose owner is long gone stays locked; to the run holding it the same
-    non-answer used to read as *lost*, which ended the separation and the GPU time in it.
-    """
-    try:
-        return _sharing(marker.read_bytes)
-    except FileNotFoundError:
-        return None
-    except OSError:
-        log.warning("Could not read the stems claim at %s, even on a retry", marker)
-        return UNREADABLE
-
-
-def _parse_claim(marker: Path, raw: bytes) -> dict[str, Any] | None:
-    """The claim as a record, or ``None`` if those bytes are not one."""
-    try:
-        parsed = json.loads(raw)
-    except ValueError:
-        log.warning("Ignoring an unreadable stems claim at %s", marker)
-        return None
-    if not isinstance(parsed, dict):
-        log.warning("Ignoring a stems claim that is not a record at %s", marker)
-        return None
-    return parsed
-
-
-def _holder(marker: Path) -> _Held:
-    """Whether this claim is still held, and by whom — or that it is there for the taking.
-
-    Four ways a claim is there for the taking, and all of them read fields the claim has
-    always written. The pid is not enough on its own: it is a number the OS re-issues, so a
-    claim outlives the process that wrote it and can end up naming a live stranger — or this
-    very process, which is how a stale claim used to lock a directory out permanently while
-    reporting that *we* were separating into it.
-
-    A claim that cannot be read at all is the one case that is *not* adoptable. Reading it is
-    a guess either way, and the two guesses are not symmetrical: read as adoptable, the likely
-    cause — a claim caught mid-write, or a rival's write this filesystem has not shown us yet
-    — costs a second separator in a directory somebody is writing, which is the whole failure
-    this file exists to prevent. Read as held, an actually-corrupt claim costs a refused job
-    until the ceiling ages it out, and the ceiling is what clears it.
-    """
-    raw = _claim_bytes(marker)
-    if raw is None:
-        return _Held(held=False, pid=None, judged=None)
-    parsed = _parse_claim(marker, raw)
-    if parsed is None:
-        return _unreadable(marker, raw)
-    pid = parsed.get("pid")
-    if not isinstance(pid, int):
-        log.warning("Ignoring a stems claim that names no process at %s", marker)
-        return _unreadable(marker, raw)
-    session = parsed.get("session")
-    if session == SESSION:
-        # This process wrote it, and no thread of ours holds the directory's lock — the caller
-        # took that before asking. So it is our own leftover, from a run that died mid-write.
-        log.info("Taking back the stems claim at %s: this process left it behind", marker)
-        return _Held(held=False, pid=pid, judged=raw)
-    if pid == os.getpid():
-        log.info(
-            "Taking over the stems claim at %s: pid %s is now this process, not the one that "
-            "wrote the claim",
-            marker,
-            pid,
-        )
-        return _Held(held=False, pid=pid, judged=raw)
-    if not pid_alive(pid):
-        log.info("Taking over the stems claim at %s from pid %s, which is gone", marker, pid)
-        return _Held(held=False, pid=pid, judged=raw)
-    claimed_at = parsed.get("claimed_at")
-    age = time.time() - claimed_at if isinstance(claimed_at, int | float) else 0.0
-    if age > CLAIM_CEILING:
-        log.warning(
-            "Taking over the stems claim at %s from pid %s: it is %.1f hours old, so that pid "
-            "is a recycled number rather than the separation that wrote it",
-            marker,
-            pid,
-            age / 3600,
-        )
-        return _Held(held=False, pid=pid, judged=raw)
-    return _Held(held=True, pid=pid, judged=raw)
-
-
-def _unreadable(marker: Path, raw: bytes) -> _Held:
-    """A claim that names no process: held while it is young, adoptable once it is not.
-
-    Its age cannot come from its content — that is the part that could not be read — so it
-    comes from the file's own timestamp, which is the moment it was linked into place.
-    """
-    try:
-        age = time.time() - marker.stat().st_mtime
-    except OSError:
-        age = 0.0
-    if age > CLAIM_CEILING:
-        log.warning(
-            "Taking over the stems claim at %s: it names no process and is %.1f hours old",
-            marker,
-            age / 3600,
-        )
-        return _Held(held=False, pid=None, judged=raw)
-    log.info(
-        "Waiting out the claim at %s: it names no process, which is what a claim being written "
-        "right now looks like",
-        marker,
-    )
-    return _Held(held=True, pid=None, judged=raw)
-
-
-def _release(marker: Path) -> None:
-    """Drop the claim, but only if it is still the one this process wrote."""
-    raw = _read_claim(marker)
-    if raw is None:
-        return
-    if raw.get("session") != SESSION or raw.get("pid") != os.getpid():
-        log.info("Leaving the claim at %s alone: it is not the one this process wrote", marker)
-        return
-    try:
-        marker.unlink(missing_ok=True)
-    except OSError:
-        log.warning("Could not clear the stems claim at %s", marker)
-        return
-    log.info("Released the stems claim at %s", marker)
-
-
-def _discard(marker: Path, judged: bytes | None) -> None:
-    """Clear the exact claim that was judged abandoned — never whatever is there now.
-
-    The gap between judging a claim and unlinking it is one in which the judged claim can be
-    released and a rival's live one can appear under the same name: unlinking by name alone
-    hands a second separator into a directory the first is writing, which is what the claim
-    exists to prevent. So the bytes are read back and matched first. That leaves a window of
-    its own, narrower by the whole liveness check and unreachable on the ordinary path — the
-    link in ``_create`` is what makes the ordinary path safe, and nothing but a claim already
-    judged stale ever reaches this.
-    """
-    if judged is None:
-        return
-    current = _claim_bytes(marker)
-    if current is None:
-        return
-    if current != judged:
-        log.info("Leaving the claim at %s alone: it changed after it was judged abandoned", marker)
-        return
-    try:
-        marker.unlink(missing_ok=True)
-    except OSError:
-        log.warning("Could not clear the abandoned stems claim at %s", marker)
-        return
-    log.info("Cleared the abandoned stems claim at %s", marker)
 
 
 def multi_pass(
@@ -1095,22 +706,16 @@ def _already_separated(mix_dir: Path, drums_dir: Path, other_dir: Path, split_wi
 
 
 def _keeping_the_claim(progress: Progress, refresh: Callable[[], None]) -> Progress:
-    """The progress bar with a claim refresh hung off it — at most one every minute.
+    """The progress bar with a claim refresh hung off it.
 
-    The bar is the only thing that reports from inside a separation, so it is the only place
-    a claim can be kept young from. Throttled because it moves several times a second while
-    the claim only has to stay younger than a ceiling measured in hours: refreshing on every
-    reading would be thousands of writes to say what one a minute already says. The clock
-    starts now rather than at zero, because the claim was written a moment ago.
+    The bar is the only thing that reports from inside a separation, so it is the only place a
+    claim can be kept young from. What is left here is the wiring: the throttle that turns
+    several readings a second into one write a minute is the lease's, so that the claim and the
+    ceiling it is measured against are kept in step by one module (``CLAIM_REFRESH``).
     """
-    last = time.monotonic()
 
     def report(fraction: float, step: str) -> None:
-        nonlocal last
-        now = time.monotonic()
-        if now - last >= CLAIM_REFRESH:
-            last = now
-            refresh()
+        refresh()
         progress(fraction, step)
 
     return report

--- a/src/resolve_mcp/jobs/lifecycle.py
+++ b/src/resolve_mcp/jobs/lifecycle.py
@@ -7,6 +7,11 @@ those pids. It reads nothing, writes nothing and decides nothing twice: the stor
 that touches a disk. Splitting it out is what makes the truth table below testable in memory —
 every row used to cost a save and a load.
 
+The pid/session/silence reading inside it is not this module's own either: a job record is a
+claim on the work exactly as a stems directory's marker file is, and ``lease.liveness`` is the
+one place that says whether the process behind a claim is still working. What is here is
+job-shaped — which pid to ask about and when, and the sentence the agent reads afterwards.
+
 Three rules decide all of it.
 
 * **A restart is detected by session, not by pid.** Every record carries the id of the server
@@ -42,17 +47,15 @@ is decided is the return value, and that depends on the arguments alone.
 
 from __future__ import annotations
 
-import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
+from ..lease import SESSION, Alive, Liveness, Owner, liveness
 from ..logging_config import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from .store import JobRecord
 
 log = get_logger("jobs")
@@ -61,9 +64,6 @@ RUNNING = "running"
 COMPLETED = "completed"
 FAILED = "failed"
 STATES = (RUNNING, COMPLETED, FAILED)
-
-SESSION = uuid.uuid4().hex
-"""This server process. Records written under any other session predate a restart."""
 
 LAUNCH_WINDOW = 120.0
 """How long a detached record may go with no worker pid before the launch is not in flight.
@@ -129,7 +129,7 @@ class Verdict:
     cause: str | None = None
 
 
-def verdict(record: JobRecord, now: datetime, alive: Callable[[int], bool]) -> Verdict:
+def verdict(record: JobRecord, now: datetime, alive: Alive) -> Verdict:
     """Whether anything is still running this job, and the sentence for it if not.
 
     ``alive`` is asked about at most one pid: the worker's when the record has one, the
@@ -148,8 +148,13 @@ def verdict(record: JobRecord, now: datetime, alive: Callable[[int], bool]) -> V
     )
 
 
-def _detached(record: JobRecord, now: datetime, alive: Callable[[int], bool]) -> Verdict:
+def _detached(record: JobRecord, now: datetime, alive: Alive) -> Verdict:
     """A detached job outlives its session on purpose, so its pid is what gets asked.
+
+    The reading itself is ``lease.liveness``: a record is a claim on the work, exactly as a
+    stems directory's marker file is, and both ask whether the process that wrote it is still
+    working. What is left here is the sentence — which record this was, and what to tell the
+    agent about a job nothing is running any more.
 
     ``None`` is a launch still in flight — the starter marks the record detached before it
     spawns, so that a reader in the microseconds between never mistakes it for a thread job
@@ -174,8 +179,16 @@ def _detached(record: JobRecord, now: datetime, alive: Callable[[int], bool]) ->
     """
     if record.pid is None:
         return _stalled_launch(record, now, alive)
-    if alive(record.pid):
-        return _running_or_silent(record, now)
+    silence = _age(record.updated_at, now)
+    reading = liveness(
+        Owner(pid=record.pid, silence=silence),
+        ceiling=HEARTBEAT_CEILING,
+        alive=alive,
+    )
+    if reading is Liveness.HELD:
+        return Verdict(Outcome.LIVE)
+    if reading is Liveness.SILENT and silence is not None:
+        return _silent(record, silence)
     log.info("Job %s lost its detached worker (pid %s)", record.job_id, record.pid)
     return Verdict(
         Outcome.WORKER_GONE,
@@ -184,17 +197,14 @@ def _detached(record: JobRecord, now: datetime, alive: Callable[[int], bool]) ->
     )
 
 
-def _running_or_silent(record: JobRecord, now: datetime) -> Verdict:
-    """A live pid is running, unless nothing has written to the record for longer than any job.
+def _silent(record: JobRecord, silence: float) -> Verdict:
+    """A live pid on a record nothing has written to for longer than the job can run silently.
 
     The worker owns this record from its adopt onwards and writes it as the work moves, so the
     time since the last write is the worker's heartbeat — the freshest one the record carries,
     and the only one that does not have to be paid for with a second file. Silence past the
     ceiling means the pid is a reissued number rather than the worker that wrote the record.
     """
-    silence = _age(record.updated_at, now)
-    if silence is None or silence <= HEARTBEAT_CEILING:
-        return Verdict(Outcome.LIVE)
     log.warning(
         "Job %s has not been written to in %.0f s while pid %s reads as alive; that number "
         "belongs to some other process now, not to the worker that ran the job",
@@ -210,7 +220,7 @@ def _running_or_silent(record: JobRecord, now: datetime) -> Verdict:
     )
 
 
-def _stalled_launch(record: JobRecord, now: datetime, alive: Callable[[int], bool]) -> Verdict:
+def _stalled_launch(record: JobRecord, now: datetime, alive: Alive) -> Verdict:
     """Why this pid-less record is not a launch in flight, or ``LIVE`` while it still is.
 
     The launcher's pid is asked first, and its own age second. A pid is a number the OS
@@ -225,34 +235,38 @@ def _stalled_launch(record: JobRecord, now: datetime, alive: Callable[[int], boo
     alive by definition, so nothing but the clock can tell a hand-off in flight from one whose
     worker died before it adopted (see ``_detached``).
     """
-    if record.launcher_pid is None or not alive(record.launcher_pid):
+    age = _age(record.updated_at, now)
+    reading = liveness(
+        Owner(pid=record.launcher_pid, silence=age),
+        ceiling=LAUNCH_WINDOW,
+        alive=alive,
+    )
+    if reading is Liveness.HELD:
+        log.debug(
+            "Job %s has no worker pid yet, but its launcher (pid %s) is still running",
+            record.job_id,
+            record.launcher_pid,
+        )
+        return Verdict(Outcome.LIVE)
+    if reading is not Liveness.SILENT or age is None:
         log.info("Job %s never got a detached worker: its launcher is gone", record.job_id)
         return Verdict(
             Outcome.STALLED_LAUNCH,
             f"The server handing {record.kind} to a detached worker exited before the worker "
             "was started, so nothing is running it.",
         )
-    age = _age(record.updated_at, now)
-    if age is not None and age > LAUNCH_WINDOW:
-        log.warning(
-            "Job %s has had no detached worker for %.0f s; pid %s is either a recycled number "
-            "rather than the launcher that wrote the record, or a launcher that never started "
-            "one",
-            record.job_id,
-            age,
-            record.launcher_pid,
-        )
-        return Verdict(
-            Outcome.STALLED_LAUNCH,
-            f"The server handing {record.kind} to a detached worker never started one: nothing "
-            f"has written to the record in {age:.0f} seconds, so the launch is not in flight.",
-        )
-    log.debug(
-        "Job %s has no worker pid yet, but its launcher (pid %s) is still running",
+    log.warning(
+        "Job %s has had no detached worker for %.0f s; pid %s is either a recycled number "
+        "rather than the launcher that wrote the record, or a launcher that never started one",
         record.job_id,
+        age,
         record.launcher_pid,
     )
-    return Verdict(Outcome.LIVE)
+    return Verdict(
+        Outcome.STALLED_LAUNCH,
+        f"The server handing {record.kind} to a detached worker never started one: nothing "
+        f"has written to the record in {age:.0f} seconds, so the launch is not in flight.",
+    )
 
 
 def _age(stamp: str, now: datetime) -> float | None:

--- a/src/resolve_mcp/jobs/runner.py
+++ b/src/resolve_mcp/jobs/runner.py
@@ -176,7 +176,7 @@ def execute(record: JobRecord, work: Work, config: Config) -> None:
     # The bar reaches disk at most once a second. It moves several times a second and a
     # separation moves it for half an hour, which is tens of thousands of writes to a file
     # ``get_job`` is polling at the same time — on Windows the two sides already have to retry
-    # around each other's handles (``store._sharing``), and one write a second says everything
+    # around each other's handles (``sharing.sharing``), and one write a second says everything
     # a poller can read anyway. Two things are never throttled: a step change, which is the one
     # line an agent reads to know what is happening and happens a dozen times in a job rather
     # than a thousand, and the ending, which ``store.finish`` writes itself — so whichever tick

--- a/src/resolve_mcp/jobs/store.py
+++ b/src/resolve_mcp/jobs/store.py
@@ -33,9 +33,7 @@ import json
 import os
 import sys
 import threading
-import time
 import uuid
-from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -43,15 +41,13 @@ from typing import Any, Protocol
 
 from ..config import Config, get_config
 from ..errors import JobInterruptedError, JobNotFoundError
+from ..lease import SESSION
 from ..logging_config import get_logger
 from ..naming import slug
-from .lifecycle import COMPLETED, FAILED, RUNNING, SESSION, Outcome, verdict
+from ..sharing import sharing
+from .lifecycle import COMPLETED, FAILED, RUNNING, Outcome, verdict
 
 log = get_logger("jobs")
-
-SHARING_ATTEMPTS = 20
-SHARING_PAUSE = 0.01
-"""How long either side of a poll waits out the other's handle. See ``_sharing``."""
 
 WORKER_TAIL_LINES = 200
 """Lines of a dead worker's own output kept on the record.
@@ -239,7 +235,7 @@ def _write(record: JobRecord, config: Config) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
     scratch = _scratch(target)
     scratch.write_text(json.dumps(record.payload(), indent=2), encoding="utf-8")
-    _sharing(lambda: os.replace(scratch, target))
+    sharing(lambda: os.replace(scratch, target))
 
 
 def _unclaimed(record: JobRecord) -> bool:
@@ -362,7 +358,7 @@ def _write_note(target: Path, pid: int, step: str) -> None:
     note = _note_path(target)
     scratch = _scratch(note)
     scratch.write_text(json.dumps({"pid": pid, "step": step}), encoding="utf-8")
-    _sharing(lambda: os.replace(scratch, note))
+    sharing(lambda: os.replace(scratch, note))
     log.info(
         "Job %s: its launcher noted detached worker pid %s beside the record", target.stem, pid
     )
@@ -372,7 +368,7 @@ def _read_note(target: Path) -> dict[str, Any] | None:
     """The launcher's note, or ``None`` if there is none or it is not legible."""
     note = _note_path(target)
     try:
-        raw = json.loads(_sharing(lambda: note.read_text(encoding="utf-8")))
+        raw = json.loads(sharing(lambda: note.read_text(encoding="utf-8")))
     except FileNotFoundError:
         return None
     except (OSError, ValueError):
@@ -455,27 +451,6 @@ def load_all(state: str | None = None, config: Config | None = None) -> list[Job
     return [one for one in found if one.state == state]
 
 
-def _sharing[T](attempt: Callable[[], T]) -> T:
-    """Do it again if the other side of a poll had the file open.
-
-    Windows refuses to replace a file while another handle holds it, and refuses the read
-    that lands mid-replace — and polling is exactly two handles on one record: ``get_job``
-    or a chained job on one side, the worker saving its progress on the other. The window
-    is microseconds wide, so a short retry closes it. Letting the error out would kill the
-    worker thread mid-save and leave the record saying ``running`` forever, which is the
-    one failure the whole store exists to prevent; on the reading side it would report a
-    running job as gone.
-    """
-    for attempt_number in range(SHARING_ATTEMPTS):
-        try:
-            return attempt()
-        except PermissionError:
-            if attempt_number == SHARING_ATTEMPTS - 1:
-                raise
-            time.sleep(SHARING_PAUSE)
-    raise AssertionError("unreachable")  # pragma: no cover
-
-
 def _read(path: Path) -> JobRecord | None:
     record = _read_raw(path)
     return None if record is None else _noted(record, path)
@@ -488,7 +463,7 @@ def _read_raw(path: Path) -> JobRecord | None:
     that question with the note itself (see ``note_worker_pid``).
     """
     try:
-        raw = json.loads(_sharing(lambda: path.read_text(encoding="utf-8")))
+        raw = json.loads(sharing(lambda: path.read_text(encoding="utf-8")))
     except FileNotFoundError:
         return None
     except (OSError, ValueError):

--- a/src/resolve_mcp/lease.py
+++ b/src/resolve_mcp/lease.py
@@ -1,0 +1,623 @@
+"""Is the owner of this claim still alive? One answer, for every kind of claim there is.
+
+Two things in this server are held across processes, and both used to reason about their
+owners on their own. A **stems directory** is claimed by a file naming the separation writing
+it (``audio/stems``). A **detached job** is claimed by the record its worker writes
+(``jobs/lifecycle``, ``jobs/store``). Neither is a lock the OS keeps for us — a detached
+worker outlives the server that started it, so disk is the only thing the two share — and both
+therefore ask exactly the same question of what they find: *is the process that wrote this
+still working, or is this what a dead run left behind?*
+
+``liveness`` is that question, as a total function of what the claim says (a pid, a session, a
+silence) plus whatever the injected ``alive`` answers about that pid. Nothing here reads a
+clock or a process table by itself, which is what makes the truth table testable in memory.
+Four things make a claim adoptable and all four are the same in both callers:
+
+* **The session says it is our own leftover.** Every claim carries the id of the process that
+  wrote it. A claim whose session is this one, found by a caller that is not already holding
+  it, is what a run of ours that died mid-write leaves behind — nothing is going to finish it.
+* **The pid is now us.** The OS reissues pids, so a claim from a dead run can end up naming
+  this very process. That used to read as "we are already working on it" and lock a directory
+  out for the life of the server.
+* **The pid names nothing.** The ordinary crash: a worker killed at the 50% mark, whose claim
+  would otherwise lock every later run out of the work it was doing.
+* **The claim has gone quiet for longer than the ceiling.** The last way a claim outlives its
+  run: a reissued pid that belongs to a live stranger, which no liveness check can see through.
+  What ages is silence rather than runtime — a run that is working says so (``beat``), a
+  worker writes its record as it goes — so a ceiling far longer than any real job cannot
+  close a live one. It is the only rule that can clear a claim whose pid answers, and after a
+  reboot, when every number on the machine has been handed out again, it is the only rule left.
+
+On top of that answer this module owns **the claim file protocol itself**: take it, hold it,
+keep it young, release it. ``claim`` is the whole of it and ``holder`` is the reading behind
+it, so a caller writes policy — how long is too long, how long to wait, what to say when it
+refuses — and nothing about links, scratch names, sharing violations or recycled pids.
+
+The exception is deliberately this module's own and deliberately plain: a caller that refuses
+in its own vocabulary (``SeparationInProgressError`` for stems) catches ``LeaseHeld`` and says
+so, and the lease never learns what the claim is for.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from .logging_config import get_logger
+from .sharing import sharing
+
+log = get_logger("lease")
+
+SESSION = uuid.uuid4().hex
+"""This server process. Anything written under another session predates a restart.
+
+Here rather than with either kind of claim because both write it and both read it: a job
+record carries it to tell a restart from a running job, a stems claim carries it to tell our
+own leftover from a rival's live work. One uuid per process, made once.
+"""
+
+Alive = Callable[[int], bool]
+"""Whether that pid names a running process. Injected: only the caller knows what it started.
+
+``jobs.store.pid_alive`` is what both callers pass — it answers for a worker this process
+started from the handle it kept, and asks the OS about everything else — and it is passed
+rather than imported so that this module can be run against a dictionary.
+"""
+
+Waiting = Callable[[int | None], None]
+"""Told, each time round, which process is being waited for. See ``claim``."""
+
+Read = Callable[[Path], bytes]
+"""How a claim's bytes come off disk. Injected so a refused read is a test, not a monkeypatch."""
+
+UNREADABLE = b""
+"""What ``_bytes`` gives back for a claim that is there but could not be read.
+
+Not the same answer as ``None``, which is no claim at all: a claim nothing can read is still
+somebody's until it ages out, while a missing one is free for the taking. Empty bytes rather
+than a sentinel of its own because a claim file with nothing in it — the window the fallback
+create leaves open — is unreadable in exactly that way and wants exactly that answer.
+"""
+
+
+class Liveness(StrEnum):
+    """What the claim's own fields say about the run that wrote it. One is held; five are not."""
+
+    UNOWNED = "unowned"
+    """The claim names no process at all."""
+
+    OURS = "ours"
+    """This process wrote it and is not holding it — a run of ours that died mid-write."""
+
+    RECYCLED = "recycled"
+    """Another session wrote it, and its pid has since been reissued to this process."""
+
+    GONE = "gone"
+    """The pid names no running process."""
+
+    SILENT = "silent"
+    """A live pid on a claim nothing has written for longer than the work can go quiet."""
+
+    HELD = "held"
+    """Somebody is working on it."""
+
+
+@dataclass(frozen=True)
+class Owner:
+    """What a claim says about whoever wrote it, however that claim is spelled on disk.
+
+    A stems claim spells it as JSON in a marker file; a job record spells it as record fields.
+    Both arrive here as these three, and everything past this point is the same reasoning.
+    """
+
+    pid: int | None = None
+    """The process that wrote the claim, when it named one legibly."""
+
+    session: str | None = None
+    """The process id of the *server* that wrote it, or ``None`` where session is not the
+    question — a detached worker outlives the session that launched it on purpose, so judging
+    one by session would fail the job the detached path exists to protect."""
+
+    silence: float | None = None
+    """Seconds since the claim was last written; ``None`` when that cannot be read.
+
+    Unknown is not stale: a timestamp nothing can parse is no evidence that the run behind it
+    stopped, and closing a live job on it is the expensive direction."""
+
+
+def liveness(
+    owner: Owner,
+    *,
+    ceiling: float,
+    alive: Alive,
+    self_pid: int | None = None,
+    self_session: str = SESSION,
+) -> Liveness:
+    """Whether the run that wrote this claim is still working, and if not, how we know.
+
+    The rules are asked in the order they are cheap and certain: what the claim says about
+    itself first, the process table second, the clock last. ``self_pid`` and ``self_session``
+    are parameters rather than reads so that a test can be two processes at once.
+    """
+    if owner.pid is None:
+        return Liveness.UNOWNED
+    if owner.session is not None:
+        if owner.session == self_session:
+            return Liveness.OURS
+        if owner.pid == (os.getpid() if self_pid is None else self_pid):
+            return Liveness.RECYCLED
+    if not alive(owner.pid):
+        return Liveness.GONE
+    if owner.silence is not None and owner.silence > ceiling:
+        return Liveness.SILENT
+    return Liveness.HELD
+
+
+class Held(NamedTuple):
+    """What the claim on disk says, as taking it needs to hear it."""
+
+    held: bool
+    """Somebody is working under this claim right now — wait rather than take over."""
+
+    pid: int | None
+    """Which process, when the claim names one legibly."""
+
+    judged: bytes | None
+    """The exact bytes this verdict was reached on, so a stale claim is cleared by identity."""
+
+
+class Reason(StrEnum):
+    """Why a lease was refused. The caller's error wording turns on this, nothing else does."""
+
+    RIVAL = "rival"
+    """Another process holds the claim."""
+
+    THREAD = "thread"
+    """Another thread of this process holds it — the file cannot separate those."""
+
+    LOST = "lost"
+    """A run that was holding the claim found it is somebody else's now."""
+
+
+class LeaseHeld(Exception):
+    """Somebody else has this claim. Caught by the caller and said in the caller's own words."""
+
+    def __init__(self, path: Path, pid: int | None, reason: Reason) -> None:
+        super().__init__(f"{path} is claimed by pid {pid} ({reason})")
+        self.path = path
+        self.pid = pid
+        self.reason = reason
+
+
+_locks: dict[str, threading.Lock] = {}
+_locks_lock = threading.Lock()
+"""One lock per claim path, for the threads of *this* process. See ``claim``."""
+
+
+def _local_lock(path: Path) -> threading.Lock:
+    """The lock this process uses for that claim, made once and kept."""
+    key = os.path.normcase(str(path.resolve()))
+    with _locks_lock:
+        return _locks.setdefault(key, threading.Lock())
+
+
+@contextmanager
+def claim(
+    path: Path,
+    *,
+    ceiling: float,
+    refresh: float,
+    alive: Alive,
+    waiting: Waiting | None = None,
+    budget: float = 0.0,
+    poll: float = 5.0,
+    sleep: Callable[[float], None] = time.sleep,
+    read: Read | None = None,
+) -> Iterator[Callable[[], None]]:
+    """Hold this claim for one run at a time, and yield the callable that keeps it young.
+
+    Two locks, because there are two kinds of rival. A file for the other *processes*: a
+    detached worker outlives the server that started it, and disk is the only thing those
+    share. The claim is written under a name of this process's own and then *linked* into
+    place, so the winner is the one whose link the filesystem accepted rather than whoever read
+    an empty directory last — and what appears under the claim's name is a complete claim,
+    never the empty file an exclusive create publishes before its content lands. And a plain
+    in-process lock for the other *threads*, which the file cannot separate at all: they share
+    a pid, so each would read the other's claim as its own and both would walk straight in.
+
+    A claim nobody is working under is taken over rather than waited on (see ``liveness``); a
+    claim that is merely unreadable is waited on, because the one thing that reliably makes a
+    claim unreadable is being read at the moment it is written.
+
+    A rival that is genuinely working is **waited out** whenever the caller passes ``waiting``
+    — the callback that says the wait is still going, so a job with a progress bar never reads
+    as hung — for up to ``budget`` seconds, looking again every ``poll``. A caller with nowhere
+    to report a wait leaves it off and is refused at once, naming the holder either way.
+
+    ``refresh`` is how often the yielded callable actually rewrites the claim: it is wired to
+    whatever reports from inside the work, which moves several times a second, while the claim
+    only has to stay younger than a ceiling measured in hours. The clock starts now rather than
+    at zero, because the claim was written a moment ago.
+    """
+    reader = Path.read_bytes if read is None else read
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock = _local_lock(path)
+    deadline = time.monotonic() + budget
+    _hold_locally(lock, path, waiting, deadline, poll, sleep)
+    try:
+        _take(path, ceiling, alive, reader, waiting, deadline, poll, sleep)
+        try:
+            yield _beat(path, refresh, reader)
+        finally:
+            _release(path, reader)
+    finally:
+        lock.release()
+
+
+def holder(
+    path: Path,
+    *,
+    ceiling: float,
+    alive: Alive,
+    read: Read | None = None,
+) -> Held:
+    """Whether this claim is still held, and by whom — or that it is there for the taking.
+
+    A claim that cannot be read at all is the one case that is *not* adoptable. Reading it is a
+    guess either way, and the two guesses are not symmetrical: read as adoptable, the likely
+    cause — a claim caught mid-write, or a rival's write this filesystem has not shown us yet —
+    costs a second run in a directory somebody is writing, which is the whole failure the claim
+    exists to prevent. Read as held, an actually-corrupt claim costs a refused job until the
+    ceiling ages it out, and the ceiling is what clears it.
+    """
+    reader = Path.read_bytes if read is None else read
+    raw = _bytes(path, reader)
+    if raw is None:
+        return Held(held=False, pid=None, judged=None)
+    parsed = _parse(path, raw)
+    if parsed is None:
+        return _unreadable(path, raw, ceiling)
+    pid = parsed.get("pid")
+    if not isinstance(pid, int):
+        log.warning("Ignoring a claim that names no process at %s", path)
+        return _unreadable(path, raw, ceiling)
+    stamped = parsed.get("claimed_at")
+    silence = time.time() - stamped if isinstance(stamped, int | float) else None
+    session = parsed.get("session")
+    owner = Owner(pid=pid, session=session if isinstance(session, str) else None, silence=silence)
+    verdict = liveness(owner, ceiling=ceiling, alive=alive)
+    if verdict is Liveness.HELD:
+        return Held(held=True, pid=pid, judged=raw)
+    log.info("Taking over the claim at %s from pid %s: it reads as %s", path, pid, verdict)
+    return Held(held=False, pid=pid, judged=raw)
+
+
+def content() -> bytes:
+    """The claim this process would write, as the bytes that go on disk."""
+    return json.dumps({"pid": os.getpid(), "session": SESSION, "claimed_at": time.time()}).encode()
+
+
+def _hold_locally(
+    lock: threading.Lock,
+    path: Path,
+    waiting: Waiting | None,
+    deadline: float,
+    poll: float,
+    sleep: Callable[[float], None],
+) -> None:
+    """Take this process's own lock on the claim, waiting out the thread that holds it.
+
+    The claim file cannot separate two threads of one process — they share a pid, so each reads
+    the other's claim as its own and both walk in — and two jobs over the same work land on one
+    claim by design. Waited out on the same terms as another process's claim, and for the same
+    reason: the thread ahead is doing the work this one is about to ask for.
+    """
+    if lock.acquire(blocking=False):
+        return
+    if waiting is not None:
+        log.info(
+            "Waiting for another thread of pid %s to release the claim on %s", os.getpid(), path
+        )
+        while time.monotonic() < deadline:
+            waiting(os.getpid())
+            sleep(poll)
+            if lock.acquire(blocking=False):
+                log.info("Took the claim on %s over from the thread that held it", path)
+                return
+        log.warning("Gave up waiting for this process's own thread to release %s", path)
+    raise LeaseHeld(path, os.getpid(), Reason.THREAD)
+
+
+def _take(
+    path: Path,
+    ceiling: float,
+    alive: Alive,
+    read: Read,
+    waiting: Waiting | None,
+    deadline: float,
+    poll: float,
+    sleep: Callable[[float], None],
+) -> None:
+    """Win the claim, or say who holds it — waiting the holder out where there is a way to wait.
+
+    A rival that is genuinely working is not on its own a reason to fail: what it is producing
+    is usually what this run came for, and a caller that can report progress waits for it
+    rather than refusing. Without ``waiting`` there is nowhere to say a wait is happening, so
+    the refusal is immediate — and it names the holder either way, at the start or after the
+    budget has gone.
+    """
+    verdict = _one_turn(path, ceiling, alive, read)
+    if verdict is None:
+        return
+    if waiting is None:
+        raise LeaseHeld(path, verdict.pid, Reason.RIVAL)
+    log.info("Waiting for pid %s to release the claim on %s", verdict.pid, path)
+    while time.monotonic() < deadline:
+        waiting(verdict.pid)
+        sleep(poll)
+        again = _one_turn(path, ceiling, alive, read)
+        if again is None:
+            log.info("Took the claim on %s after waiting for pid %s", path, verdict.pid)
+            return
+        verdict = again
+    log.warning("Gave up waiting for pid %s to release the claim on %s", verdict.pid, path)
+    raise LeaseHeld(path, verdict.pid, Reason.RIVAL)
+
+
+def _one_turn(path: Path, ceiling: float, alive: Alive, read: Read) -> Held | None:
+    """One go at the claim: ``None`` once it is this run's, or what holds it if it is not.
+
+    Reading first and writing after is two runs both finding an empty directory and both
+    proceeding; the link is what makes the answer the filesystem's. A link that is refused is
+    not yet a refusal to run: the claim on disk may be one nothing is holding, and then it is
+    cleared and the link tried once more. Only once more per go — a second loser is a live
+    rival, not a stale file, and a caller that means to wait comes back round anyway.
+    """
+    if _create(path):
+        return None
+    verdict = holder(path, ceiling=ceiling, alive=alive, read=read)
+    if not verdict.held:
+        _discard(path, verdict.judged, read)
+        if _create(path):
+            return None
+        verdict = holder(path, ceiling=ceiling, alive=alive, read=read)
+    return verdict
+
+
+def _create(path: Path) -> bool:
+    """Publish this process's claim only if nobody else has one; ``False`` means somebody does.
+
+    Written under a name of this process's own and hard-linked into place, rather than created
+    exclusively and then filled in. Both refuse a second winner, but an exclusive create
+    publishes the claim's *name* before its content: a rival reading in that instant finds an
+    empty file, reads it as unreadable, and the recovery for an unreadable claim — whatever it
+    is — is being run against the winner's live claim rather than against a stale one. A link
+    makes the name and the content appear together, so there is no such instant to read.
+
+    A filesystem that refuses hard links altogether (a cache directory on exFAT) falls back to
+    the exclusive create, which is still correct about who won; the empty-file window is then
+    covered by ``holder`` reading an unreadable claim as held rather than adoptable.
+    """
+    scratch = _scratch(path)
+    payload = content()
+    try:
+        scratch.write_bytes(payload)
+        try:
+            os.link(scratch, path)
+        except FileExistsError:
+            return False
+        except OSError as exc:
+            log.warning(
+                "This filesystem will not link a claim into place (%s); falling back to an "
+                "exclusive create at %s",
+                exc,
+                path,
+            )
+            return _create_exclusively(path, payload)
+    finally:
+        scratch.unlink(missing_ok=True)
+    log.info("Claimed %s for pid %s", path, os.getpid())
+    return True
+
+
+def _create_exclusively(path: Path, payload: bytes) -> bool:
+    """The fallback for a filesystem with no hard links: create, then fill in."""
+    try:
+        handle = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        return False
+    with os.fdopen(handle, "wb") as sink:
+        sink.write(payload)
+    log.info("Claimed %s for pid %s", path, os.getpid())
+    return True
+
+
+def _beat(path: Path, refresh: float, read: Read) -> Callable[[], None]:
+    """The callable a run holding the claim reports through, rewriting it at most every
+    ``refresh`` seconds."""
+    last = time.monotonic()
+
+    def beat() -> None:
+        nonlocal last
+        now = time.monotonic()
+        if now - last < refresh:
+            return
+        last = now
+        _touch(path, read)
+
+    return beat
+
+
+def _touch(path: Path, read: Read) -> None:
+    """Say the claim is still being worked on, so the ceiling measures silence not runtime.
+
+    The ceiling exists for a claim whose process is gone in a way the pid check cannot see, and
+    it can only mean that if a claim that *is* being worked on stays young. Without this a run
+    long enough to pass the ceiling — the whole case the ceiling is written for — has its own
+    claim read as abandoned and a second run walks into the work it is still doing. Rewritten
+    rather than ``utime``d because the age is read out of the claim's content, and only while
+    the claim is still this process's to rewrite.
+
+    Finding the claim is somebody else's stops the run rather than skipping the refresh. The
+    claim is what says who may write these files, so a run that has lost it is a run writing
+    into a directory another owns — the interleaving the claim exists to prevent, arrived at
+    from the inside. Carrying on quietly would produce exactly the half-and-half set that looks
+    complete to whatever reads it next, so the run is failed here instead, naming whoever holds
+    the claim now.
+
+    A refresh that cannot be *written* is only a claim left to age, so that stays a warning:
+    the claim is still ours and the work still running, and the next reading tries again. A
+    refresh whose claim cannot be *read* is the same warning for the same reason. Finding
+    somebody else's claim is evidence; finding no answer at all is not, and reading it as a
+    loss ended half an hour of GPU work every time the filesystem refused one read — which on
+    Windows is a routine thing for it to do, and is why the read retries first.
+    """
+    raw = _bytes(path, read)
+    if raw == UNREADABLE:
+        log.warning(
+            "Could not read the claim at %s to refresh it; it is this run's until something "
+            "legible says otherwise, so the work carries on",
+            path,
+        )
+        return
+    held = None if raw is None else _parse(path, raw)
+    if held is None or held.get("session") != SESSION or held.get("pid") != os.getpid():
+        raise _lost(path, held)
+    scratch = _scratch(path)
+    try:
+        scratch.write_bytes(content())
+        os.replace(scratch, path)
+    except OSError:
+        log.warning("Could not refresh the claim at %s", path)
+        # Guarded in its own right: this runs on the path where writing that very file already
+        # failed, and on Windows a scratch file another handle still holds refuses the unlink
+        # too. Letting that out would end a running job over a leftover file nothing reads —
+        # the scratch name carries this process's pid, so no other run reads it as a claim.
+        try:
+            scratch.unlink(missing_ok=True)
+        except OSError:  # pragma: no cover - a scratch claim left behind is read by nothing
+            log.debug("Could not clear the scratch claim at %s", scratch)
+
+
+def _lost(path: Path, raw: dict[str, Any] | None) -> LeaseHeld:
+    """Why a run stops mid-work: the claim it is writing under is not its own any more."""
+    named = raw.get("pid") if raw is not None else None
+    pid = named if isinstance(named, int) else None
+    log.warning("The claim at %s is no longer this process's; stopping the work", path)
+    return LeaseHeld(path, pid, Reason.LOST)
+
+
+def _release(path: Path, read: Read) -> None:
+    """Drop the claim, but only if it is still the one this process wrote."""
+    raw = _bytes(path, read)
+    parsed = None if raw is None else _parse(path, raw)
+    if parsed is None:
+        return
+    if parsed.get("session") != SESSION or parsed.get("pid") != os.getpid():
+        log.info("Leaving the claim at %s alone: it is not the one this process wrote", path)
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        log.warning("Could not clear the claim at %s", path)
+        return
+    log.info("Released the claim at %s", path)
+
+
+def _discard(path: Path, judged: bytes | None, read: Read) -> None:
+    """Clear the exact claim that was judged abandoned — never whatever is there now.
+
+    The gap between judging a claim and unlinking it is one in which the judged claim can be
+    released and a rival's live one can appear under the same name: unlinking by name alone
+    hands a second run into work the first is doing, which is what the claim exists to prevent.
+    So the bytes are read back and matched first. That leaves a window of its own, narrower by
+    the whole liveness check and unreachable on the ordinary path — the link in ``_create`` is
+    what makes the ordinary path safe, and nothing but a claim already judged stale ever
+    reaches this.
+    """
+    if judged is None:
+        return
+    current = _bytes(path, read)
+    if current is None:
+        return
+    if current != judged:
+        log.info("Leaving the claim at %s alone: it changed after it was judged abandoned", path)
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        log.warning("Could not clear the abandoned claim at %s", path)
+        return
+    log.info("Cleared the abandoned claim at %s", path)
+
+
+def _scratch(path: Path) -> Path:
+    """The name this process writes a claim under before it is linked into place."""
+    return path.with_name(f"{path.name}.{os.getpid()}")
+
+
+def _bytes(path: Path, read: Read) -> bytes | None:
+    """The claim exactly as it is on disk, ``None`` for no claim, ``UNREADABLE`` for no answer.
+
+    Retried the way the store retries a record read, and for the same reason: Windows refuses
+    the read that lands while another handle holds the file, and a claim has two handles on it
+    whenever anything is looking — a rival deciding whether to wait, the run holding it
+    refreshing once a minute. Believing one refusal is expensive at both ends: to a rival an
+    unreadable claim reads as held, so work whose owner is long gone stays locked out; to the
+    run holding it the same non-answer used to read as *lost*, which ended the job and the GPU
+    time in it.
+    """
+    try:
+        return sharing(lambda: read(path))
+    except FileNotFoundError:
+        return None
+    except OSError:
+        log.warning("Could not read the claim at %s, even on a retry", path)
+        return UNREADABLE
+
+
+def _parse(path: Path, raw: bytes) -> dict[str, Any] | None:
+    """The claim as a record, or ``None`` if those bytes are not one."""
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        log.warning("Ignoring an unreadable claim at %s", path)
+        return None
+    if not isinstance(parsed, dict):
+        log.warning("Ignoring a claim that is not a record at %s", path)
+        return None
+    return parsed
+
+
+def _unreadable(path: Path, raw: bytes, ceiling: float) -> Held:
+    """A claim that names no process: held while it is young, adoptable once it is not.
+
+    Its age cannot come from its content — that is the part that could not be read — so it
+    comes from the file's own timestamp, which is the moment it was linked into place.
+    """
+    try:
+        age = time.time() - path.stat().st_mtime
+    except OSError:
+        age = 0.0
+    if age > ceiling:
+        log.warning(
+            "Taking over the claim at %s: it names no process and is %.1f hours old",
+            path,
+            age / 3600,
+        )
+        return Held(held=False, pid=None, judged=raw)
+    log.info(
+        "Waiting out the claim at %s: it names no process, which is what a claim being written "
+        "right now looks like",
+        path,
+    )
+    return Held(held=True, pid=None, judged=raw)

--- a/src/resolve_mcp/lease.py
+++ b/src/resolve_mcp/lease.py
@@ -79,7 +79,7 @@ Waiting = Callable[[int | None], None]
 Read = Callable[[Path], bytes]
 """How a claim's bytes come off disk. Injected so a refused read is a test, not a monkeypatch."""
 
-UNREADABLE = b""
+_UNREADABLE = b""
 """What ``_bytes`` gives back for a claim that is there but could not be read.
 
 Not the same answer as ``None``, which is no claim at all: a claim nothing can read is still
@@ -301,9 +301,20 @@ def holder(
     return Held(held=False, pid=pid, judged=raw)
 
 
-def content() -> bytes:
+def _content() -> bytes:
     """The claim this process would write, as the bytes that go on disk."""
     return json.dumps({"pid": os.getpid(), "session": SESSION, "claimed_at": time.time()}).encode()
+
+
+def _ours(claim: dict[str, Any] | None) -> bool:
+    """Whether that claim is the one this process wrote — the question both writers ask.
+
+    A refresh is a write onto the claim and a release is a delete of it, so both have to be
+    sure it is still ours: a rewrite of somebody else's claim is the theft the file exists to
+    prevent, and a delete of one is that theft with an extra step. Asked in one place because
+    two spellings of "still ours" would be two chances to disagree about it.
+    """
+    return claim is not None and claim.get("session") == SESSION and claim.get("pid") == os.getpid()
 
 
 def _hold_locally(
@@ -408,7 +419,7 @@ def _create(path: Path) -> bool:
     covered by ``holder`` reading an unreadable claim as held rather than adoptable.
     """
     scratch = _scratch(path)
-    payload = content()
+    payload = _content()
     try:
         scratch.write_bytes(payload)
         try:
@@ -482,7 +493,7 @@ def _touch(path: Path, read: Read) -> None:
     Windows is a routine thing for it to do, and is why the read retries first.
     """
     raw = _bytes(path, read)
-    if raw == UNREADABLE:
+    if raw == _UNREADABLE:
         log.warning(
             "Could not read the claim at %s to refresh it; it is this run's until something "
             "legible says otherwise, so the work carries on",
@@ -490,11 +501,11 @@ def _touch(path: Path, read: Read) -> None:
         )
         return
     held = None if raw is None else _parse(path, raw)
-    if held is None or held.get("session") != SESSION or held.get("pid") != os.getpid():
+    if not _ours(held):
         raise _lost(path, held)
     scratch = _scratch(path)
     try:
-        scratch.write_bytes(content())
+        scratch.write_bytes(_content())
         os.replace(scratch, path)
     except OSError:
         log.warning("Could not refresh the claim at %s", path)
@@ -522,7 +533,7 @@ def _release(path: Path, read: Read) -> None:
     parsed = None if raw is None else _parse(path, raw)
     if parsed is None:
         return
-    if parsed.get("session") != SESSION or parsed.get("pid") != os.getpid():
+    if not _ours(parsed):
         log.info("Leaving the claim at %s alone: it is not the one this process wrote", path)
         return
     try:
@@ -566,7 +577,7 @@ def _scratch(path: Path) -> Path:
 
 
 def _bytes(path: Path, read: Read) -> bytes | None:
-    """The claim exactly as it is on disk, ``None`` for no claim, ``UNREADABLE`` for no answer.
+    """The claim exactly as it is on disk, ``None`` for no claim, ``_UNREADABLE`` for no answer.
 
     Retried the way the store retries a record read, and for the same reason: Windows refuses
     the read that lands while another handle holds the file, and a claim has two handles on it
@@ -582,7 +593,7 @@ def _bytes(path: Path, read: Read) -> bytes | None:
         return None
     except OSError:
         log.warning("Could not read the claim at %s, even on a retry", path)
-        return UNREADABLE
+        return _UNREADABLE
 
 
 def _parse(path: Path, raw: bytes) -> dict[str, Any] | None:

--- a/src/resolve_mcp/sharing.py
+++ b/src/resolve_mcp/sharing.py
@@ -1,0 +1,35 @@
+"""Do it again if the other side of a poll had the file open.
+
+Windows refuses to replace a file while another handle holds it, and refuses the read that
+lands mid-replace. Every file this server polls has two handles on it whenever anything is
+looking — a job record with ``get_job`` on one side and the worker saving its progress on the
+other, a claim file with a rival deciding whether to wait on one side and the run holding it
+refreshing on the other. The window is microseconds wide, so a short retry closes it.
+
+Letting the error out is expensive at both ends and in every caller: on the writing side it
+kills the worker mid-save and leaves a record saying ``running`` for ever; on the reading side
+it reports a running job as gone, or a dead run's claim as one nobody may take. Neutral
+ground, beside ``spill``, because nothing about the retry is job-shaped: it is a fact about
+the filesystem, and a second copy of it anywhere would be a second policy to keep in step.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+ATTEMPTS = 20
+PAUSE = 0.01
+"""How long either side of a poll waits out the other's handle. See ``sharing``."""
+
+
+def sharing[T](attempt: Callable[[], T]) -> T:
+    """Run it, and run it again while Windows says another handle has the file."""
+    for attempt_number in range(ATTEMPTS):
+        try:
+            return attempt()
+        except PermissionError:
+            if attempt_number == ATTEMPTS - 1:
+                raise
+            time.sleep(PAUSE)
+    raise AssertionError("unreachable")  # pragma: no cover

--- a/tests/test_detached_jobs.py
+++ b/tests/test_detached_jobs.py
@@ -36,6 +36,7 @@ from typing import Any
 
 import pytest
 
+from resolve_mcp import lease
 from resolve_mcp.audio import stems
 from resolve_mcp.audio.stems import (
     CLAIM,
@@ -674,7 +675,7 @@ def test_a_launch_of_our_own_that_never_produced_a_worker_is_closed_like_anybody
 
     failed = store.load(record.job_id)
 
-    assert failed.session == lifecycle.SESSION
+    assert failed.session == lease.SESSION
     assert failed.state == lifecycle.FAILED
     assert failed.error is not None
     assert failed.error["code"] == "job_interrupted"
@@ -952,7 +953,7 @@ def test_the_worker_takes_the_record_over_closes_it_and_caches_what_it_made(
     assert finished.state == lifecycle.COMPLETED
     assert finished.result == {"from": {"audio": {"path": "mix.wav"}}}
     assert finished.pid == os.getpid()
-    assert finished.session == lifecycle.SESSION
+    assert finished.session == lease.SESSION
     assert cache.lookup("the-key") == {"from": {"audio": {"path": "mix.wav"}}}
 
 
@@ -1059,7 +1060,7 @@ def test_a_real_detached_worker_finds_the_record_and_closes_it() -> None:
     assert "No detached worker" in finished.error["cause"]
     assert finished.pid is not None
     assert finished.pid != os.getpid()
-    assert finished.session != lifecycle.SESSION
+    assert finished.session != lease.SESSION
     assert store.worker_log(record.job_id, get_config()).exists()
 
 
@@ -1174,141 +1175,22 @@ def test_a_second_thread_of_this_process_is_refused_a_directory_this_one_is_sepa
     assert refused[0].detail["pid"] == os.getpid()
 
 
-def test_a_stems_claim_left_by_a_run_that_is_gone_is_taken_over_even_wearing_this_pid(
+def test_a_claim_this_process_no_longer_holds_stops_the_separation(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """pids are reissued, and the one it names can end up being ours.
-
-    Then the claim is read as our own, which used to mean the directory was locked out for
-    good behind an error saying this process was already separating into it. The session the
-    claim carries is what tells the two apart, and it has been written since the claim
-    existed without anything ever reading it.
-    """
-    directory = tmp_path / "stems-abc123"
-    _claim_held_by(directory, os.getpid())
-
-    with claimed(directory):
-        held = json.loads((directory / CLAIM).read_text(encoding="utf-8"))
-
-    assert held["session"] == lifecycle.SESSION
-    assert not (directory / CLAIM).exists()
-
-
-def test_a_stems_claim_older_than_any_separation_is_taken_over_however_alive_its_pid_looks(
-    tmp_path: Path,
-) -> None:
-    """The last way a claim outlives its run: a recycled pid that belongs to a live stranger.
-
-    Nothing about that pid says it is not the separator, so the age is the only evidence left.
-    The ceiling is far longer than the longest measured pass, so crossing it cannot be a
-    separation that is merely slow.
-    """
-    directory = tmp_path / "stems-abc123"
-
-    with _a_live_process() as other:
-        marker = _claim_held_by(directory, other.pid, claimed_at=time.time() - CLAIM_CEILING - 60)
-
-        with claimed(directory):
-            held = json.loads(marker.read_text(encoding="utf-8"))
-
-    assert held["pid"] == os.getpid()
-
-
-def test_a_claim_that_changed_after_it_was_judged_abandoned_is_left_alone(tmp_path: Path) -> None:
-    """Two processes reading one abandoned claim is two processes deciding to clear it.
-
-    The first clears it, wins the create and starts separating; the second arrives a moment
-    later with the same verdict and unlinks — by name — the claim the first is now holding.
-    Nothing then refuses the second, and two separators write one directory, which is the
-    exact failure the claim exists to prevent. So the bytes that were judged are matched
-    against the bytes on disk before anything is unlinked.
-    """
-    directory = tmp_path / "stems-abc123"
-    marker = _claim_held_by(directory, _a_pid_that_has_exited())
-    judged = marker.read_bytes()
-    live = json.dumps({"pid": os.getpid(), "session": "the-winner", "claimed_at": time.time()})
-    marker.write_text(live, encoding="utf-8")
-
-    stems._discard(marker, judged)
-
-    assert marker.exists(), "a live claim was cleared by a process judging a stale one"
-    assert marker.read_text(encoding="utf-8") == live
-
-
-def test_a_claim_that_cannot_be_read_is_waited_out_rather_than_taken_over(tmp_path: Path) -> None:
-    """An empty claim is what a claim being written *right now* looks like.
-
-    An exclusive create publishes the name before the content lands, so a rival reading in
-    that instant sees zero bytes — and reading that as abandoned has it clear the winner's
-    fresh claim and walk in. The claim is linked into place rather than created empty, so the
-    window is gone on this filesystem; read as held, an unreadable claim also costs nothing on
-    one where the fallback create is what ran.
-    """
-    directory = tmp_path / "stems-abc123"
-    directory.mkdir(parents=True)
-    (directory / CLAIM).write_bytes(b"")
-
-    with pytest.raises(SeparationInProgressError) as raised, claimed(directory):
-        pass  # pragma: no cover - the claim is refused on the way in
-
-    assert raised.value.detail["pid"] is None
-    assert (directory / CLAIM).read_bytes() == b"", "the claim being written was cleared"
-
-
-def test_an_unreadable_claim_older_than_the_ceiling_is_still_taken_over(tmp_path: Path) -> None:
-    """Held is not held for ever: a genuinely corrupt claim ages out like any other.
-
-    Its age cannot come from its content — that is the part that could not be read — so it
-    comes from the file's own timestamp.
-    """
-    directory = tmp_path / "stems-abc123"
-    directory.mkdir(parents=True)
-    marker = directory / CLAIM
-    marker.write_bytes(b"{ half a claim")
-    aged = time.time() - CLAIM_CEILING - 60
-    os.utime(marker, (aged, aged))
-
-    with claimed(directory):
-        held = json.loads(marker.read_text(encoding="utf-8"))
-
-    assert held["pid"] == os.getpid()
-
-
-def test_a_claim_is_refreshed_by_the_run_that_is_holding_it(tmp_path: Path) -> None:
-    """The ceiling has to measure silence, not runtime, or it steals from a live separation.
-
-    Six hours is longer than any measured pass, but the claim is written once at the start and
-    never touched again — so a separation that is genuinely slow (a full set, a busy box, a
-    model downloading) has its own claim read as abandoned while it is still writing, and the
-    ceiling built to rescue a dead run hands a second separator into a live one instead.
-    """
-    directory = tmp_path / "stems-abc123"
-
-    with claimed(directory) as refresh:
-        marker = directory / CLAIM
-        held = json.loads(marker.read_text(encoding="utf-8"))
-        aged = time.time() - CLAIM_CEILING - 60
-        marker.write_text(json.dumps({**held, "claimed_at": aged}), encoding="utf-8")
-
-        refresh()
-
-        refreshed = json.loads(marker.read_text(encoding="utf-8"))
-
-    assert refreshed["claimed_at"] > aged + CLAIM_CEILING, "the claim was left at its old age"
-    assert refreshed["pid"] == os.getpid()
-    assert refreshed["session"] == lifecycle.SESSION
-
-
-def test_a_claim_this_process_no_longer_holds_stops_the_separation(tmp_path: Path) -> None:
-    """A refresh is a write, and a write onto somebody else's claim is the theft it prevents.
+    """A separation that has lost its directory hears it in this module's words, not the lease's.
 
     Not refreshing is only half of it: the claim says who may write the directory, so a run
     that reads somebody else's is a run whose stem files are landing in a directory another
     separator owns — the interleaving the claim exists to stop, reached from the inside. It
     stops rather than carrying on quietly, because what carrying on produces is a set of
-    stems from two runs that looks complete to the reuse check reading it next.
+    stems from two runs that looks complete to the reuse check reading it next. The reading
+    itself is ``lease``'s; what is asked here is that it arrives as a separation error, at the
+    moment the bar reports, naming the directory and whoever holds it now.
     """
     directory = tmp_path / "stems-abc123"
+    monkeypatch.setattr(stems, "CLAIM_REFRESH", 0.0)  # every reading of the bar, not one a minute
 
     with claimed(directory) as refresh:
         marker = directory / CLAIM
@@ -1323,9 +1205,13 @@ def test_a_claim_this_process_no_longer_holds_stops_the_separation(tmp_path: Pat
         assert marker.read_text(encoding="utf-8") == theirs
 
 
-def test_a_claim_that_vanished_under_a_running_separation_also_stops_it(tmp_path: Path) -> None:
+def test_a_claim_that_vanished_under_a_running_separation_also_stops_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """No claim is no better than a rival's: nothing is holding the directory for this run."""
     directory = tmp_path / "stems-abc123"
+    monkeypatch.setattr(stems, "CLAIM_REFRESH", 0.0)
 
     with claimed(directory) as refresh:
         (directory / CLAIM).unlink()
@@ -1336,42 +1222,12 @@ def test_a_claim_that_vanished_under_a_running_separation_also_stops_it(tmp_path
         assert raised.value.detail["pid"] is None
 
 
-def test_a_refresh_that_cannot_be_written_leaves_the_separation_running(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The other half: a claim that could not be rewritten is ours still, only older.
-
-    Both the write and the cleanup of what it left behind are refused here — Windows refuses
-    to unlink a file another handle holds, and that unlink runs inside the handler for the
-    write that already failed. Unguarded it escapes ``_touch`` and takes half an hour of GPU
-    work with it, over a scratch file named for this process that nothing else ever reads.
-    """
-    directory = tmp_path / "stems-abc123"
-
-    with claimed(directory) as refresh:
-        marker = directory / CLAIM
-        held = marker.read_text(encoding="utf-8")
-
-        def refuses(*args: Any, **kwargs: Any) -> None:
-            raise PermissionError("the file is open in another process")
-
-        monkeypatch.setattr(os, "replace", refuses)
-        monkeypatch.setattr(Path, "unlink", refuses)
-
-        refresh()  # the separation carries on
-
-        monkeypatch.undo()
-        assert marker.read_text(encoding="utf-8") == held
-
-
-def test_the_bar_a_separation_reports_through_keeps_the_claim_young(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_the_bar_a_separation_reports_through_keeps_the_claim_young() -> None:
     """Hung off the progress bar because that is the only thing reporting from inside a pass.
 
-    Throttled because the bar moves several times a second and the claim only has to stay
-    younger than a ceiling measured in hours.
+    The throttle that turns several readings a second into one write a minute is the lease's
+    (``CLAIM_REFRESH``, tested in ``test_lease``); what is asked here is the wiring — every
+    reading tells the claim it is still being worked on, and the bar still reports.
     """
     refreshed: list[int] = []
     reported: list[tuple[float, str]] = []
@@ -1382,12 +1238,9 @@ def test_the_bar_a_separation_reports_through_keeps_the_claim_young(
 
     beat(0.1, "separating four stems (10%)")
     beat(0.2, "separating four stems (20%)")
-    assert refreshed == [], "the claim was rewritten twice in a second"
-
-    monkeypatch.setattr(stems, "CLAIM_REFRESH", 0.0)
     beat(0.3, "separating four stems (30%)")
 
-    assert refreshed == [1]
+    assert refreshed == [1, 1, 1], "a reading of the bar did not reach the claim"
     assert reported == [
         (0.1, "separating four stems (10%)"),
         (0.2, "separating four stems (20%)"),
@@ -1451,66 +1304,6 @@ def test_a_finished_separation_holds_the_claim_for_the_passes_and_leaves_none_be
 
     assert held and all(held), "the separator ran without the directory being claimed"
     assert not (Path(str(output.result["directory"])) / CLAIM).exists()
-
-
-def test_a_claim_read_the_filesystem_refused_for_an_instant_is_read_again_not_believed(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A sharing violation is the file being read, not the directory being held.
-
-    Two handles land on a claim whenever anything is looking — a rival deciding whether to
-    wait, the run holding it refreshing once a minute — and Windows refuses the read that
-    arrives while the other side has it open. Believed the first time, that verdict reads an
-    unreadable claim as held and costs this run a directory whose owner is long gone. The
-    store retries its record reads for exactly this reason; a claim file is the same file.
-    """
-    directory = tmp_path / "stems-abc123"
-    _claim_held_by(directory, _a_pid_that_has_exited())
-    refused: list[int] = []
-    read_bytes = Path.read_bytes
-
-    def refuses_once(self: Path) -> bytes:
-        if self.name == CLAIM and not refused:
-            refused.append(1)
-            raise PermissionError("the file is open in another process")
-        return read_bytes(self)
-
-    monkeypatch.setattr(Path, "read_bytes", refuses_once)
-
-    with claimed(directory):
-        held = json.loads((directory / CLAIM).read_text(encoding="utf-8"))
-
-    assert refused == [1], "the refused read this test is about never happened"
-    assert held["pid"] == os.getpid(), "one refused read locked this run out of a dead run's claim"
-
-
-def test_a_refresh_whose_read_is_refused_leaves_the_separation_running(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The other half of the refresh: a claim that could not be *read* is this run's still.
-
-    The refresh runs once a minute from inside a pass that lasts half an hour, and a read the
-    filesystem refuses used to arrive as "somebody else has the directory" — ending the
-    separation, and all the GPU time in it, over a file nothing had touched. It is the same
-    verdict as a refresh that could not be written: the claim is ours, only older.
-    """
-    directory = tmp_path / "stems-abc123"
-
-    with claimed(directory) as refresh:
-        marker = directory / CLAIM
-        held = marker.read_text(encoding="utf-8")
-
-        def refuses(self: Path) -> bytes:
-            raise PermissionError("the file is open in another process")
-
-        monkeypatch.setattr(Path, "read_bytes", refuses)
-
-        refresh()  # the separation carries on
-
-        monkeypatch.undo()
-        assert marker.read_text(encoding="utf-8") == held, "an unreadable claim was written over"
 
 
 def test_a_run_waits_out_the_separation_already_under_way_rather_than_refusing_it(

--- a/tests/test_job_lifecycle.py
+++ b/tests/test_job_lifecycle.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+from resolve_mcp import lease
 from resolve_mcp.jobs import lifecycle
 from resolve_mcp.jobs.lifecycle import Outcome, verdict
 from resolve_mcp.jobs.store import JobRecord
@@ -48,7 +49,7 @@ def _record(
     state: str = lifecycle.RUNNING,
     *,
     detached: bool = False,
-    session: str = lifecycle.SESSION,
+    session: str = lease.SESSION,
     pid: int | None = None,
     launcher_pid: int | None = None,
     silence: float = 1.0,

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -13,9 +13,10 @@ from pathlib import Path
 
 import pytest
 
+from resolve_mcp import lease
 from resolve_mcp.config import get_config
 from resolve_mcp.errors import JobNotFoundError
-from resolve_mcp.jobs import lifecycle, store
+from resolve_mcp.jobs import store
 
 SAVES = 300
 
@@ -41,41 +42,13 @@ def test_progress_reads_back_from_disk_not_from_memory() -> None:
     assert reloaded.step == "separating"
 
 
-def test_a_write_that_loses_the_race_with_a_reader_is_tried_again() -> None:
-    """The rule the retry encodes, testable off Windows where the race cannot happen.
-
-    A reader holding the file is a refusal to wait out, not a failure to report: giving up
-    would kill the worker thread mid-save and leave the record saying running forever.
-    """
-    attempts: list[int] = []
-
-    def flaky() -> str:
-        attempts.append(len(attempts))
-        if len(attempts) < 3:
-            raise PermissionError(32, "The process cannot access the file")
-        return "written"
-
-    assert store._sharing(flaky) == "written"
-    assert len(attempts) == 3
-
-
-def test_a_reader_that_never_lets_go_is_still_an_error() -> None:
-    """Retrying forever would hide a genuinely locked cache directory."""
-
-    def locked() -> str:
-        raise PermissionError(32, "The process cannot access the file")
-
-    with pytest.raises(PermissionError):
-        store._sharing(locked)
-
-
 def test_a_record_written_while_it_is_being_polled_survives_both_sides() -> None:
     """The bug this guards, found by the first job to follow another job's record.
 
     On Windows a replace fails while a reader holds the file, and a read fails mid-replace.
     Unguarded, the write killed the worker thread mid-save and left the record saying
     running forever — which is exactly what a polling agent, or a chained job, provokes.
-    Only Windows can fail this one; the retry itself is pinned by the two tests above.
+    Only Windows can fail this one; the retry itself is pinned in ``test_sharing``.
     """
     record = store.new_job("separate_stems", {"scope": "timeline"})
     done = threading.Event()
@@ -152,7 +125,7 @@ def test_the_interruption_is_written_back_so_the_verdict_is_reached_once() -> No
 
     on_disk = json.loads(_record_path(record.job_id).read_text(encoding="utf-8"))
     assert on_disk["state"] == "failed"
-    assert on_disk["session"] == lifecycle.SESSION
+    assert on_disk["session"] == lease.SESSION
 
 
 def test_a_finished_job_from_a_previous_server_is_left_alone() -> None:

--- a/tests/test_lease.py
+++ b/tests/test_lease.py
@@ -1,0 +1,508 @@
+"""The one lease: is the owner of this claim still alive, and who may take it over.
+
+Two things in this server are claimed across processes — a stems directory and a detached
+job's record — and both used to reason about their owners on their own. The truth table is
+here, asked of ``liveness`` in memory: no clock, no process table, no disk. What follows it is
+the claim file protocol itself, exercised through ``claim`` and ``holder`` with the liveness
+answer and the read both injected, so a dead process, a recycled pid and a filesystem that
+refuses a read are all arrangements rather than monkeypatches.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp import lease
+from resolve_mcp.lease import Liveness, Owner
+
+CEILING = 6 * 60 * 60
+"""A ceiling in the shape both callers use one: far longer than the work it measures."""
+
+BUDGET = 5.0
+"""Long enough that a wait in these tests is bounded by its own arrangement, not the clock."""
+
+
+def _gone(pid: int) -> bool:
+    """Liveness for a claim whose process is not there any more."""
+    return False
+
+
+def _running(pid: int) -> bool:
+    """Liveness for a claim whose pid answers — whoever that pid now belongs to."""
+    return True
+
+
+def _written_by(
+    path: Path,
+    pid: int,
+    session: str = "another-server",
+    claimed_at: float | None = None,
+) -> Path:
+    """A claim somebody else says they are working under."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    held: dict[str, Any] = {"pid": pid, "session": session}
+    if claimed_at is not None:
+        held["claimed_at"] = claimed_at
+    path.write_text(json.dumps(held), encoding="utf-8")
+    return path
+
+
+def _reading(*answers: bytes | BaseException) -> lease.Read:
+    """A filesystem that gives these answers in order, then reads the file for real."""
+    remaining = list(answers)
+
+    def read(path: Path) -> bytes:
+        if remaining:
+            answer = remaining.pop(0)
+            if isinstance(answer, BaseException):
+                raise answer
+            return answer
+        return path.read_bytes()
+
+    return read
+
+
+def test_a_claim_this_session_wrote_is_our_own_leftover() -> None:
+    """Asked by a caller that is not holding it, so it is a run of ours that died mid-write.
+
+    Nothing is going to finish it: the thread that was working under it is gone with the run.
+    """
+    owner = Owner(pid=os.getpid(), session=lease.SESSION, silence=0.0)
+
+    assert liveness_of(owner) is Liveness.OURS
+
+
+def test_a_claim_from_another_session_wearing_this_pid_is_a_recycled_number() -> None:
+    """pids are reissued, and the one a dead run named can end up being ours.
+
+    Read as our own it used to lock the work out for good behind an error saying this very
+    process was already doing it. The session is what tells the two apart.
+    """
+    owner = Owner(pid=os.getpid(), session="another-server", silence=0.0)
+
+    assert liveness_of(owner) is Liveness.RECYCLED
+
+
+def test_a_claim_whose_process_is_gone_is_adoptable() -> None:
+    """The ordinary crash: a worker killed at the 50% mark must not lock everyone else out."""
+    owner = Owner(pid=4242, session="another-server", silence=0.0)
+
+    assert liveness_of(owner, alive=_gone) is Liveness.GONE
+
+
+def test_a_claim_that_has_gone_quiet_for_longer_than_the_ceiling_is_not_believed() -> None:
+    """The last way a claim outlives its run: a reissued pid belonging to a live stranger.
+
+    Nothing about that pid says it is not the owner, so the silence is the only evidence left
+    — and it is silence rather than runtime, because a run that is working says so.
+    """
+    owner = Owner(pid=4242, session="another-server", silence=CEILING + 60)
+
+    assert liveness_of(owner) is Liveness.SILENT
+
+
+def test_a_live_pid_inside_the_ceiling_is_somebody_working() -> None:
+    """The one reading that means wait: a live process that has written recently."""
+    owner = Owner(pid=4242, session="another-server", silence=60.0)
+
+    assert liveness_of(owner) is Liveness.HELD
+
+
+def test_a_silence_that_cannot_be_read_is_no_evidence_that_the_run_stopped() -> None:
+    """Unknown is not stale. Closing a live job over an unparseable timestamp is the expensive
+    direction, and the claim's pid still answers."""
+    owner = Owner(pid=4242, session="another-server", silence=None)
+
+    assert liveness_of(owner) is Liveness.HELD
+
+
+def test_a_claim_naming_no_process_is_owned_by_nobody() -> None:
+    """A detached record with no worker pid yet, or a claim whose pid field is not one."""
+    assert liveness_of(Owner(pid=None, session="another-server")) is Liveness.UNOWNED
+
+
+def test_a_claim_judged_by_pid_alone_is_never_judged_by_its_session() -> None:
+    """The detached path's whole point: a worker outlives the session that launched it.
+
+    Its record carries the launching server's session, and reading that as "ours, therefore a
+    leftover" would close the half-hour separation the detached path exists to protect. So the
+    caller leaves the session out, and only the pid and the silence answer.
+    """
+    owner = Owner(pid=os.getpid(), session=None, silence=60.0)
+
+    assert liveness_of(owner) is Liveness.HELD
+
+
+def liveness_of(owner: Owner, alive: lease.Alive = _running) -> Liveness:
+    """The reading, at the ceiling these tests share."""
+    return lease.liveness(owner, ceiling=CEILING, alive=alive)
+
+
+def test_a_claim_somebody_is_working_under_is_refused_and_names_them(tmp_path: Path) -> None:
+    """Two runs writing one directory interleave into work that is neither run's."""
+    path = tmp_path / "work" / ".claim.json"
+    _written_by(path, 4242, claimed_at=time.time())
+
+    with pytest.raises(lease.LeaseHeld) as raised, lease.claim(
+        path, ceiling=CEILING, refresh=0.0, alive=_running
+    ):
+        pass  # pragma: no cover - the claim is refused on the way in
+
+    assert raised.value.pid == 4242
+    assert raised.value.reason is lease.Reason.RIVAL
+
+
+def test_a_claim_whose_process_is_gone_is_taken_over_not_waited_on(tmp_path: Path) -> None:
+    """A worker killed mid-run must not lock every later run out of its work."""
+    path = tmp_path / "work" / ".claim.json"
+    _written_by(path, 4242, claimed_at=time.time())
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_gone):
+        held = json.loads(path.read_text(encoding="utf-8"))
+
+    assert held["pid"] == os.getpid()
+    assert held["session"] == lease.SESSION
+    assert not path.exists(), "the claim outlived the run holding it"
+
+
+def test_a_claim_this_process_left_behind_is_taken_back(tmp_path: Path) -> None:
+    """Our own session, and no thread of ours holding the lock: a run of ours that died."""
+    path = tmp_path / "work" / ".claim.json"
+    _written_by(path, os.getpid(), session=lease.SESSION, claimed_at=time.time())
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running):
+        held = json.loads(path.read_text(encoding="utf-8"))
+
+    assert held["session"] == lease.SESSION
+    assert not path.exists()
+
+
+def test_a_claim_left_by_a_run_that_is_gone_is_taken_over_even_wearing_this_pid(
+    tmp_path: Path,
+) -> None:
+    """A recycled pid that happens to be ours used to lock the work out permanently."""
+    path = tmp_path / "work" / ".claim.json"
+    _written_by(path, os.getpid(), claimed_at=time.time())
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running):
+        held = json.loads(path.read_text(encoding="utf-8"))
+
+    assert held["session"] == lease.SESSION
+
+
+def test_a_claim_older_than_the_ceiling_is_taken_over_however_alive_its_pid_looks(
+    tmp_path: Path,
+) -> None:
+    """The ceiling is the only rule that can clear a claim whose pid still answers."""
+    path = tmp_path / "work" / ".claim.json"
+    _written_by(path, 4242, claimed_at=time.time() - CEILING - 60)
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running):
+        held = json.loads(path.read_text(encoding="utf-8"))
+
+    assert held["pid"] == os.getpid()
+
+
+def test_a_claim_that_cannot_be_read_is_waited_out_rather_than_taken_over(tmp_path: Path) -> None:
+    """An empty claim is what a claim being written *right now* looks like.
+
+    Read as abandoned it would have a rival clear the winner's fresh claim and walk in, which
+    is the whole failure the claim exists to prevent.
+    """
+    path = tmp_path / "work" / ".claim.json"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"")
+
+    with pytest.raises(lease.LeaseHeld) as raised, lease.claim(
+        path, ceiling=CEILING, refresh=0.0, alive=_gone
+    ):
+        pass  # pragma: no cover - the claim is refused on the way in
+
+    assert raised.value.pid is None
+    assert path.read_bytes() == b"", "the claim being written was cleared"
+
+
+def test_an_unreadable_claim_older_than_the_ceiling_is_still_taken_over(tmp_path: Path) -> None:
+    """Held is not held for ever: a genuinely corrupt claim ages out like any other.
+
+    Its age cannot come from its content — that is the part that could not be read — so it
+    comes from the file's own timestamp.
+    """
+    path = tmp_path / "work" / ".claim.json"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"{ half a claim")
+    aged = time.time() - CEILING - 60
+    os.utime(path, (aged, aged))
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_gone):
+        held = json.loads(path.read_text(encoding="utf-8"))
+
+    assert held["pid"] == os.getpid()
+
+
+def test_a_claim_that_changed_after_it_was_judged_abandoned_is_left_alone(tmp_path: Path) -> None:
+    """Two runs reading one abandoned claim is two runs deciding to clear it.
+
+    The first clears it, wins the create and starts working; the second arrives a moment later
+    with the same verdict and unlinks — by name — the claim the first is now holding. Nothing
+    then refuses the second, and two runs write one directory. So the bytes that were judged
+    are matched against the bytes on disk before anything is unlinked. Here the filesystem
+    shows the stale claim once and the winner's live one from then on, which is that race.
+    """
+    path = tmp_path / "work" / ".claim.json"
+    stale = json.dumps({"pid": 4242, "session": "a-dead-run", "claimed_at": time.time()})
+    _written_by(path, 4242, claimed_at=time.time())
+    path.write_text(stale, encoding="utf-8")
+    live = json.dumps({"pid": 9001, "session": "the-winner", "claimed_at": time.time()}).encode()
+    read = _reading(stale.encode(), live, live, live, live)
+
+    with pytest.raises(lease.LeaseHeld) as raised, lease.claim(
+        path, ceiling=CEILING, refresh=0.0, alive=lambda pid: pid == 9001, read=read
+    ):
+        pass  # pragma: no cover - the live claim is refused on the way in
+
+    assert raised.value.pid == 9001
+    assert path.read_text(encoding="utf-8") == stale, "a claim that had changed was cleared"
+
+
+def test_a_read_the_filesystem_refused_for_an_instant_is_read_again_not_believed(
+    tmp_path: Path,
+) -> None:
+    """A sharing violation is the file being read, not the work being held.
+
+    Two handles land on a claim whenever anything is looking — a rival deciding whether to
+    wait, the run holding it refreshing once a minute — and Windows refuses the read that
+    arrives while the other side has it open. Believed the first time, that verdict reads an
+    unreadable claim as held and costs this run work whose owner is long gone.
+    """
+    path = tmp_path / "work" / ".claim.json"
+    _written_by(path, 4242, claimed_at=time.time())
+    read = _reading(PermissionError("the file is open in another process"))
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_gone, read=read):
+        held = json.loads(path.read_text(encoding="utf-8"))
+
+    assert held["pid"] == os.getpid(), "one refused read locked this run out of a dead claim"
+
+
+def test_a_claim_is_refreshed_by_the_run_that_is_holding_it(tmp_path: Path) -> None:
+    """The ceiling has to measure silence, not runtime, or it steals from a live run.
+
+    Six hours is longer than any pass, but a claim written once at the start and never touched
+    again has a genuinely slow run's own claim read as abandoned while it is still writing.
+    """
+    path = tmp_path / "work" / ".claim.json"
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running) as beat:
+        held = json.loads(path.read_text(encoding="utf-8"))
+        aged = time.time() - CEILING - 60
+        path.write_text(json.dumps({**held, "claimed_at": aged}), encoding="utf-8")
+
+        beat()
+
+        refreshed = json.loads(path.read_text(encoding="utf-8"))
+
+    assert refreshed["claimed_at"] > aged + CEILING, "the claim was left at its old age"
+    assert refreshed["pid"] == os.getpid()
+    assert refreshed["session"] == lease.SESSION
+
+
+def test_the_refresh_is_throttled_to_one_write_however_often_it_is_reported_to(
+    tmp_path: Path,
+) -> None:
+    """It is wired to whatever reports from inside the work, which moves several times a second.
+
+    The claim only has to stay younger than a ceiling measured in hours, so rewriting on every
+    reading would be thousands of writes to say what one a minute already says. The clock
+    starts at the claim rather than at zero, because the claim was written a moment ago.
+    """
+    path = tmp_path / "work" / ".claim.json"
+
+    with lease.claim(path, ceiling=CEILING, refresh=60.0, alive=_running) as beat:
+        written = json.loads(path.read_text(encoding="utf-8"))["claimed_at"]
+
+        beat()
+        beat()
+
+        assert json.loads(path.read_text(encoding="utf-8"))["claimed_at"] == written
+
+
+def test_a_claim_this_process_no_longer_holds_stops_the_run(tmp_path: Path) -> None:
+    """A refresh is a write, and a write onto somebody else's claim is the theft it prevents.
+
+    Not refreshing is only half of it: the claim says who may write these files, so a run that
+    reads somebody else's is one whose output is landing in work another owns.
+    """
+    path = tmp_path / "work" / ".claim.json"
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running) as beat:
+        theirs = json.dumps({"pid": 4242, "session": "another-server", "claimed_at": time.time()})
+        path.write_text(theirs, encoding="utf-8")
+
+        with pytest.raises(lease.LeaseHeld) as raised:
+            beat()
+
+        assert raised.value.pid == 4242
+        assert raised.value.reason is lease.Reason.LOST
+        assert path.read_text(encoding="utf-8") == theirs
+
+
+def test_a_claim_that_vanished_under_a_running_run_also_stops_it(tmp_path: Path) -> None:
+    """No claim is no better than a rival's: nothing is holding the work for this run."""
+    path = tmp_path / "work" / ".claim.json"
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running) as beat:
+        path.unlink()
+
+        with pytest.raises(lease.LeaseHeld) as raised:
+            beat()
+
+        assert raised.value.pid is None
+        assert raised.value.reason is lease.Reason.LOST
+
+
+def test_a_refresh_that_cannot_be_written_leaves_the_run_going(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A claim that could not be rewritten is ours still, only older.
+
+    Both the write and the cleanup of what it left behind are refused here — Windows refuses to
+    unlink a file another handle holds, and that unlink runs inside the handler for the write
+    that already failed. Unguarded it escapes and takes half an hour of GPU work with it, over
+    a scratch file named for this process that nothing else ever reads.
+    """
+    path = tmp_path / "work" / ".claim.json"
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running) as beat:
+        held = path.read_text(encoding="utf-8")
+
+        def refuses(*args: Any, **kwargs: Any) -> None:
+            raise PermissionError("the file is open in another process")
+
+        monkeypatch.setattr(os, "replace", refuses)
+        monkeypatch.setattr(Path, "unlink", refuses)
+
+        beat()  # the run carries on
+
+        monkeypatch.undo()
+        assert path.read_text(encoding="utf-8") == held
+
+
+def test_a_refresh_whose_read_is_refused_leaves_the_run_going(tmp_path: Path) -> None:
+    """The other half: a claim that could not be *read* is this run's still.
+
+    A read the filesystem refused used to arrive as "somebody else has it" — ending the run,
+    and all the GPU time in it, over a file nothing had touched.
+    """
+    path = tmp_path / "work" / ".claim.json"
+    refusing = _reading(*[PermissionError("the file is open in another process")] * 40)
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running, read=refusing) as beat:
+        held = path.read_text(encoding="utf-8")
+
+        beat()  # the run carries on
+
+        assert path.read_text(encoding="utf-8") == held, "an unreadable claim was written over"
+
+
+def test_a_second_thread_of_this_process_is_refused_the_claim_this_one_holds(
+    tmp_path: Path,
+) -> None:
+    """The file names a pid, and two threads of one process share it.
+
+    Both would read the claim as their own and walk in, which is the interleaving the claim
+    exists to stop — and it is not a hypothetical: the server runs jobs on threads.
+    """
+    path = tmp_path / "work" / ".claim.json"
+    refused: list[BaseException] = []
+
+    def second_thread() -> None:
+        try:
+            with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running):
+                pass  # pragma: no cover - the claim is refused on the way in
+        except BaseException as exc:  # noqa: BLE001 - whatever it raised is the finding
+            refused.append(exc)
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running):
+        thread = threading.Thread(target=second_thread)
+        thread.start()
+        thread.join(timeout=BUDGET)
+
+    assert len(refused) == 1, "a second thread walked into work already being done"
+    held = refused[0]
+    assert isinstance(held, lease.LeaseHeld)
+    assert held.reason is lease.Reason.THREAD
+    assert held.pid == os.getpid()
+
+
+def test_a_run_waits_out_the_claim_already_under_way_rather_than_refusing_it(
+    tmp_path: Path,
+) -> None:
+    """What the holder is producing is usually what the waiting run came for.
+
+    A retry, a second agent, or the same call made twice all land here, so refusing tells a
+    caller to go away empty-handed in the middle of the production of what it asked for.
+    """
+    path = tmp_path / "work" / ".claim.json"
+    _written_by(path, 4242, claimed_at=time.time())
+    watched: list[int | None] = []
+
+    def waiting(pid: int | None) -> None:
+        watched.append(pid)
+        if len(watched) == 2:
+            path.unlink()  # that run has finished and dropped its claim
+
+    with lease.claim(
+        path,
+        ceiling=CEILING,
+        refresh=0.0,
+        alive=_running,
+        waiting=waiting,
+        budget=BUDGET,
+        poll=0.0,
+        sleep=lambda seconds: None,
+    ):
+        held = json.loads(path.read_text(encoding="utf-8"))
+
+    assert watched == [4242, 4242], "the wait never reported who it was waiting for"
+    assert held["pid"] == os.getpid(), "the run that waited never got the claim"
+
+
+def test_a_wait_that_outlasts_its_budget_still_names_the_holder(tmp_path: Path) -> None:
+    """Bounded: a rival that never finishes ends as the refusal it always was, not as a hang."""
+    path = tmp_path / "work" / ".claim.json"
+    _written_by(path, 4242, claimed_at=time.time())
+
+    with pytest.raises(lease.LeaseHeld) as raised, lease.claim(
+        path,
+        ceiling=CEILING,
+        refresh=0.0,
+        alive=_running,
+        waiting=lambda pid: None,
+        budget=0.0,
+        poll=0.0,
+        sleep=lambda seconds: None,
+    ):
+        pass  # pragma: no cover - the claim is refused once the budget has gone
+
+    assert raised.value.pid == 4242
+    assert raised.value.reason is lease.Reason.RIVAL
+
+
+def test_a_claim_that_is_not_ours_is_left_behind_when_the_run_ends(tmp_path: Path) -> None:
+    """Releasing by name alone would drop the claim of whoever took the work over."""
+    path = tmp_path / "work" / ".claim.json"
+    theirs = json.dumps({"pid": 4242, "session": "another-server", "claimed_at": time.time()})
+
+    with lease.claim(path, ceiling=CEILING, refresh=0.0, alive=_running):
+        path.write_text(theirs, encoding="utf-8")
+
+    assert path.read_text(encoding="utf-8") == theirs, "a rival's claim was released by name"

--- a/tests/test_lease.py
+++ b/tests/test_lease.py
@@ -145,6 +145,27 @@ def liveness_of(owner: Owner, alive: lease.Alive = _running) -> Liveness:
     return lease.liveness(owner, ceiling=CEILING, alive=alive)
 
 
+def test_the_holder_reading_says_held_or_free_and_names_who(tmp_path: Path) -> None:
+    """The other half of the interface, asked on its own: who has this, if anyone.
+
+    ``claim`` is what a run uses, but the reading behind it is a question worth asking without
+    taking anything — and the three answers it gives are the three a caller acts on: nobody has
+    it, somebody is working under it, or the run that wrote it is gone and it can be taken.
+    """
+    free = tmp_path / "free" / ".claim.json"
+    taken = tmp_path / "taken" / ".claim.json"
+    _written_by(taken, 4242, claimed_at=time.time())
+
+    assert lease.holder(free, ceiling=CEILING, alive=_running) == lease.Held(False, None, None)
+
+    working = lease.holder(taken, ceiling=CEILING, alive=_running)
+    abandoned = lease.holder(taken, ceiling=CEILING, alive=_gone)
+
+    assert (working.held, working.pid) == (True, 4242)
+    assert (abandoned.held, abandoned.pid) == (False, 4242)
+    assert abandoned.judged == taken.read_bytes(), "the verdict named bytes it had not read"
+
+
 def test_a_claim_somebody_is_working_under_is_refused_and_names_them(tmp_path: Path) -> None:
     """Two runs writing one directory interleave into work that is neither run's."""
     path = tmp_path / "work" / ".claim.json"

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -1,0 +1,40 @@
+"""The Windows sharing retry, on its own — the rule two very different files depend on.
+
+A job record and a claim file are the same problem: another handle holds the file for the
+microsecond of a poll, and Windows refuses the read or the replace that lands in it. Both
+reach for this, which is why it is neither of theirs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from resolve_mcp.sharing import sharing
+
+
+def test_a_write_that_loses_the_race_with_a_reader_is_tried_again() -> None:
+    """The rule the retry encodes, testable off Windows where the race cannot happen.
+
+    A reader holding the file is a refusal to wait out, not a failure to report: giving up
+    would kill the worker thread mid-save and leave the record saying running forever.
+    """
+    attempts: list[int] = []
+
+    def flaky() -> str:
+        attempts.append(len(attempts))
+        if len(attempts) < 3:
+            raise PermissionError(32, "The process cannot access the file")
+        return "written"
+
+    assert sharing(flaky) == "written"
+    assert len(attempts) == 3
+
+
+def test_a_reader_that_never_lets_go_is_still_an_error() -> None:
+    """Retrying forever would hide a genuinely locked cache directory."""
+
+    def locked() -> str:
+        raise PermissionError(32, "The process cannot access the file")
+
+    with pytest.raises(PermissionError):
+        sharing(locked)

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -12,6 +12,7 @@ rather than empty files.
 
 from __future__ import annotations
 
+import ast
 import locale
 import shutil
 import sys
@@ -21,7 +22,7 @@ from typing import Any
 
 import pytest
 
-from resolve_mcp.audio import separator
+from resolve_mcp.audio import separator, stems
 from resolve_mcp.audio.acquire import audio_source
 from resolve_mcp.audio.stems import (
     DRUM_PASS,
@@ -95,6 +96,28 @@ def splitting() -> FakeSeparator:
 
 
 # --- the two passes ----------------------------------------------------------------------
+
+
+def test_the_stems_module_reaches_for_no_private_name_in_the_job_store() -> None:
+    """The seam, asserted rather than admitted in a comment.
+
+    This module used to import ``store._sharing`` deliberately — a general Windows retry that
+    happened to live in the store — and a private name reached for across a package boundary is
+    a seam that is not one: nothing warns when the owner changes it, and the next module with
+    the same need copies it instead. The retry has a neutral home now (``sharing``), the
+    process identity and the claim protocol have theirs (``lease``), and what is left of this
+    import is job-shaped: the record type, and the liveness the launcher can answer for.
+    """
+    tree = ast.parse(Path(stems.__file__).read_text(encoding="utf-8"))
+    imported = [
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and (node.module or "").endswith("jobs.store")
+        for alias in node.names
+    ]
+
+    assert imported, "the import this is about has moved; point it at wherever it went"
+    assert [name for name in imported if name.startswith("_")] == []
 
 
 def test_four_stems_land_on_disk_keyed_by_content_hash_and_params(


### PR DESCRIPTION
Closes #217.

A stems directory and a detached job record are the same claim asked the same question — is
the process that wrote this still working? — and each answered it on its own. `lease` answers
it once:

- `liveness(owner, ceiling=, alive=)` is the pid/session/silence truth table as a pure
  function. Five readings make a claim adoptable (`UNOWNED`, `OURS`, `RECYCLED`, `GONE`,
  `SILENT`); one means wait (`HELD`).
- The claim file protocol sits on top of it — `claim(path, ceiling=, refresh=, alive=)` as a
  context manager yielding the throttled refresh, and `holder(path, ceiling=, alive=)` as the
  reading behind it.

The two adapters: `audio/stems.claimed` (policy — `CLAIM_CEILING`, `CLAIM_WAIT`,
`CLAIM_REFRESH` — plus the wording the agent reads, mapping `LeaseHeld` to
`SeparationInProgressError` for all three refusals) and `jobs/lifecycle._detached` /
`_stalled_launch` (which pid to ask about, and the sentence for a job nothing is running).
`audio/stems.py` sheds ~520 lines.

It also ends the admitted seam failure: the Windows sharing retry moves out of `jobs/store`
to a neutral `sharing` module beside `spill`, `SESSION` moves to `lease`, and `audio/stems`
now imports only `JobRecord` and `pid_alive` from the store — asserted by AST in the fake
tier rather than admitted in a comment.

**Test seam:** fake tier. The claim protocol tests move to `tests/test_lease.py`, where both
the liveness answer and the read are injected — so a dead process, a recycled pid and a
filesystem that refuses a read are arrangements rather than monkeypatches on
`Path.read_bytes`. `tests/test_detached_jobs.py` keeps what is stems-shaped over it (the
refusals' wording, the claim held across the passes and dropped after them);
`tests/test_sharing.py` pins the retry both files depend on. Fake tier, mypy strict (src and
tests) and ruff all green. No live AC: the ticket's criteria are all fake-tier, and the
long-separation path is covered by the existing live arrangement.

## Review

Two-axis review (`/code-review`) against `origin/main`, Standards and Spec as parallel
sub-agents. Findings and their resolutions:

1. **Standards, hard — stale pointer.** `jobs/runner.py:179` still cited `store._sharing`, a
   name this branch deletes. *Fixed:* it cites `sharing.sharing` (383e690).
2. **Standards, judgement — Duplicated Code.** "Is this claim still ours" was spelled twice,
   in `_touch` and `_release`. *Fixed:* one `_ours` predicate — two spellings are two chances
   to disagree about who may write the file.
3. **Standards, judgement — Speculative Generality.** `content()` and `UNREADABLE` were
   public with no caller outside the module. *Fixed:* both private.
4. **Standards, judgement — Mysterious Name** (`Held`/`holder`/`LeaseHeld`). *Not taken:*
   `holder` returning held-or-free is the interface the ticket names, and `Held` is the shape
   of that answer.
5. **Spec, partial — `holder` had no test of its own** and no caller outside `claim`, so half
   the named interface was effectively private. *Fixed:* a direct test of the three answers
   it gives (free, held, abandoned) without taking anything.
6. **Spec, AC5.** The reviewer mapped all nine tests deleted from `test_detached_jobs.py` to
   their counterparts in `test_lease.py` and found no behaviour lost; the two
   `monkeypatch.setattr(stems, "CLAIM_REFRESH", 0.0)` additions follow the throttle moving
   from stems' bar wrapper into `lease._beat`, and the end-to-end cadence is unchanged.
7. **Spec, scope creep:** none material. Standards axis confirmed the CONTEXT.md map edits
   match the code.

Fix diff re-checked on its own: `_ours(None)` preserves the old `held is None` branch, the
rest is renames.

Review: clean



---

**Merge with `origin/main` (51359d9):** three conflicts, all import/doc unions — `CONTEXT.md` keeps both the `sharing.py` row and main's `spill.py` row; `jobs/store.py` takes main's `InvalidRequestError`/`STATES` imports alongside the branch's `SESSION`-from-`lease`; `test_job_store.py` drops the now-unused `lifecycle` import. No behaviour change. ruff / mypy strict / fake tier (2324 passed) green.

Review: clean — merge resolution, imports and doc rows only



**Merge with `origin/main` (3a32ea7, after #239):** one conflict, `CONTEXT.md` tests section — both branches added a paragraph at the same spot; both kept. ruff / mypy strict / fake tier (2325 passed) green.

Review: clean — merge resolution, prose only
