### PR TITLE
Package the findings report; one envelope shape for started jobs (#219)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,7 +22,9 @@ timelines. The server measures; Claude decides.
 - **job** — background compute (analysis, stems, scenes) with one JSON
   record on disk; disk is the only source of truth.
 - **envelope** — the shared tool-result shape every MCP tool returns
-  (`tools/envelope.py`).
+  (`tools/envelope.py`). A tool that hands back a job record replies
+  `{"job": record}`; the decorator recognises the record and wraps it, so no
+  starter builds that key itself (#219).
 - **spill** — oversized results written to disk for the agent to grep
   instead of truncating. Every listing that can outgrow a reply is capped by
   `spill.capped`, so `truncated` and `spilled_to` mean one thing everywhere and
@@ -106,10 +108,10 @@ Top level:
 | --- | --- |
 | `config.py` | zero-config defaults, `RESOLVE_MCP_*` env overrides |
 | `deliver.py` | render preset + timeline span as a background job |
-| `document.py` | read agent-authored JSON off disk, hash exactly the bytes read |
+| `document.py` | read agent-authored JSON off disk, hash exactly the bytes read; `Preflight` — the shared *loaded document + findings* shape both contracts subclass (#219) |
 | `errors.py` | structured cause/fix errors; tracebacks never reach the agent |
 | `ffmpeg.py` | the one place the server shells out to ffmpeg (argv lists) |
-| `findings.py` | shared finding shape `{rule, id, message, fix_hint}` |
+| `findings.py` | shared finding shape `{rule, id, message, fix_hint}`; `report` is the one `{errors, warnings}` reply and `refuse` the one raise-if-errors preamble (#219) |
 | `interpreter.py` | guard on which interpreters may attach to fusionscript (ADR 0001) |
 | `lease.py` | is the owner of this claim still alive — `SESSION`, `liveness`, `claim`/`holder` (#217) |
 | `logging_config.py` | stderr-only logging (stdout belongs to MCP transport) |
@@ -306,7 +308,8 @@ outlives the import until the caller has read the shots back on it, #221),
 `get_titles_schema`), `validate` (9 errors + 2 warnings).
 
 `tools/` — MCP tool layer, thin, grouped by workflow: `analysis`, `cut`,
-`envelope` (**shared envelope + `@tool` decorator + handle-death retry**),
+`envelope` (**shared envelope + `@tool` decorator + handle-death retry + the
+job-record wrap**),
 `escape_hatch` (`run_python`), `jobs`, `media`, `project`, `render`,
 `stems`, `timeline`, `titles`, `video`. Registration: each module exposes
 `TOOLS: tuple`; `server.build_server()` iterates every module's `TOOLS`
@@ -355,6 +358,13 @@ covers `resolve/media` (what the six operations do with what the adapter hands
 them). Both drive the fake seam through `tools/media`, and both build their
 pools from `tests/mediapool.py` (`a_file`, `a_clip`, `a_shallow_copy_pool`) so
 the pair cannot drift on what a clip or a shadowed copy looks like.
+
+`test_findings.py` covers `findings` and the pre-flight shape in `document`:
+the severity split, the packaged `{errors, warnings}` reply, the refusal
+sentence, and that the cut and titles contracts subclass the one shape.
+`test_envelope.py` covers the job-record wrap in `tools/envelope` — including
+the reconnect path, which is a second return statement and so a second place
+the shape can drift (#219).
 
 `test_lease.py` covers `lease` — the liveness truth table in memory, then the
 claim protocol with both the liveness answer and the read injected, so a dead

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ exposes, since a media-pool template has no comp to ask. The edit changes the *t
 and not `titles.json`, so the next `apply_titles` puts the old wording back: fix the file
 too whenever the change is one worth keeping.
 
-Heavy work runs as a background job: the starter returns a `job_id` immediately, `get_job`
+Heavy work runs as a background job: every starter replies `{"job": record}` immediately —
+one shape whichever starter it was — `get_job`
 polls it, and results are cached under the cache root against the media and the parameters,
 so an unchanged rerun is instant. Job records live on disk, which is what lets `list_jobs`
 recover after a restart — a job that was still running when the server went down comes back

--- a/src/resolve_mcp/analysis/virtual.py
+++ b/src/resolve_mcp/analysis/virtual.py
@@ -35,7 +35,7 @@ from ..cut.document import read_cut_file
 from ..cut.layout import is_gap, overlay_positions, positions, total_frames
 from ..document import LoadedDocument
 from ..errors import InvalidRequestError
-from ..findings import Finding, ordered
+from ..findings import Finding, ordered, report
 from ..spill import capped
 from ..timing import IN_POINT, OUT_POINT, SECONDS_PRECISION, dual_time, frames_from_seconds
 from . import records
@@ -176,7 +176,7 @@ def _result(
             "segments": read_back,
             "seams": seams,
             "counts": counts,
-            "warnings": [finding.as_dict() for finding in findings],
+            **report(findings),
         },
         key="words",
         whole=rows,

--- a/src/resolve_mcp/document.py
+++ b/src/resolve_mcp/document.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 from .errors import InvalidRequestError
-from .findings import Finding
+from .findings import Finding, errors_in, warnings_in
 
 HASH_DIGEST_BYTES = 16
 """BLAKE2b digest length: 32 hex characters, short enough to read in a report."""
@@ -51,11 +51,11 @@ class Preflight:
 
     @property
     def errors(self) -> list[Finding]:
-        return [finding for finding in self.findings if finding.severity == "error"]
+        return errors_in(self.findings)
 
     @property
     def warnings(self) -> list[Finding]:
-        return [finding for finding in self.findings if finding.severity == "warning"]
+        return warnings_in(self.findings)
 
 
 def content_hash(data: bytes) -> str:

--- a/src/resolve_mcp/document.py
+++ b/src/resolve_mcp/document.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -33,6 +34,28 @@ class LoadedDocument(NamedTuple):
     content_hash: str
     doc: Any  # the parsed document, or None when parse_error says why there is none
     parse_error: Finding | None
+
+
+@dataclass(frozen=True)
+class Preflight:
+    """A file as read, and what the rules said about it — the shape every dry run has.
+
+    The cut and the titles rule sets share nothing but this: the document they were run
+    over travels with their findings, so the operation that follows is judged on and
+    built from the same reading. Each rule set subclasses this to carry whatever else its
+    apply needs; the pair and the severity split are defined once, here.
+    """
+
+    loaded: LoadedDocument
+    findings: list[Finding]
+
+    @property
+    def errors(self) -> list[Finding]:
+        return [finding for finding in self.findings if finding.severity == "error"]
+
+    @property
+    def warnings(self) -> list[Finding]:
+        return [finding for finding in self.findings if finding.severity == "warning"]
 
 
 def content_hash(data: bytes) -> str:
@@ -66,4 +89,10 @@ def read_document(
     return LoadedDocument(path, digest, doc, None)
 
 
-__all__ = ["HASH_DIGEST_BYTES", "LoadedDocument", "content_hash", "read_document"]
+__all__ = [
+    "HASH_DIGEST_BYTES",
+    "LoadedDocument",
+    "Preflight",
+    "content_hash",
+    "read_document",
+]

--- a/src/resolve_mcp/findings.py
+++ b/src/resolve_mcp/findings.py
@@ -17,11 +17,22 @@ hand.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 from .errors import ResolveMcpError
+
+
+class Refusal(Protocol):
+    """The error a rule set raises when its own rules blocked.
+
+    A protocol rather than a bare callable so the two keywords ``refuse`` passes stay
+    checked: an error class that stopped taking a ``detail`` would be caught here rather
+    than at the raise.
+    """
+
+    def __call__(self, *, cause: str, detail: dict[str, Any]) -> ResolveMcpError: ...
 
 
 def severity_of(rule: str) -> str:
@@ -62,6 +73,16 @@ def ordered(findings: list[Finding]) -> list[Finding]:
     return [finding for _, finding in sorted(enumerate(findings), key=key)]
 
 
+def errors_in(findings: Iterable[Finding]) -> list[Finding]:
+    """The findings that block. One definition, so a pre-flight and a report cannot differ."""
+    return [finding for finding in findings if finding.severity == "error"]
+
+
+def warnings_in(findings: Iterable[Finding]) -> list[Finding]:
+    """The findings that are reported and never block."""
+    return [finding for finding in findings if finding.severity == "warning"]
+
+
 def report(findings: Iterable[Finding]) -> dict[str, list[dict[str, str | None]]]:
     """The ``{errors, warnings}`` pair, split by severity, in the order they were found.
 
@@ -71,15 +92,15 @@ def report(findings: Iterable[Finding]) -> dict[str, list[dict[str, str | None]]
     """
     listed = list(findings)
     return {
-        "errors": [finding.as_dict() for finding in listed if finding.severity == "error"],
-        "warnings": [finding.as_dict() for finding in listed if finding.severity == "warning"],
+        "errors": [finding.as_dict() for finding in errors_in(listed)],
+        "warnings": [finding.as_dict() for finding in warnings_in(listed)],
     }
 
 
 def refuse(
     findings: Iterable[Finding],
     *,
-    error: Callable[..., ResolveMcpError],
+    error: Refusal,
     what: str,
     consequence: str,
     detail: dict[str, Any],
@@ -101,4 +122,13 @@ def refuse(
     )
 
 
-__all__ = ["Finding", "ordered", "refuse", "report", "severity_of"]
+__all__ = [
+    "Finding",
+    "Refusal",
+    "errors_in",
+    "ordered",
+    "refuse",
+    "report",
+    "severity_of",
+    "warnings_in",
+]

--- a/src/resolve_mcp/findings.py
+++ b/src/resolve_mcp/findings.py
@@ -7,11 +7,21 @@ cannot drift apart in shape while they evolve apart in content.
 
 The rule code carries the severity: ``W`` for a warning that never blocks, anything else
 for an error that does. Nothing outside a rule set needs to know which letters it uses.
+
+Packaging lives here too. ``report`` is the one place a list of findings becomes the
+``{errors, warnings}`` pair a reply carries, and ``refuse`` is the one place errors in
+that list become a refusal — so a rule set that grows a severity, or a report that grows
+a key, changes in one file rather than at the six sites that used to build the dict by
+hand.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from typing import Any
+
+from .errors import ResolveMcpError
 
 
 def severity_of(rule: str) -> str:
@@ -52,4 +62,43 @@ def ordered(findings: list[Finding]) -> list[Finding]:
     return [finding for _, finding in sorted(enumerate(findings), key=key)]
 
 
-__all__ = ["Finding", "ordered", "severity_of"]
+def report(findings: Iterable[Finding]) -> dict[str, list[dict[str, str | None]]]:
+    """The ``{errors, warnings}`` pair, split by severity, in the order they were found.
+
+    Both keys are always present, including on a reply that could only ever carry
+    warnings: the agent reads one shape whether it is holding a refusal or a success, and
+    an empty ``errors`` is the statement that the rules found none.
+    """
+    listed = list(findings)
+    return {
+        "errors": [finding.as_dict() for finding in listed if finding.severity == "error"],
+        "warnings": [finding.as_dict() for finding in listed if finding.severity == "warning"],
+    }
+
+
+def refuse(
+    findings: Iterable[Finding],
+    *,
+    error: Callable[..., ResolveMcpError],
+    what: str,
+    consequence: str,
+    detail: dict[str, Any],
+) -> None:
+    """Raise ``error`` if anything in ``findings`` is an error; otherwise return.
+
+    Every validating operation opens the same way — run the rules, and if any of them
+    blocked, refuse before touching the project — so the sentence the agent reads is
+    built once here: *The <what> has N error(s), so <consequence>.* ``detail`` carries
+    the provenance the caller owns (the file, its hash) and the packaged findings are
+    merged onto it, so a refusal reports every rule that fired, not just the count.
+    """
+    packaged = report(findings)
+    if not packaged["errors"]:
+        return
+    raise error(
+        cause=f"The {what} has {len(packaged['errors'])} error(s), so {consequence}.",
+        detail={**detail, **packaged},
+    )
+
+
+__all__ = ["Finding", "ordered", "refuse", "report", "severity_of"]

--- a/src/resolve_mcp/resolve/apply.py
+++ b/src/resolve_mcp/resolve/apply.py
@@ -37,6 +37,7 @@ from dataclasses import dataclass
 from typing import Any, Final, NamedTuple
 
 from ..errors import TitlesApplyFailedError, TitlesInvalidError
+from ..findings import refuse, report
 from ..logging_config import get_logger
 from ..timing import dual_time
 from ..titles.assets import Asset
@@ -105,17 +106,16 @@ class OwnedTrack:
 def apply_titles(connection: ResolveConnection, titles_file: str) -> dict[str, Any]:
     """Clear the Titles track and re-place every event in ``titles_file`` onto it."""
     checked = titles_read.preflight(connection, titles_file)
-    if checked.errors:
-        raise TitlesInvalidError(
-            cause=f"The titles file has {len(checked.errors)} error(s), so nothing was "
-            f"applied and the Titles track was not touched.",
-            detail={
-                "titles_file": str(checked.loaded.path),
-                "content_hash": checked.loaded.content_hash,
-                "errors": [finding.as_dict() for finding in checked.errors],
-                "warnings": [finding.as_dict() for finding in checked.warnings],
-            },
-        )
+    refuse(
+        checked.findings,
+        error=TitlesInvalidError,
+        what="titles file",
+        consequence="nothing was applied and the Titles track was not touched",
+        detail={
+            "titles_file": str(checked.loaded.path),
+            "content_hash": checked.loaded.content_hash,
+        },
+    )
     # No error means the document parsed, matched the schema and resolved against the
     # project — every reading below is one the rules have already been over.
     project, timeline = checked.project, checked.timeline
@@ -150,7 +150,7 @@ def apply_titles(connection: ResolveConnection, titles_file: str) -> dict[str, A
         "track": track.as_dict(),
         "cleared": cleared,
         "placed": [_placed(one, checked.fps, checked.assets.get(one.event.id)) for one in titled],
-        "warnings": [finding.as_dict() for finding in checked.warnings],
+        **report(checked.findings),
     }
 
 

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -58,7 +58,7 @@ from ..cut.layout import (
     placements,
 )
 from ..errors import BuildFailedError, CutInvalidError, TimelineNotFoundError
-from ..findings import Finding
+from ..findings import Finding, refuse, report
 from ..logging_config import get_logger
 from ..naming import latest_version, next_version_name, version_name
 from . import cut, markers, mix, settings, takes
@@ -173,16 +173,16 @@ def build_timeline(
 ) -> dict[str, Any]:
     """Build ``cut_file`` as a fresh ``<name> v<N>`` timeline and report what landed."""
     checked = cut.preflight(connection, cut_file, min_segment_frames)
-    if checked.errors:
-        raise CutInvalidError(
-            cause=f"The cut file has {len(checked.errors)} error(s), so nothing was built.",
-            detail={
-                "cut_file": str(checked.loaded.path),
-                "content_hash": checked.loaded.content_hash,
-                "errors": [finding.as_dict() for finding in checked.errors],
-                "warnings": [finding.as_dict() for finding in checked.warnings],
-            },
-        )
+    refuse(
+        checked.findings,
+        error=CutInvalidError,
+        what="cut file",
+        consequence="nothing was built",
+        detail={
+            "cut_file": str(checked.loaded.path),
+            "content_hash": checked.loaded.content_hash,
+        },
+    )
     # E1 is an error, so a pre-flight with no errors has a document that parsed and matched
     # the schema — every read of it below is a field the rules have already been over.
     doc: dict[str, Any] = checked.loaded.doc
@@ -298,7 +298,7 @@ def build_timeline(
         # reads back whether the device it asked for is the device that arrived.
         "tail": applied,
         "markers": carried,
-        "warnings": [finding.as_dict() for finding in checked.warnings],
+        **report(checked.findings),
     }
 
 
@@ -687,7 +687,7 @@ def _refuse_locked_tracks(timeline: Timeline, shots: list[Shot], name: str) -> N
     raise BuildFailedError(
         cause=f"{len(locked)} target track(s) of {name!r} are locked, so nothing was appended.",
         fix="Unlock the track in the timeline header and build again.",
-        detail={"timeline": name, "errors": [finding.as_dict() for finding in locked]},
+        detail={"timeline": name, **report(locked)},
     )
 
 

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -14,6 +14,7 @@ here is a file that will not abort a build on validation.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Any, NamedTuple
 
 from ..cut.document import read_cut_file
@@ -27,8 +28,8 @@ from ..cut.validate import (
     validate_project,
     validate_structure,
 )
-from ..document import LoadedDocument
-from ..findings import Finding, severity_of
+from ..document import Preflight as LoadedPreflight
+from ..findings import report, severity_of
 from ..logging_config import get_logger
 from ..timing import dual_time
 from . import pool as mediapool
@@ -72,20 +73,11 @@ class Source(NamedTuple):
     located: mediapool.LocatedClip
 
 
-class Preflight(NamedTuple):
+@dataclass(frozen=True)
+class Preflight(LoadedPreflight):
     """One pass of the rules, and the pool reading they were judged against."""
 
-    loaded: LoadedDocument
-    findings: list[Finding]
-    sources: list[Source]
-
-    @property
-    def errors(self) -> list[Finding]:
-        return [finding for finding in self.findings if finding.severity == "error"]
-
-    @property
-    def warnings(self) -> list[Finding]:
-        return [finding for finding in self.findings if finding.severity == "warning"]
+    sources: list[Source] = field(default_factory=list)
 
     @property
     def facts(self) -> list[ClipFacts]:
@@ -189,8 +181,7 @@ def _report(checked: Preflight) -> dict[str, Any]:
         "cut_file": str(checked.loaded.path),
         "content_hash": checked.loaded.content_hash,
         "valid": not checked.errors,
-        "errors": [finding.as_dict() for finding in checked.errors],
-        "warnings": [finding.as_dict() for finding in checked.warnings],
+        **report(checked.findings),
         "cut": _summary(_readable_doc(checked)),
     }
 

--- a/src/resolve_mcp/resolve/cut.py
+++ b/src/resolve_mcp/resolve/cut.py
@@ -14,9 +14,10 @@ here is a file that will not abort a build on validation.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, NamedTuple
 
+from .. import document
 from ..cut.document import read_cut_file
 from ..cut.layout import gaps, shots, total_frames
 from ..cut.schema import ANNOTATED_EXAMPLE, SCHEMA_DOC, SCHEMA_VERSION
@@ -28,7 +29,6 @@ from ..cut.validate import (
     validate_project,
     validate_structure,
 )
-from ..document import Preflight as LoadedPreflight
 from ..findings import report, severity_of
 from ..logging_config import get_logger
 from ..timing import dual_time
@@ -74,10 +74,14 @@ class Source(NamedTuple):
 
 
 @dataclass(frozen=True)
-class Preflight(LoadedPreflight):
-    """One pass of the rules, and the pool reading they were judged against."""
+class Preflight(document.Preflight):
+    """One pass of the rules, and the pool reading they were judged against.
 
-    sources: list[Source] = field(default_factory=list)
+    ``sources`` has no default: a pre-flight that read no clips read none *because* the
+    rules stopped it, and that is a decision the caller states rather than one it omits.
+    """
+
+    sources: list[Source]
 
     @property
     def facts(self) -> list[ClipFacts]:

--- a/src/resolve_mcp/resolve/takes.py
+++ b/src/resolve_mcp/resolve/takes.py
@@ -37,7 +37,7 @@ from ..errors import (
     ResolveMcpError,
     TimelineOperationError,
 )
-from ..findings import Finding
+from ..findings import Finding, refuse
 from ..logging_config import get_logger
 from ..timing import dual_time
 from . import timeline as timeline_read
@@ -219,16 +219,13 @@ def _checked_cut(cut_file: str) -> LoadedDocument:
     findings: list[Finding] = (
         [loaded.parse_error] if loaded.parse_error is not None else validate_structure(loaded.doc)
     )
-    errors = [finding for finding in findings if finding.severity == "error"]
-    if errors:
-        raise CutInvalidError(
-            cause=f"The cut file has {len(errors)} error(s), so no take was swapped.",
-            detail={
-                "cut_file": str(loaded.path),
-                "content_hash": loaded.content_hash,
-                "errors": [finding.as_dict() for finding in errors],
-            },
-        )
+    refuse(
+        findings,
+        error=CutInvalidError,
+        what="cut file",
+        consequence="no take was swapped",
+        detail={"cut_file": str(loaded.path), "content_hash": loaded.content_hash},
+    )
     return loaded
 
 

--- a/src/resolve_mcp/resolve/titles.py
+++ b/src/resolve_mcp/resolve/titles.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from ..document import LoadedDocument
-from ..findings import Finding, severity_of
+from ..document import Preflight as LoadedPreflight
+from ..findings import report, severity_of
 from ..logging_config import get_logger
 from ..titles.assets import Asset
 from ..titles.document import read_titles_file
@@ -63,7 +63,7 @@ def get_titles_schema() -> dict[str, Any]:
 
 
 @dataclass(frozen=True)
-class Preflight:
+class Preflight(LoadedPreflight):
     """One pass of the rules, and everything the apply would need if they pass.
 
     The timeline, the templates and the events travel with the findings so the apply
@@ -71,22 +71,12 @@ class Preflight:
     another is the failure this pairing makes impossible.
     """
 
-    loaded: LoadedDocument
-    findings: list[Finding]
     project: Project | None = None
     timeline: Timeline | None = None
     fps: float | None = None
     templates: dict[str, mediapool.LocatedClip] = field(default_factory=dict)
     assets: dict[str, Asset] = field(default_factory=dict)
     events: list[Event] = field(default_factory=list)
-
-    @property
-    def errors(self) -> list[Finding]:
-        return [finding for finding in self.findings if finding.severity == "error"]
-
-    @property
-    def warnings(self) -> list[Finding]:
-        return [finding for finding in self.findings if finding.severity == "warning"]
 
 
 def preflight(connection: ResolveConnection, titles_file: str) -> Preflight:
@@ -210,8 +200,7 @@ def _report(checked: Preflight) -> dict[str, Any]:
         "titles_file": str(checked.loaded.path),
         "content_hash": checked.loaded.content_hash,
         "valid": not checked.errors,
-        "errors": [finding.as_dict() for finding in checked.errors],
-        "warnings": [finding.as_dict() for finding in checked.warnings],
+        **report(checked.findings),
         "timeline": (
             None if checked.timeline is None else timeline_read.name_of(checked.timeline)
         ),

--- a/src/resolve_mcp/resolve/titles.py
+++ b/src/resolve_mcp/resolve/titles.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from ..document import Preflight as LoadedPreflight
+from .. import document
 from ..findings import report, severity_of
 from ..logging_config import get_logger
 from ..titles.assets import Asset
@@ -63,7 +63,7 @@ def get_titles_schema() -> dict[str, Any]:
 
 
 @dataclass(frozen=True)
-class Preflight(LoadedPreflight):
+class Preflight(document.Preflight):
     """One pass of the rules, and everything the apply would need if they pass.
 
     The timeline, the templates and the events travel with the findings so the apply

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -51,16 +51,14 @@ def analyze_music(
     default, which is the EBU short-term window. beats=false or energy=false runs one half.
     Reruns on unchanged audio come back from cache immediately; refresh=true redoes the work.
     """
-    return {
-        "job": music.analyze_music(
-            audio,
-            beats=beats,
-            energy=energy,
-            window_seconds=window_seconds,
-            hop_seconds=hop_seconds,
-            refresh=refresh,
-        )
-    }
+    return music.analyze_music(
+        audio,
+        beats=beats,
+        energy=energy,
+        window_seconds=window_seconds,
+        hop_seconds=hop_seconds,
+        refresh=refresh,
+    )
 
 
 @tool
@@ -136,22 +134,20 @@ def analyze_structure(
     before it is called where it was measured instead. Reruns on unchanged audio come back
     from cache immediately.
     """
-    return {
-        "job": structure.analyze_structure(
-            audio,
-            tunes=tunes,
-            solos=solos,
-            stems=stems,
-            threshold=threshold,
-            scale=scale,
-            tune_seconds=tune_seconds,
-            settle_seconds=settle_seconds,
-            density_per_second=density_per_second,
-            solo_seconds=solo_seconds,
-            snap_seconds=snap_seconds,
-            refresh=refresh,
-        )
-    }
+    return structure.analyze_structure(
+        audio,
+        tunes=tunes,
+        solos=solos,
+        stems=stems,
+        threshold=threshold,
+        scale=scale,
+        tune_seconds=tune_seconds,
+        settle_seconds=settle_seconds,
+        density_per_second=density_per_second,
+        solo_seconds=solo_seconds,
+        snap_seconds=snap_seconds,
+        refresh=refresh,
+    )
 
 
 @tool
@@ -185,20 +181,18 @@ def transcribe_audio(
     audio the cache would otherwise answer for.
     """
     connection = get_connection()
-    return {
-        "job": transcribe.transcribe_audio(
-            connection,
-            clip=clip,
-            bin=bin,
-            timeline=timeline,
-            model=model,
-            language=language,
-            low_confidence=low_confidence,
-            silence_threshold_db=silence_threshold_db,
-            min_silence_seconds=min_silence_seconds,
-            refresh=refresh,
-        )
-    }
+    return transcribe.transcribe_audio(
+        connection,
+        clip=clip,
+        bin=bin,
+        timeline=timeline,
+        model=model,
+        language=language,
+        low_confidence=low_confidence,
+        silence_threshold_db=silence_threshold_db,
+        min_silence_seconds=min_silence_seconds,
+        refresh=refresh,
+    )
 
 
 @tool
@@ -311,24 +305,22 @@ def correlate_timeline(
     counts as musical belongs in your style profile, not in this server.
     """
     connection = get_connection()
-    return {
-        "job": correlate.correlate_timeline(
-            connection,
-            beats=beats,
-            timeline=timeline,
-            audio=audio,
-            tunes=tunes,
-            solos=solos,
-            deltas=deltas,
-            supers=supers,
-            quality=quality,
-            bars=bars,
-            angles=angles,
-            track=track,
-            audio_at=audio_at,
-            refresh=refresh,
-        )
-    }
+    return correlate.correlate_timeline(
+        connection,
+        beats=beats,
+        timeline=timeline,
+        audio=audio,
+        tunes=tunes,
+        solos=solos,
+        deltas=deltas,
+        supers=supers,
+        quality=quality,
+        bars=bars,
+        angles=angles,
+        track=track,
+        audio_at=audio_at,
+        refresh=refresh,
+    )
 
 
 @tool
@@ -357,14 +349,12 @@ def detect_drum_fills(
     counted and left out — that is a drum solo, a different question. minimum_confidence is
     the floor on what gets written; refresh redoes work the cache would answer for.
     """
-    return {
-        "job": fills.detect_drum_fills(
-            stems,
-            audio,
-            minimum_confidence=minimum_confidence,
-            refresh=refresh,
-        )
-    }
+    return fills.detect_drum_fills(
+        stems,
+        audio,
+        minimum_confidence=minimum_confidence,
+        refresh=refresh,
+    )
 
 
 @tool
@@ -397,15 +387,13 @@ def detect_phrases(
     twice. minimum_confidence is the floor on what gets written; refresh redoes work the cache
     would answer for.
     """
-    return {
-        "job": phrases.detect_phrases(
-            stems,
-            audio,
-            stem=stem,
-            minimum_confidence=minimum_confidence,
-            refresh=refresh,
-        )
-    }
+    return phrases.detect_phrases(
+        stems,
+        audio,
+        stem=stem,
+        minimum_confidence=minimum_confidence,
+        refresh=refresh,
+    )
 
 
 @tool
@@ -457,17 +445,15 @@ def detect_bars(
     brushes, a quiet room — because the bass walks quarters and is the strongest witness to
     the beat there is. refresh redoes work the cache would answer for.
     """
-    return {
-        "job": bars_module.detect_bars(
-            audio,
-            stems=stems,
-            stem=stem,
-            start_seconds=start_seconds,
-            end_seconds=end_seconds,
-            minimum_confidence=minimum_confidence,
-            refresh=refresh,
-        )
-    }
+    return bars_module.detect_bars(
+        audio,
+        stems=stems,
+        stem=stem,
+        start_seconds=start_seconds,
+        end_seconds=end_seconds,
+        minimum_confidence=minimum_confidence,
+        refresh=refresh,
+    )
 
 
 TOOLS: tuple[Any, ...] = (

--- a/src/resolve_mcp/tools/envelope.py
+++ b/src/resolve_mcp/tools/envelope.py
@@ -1,11 +1,12 @@
 """The shape every tool result has.
 
-Two guarantees live here, so no individual tool has to remember them:
+Three guarantees live here, so no individual tool has to remember them:
 
 * every result echoes the current project/timeline context, so a project switch is
   visible the moment it happens;
 * every failure is ``ok: false`` with a structured ``cause``/``fix`` — never an exception
-  across the tool boundary, never a traceback in the payload.
+  across the tool boundary, never a traceback in the payload;
+* a tool that hands back a job record replies ``{"job": record}``, whichever tool it is.
 """
 
 from __future__ import annotations
@@ -23,9 +24,27 @@ log = get_logger("tools")
 
 Envelope = dict[str, Any]
 
+JOB_RECORD_KEYS = frozenset({"job_id", "kind", "state"})
+"""What identifies a returned payload as a job record rather than a result of its own.
+
+The three fields every record has from the moment it is created — and which no other tool
+payload carries together — so recognising them costs nothing and cannot be forgotten the
+way the ``{"job": ...}`` wrap was at the video tools (#219).
+"""
+
 
 def current_context() -> dict[str, Any]:
     return context(get_connection())
+
+
+def shaped(payload: dict[str, Any]) -> dict[str, Any]:
+    """A job record becomes ``{"job": record}``; every other payload passes through.
+
+    One envelope for "I started a job", built here rather than at each starter: the agent
+    polls what ``get_job`` returns, so a starter that spliced the record into the envelope
+    top level made the same concept read two ways depending on which tool it came from.
+    """
+    return {"job": payload} if payload.keys() >= JOB_RECORD_KEYS else payload
 
 
 def tool[**P](fn: Callable[P, dict[str, Any]]) -> Callable[P, Envelope]:
@@ -44,7 +63,7 @@ def tool[**P](fn: Callable[P, dict[str, Any]]) -> Callable[P, Envelope]:
                 return retried
             log.exception("%s raised unexpectedly", fn.__name__)
             return failure(InternalError(cause=f"{type(exc).__name__}: {exc}"))
-        return {"ok": True, **payload, "context": current_context()}
+        return {"ok": True, **shaped(payload), "context": current_context()}
 
     return wrapper
 
@@ -80,7 +99,7 @@ def _retry_if_the_handle_died[**P](
                 f"({type(original).__name__}: {original}).",
             )
         )
-    return {"ok": True, **payload, "context": current_context()}
+    return {"ok": True, **shaped(payload), "context": current_context()}
 
 
 def failure(error: ResolveMcpError) -> Envelope:

--- a/src/resolve_mcp/tools/jobs.py
+++ b/src/resolve_mcp/tools/jobs.py
@@ -26,7 +26,7 @@ def get_job(job_id: str) -> dict[str, Any]:
     cause/fix shape as any other failure; cached is true when the result came back without
     the work being redone.
     """
-    return {"job": store.load(job_id).payload()}
+    return store.load(job_id).payload()
 
 
 @tool

--- a/src/resolve_mcp/tools/render.py
+++ b/src/resolve_mcp/tools/render.py
@@ -75,18 +75,16 @@ def render_timeline(
     hand would; the timeline the director had open is the one thing put back.
     """
     connection = get_connection()
-    return {
-        "job": deliver.render_timeline(
-            connection,
-            preset=preset,
-            timeline=timeline,
-            name=name,
-            target_dir=target_dir,
-            start=start,
-            end=end,
-            refresh=refresh,
-        )
-    }
+    return deliver.render_timeline(
+        connection,
+        preset=preset,
+        timeline=timeline,
+        name=name,
+        target_dir=target_dir,
+        start=start,
+        end=end,
+        refresh=refresh,
+    )
 
 
 TOOLS: tuple[Any, ...] = (list_render_presets, render_timeline)

--- a/src/resolve_mcp/tools/stems.py
+++ b/src/resolve_mcp/tools/stems.py
@@ -26,7 +26,7 @@ def separate_stems(
 ) -> dict[str, Any]:
     """Split audio into stems on the GPU, in two passes or three, as a background job.
 
-    Returns a job to poll with get_job immediately. Pass one splits the mix into
+    Returns a job immediately — poll it with get_job. Pass one splits the mix into
     vocals, drums, bass and other; pass two decomposes the drum stem into kick, snare and
     toms, which is what fill detection reads. The result is paths on disk, not audio.
 

--- a/src/resolve_mcp/tools/stems.py
+++ b/src/resolve_mcp/tools/stems.py
@@ -26,7 +26,7 @@ def separate_stems(
 ) -> dict[str, Any]:
     """Split audio into stems on the GPU, in two passes or three, as a background job.
 
-    Returns a job_id immediately — poll it with get_job. Pass one splits the mix into
+    Returns a job to poll with get_job immediately. Pass one splits the mix into
     vocals, drums, bass and other; pass two decomposes the drum stem into kick, snare and
     toms, which is what fill detection reads. The result is paths on disk, not audio.
 
@@ -53,18 +53,16 @@ def separate_stems(
     job waits for the first and returns the stems it wrote rather than failing or separating
     the same audio twice, so it reports "waiting" for as long as the first one takes.
     """
-    return {
-        "job": stems.separate_stems(
-            get_connection(),
-            scope=scope,
-            timeline=timeline,
-            clip=clip,
-            bin=bin,
-            refresh=refresh,
-            split_wind=split_wind,
-            detach=detach,
-        )
-    }
+    return stems.separate_stems(
+        get_connection(),
+        scope=scope,
+        timeline=timeline,
+        clip=clip,
+        bin=bin,
+        refresh=refresh,
+        split_wind=split_wind,
+        detach=detach,
+    )
 
 
 TOOLS: tuple[Any, ...] = (separate_stems,)

--- a/src/resolve_mcp/tools/video.py
+++ b/src/resolve_mcp/tools/video.py
@@ -53,7 +53,7 @@ def detect_scene_cuts(
 ) -> dict[str, Any]:
     """Start a job cataloguing every scene cut in a clip — the b-roll question, answered once.
 
-    Returns a job_id to poll with get_job. The finished result is a gist: how many cuts, how
+    Returns a job to poll with get_job. The finished result is a gist: how many cuts, how
     many shots, the shot lengths, the first few cut times — and path, the JSON catalog with
     every cut and every shot in dual time. Read or grep that file for the span you care
     about rather than asking for it all inline.
@@ -86,7 +86,7 @@ def analyze_occlusion(
     """Start a job scoring how much of an angle is blocked by something in the near field.
 
     The question before you cut to a camera: is anyone's head, hat, phone or back in the way?
-    Returns a job_id to poll with get_job. Run it over the range of a song on every angle you
+    Returns a job to poll with get_job. Run it over the range of a song on every angle you
     are considering, then keep your cuts out of the windows it reports.
 
     start and end are the clip's own frame numbers, dual time as everywhere — start=85653 or
@@ -141,7 +141,7 @@ def analyze_quality(
     """Start a job scoring how good the picture is across a range of an angle.
 
     The other question before you cut to a camera: is this take soft, blown out or shaky?
-    Returns a job_id to poll with get_job. Run it over a song's range on the angles you are
+    Returns a job to poll with get_job. Run it over a song's range on the angles you are
     choosing between, rank them on what comes back, and keep your cuts out of its windows.
 
     start and end are the clip's own frame numbers, dual time as everywhere — start=85653 or

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,0 +1,102 @@
+"""One envelope shape for "I started a job" (#219).
+
+Analysis, render and stems used to wrap their record as ``{"job": record}`` while the video
+tools spliced the same record into the envelope top level — the same concept in two shapes,
+depending on which tool the agent had called. The wrap now happens once, in the decorator,
+so what is pinned here is the recognition itself and that every family comes back the same:
+including on the reconnect path, which is a second return statement and so a second place
+the shape can drift.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from resolve_mcp.resolve.connection import get_connection
+from resolve_mcp.tools.envelope import shaped, tool
+
+from .conftest import Attach
+from .fakes import studio
+
+
+def a_record(**overrides: Any) -> dict[str, Any]:
+    """A job record as ``store.JobRecord.payload`` hands one back, trimmed to what matters."""
+    return {
+        "job_id": "scene-cuts-0123456789ab",
+        "kind": "scene_cuts",
+        "state": "running",
+        "progress": 0.0,
+        "result": None,
+        **overrides,
+    }
+
+
+# --- recognising a record ----------------------------------------------------------------------
+
+
+def test_a_returned_job_record_is_wrapped_as_the_job() -> None:
+    assert shaped(a_record()) == {"job": a_record()}
+
+
+def test_a_payload_that_is_not_a_record_passes_straight_through() -> None:
+    payload = {"frames": [], "clip": "cam_a", "state": "ok"}
+
+    assert shaped(payload) is payload
+
+
+def test_a_record_is_recognised_in_every_state_it_can_come_back_in() -> None:
+    """A cache hit replies completed and a refusal replies failed — all of them are jobs."""
+    for state in ("running", "completed", "failed"):
+        assert shaped(a_record(state=state)) == {"job": a_record(state=state)}
+
+
+# --- through the decorator ---------------------------------------------------------------------
+
+
+def test_a_tool_that_starts_a_job_replies_with_the_record_under_job(attach: Attach) -> None:
+    attach(studio())
+
+    @tool
+    def start_one() -> dict[str, Any]:
+        return a_record()
+
+    envelope = start_one()
+
+    assert envelope["ok"] is True
+    assert envelope["job"] == a_record()
+    assert "job_id" not in envelope
+    assert "context" in envelope
+
+
+def test_a_tool_that_returns_a_result_of_its_own_is_left_alone(attach: Attach) -> None:
+    attach(studio())
+
+    @tool
+    def read_one() -> dict[str, Any]:
+        return {"frames": ["a.jpg"]}
+
+    envelope = read_one()
+
+    assert envelope["frames"] == ["a.jpg"]
+    assert "job" not in envelope
+
+
+def test_a_job_started_after_a_reconnect_comes_back_in_the_same_envelope(
+    attach: Attach,
+) -> None:
+    """The retry is a second return, and a second return is where one shape becomes two."""
+    dying = studio()
+    dying.die_after(1)  # passes the connection's probe, dies on the very next call
+    connector = attach(dying, studio())
+
+    @tool
+    def start_one() -> dict[str, Any]:
+        get_connection().handle().GetProjectManager()
+        return a_record()
+
+    envelope = start_one()
+
+    assert envelope["ok"] is True, envelope.get("error")
+    assert connector.attempts == 2
+    assert envelope["job"] == a_record()
+    assert "job_id" not in envelope

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -1,0 +1,142 @@
+"""The findings module: one packaged report, one refusal, one pre-flight shape (#219).
+
+Every validating route used to build ``{"errors": [...], "warnings": [...]}`` by hand, and
+the cut and titles contracts each carried their own severity split. What is pinned here is
+that the packaging is now a single function, that the refusal preamble reads the same
+sentence whichever file it is refusing, and that both contracts split severity through the
+one shared pre-flight shape rather than through a copy of it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from resolve_mcp.document import LoadedDocument, Preflight
+from resolve_mcp.errors import CutInvalidError, ResolveMcpError, TitlesInvalidError
+from resolve_mcp.findings import Finding, refuse, report
+from resolve_mcp.resolve import cut as cut_read
+from resolve_mcp.resolve import titles as titles_read
+
+BAD_SCHEMA = Finding("E1", None, "not a cut file", "author one")
+NO_SUCH_CLIP = Finding("E4", "s001", "no clip named cam_a", "check the pool")
+NO_BOUNDS = Finding("W9", "s002", "no usable bounds", "ignore or re-ingest")
+
+
+def a_document() -> LoadedDocument:
+    return LoadedDocument(Path("cut.json"), "abc123", {}, None)
+
+
+# --- report ------------------------------------------------------------------------------------
+
+
+def test_a_report_splits_the_findings_by_severity() -> None:
+    packaged = report([NO_SUCH_CLIP, NO_BOUNDS])
+
+    assert packaged["errors"] == [NO_SUCH_CLIP.as_dict()]
+    assert packaged["warnings"] == [NO_BOUNDS.as_dict()]
+
+
+def test_a_report_always_carries_both_keys() -> None:
+    """The agent reads one shape whether the rules blocked or only remarked."""
+    assert report([]) == {"errors": [], "warnings": []}
+    assert report([NO_BOUNDS])["errors"] == []
+    assert report([NO_SUCH_CLIP])["warnings"] == []
+
+
+def test_a_report_keeps_the_order_the_findings_arrived_in() -> None:
+    """Ordering is ``ordered``'s job; packaging must not quietly re-sort on top of it."""
+    packaged = report([NO_SUCH_CLIP, BAD_SCHEMA])
+
+    assert [one["rule"] for one in packaged["errors"]] == ["E4", "E1"]
+
+
+# --- refuse ------------------------------------------------------------------------------------
+
+
+def test_a_pass_with_no_errors_is_not_refused() -> None:
+    refuse(
+        [NO_BOUNDS],
+        error=CutInvalidError,
+        what="cut file",
+        consequence="nothing was built",
+        detail={"cut_file": "cut.json"},
+    )
+
+
+def test_a_refusal_counts_the_errors_and_names_the_consequence() -> None:
+    with pytest.raises(CutInvalidError) as raised:
+        refuse(
+            [BAD_SCHEMA, NO_SUCH_CLIP, NO_BOUNDS],
+            error=CutInvalidError,
+            what="cut file",
+            consequence="nothing was built",
+            detail={"cut_file": "cut.json"},
+        )
+
+    assert raised.value.cause == "The cut file has 2 error(s), so nothing was built."
+
+
+def test_a_refusal_carries_the_provenance_and_every_rule_that_fired() -> None:
+    """A count alone cannot be acted on: the refusal is what the agent fixes the file from."""
+    with pytest.raises(TitlesInvalidError) as raised:
+        refuse(
+            [BAD_SCHEMA, NO_BOUNDS],
+            error=TitlesInvalidError,
+            what="titles file",
+            consequence="nothing was applied",
+            detail={"titles_file": "titles.json", "content_hash": "abc123"},
+        )
+
+    detail = raised.value.payload()["detail"]
+    assert detail["titles_file"] == "titles.json"
+    assert detail["content_hash"] == "abc123"
+    assert detail["errors"] == [BAD_SCHEMA.as_dict()]
+    assert detail["warnings"] == [NO_BOUNDS.as_dict()]
+
+
+def test_a_refusal_raises_the_error_its_caller_owns() -> None:
+    """The rule set names the failure; the packaging never picks one for it."""
+
+    def _refuse(error: Any) -> None:
+        refuse(
+            [BAD_SCHEMA],
+            error=error,
+            what="cut file",
+            consequence="no take was swapped",
+            detail={},
+        )
+
+    for error in (CutInvalidError, TitlesInvalidError):
+        with pytest.raises(ResolveMcpError) as raised:
+            _refuse(error)
+        assert isinstance(raised.value, error)
+
+
+# --- one pre-flight shape ----------------------------------------------------------------------
+
+
+def test_both_contracts_pre_flight_through_the_one_shape() -> None:
+    """Byte-identical severity splits in two contracts is how the two drift apart."""
+    assert issubclass(cut_read.Preflight, Preflight)
+    assert issubclass(titles_read.Preflight, Preflight)
+
+
+def test_the_shared_shape_splits_severity_for_both_contracts() -> None:
+    findings = [BAD_SCHEMA, NO_BOUNDS]
+    loaded = a_document()
+
+    for checked in (
+        cut_read.Preflight(loaded, findings),
+        titles_read.Preflight(loaded, findings),
+    ):
+        assert checked.errors == [BAD_SCHEMA]
+        assert checked.warnings == [NO_BOUNDS]
+
+
+def test_each_contract_still_carries_what_its_own_apply_needs() -> None:
+    """One shared shape, not one shape: the pool reading and the events are not interchangeable."""
+    assert cut_read.Preflight(a_document(), []).sources == []
+    assert titles_read.Preflight(a_document(), []).events == []

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -129,7 +129,7 @@ def test_the_shared_shape_splits_severity_for_both_contracts() -> None:
     loaded = a_document()
 
     for checked in (
-        cut_read.Preflight(loaded, findings),
+        cut_read.Preflight(loaded, findings, []),
         titles_read.Preflight(loaded, findings),
     ):
         assert checked.errors == [BAD_SCHEMA]
@@ -138,5 +138,5 @@ def test_the_shared_shape_splits_severity_for_both_contracts() -> None:
 
 def test_each_contract_still_carries_what_its_own_apply_needs() -> None:
     """One shared shape, not one shape: the pool reading and the events are not interchangeable."""
-    assert cut_read.Preflight(a_document(), []).sources == []
+    assert cut_read.Preflight(a_document(), [], []).sources == []
     assert titles_read.Preflight(a_document(), []).events == []

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -1317,7 +1317,9 @@ def test_a_real_quality_scan_reads_an_angle_on_its_own_clock() -> None:
     last = min(bounds["out"]["frames"], first + int(fps * QUALITY_SCAN_SECONDS))
 
     started = analyze_quality(footage["name"], bin=footage["bin"], start=first, end=last)
-    record = wait_for(started["job_id"], timeout=1800.0)
+    # The one envelope shape for a started job, on a real box (#219): the video tools used
+    # to splice the record into the top level and the analysis tools to wrap it.
+    record = wait_for(started["job"]["job_id"], timeout=1800.0)
 
     assert started["ok"] is True, started.get("error")
     assert record.state == "completed", record.error
@@ -1429,7 +1431,7 @@ def test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock(
     bounds = inspect_clip(chosen["name"], bin=chosen["bin"])["bounds"]["media"]
 
     started = detect_scene_cuts(chosen["name"], bin=chosen["bin"])
-    record = wait_for(started["job_id"], timeout=1800.0)
+    record = wait_for(started["job"]["job_id"], timeout=1800.0)
 
     assert started["ok"] is True, started.get("error")
     assert record.state == "completed", record.error

--- a/tests/test_occlusion.py
+++ b/tests/test_occlusion.py
@@ -753,7 +753,7 @@ def test_real_ffmpeg_samples_a_clip_whose_lower_half_goes_black(
     attach(_studio_holding(source, {"FPS": "10", "Start": "0", "End": "59", "Frames": "60"}))
 
     envelope = video_tools.analyze_occlusion(source.name)
-    record = wait_for(envelope["job_id"])
+    record = wait_for(envelope["job"]["job_id"])
 
     assert envelope["ok"] is True, envelope.get("error")
     assert record.state == "completed", record.error

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -414,7 +414,7 @@ def test_real_ffmpeg_samples_a_clip_that_goes_out_of_focus(attach: Attach, tmp_p
     attach(_studio_holding(source, {"FPS": "10", "Start": "0", "End": "59", "Frames": "60"}))
 
     envelope = video_tools.analyze_quality(source.name)
-    record = wait_for(envelope["job_id"])
+    record = wait_for(envelope["job"]["job_id"])
 
     assert envelope["ok"] is True, envelope.get("error")
     assert record.state == "completed", record.error

--- a/tests/test_scene_cuts.py
+++ b/tests/test_scene_cuts.py
@@ -26,7 +26,12 @@ from resolve_mcp.ffmpeg import Completed, Runner
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.resolve.connection import get_connection
 from resolve_mcp.tools import video as video_tools
-from resolve_mcp.video.scenes import DEFAULT_THRESHOLD, INLINE_CUTS, detect_scene_cuts
+from resolve_mcp.video.scenes import (
+    DEFAULT_THRESHOLD,
+    INLINE_CUTS,
+    KIND,
+    detect_scene_cuts,
+)
 
 from .conftest import Attach
 from .fakes import (
@@ -305,6 +310,20 @@ def test_the_tool_shapes_a_refusal_rather_than_raising(attach: Attach, fixture_v
     assert "context" in envelope
 
 
+def test_the_tool_hands_the_job_back_in_the_one_envelope_shape(
+    attach: Attach, fixture_video: Path
+) -> None:
+    """The same shape the analysis and render starters reply with (#219) — record under job."""
+    attach(_studio_holding(fixture_video))
+
+    envelope = video_tools.detect_scene_cuts("broll_pan.mp4")
+
+    assert envelope["ok"] is True, envelope.get("error")
+    assert envelope["job"]["kind"] == KIND
+    assert envelope["job"]["job_id"].startswith(KIND)
+    assert "job_id" not in envelope
+
+
 # --- against real ffmpeg -----------------------------------------------------------------------
 
 
@@ -315,7 +334,7 @@ def test_real_ffmpeg_finds_the_one_cut_in_a_two_shot_clip(attach: Attach, tmp_pa
     attach(_studio_holding(source, {"FPS": "10", "Start": "0", "End": "19", "Frames": "20"}))
 
     envelope = video_tools.detect_scene_cuts("broll_pan.mp4")
-    record = wait_for(envelope["job_id"])
+    record = wait_for(envelope["job"]["job_id"])
 
     assert envelope["ok"] is True, envelope.get("error")
     assert record.state == "completed", record.error

--- a/tests/test_virtual_transcript.py
+++ b/tests/test_virtual_transcript.py
@@ -269,7 +269,8 @@ def test_nothing_here_blocks_a_cut(tmp_path: Path) -> None:
 
     assert set(rules(reading)) >= {"W3", "W4", "W7"}
     assert all(rule.startswith("W") for rule in rules(reading))
-    assert "errors" not in reading
+    # The packaged report always carries both keys (#219); an empty one is the statement.
+    assert reading["errors"] == []
 
 
 def test_a_long_reading_goes_to_disk(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #219.

Two unifications at the envelope layer, both about one shape defined once.

## 1. Findings packaging

`findings.report(findings)` is now the only place a list of findings becomes the
`{errors, warnings}` reply, and `findings.refuse(...)` the only place errors in that list
become a refusal — it builds the sentence (*The &lt;what&gt; has N error(s), so
&lt;consequence&gt;.*), counts the errors, and merges the caller's provenance detail with the
packaged findings. `errors_in`/`warnings_in` are the single definition of the severity
split that both the report and the pre-flight read.

The eight hand-assembled sites are gone: `resolve/build.py` ×3, `resolve/apply.py` ×2,
`resolve/cut.py`, `resolve/titles.py`, `resolve/takes.py`, `analysis/virtual.py`.

The cut and titles contracts carried a byte-identical `Preflight`; both now subclass one
`document.Preflight` (loaded document + findings + the severity split) and add only what
their own apply needs. The cut one changed `NamedTuple` → frozen dataclass; every
construction site is positional and still valid, and nothing unpacks, indexes or
`_replace`s it.

**Observable shape change:** replies that could only ever carry warnings now carry
`"errors": []` as well (`build_timeline`, `apply_titles`, `virtual_transcript`), and the
locked-track and take-swap refusal details gain `"warnings"`. That is what one shape
costs: the agent reads the same pair whether the rules blocked or only remarked.

## 2. One envelope for "I started a job"

The `@tool` decorator recognises a returned job record by `{job_id, kind, state}` and
wraps it as `{"job": record}`. The wrap is gone from all seven analysis starters, stems,
render and `get_job`; the video tools stop diverging with no change to their bodies.

**Bug caught while building:** the handle-death retry in `envelope.py` is a *second*
return statement, and it would have kept the old un-wrapped shape after a reconnect — so
the same tool answered two ways depending on whether Resolve had dropped mid-call. Fixed,
and pinned by `test_envelope.py::test_a_job_started_after_a_reconnect_comes_back_in_the_same_envelope`.

## Seam

Fake tier for every shape — `tests/test_findings.py` (packaging, refusal, one pre-flight)
and `tests/test_envelope.py` (recognition, both decorator return paths), plus the video
tool tests asserting `envelope["job"]`. Live smoke for the same shape on a real box.

## Review record

`/code-review` against `origin/main`, two axes in parallel.

**Spec axis — clean.** All five ACs implemented; no correctness defects. Verified by
sweeping the whole source tree, not just the diff: no `"errors":`/`"warnings":` reply is
built outside `findings.report`; no tool body builds the `"job"` key; no `Returns a
job_id` docstring remains. Confirmed `shaped`'s duck-typing cannot false-positive — no
non-job payload in `src/` carries all three keys at top level. Two notes taken as
findings, both fixed below.

**Standards axis — documented-standard compliance clean.** CONTEXT.md map updated in the
same PR; no implicit re-export; docstring density matches neighbours. Six findings, all
fixed below. Correctness checks it ran (dataclass/NamedTuple semantics, reply-shape
deltas, `shaped` false positives, stale `["job_id"]` assertions) all came back clear.

### Findings and their resolutions

1. **Doc drift, `README.md:113`** — "the starter returns a `job_id` immediately" described
   the shape this PR removes. *Fixed:* it now describes the one shape.
2. **Duplicated Code** — the severity split lived twice, in `document.Preflight` and again
   inside `findings.report`. For a PR whose thesis is "one findings report", that was the
   loose thread. *Fixed:* `errors_in`/`warnings_in` are the one definition both read.
3. **Speculative Generality** — `cut.Preflight.sources` had a `default_factory` no caller
   needed and dataclass ordering did not require, making a pre-flight with no pool reading
   silently constructible. *Fixed:* dropped; the caller states it.
4. **Mysterious Name** — `LoadedPreflight` named nothing in the domain and existed only to
   dodge the name it was subclassed into. *Fixed:* both contracts subclass
   `document.Preflight` through the module.
5. **Weak typing at the seam** — `refuse(error: Callable[..., ResolveMcpError])` dropped
   mypy's check on the `cause=`/`detail=` keywords it invokes the callable with. *Fixed:*
   a `Refusal` protocol.
6. **Prose, `tools/stems.py`** — "Returns a job to poll with get_job immediately" read as
   *poll immediately*. *Fixed:* "Returns a job immediately — poll it with get_job."
7. **Primitive Obsession on `shaped`** (judgement call) — the decorator sniffs a dict's
   keys for a concept that has a type, `store.JobRecord`, which the starters erase with
   `.payload()` before the decorator sees it. *Not taken:* the spec asks for exactly this
   ("the `@tool` decorator learns to recognise a returned job record"), and threading the
   record type through the MCP boundary is a larger change than this ticket.

Fix diff re-checked on its own (7 files, +55/−20); no full second pass, per the workflow.

## Gates

- `uv run pytest -m 'not live'` — green, no failures.
- `uv run mypy src tests` — `Success: no issues found in 219 source files`.
- `uv run ruff check src tests` — `All checks passed!`.

### Live smoke — AC 5, ran and passed

Hardware: Windows 11 Home 10.0.26200, DaVinci Resolve Studio running with a project open.
Interpreter: CPython 3.12.10 from the python.org install
(`C:\Users\Daniel\AppData\Local\Programs\Python\Python312`), which is what ADR 0001
requires for the attach.

One job-starting tool from each formerly-divergent family, all asserting
`started["job"]["job_id"]` so a wrong shape fails rather than skips:

| Test | Family | Outcome |
| --- | --- | --- |
| `test_a_real_quality_scan_reads_an_angle_on_its_own_clock` | video (used to splice the record into the envelope top level) | **passed** |
| `test_a_real_scene_scan_reports_cuts_on_the_clips_own_clock` | video (same) | **passed** |
| `test_the_shipped_default_preset_is_a_built_in_on_this_machine` | render (used to wrap the record by hand) | **passed** |

`test_correlate_measures_a_real_hand_edited_timeline` skipped — it wants
`RESOLVE_MCP_CORRELATE_BEATS` pointed at a beats file from a real analysis, which is an
input this session did not have. It is the same wrapped family the render test covers, so
AC 5 is met without it.

Review: clean
