### PR TITLE
GPU-first: CLAUDE.md compute-device rule; separator refuses a +cpu torch build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,8 +187,8 @@ a reason to set the override on this box. Check before a live run:
 
     audio-separator --env_info 2>&1 | grep -E "PyTorch|ONNX"
 
-The separator's own torch decides its device — a `+cpu` build there runs
-every stem pass on the CPU whatever the server's config says. On the live
+The separator's own torch decides its device — the server's config cannot
+move a `+cpu` build onto the card, only refuse it. On the live
 box `audio-separator` resolves to the system Python 3.12
 (`%LOCALAPPDATA%\Programs\Python\Python312`), separate from the repo
 venv; its torch must be a `+cu` build. Restore one (driver is CUDA 13.x)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,37 @@ Long multi-PR sweeps (merge trains, cross-PR audits) shard per-PR into
 subagents; the orchestrating session keeps receipts, not diffs — past
 sweeps that inlined everything ended at 2× the usable context budget.
 
+## Compute device
+
+**GPU-first.** Every compute path runs on the card wherever a GPU path
+exists; the CPU is a fallback the log and the job record name at WARNING.
+The per-path table — which paths have a GPU path, which are CPU by policy
+(beats and applause: the corpus was measured on the CPU torch build,
+flipping that is the director's call), and how each reports a fallback —
+is `docs/reference/compute-device-inventory.md`. Read it before you launch
+a separation, transcription or beat-grid job, before you touch a compute
+path, and when you add one — a new path takes its own row in the same PR.
+
+A CPU reading where the table says a GPU path exists is a **broken install,
+not a slow box**: stop, fix it (or hand it to the human under `## Needs
+from you`), then run. Waiting it out is the G10 failure (#202) — the
+separator ran hours on the CPU for a week because the log said "slow".
+Check before a live run:
+
+    audio-separator --env_info 2>&1 | grep -E "PyTorch|ONNX"
+
+The separator's own torch decides its device — a `+cpu` build there runs
+every stem pass on the CPU whatever the server's config says. On the live
+box `audio-separator` resolves to the system Python 3.12
+(`%LOCALAPPDATA%\Programs\Python\Python312`), separate from the repo
+venv; its torch must be a `+cu` build. Restore one (driver is CUDA 13.x)
+with:
+
+    py -3.12 -m pip install "torch==2.13.0+cu130" "torchvision==0.28.0+cu130" --index-url https://download.pytorch.org/whl/cu130 --extra-index-url https://pypi.org/simple
+
+`pip index versions torch --index-url .../cu130` lists the versions when
+the pin moves. Live-tier separation tests are only a pass on a `+cu` build.
+
 ## Gotchas
 
 Facts rediscovered across sessions, promoted from session memory. Each one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,8 +170,9 @@ sweeps that inlined everything ended at 2× the usable context budget.
 **GPU-first.** Every compute path runs on the card wherever a GPU path
 exists; the CPU is a fallback the log and the job record name at WARNING.
 The per-path table — which paths have a GPU path, which are CPU by policy
-(beats and applause: the corpus was measured on the CPU torch build,
-flipping that is the director's call), and how each reports a fallback —
+(beats and applause: the corpus was measured on the CPU torch build; the
+director has called the flip — #245 moves them to CUDA and re-measures),
+and how each reports a fallback —
 is `docs/reference/compute-device-inventory.md`. Read it before you launch
 a separation, transcription or beat-grid job, before you touch a compute
 path, and when you add one — a new path takes its own row in the same PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,8 +179,11 @@ path, and when you add one — a new path takes its own row in the same PR.
 A CPU reading where the table says a GPU path exists is a **broken install,
 not a slow box**: stop, fix it (or hand it to the human under `## Needs
 from you`), then run. Waiting it out is the G10 failure (#202) — the
-separator ran hours on the CPU for a week because the log said "slow".
-Check before a live run:
+separator ran hours on the CPU under a WARNING nobody acted on. The
+server now refuses a `+cpu` separator outright
+(`RESOLVE_MCP_SEPARATOR_ALLOW_CPU`, README) and the live separator test
+is red on a CPU device; treat either as the install fix below, never as
+a reason to set the override on this box. Check before a live run:
 
     audio-separator --env_info 2>&1 | grep -E "PyTorch|ONNX"
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Zero-config by default; every path has an environment override.
 | `RESOLVE_MCP_CACHE` | `%LOCALAPPDATA%\resolve-mcp` | Cache root: snapshots, job records, cached results, acquired audio, grabbed frames, analysis catalogs, separated stems, model weights |
 | `RESOLVE_MCP_FFMPEG` | `ffmpeg` (found on PATH) | ffmpeg executable used for per-clip audio extraction, frame grabs and scene-cut detection |
 | `RESOLVE_MCP_AUDIO_SEPARATOR` | `audio-separator` (found on PATH) | python-audio-separator CLI used for stem separation |
+| `RESOLVE_MCP_SEPARATOR_ALLOW_CPU` | `0` | A separator whose torch is the CPU build (`+cpu`) refuses to run — a GPU-capable box with that install is misconfigured, and the error names the fix. `1` accepts the CPU run on a box with no CUDA device; it is then a warning on the job record |
 | `RESOLVE_MCP_STEM_MODEL` | `htdemucs_ft.yaml` | Pass one: the 4-stem model (vocals, drums, bass, other) |
 | `RESOLVE_MCP_DRUM_MODEL` | `MDX23C-DrumSep-aufr33-jarredou.ckpt` | Pass two: the drum decomposition model (kick, snare, toms, ride, crash) |
 | `RESOLVE_MCP_DEFAULT_RENDER_PRESET` | `H.265 Master` | Render preset `render_timeline` uses when the call names none. Must be a preset the project offers — an unknown name is refused, never swapped for another |

--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -108,9 +108,11 @@ build, carries it in the job record, and refuses a `+cpu` build (a
 WARNING only under the `RESOLVE_MCP_SEPARATOR_ALLOW_CPU=1` opt-in). The fix — CUDA
 torch installed into whatever environment owns the PATH
 `audio-separator`, or `RESOLVE_MCP_AUDIO_SEPARATOR` pointed at one that
-has it — is an install action on the box. Still `+cpu` on 2026-08-15 (a
-live run was on the CPU as this was written); the exact command is in
-CLAUDE.md, "Compute device". Since then a `+cpu` build refuses the job
+has it — is an install action on the box. Still `+cpu` on the morning of
+2026-08-15 (a live run was on the CPU as this was written); **fixed that
+day**: `torch 2.13.0+cu130` in the system Python 3.12, `--env_info` now
+reports `+cu130` and `CUDAExecutionProvider available`. The exact command
+is in CLAUDE.md, "Compute device". A `+cpu` build now refuses the job
 (`RESOLVE_MCP_SEPARATOR_ALLOW_CPU`, README) and the live separator test
 fails on a CPU device, so the state cannot go unnoticed again.
 

--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -104,7 +104,8 @@ copied to the separator, which is exactly what G10 was.
 passes (`htdemucs_ft`, the drum and wind models) run torch, so every
 separation on this box is currently CPU-bound — G10's class of bug, live.
 The server now probes `--env_info` before each fresh separation, logs the
-build, carries it in the job record, and warns on `+cpu`. The fix — CUDA
+build, carries it in the job record, and refuses a `+cpu` build (a
+WARNING only under the `RESOLVE_MCP_SEPARATOR_ALLOW_CPU=1` opt-in). The fix — CUDA
 torch installed into whatever environment owns the PATH
 `audio-separator`, or `RESOLVE_MCP_AUDIO_SEPARATOR` pointed at one that
 has it — is an install action on the box. Still `+cpu` on 2026-08-15 (a
@@ -123,6 +124,7 @@ reading is the one recorded, because a run that reached the card once and
 then could not is a CPU run. A CPU device under a GPU-capable build is the
 fallback G10 hid behind "it was slow": it is a WARNING in the log at the
 pass that announced it, and a `warning` on the record — except under a
-`+cpu` build, whose warning is the same news with the fix attached. A
+`+cpu` build, which only gets this far on the opt-in box, where the
+build's own warning already carries the same news with the fix. A
 build the probe could not read is not that case: its warning says whether
 this ran on the GPU is unknown, which a CPU reading has just answered.

--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -20,7 +20,7 @@ says so in the log and the job record.**
 | Beat grid | `analysis/beats` (beat_this, torch) | **CPU by policy** — see below | exists upstream (CUDA torch) | `device.announce("beat_this")` at inference; `torch` note in the music/structure job results |
 | Applause curve | `analysis/applause` (PANNs, torch) | **CPU by policy** — same decision | exists upstream | `device.announce("PANNs")`; same `torch` note |
 | Transcription | `analysis/whisper` (faster-whisper/CTranslate2) | **CUDA** (`whisper_device=auto`, runtime shipped by the analysis extra, #128) | yes — already wired | resolved device logged after model load; `auto`→CPU resolve is a WARNING |
-| Stem separation | `audio/separator` (external CLI, its own torch) | whatever the PATH install has — **found `2.13.0+cpu` on the live box, 2026-08-14** | yes — CUDA torch in the separator's env | `--env_info` probed before every fresh separation; build in the log + job record; `+cpu` build is a WARNING; each pass's own device read off its banner into `separator.device` (#188), CPU under a GPU build is a WARNING |
+| Stem separation | `audio/separator` (external CLI, its own torch) | whatever the PATH install has — **found `2.13.0+cpu` on the live box, 2026-08-14** | yes — CUDA torch in the separator's env | `--env_info` probed before every fresh separation; build in the log + job record; `+cpu` build **refuses the job** (opt into the CPU run with `RESOLVE_MCP_SEPARATOR_ALLOW_CPU=1`, then a WARNING); each pass's own device read off its banner into `separator.device` (#188), CPU under a GPU build is a WARNING |
 | Rendering | `resolve/render`, `deliver` | Resolve's own GPU pipeline | Resolve's business | out of scope — Resolve manages its own devices |
 
 Deliberately out of scope: the gauntlet A/B pack's decodes
@@ -109,8 +109,9 @@ torch installed into whatever environment owns the PATH
 `audio-separator`, or `RESOLVE_MCP_AUDIO_SEPARATOR` pointed at one that
 has it — is an install action on the box. Still `+cpu` on 2026-08-15 (a
 live run was on the CPU as this was written); the exact command is in
-CLAUDE.md, "Compute device", and the live separator test now fails on a
-CPU device so the state cannot go unnoticed again.
+CLAUDE.md, "Compute device". Since then a `+cpu` build refuses the job
+(`RESOLVE_MCP_SEPARATOR_ALLOW_CPU`, README) and the live separator test
+fails on a CPU device, so the state cannot go unnoticed again.
 
 The build says what the install *can* do; it does not say what a run
 *did*. Each pass announces its own device in its opening banner, and that

--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -74,7 +74,11 @@ concert footage is all 4:2:2 (FX6 XAVC Intra H.264 4:2:2, A7IV H.265
 losing case is long 1080p H.264, rare in a 4K pipeline — a box that works
 mostly on those should set `RESOLVE_MCP_FFMPEG_HWACCEL=off`.
 
-## The torch decision: beats and applause stay on the CPU
+## The torch decision: beats and applause stay on the CPU (until #245)
+
+**Superseded in intent, 2026-08-15:** the director called the flip — #245
+moves both models to CUDA torch and re-measures the corpus against a stated
+tolerance. Until it lands, what follows is still the live state.
 
 The analysis extra pins the PyPI torch wheel, which on Windows is the CPU
 build (`pyproject.toml`), and beat_this is pinned to the commit the corpus

--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -107,7 +107,10 @@ The server now probes `--env_info` before each fresh separation, logs the
 build, carries it in the job record, and warns on `+cpu`. The fix — CUDA
 torch installed into whatever environment owns the PATH
 `audio-separator`, or `RESOLVE_MCP_AUDIO_SEPARATOR` pointed at one that
-has it — is an install action on the box, recorded on ticket #202.
+has it — is an install action on the box. Still `+cpu` on 2026-08-15 (a
+live run was on the CPU as this was written); the exact command is in
+CLAUDE.md, "Compute device", and the live separator test now fails on a
+CPU device so the state cannot go unnoticed again.
 
 The build says what the install *can* do; it does not say what a run
 *did*. Each pass announces its own device in its opening banner, and that

--- a/src/resolve_mcp/audio/separator.py
+++ b/src/resolve_mcp/audio/separator.py
@@ -33,7 +33,7 @@ from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 from typing import Any
 
-from ..config import Config, get_config
+from ..config import SEPARATOR_ALLOW_CPU_ENV, Config, get_config
 from ..errors import SeparatorUnavailableError, StemSeparationError
 from ..logging_config import get_logger
 
@@ -147,8 +147,10 @@ def environment(
     ``config.audio_separator`` names a binary, and PATH decides which install — and which
     torch — that is. A CPU-build torch turns a forty-minute separation into a day's, and the
     only symptom used to be that it was slow; here the build goes into the log and the job
-    record, and a ``+cpu`` build is a warning. A separator too old to answer ``--env_info``
-    still separates: the report says the build is unknown rather than failing the job.
+    record, and a ``+cpu`` build refuses the job unless the box opted into the CPU run
+    (``RESOLVE_MCP_SEPARATOR_ALLOW_CPU``), where it is a warning. A separator too old to
+    answer ``--env_info`` still separates: the report says the build is unknown rather than
+    failing the job.
     """
     config = config or get_config()
     lines: list[str] = []
@@ -176,12 +178,26 @@ def environment(
         )
         log.warning("%s", report["warning"])
     elif "+cpu" in report["torch"]:
-        report["warning"] = (
+        message = (
             f"The separator's torch is the CPU build ({report['torch']}): separations run "
             "on the CPU at a fraction of GPU speed. Install CUDA torch into the "
             "environment that owns the audio-separator on PATH, or point "
             "RESOLVE_MCP_AUDIO_SEPARATOR at one that has it."
         )
+        if not config.separator_allow_cpu:
+            # G10 ran for hours under a warning nobody acted on; refusing is the only
+            # signal that stops a job. A box that really has no card says so once, in env.
+            log.error("%s", message)
+            raise SeparatorUnavailableError(
+                cause=message,
+                fix=(
+                    "Install CUDA torch for the separator (see CLAUDE.md, Compute device), "
+                    f"or set {SEPARATOR_ALLOW_CPU_ENV}=1 on a box with no CUDA device to "
+                    "accept the CPU run."
+                ),
+                detail={"executable": config.audio_separator, "torch": report["torch"]},
+            )
+        report["warning"] = message
         log.warning("%s", report["warning"])
     else:
         log.info("audio-separator torch build: %s", report["torch"])

--- a/src/resolve_mcp/config.py
+++ b/src/resolve_mcp/config.py
@@ -24,6 +24,11 @@ DEFAULT_FFMPEG = "ffmpeg"
 # route reports the device it decoded on — a silent CPU decode is the G10 failure.
 DEFAULT_FFMPEG_HWACCEL = "auto"
 DEFAULT_AUDIO_SEPARATOR = "audio-separator"
+# The separator's own torch decides its device, and a CPU wheel turns a forty-minute
+# separation into a day's with "slow" as the only symptom (G10, #202). By default a +cpu
+# build refuses the job and names the fix; a box with no card opts into the slow path with
+# RESOLVE_MCP_SEPARATOR_ALLOW_CPU=1, and the choice is then on the record, not accidental.
+SEPARATOR_ALLOW_CPU_ENV = "RESOLVE_MCP_SEPARATOR_ALLOW_CPU"
 DEFAULT_STEM_MODEL = "htdemucs_ft.yaml"
 # The name audio-separator 0.44.5 lists for the six-stem MDX23C drum model; the
 # "MDX23C-DrumSep-6stem-FT.ckpt" spelling is not in its catalog and fails to load.
@@ -59,6 +64,7 @@ class Config:
     ffmpeg: str = DEFAULT_FFMPEG
     ffmpeg_hwaccel: str = DEFAULT_FFMPEG_HWACCEL
     audio_separator: str = DEFAULT_AUDIO_SEPARATOR
+    separator_allow_cpu: bool = False
     stem_model: str = DEFAULT_STEM_MODEL
     drum_model: str = DEFAULT_DRUM_MODEL
     wind_model: str = DEFAULT_WIND_MODEL
@@ -82,6 +88,7 @@ class Config:
             ffmpeg=env.get("RESOLVE_MCP_FFMPEG") or DEFAULT_FFMPEG,
             ffmpeg_hwaccel=env.get("RESOLVE_MCP_FFMPEG_HWACCEL") or DEFAULT_FFMPEG_HWACCEL,
             audio_separator=env.get("RESOLVE_MCP_AUDIO_SEPARATOR") or DEFAULT_AUDIO_SEPARATOR,
+            separator_allow_cpu=(env.get(SEPARATOR_ALLOW_CPU_ENV) or "").lower() in TRUTHY,
             stem_model=env.get("RESOLVE_MCP_STEM_MODEL") or DEFAULT_STEM_MODEL,
             drum_model=env.get("RESOLVE_MCP_DRUM_MODEL") or DEFAULT_DRUM_MODEL,
             wind_model=env.get("RESOLVE_MCP_WIND_MODEL") or DEFAULT_WIND_MODEL,
@@ -112,6 +119,7 @@ class Config:
             "RESOLVE_MCP_FFMPEG": self.ffmpeg,
             "RESOLVE_MCP_FFMPEG_HWACCEL": self.ffmpeg_hwaccel,
             "RESOLVE_MCP_AUDIO_SEPARATOR": self.audio_separator,
+            SEPARATOR_ALLOW_CPU_ENV: "1" if self.separator_allow_cpu else "0",
             "RESOLVE_MCP_STEM_MODEL": self.stem_model,
             "RESOLVE_MCP_DRUM_MODEL": self.drum_model,
             "RESOLVE_MCP_WIND_MODEL": self.wind_model,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -132,6 +132,14 @@ def test_the_transcriber_takes_the_backends_own_device_and_precision_unless_told
     assert config.whisper_compute_type == "float32"
 
 
+def test_the_separator_refuses_a_cpu_torch_build_unless_the_box_opts_in() -> None:
+    """GPU-first is the default (CLAUDE.md, Compute device): a +cpu separator build refuses
+    the job, and only an explicit env opt-in accepts the slow run — the choice goes on record."""
+    assert Config.from_env({}).separator_allow_cpu is False
+    assert Config.from_env({"RESOLVE_MCP_SEPARATOR_ALLOW_CPU": "1"}).separator_allow_cpu
+    assert Config.from_env({"RESOLVE_MCP_SEPARATOR_ALLOW_CPU": "0"}).separator_allow_cpu is False
+
+
 def test_ffmpeg_is_a_bare_name_on_path_until_told_otherwise() -> None:
     assert Config.from_env({}).ffmpeg == "ffmpeg"
     assert Config.from_env({"RESOLVE_MCP_FFMPEG": r"D:\tools\ffmpeg.exe"}).ffmpeg == (

--- a/tests/test_detached_jobs.py
+++ b/tests/test_detached_jobs.py
@@ -185,6 +185,7 @@ def test_a_config_survives_the_trip_through_the_environment() -> None:
         ffmpeg="D:/tools/ffmpeg.exe",
         ffmpeg_hwaccel="off",
         audio_separator="D:/tools/audio-separator.exe",
+        separator_allow_cpu=True,
         stem_model="some-stem-model.ckpt",
         drum_model="some-drum-model.ckpt",
         wind_model="some-wind-model.ckpt",

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -1228,10 +1228,18 @@ def test_the_real_separator_produces_the_stems_the_passes_expect(tmp_path: Path)
     assert all(Path(one).stat().st_size > 0 for one in output.result["drums"].values())
     assert all(Path(one).stat().st_size > 0 for one in output.result["other"].values())
     # The other thing no fake can answer: that the real banner still names its device in
-    # words ``device_of`` reads (#188). Which device it is depends on the install and is the
-    # box's business — that it parsed at all is this tier's. ``reuse=False`` because the
-    # fixture tone hashes the same every run, and stems read off disk announce nothing.
-    assert output.result["separator"]["device"] != separator.UNKNOWN_DEVICE
+    # words ``device_of`` reads (#188), and that the device is the card. A CPU reading here
+    # is a broken install, not a slow box (CLAUDE.md, "Compute device"): the separator's own
+    # torch decides, and a ``+cpu`` build ran every pass on the CPU for a week under a
+    # WARNING nobody acted on (#202). Red is the only signal a session cannot wait out.
+    # ``reuse=False`` because the fixture tone hashes the same every run, and stems read
+    # off disk announce nothing.
+    report = output.result["separator"]
+    assert report["device"] != separator.UNKNOWN_DEVICE
+    assert report["device"] != separator.CPU_DEVICE, (
+        f"separation ran on the CPU (torch {report.get('torch')!r}); the live box's "
+        "audio-separator needs a +cu torch build — see CLAUDE.md, Compute device"
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -1230,10 +1230,12 @@ def test_the_real_separator_produces_the_stems_the_passes_expect(tmp_path: Path)
     # The other thing no fake can answer: that the real banner still names its device in
     # words ``device_of`` reads (#188), and that the device is the card. A CPU reading here
     # is a broken install, not a slow box (CLAUDE.md, "Compute device"): the separator's own
-    # torch decides, and a ``+cpu`` build ran every pass on the CPU for a week under a
-    # WARNING nobody acted on (#202). Red is the only signal a session cannot wait out.
-    # ``reuse=False`` because the fixture tone hashes the same every run, and stems read
-    # off disk announce nothing.
+    # torch decides, and a ``+cpu`` build ran hours on the CPU under a WARNING nobody acted
+    # on (#202). That build now refuses in ``environment()`` before this line is reached —
+    # ``multi_pass`` raises SeparatorUnavailableError, red all the same; the assertion is
+    # for the other case, a ``+cu`` build whose passes still landed on the CPU. Red is the
+    # only signal a session cannot wait out. ``reuse=False`` because the fixture tone hashes
+    # the same every run, and stems read off disk announce nothing.
     report = output.result["separator"]
     assert report["device"] != separator.UNKNOWN_DEVICE
     assert report["device"] != separator.CPU_DEVICE, (

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -17,6 +17,7 @@ import locale
 import shutil
 import sys
 from collections.abc import Sequence
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -903,10 +904,27 @@ def test_the_environment_report_reads_the_torch_build_off_env_info() -> None:
     assert fake.probes == [[get_config().audio_separator, "--env_info"]]
 
 
-def test_a_cpu_torch_build_is_a_warning_naming_the_fix() -> None:
+def test_a_cpu_torch_build_refuses_the_job_naming_the_fix() -> None:
     """G10's bug class: PATH picked a separator whose torch is the CPU wheel, and the only
-    symptom used to be that a forty-minute job took a day."""
-    report = separator.environment(runner=FakeSeparator(torch_build="2.13.0+cpu"))
+    symptom used to be that a forty-minute job took a day. A warning ran for a week unread;
+    the refusal is the signal a session cannot wait out (CLAUDE.md, Compute device)."""
+    with pytest.raises(SeparatorUnavailableError) as raised:
+        separator.environment(runner=FakeSeparator(torch_build="2.13.0+cpu"))
+
+    assert "CPU build" in raised.value.cause
+    assert "RESOLVE_MCP_AUDIO_SEPARATOR" in raised.value.cause
+    assert "RESOLVE_MCP_SEPARATOR_ALLOW_CPU" in raised.value.fix
+    assert raised.value.detail["torch"] == "2.13.0+cpu"
+
+
+def test_a_box_that_opted_into_the_cpu_run_gets_a_warning_instead() -> None:
+    """A box with no card says so once, in env; the build then rides the record as a warning."""
+    config = replace(get_config(), separator_allow_cpu=True)
+
+    report = separator.environment(
+        runner=FakeSeparator(torch_build="2.13.0+cpu"),
+        config=config,
+    )
 
     assert report["torch"] == "2.13.0+cpu"
     assert "CPU build" in report["warning"]
@@ -932,7 +950,9 @@ def test_a_parsed_build_is_believed_even_when_the_probe_exits_nonzero() -> None:
         on_line("2026-01-01 00:00:00,000 - INFO - separator - PyTorch Version: 2.13.0+cpu")
         return 1
 
-    report = separator.environment(runner=grumbling)
+    report = separator.environment(
+        runner=grumbling, config=replace(get_config(), separator_allow_cpu=True)
+    )
 
     assert report["torch"] == "2.13.0+cpu"
     assert "CPU build" in report["warning"]
@@ -945,11 +965,25 @@ def test_a_missing_separator_fails_the_probe_by_name() -> None:
 
 def test_a_fresh_separation_carries_the_torch_build_in_its_record(tmp_path: Path) -> None:
     fake = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, torch_build="2.13.0+cpu")
+    config = replace(get_config(), separator_allow_cpu=True)
 
-    output = multi_pass(_acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake)
+    output = multi_pass(
+        _acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake, config=config
+    )
 
     assert output.result["separator"]["torch"] == "2.13.0+cpu"
     assert "CPU build" in output.result["separator"]["warning"]
+
+
+def test_a_fresh_separation_on_a_cpu_build_refuses_before_any_pass_runs(
+    tmp_path: Path,
+) -> None:
+    fake = FakeSeparator(FOUR_STEMS, SIX_DRUM_STEMS, torch_build="2.13.0+cpu")
+
+    with pytest.raises(SeparatorUnavailableError):
+        multi_pass(_acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake)
+
+    assert fake.calls == []
 
 
 def test_a_reused_separation_reports_no_environment_because_nothing_ran(
@@ -1028,8 +1062,11 @@ def test_a_cpu_build_keeps_its_own_warning_because_that_one_names_the_fix(
     fake = FakeSeparator(
         FOUR_STEMS, SIX_DRUM_STEMS, torch_build="2.13.0+cpu", banners=(CPU_BANNER,)
     )
+    config = replace(get_config(), separator_allow_cpu=True)
 
-    output = multi_pass(_acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake)
+    output = multi_pass(
+        _acquired(tmp_path), {"scope": "timeline"}, _ignored, runner=fake, config=config
+    )
 
     report = output.result["separator"]
     assert report["device"] == "cpu"


### PR DESCRIPTION
## Why

Sessions kept running the separator on the CPU. Root cause on the live box: the PATH `audio-separator` (system Python 3.12) still has `torch 2.13.0+cpu` — the install fix recorded on #202 never happened — and CLAUDE.md carried no pointer to the compute-device inventory, so the "CUDA where a GPU path exists" rule was never in context. A live separation was running on the CPU (1490 s+ CPU time) while this was written.

## What

- **CLAUDE.md `## Compute device`** (writing-for-agents pass): GPU-first rule, pointer to `docs/reference/compute-device-inventory.md` with the triggers (before a separation/transcription/beat-grid job, before touching or adding a compute path), the "CPU reading = broken install, not a slow box" stop rule, the pre-run `--env_info` check, and the exact pip command that restores a `+cu` build in the separator's interpreter.
- **Runtime guard**: `RESOLVE_MCP_SEPARATOR_ALLOW_CPU` (default off). `separator.environment()` raises `SeparatorUnavailableError` (cause + fix + detail) on a `+cpu` build before any pass runs; with the opt-in it stays the WARNING on the record. README env row; inventory updated.
- **Live seam**: the real-separator smoke test fails on a CPU device reading.
- Fake tier: refusal by default, warning on opt-in, no pass runs before the refusal, config round-trip carries the field.

## Seams

Fake tier: 2328 passed. mypy strict clean, ruff clean.
Live: `test_the_real_separator_produces_the_stems_the_passes_expect` **passed** 2026-08-15 on the live box (Windows 11, RTX 4080 SUPER, Resolve Studio up, system Python 3.12 separator on `torch 2.13.0+cu130`) — first run was skipped with Resolve down, re-run after the CUDA install.

## Review record

`/code-review` (mattpocock two-axis) on c199851, focused fix-diff pass on c4c5c96.

- Standards: rule sentence in CLAUDE.md restates the inventory's rule — kept deliberately: the always-loaded pointer must carry the rule, that missing line was the bug. "for a week" unsourced — reworded to "hours … under a WARNING nobody acted on".
- Spec: doc-only change was voluntary, no runtime guard → added the `+cpu` refusal (c4c5c96).
- Fix-diff pass: three doc sentences still said "+cpu is a warning" (inventory ×2, CLAUDE.md) → reconciled; live test comment names the raise path (539ae24). Raise path, envelope handling and tests verified correct.

Review: clean

Post-open commits da85b6f, d9a9bf4 (inventory records the +cu130 install; CLAUDE.md + inventory point the beats/applause policy at #245; prose only).
Review: clean — prose only, single-pass

## Needs from you

1. ~~Install CUDA torch into the separator's interpreter~~ — done 2026-08-15: `--env_info` reports `PyTorch 2.13.0+cu130`, `CUDAExecutionProvider available`.
2. ~~Live AC~~ — run, passed (see Seams).
3. ~~Decision on beats/applause~~ — called: CUDA. Ticket #245 (flip the torch build, re-measure the corpus against a stated tolerance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
