### PR TITLE
docs: workflow-audit pass on CLAUDE.md and agent docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ Studio — the server measures; Claude decides. Map and vocabulary:
 
 Before building a ticket, decide **which seam verifies it** and say so in the
 PR. A ticket whose acceptance criteria cannot be checked at any seam is not
-ready to build — that is the thing to resolve first. Spec #22 already names
-each ticket's seam inline; keep that habit.
+ready to build — that is the thing to resolve first. Every AC line ends
+with its seam — `(fake tier)`, `(live smoke)`, or `(human)`.
 
 **1. Fake tier — `uv run pytest -m 'not live'` (the default).**
 `tests/fakes/` substitutes the Resolve singleton at the connection manager —
@@ -29,10 +29,23 @@ Resolve is unreachable. Sessions run on the live Windows 11 box with Resolve
 Studio up, so run this tier yourself: an AC marked "(live smoke)" is yours to
 execute, and a live pass means the tests **ran** — a run that skipped means
 Resolve was unreachable, not that the tier passed. Record the result on the
-ticket (hardware, interpreter, outcome); an unrecorded pass gets re-run. ACs
-that need the human's hands — a specific project open, media only they have,
-a click in the UI — go to the human: flag them **before opening the PR** so
-they can run first, and list them under the ticket's `## Needs from you`.
+**ticket** (hardware, interpreter, outcome — the PR may duplicate it, never
+replace it); an unrecorded pass gets re-run. ACs that need the human's hands
+— a specific project open, media only they have, a click in the UI — go to
+the human: flag them **before opening the PR** so they can run first, and
+list them under the ticket's `## Needs from you`.
+
+Running it: open project `mcp-tests-zinc` (a copy of the client media —
+the suite deletes timelines, so never the client project); **one
+`pytest -m live` at a time across all sessions** — every run attaches to
+the single Resolve instance, so schedule the live *step*, not the whole
+ticket; scratch projects the run creates cannot be deleted through the API
+(`DeleteProject` returns `False` on this box) — list them for hand
+deletion under `## Needs from you`; `-m live -k real_separator` needs no
+Resolve (only `audio-separator` on PATH) and is the one seam that proves
+stem labels; a leftover timeline gets deleted in a later pass, after the
+switch away from it has settled — switch-then-delete in one pass crashed
+Resolve mid-autosave.
 
 **What no seam covers, and why it is the dangerous part:** whether
 fusionscript accepts the attach on a given interpreter at all. ADR 0001: on a
@@ -45,12 +58,10 @@ proof of decisions, never of the attach.
 
 **Log a line for every connection state change** (attach, reconnect, handle
 death) — a live failure outside your session (a human-run AC, real MCP use)
-gets diagnosed from the log or not at all. (forest-shell #81: a silent lifecycle left a
-cannot-unlock bug with two candidate causes for a week.)
-
-Why the seam rule exists: forest-shell ran seven tickets green against its
-unit tier alone; the first pass on a real compositor produced eight bugs at
-once.
+gets diagnosed from the log or not at all (forest-shell #81: a silent
+lifecycle hid a bug's cause for a week). The seam rule exists because a
+sister repo ran seven tickets green on fakes alone and met eight bugs on the
+first real pass.
 
 ## Session workflow
 
@@ -72,8 +83,11 @@ produced no work; relaunch rather than assume.)
      YAML — gets `/code-review` (the two-axis mattpocock skill — Standards
      and Spec as parallel sub-agents). Hooks and workflows count: they are
      config that executes, and a broken gate fails silently for weeks.
-   - **Pure prose** — docs, README, CLAUDE.md — gets one lightweight inline
-     pass, and the line reads `Review: clean — prose only, single-pass`.
+   - **Pure prose** — docs, README, CLAUDE.md — is written and reviewed
+     under `/writing-for-agents` (load the skill before the first edit;
+     the pass checks pointers, hierarchy, leading words, negation,
+     pruning), and the line reads `Review: clean — prose only,
+     /writing-for-agents pass`.
 3. **Fix findings; re-check the fix diff only** — a focused pass over what
    changed, not a second full review. One full review per PR is the
    default; a fresh full pass is only for fixes large enough to be a new
@@ -89,24 +103,20 @@ produced no work; relaunch rather than assume.)
 5. **Merge through the PR** — everything reaches `main` through a PR, never
    a direct commit.
 6. **After a stacked PR merges, verify its commits reached main by
-   content.** PRs here land both ways — merge commits and squashes — so
-   check `git log origin/main` for either the `Merge pull request #<n>`
-   commit or a squashed subject ending `(#<n>)`, and confirm the files
-   landed. `git merge-base --is-ancestor <head-sha> origin/main` proves a
-   merge-commit PR, but exits 1 for every squashed one — a failing check
-   alone proves nothing (#45: squashed PR #109 read as unlanded). The risk
-   the check exists for is real either way: a PR that merges into a
-   just-consumed parent branch reads MERGED while its commits never reach
-   main.
-7. **If the PR was squashed, continue its ticket on a fresh branch.** The
-   old branch then sits on history main no longer shares; a second PR from
-   it drags the already-merged commits back in. Branch from `origin/main`
-   and cherry-pick only the new commits — never force-push. (#45: after
-   #109's squash, the continuation landed cleanly from the fresh branch
-   `issue-45-entries-2-3` as PR #111. After a merge-commit PR, continuing
-   on the same branch is safe.)
-8. **Close the ticket with the PR link**; name any unrun live ACs in the
-   close comment.
+   content** — `git log origin/main` shows `Merge pull request #<n>` (the
+   default here, `.claude/dispatch.json`) or a squashed subject ending
+   `(#<n>)`, and the files are there. `merge-base --is-ancestor` exits 1
+   for every squashed PR, so a failing check alone proves nothing. The risk
+   is real either way: a PR merged into a just-consumed parent branch reads
+   MERGED while its commits never reach main.
+7. **If the PR was squashed, continue on a fresh branch** from
+   `origin/main`, cherry-picking only the new commits — never force-push;
+   the old branch would drag merged commits back in. After a merge-commit
+   PR the same branch is safe.
+8. **Close the ticket with a comment** — PR link, what landed, the live
+   record, any unrun live ACs. Never a bare close: a ticket the PR
+   auto-closed still gets the comment (#219 closed with none; #167–#178
+   were bulk-closed silent and a reader has no outcome).
 
 When resolving merge conflicts, grep every conflicted file for `<<<<<<<`
 before committing — especially markdown: CI never reads it, and a leftover
@@ -116,9 +126,11 @@ Runner`), never as `sibling.Runner` through a module that merely imports it.
 
 Every implementation comment on a ticket (close or status) ends with a
 `## Needs from you` section as its **last** section, listing each item that
-requires the human — decisions to make, live ACs to run, installs — even when
-already discussed above. If nothing is needed, omit the section; its absence
-is the signal that the ticket asks nothing of you.
+requires the human — decisions to make, live ACs to run, installs, scratch
+projects to delete — even when already discussed above. "Merge PR #n" is
+not an item: an open PR already says it, and fourteen identical
+"merge it" sections buried the two real asks. If nothing is needed, omit
+the section; its absence is the signal that the ticket asks nothing of you.
 
 CI (`.github/workflows/ci.yml`) runs the fake tier, mypy strict, and ruff on
 every PR; `review-gate.yml` blocks merge until the PR body's `Review:` line
@@ -140,26 +152,45 @@ from the session's own cwd — a worktree session already starts in its
 worktree — to a gitignored repo-local log:
 
     uv run pytest -m 'not live' > pytest.scratch.log 2>&1
+    uv run mypy src tests > mypy.scratch.log 2>&1
+    uv run ruff check src tests > ruff.scratch.log 2>&1
+    gh issue view <n> --json body -q .body > issue.scratch.log
+    gh pr diff <n> > pr.scratch.log
+    git merge origin/main --no-edit > merge.scratch.log 2>&1
 
-then Grep `FAILED|passed|error` in `pytest.scratch.log` (`*.scratch.log` is
-gitignored; never commit a log). Never `| tail` — a tail caps one run and
-runs repeat. Delegate exploration to
-a read-only subagent; Read only what you will edit, ranged (grep first) on
-big files; do not re-read a file after editing it. The hooks in
-`.claude/hooks/` enforce the cat/tail rules, whole-file re-reads, and
-whole-file reads of code/config files over 400 lines (markdown exempt) — a
-block from them is the rule firing, not an obstacle to route around; the
-block message names the fix.
+then Grep `FAILED|passed|error` (or the section you need) in the log
+(`*.scratch.log` is gitignored; never commit a log). Every one of these is
+the whole command: no `;`, no `&&`, no `$(mktemp)`, no `for`/`while`, no
+`sleep N;` prefix (the harness blocks it — 154 guard rejections and 25
+sleep blocks were the largest wasted-turn class in the transcripts). Never
+`| tail` — a tail caps one run and runs repeat. Waiting on CI is one
+`Monitor` (or one `gh pr checks <n>` after a wakeup), not a `--watch` or a
+sleep loop. Delegate exploration to a read-only subagent; Read only what
+you will edit, ranged (grep first) on big files; do not re-read a file
+after editing it. The hooks in `.claude/hooks/` enforce the cat/tail
+rules, whole-file re-reads, and whole-file reads of code/config files over
+400 lines (markdown exempt) — a block from them is the rule firing, not an
+obstacle to route around; the block message names the fix, and `sed -n`
+or `head` on the same file is the same cost, not a way through.
 
 The same scratch-file rule covers `gh` — issue bodies, comment threads,
-and PR diffs were the biggest single results in past sessions:
-`gh issue view <n> --json body -q .body > issue.scratch.log`, then Grep
-back the section you need.
+and PR diffs were the biggest single results in past sessions.
 
 **Orient from `CONTEXT.md` first** — the repo map answers "which module
 owns X, where is the seam, which test file covers Y"; explores are for
-what a map can't hold (exact signatures, current behaviour). A PR that
-adds, moves, or deletes a module updates the map in the same PR.
+what a map can't hold (exact signatures, current behaviour). It is 500+
+lines (~9k tokens): Grep it for the area you are about to touch and Read
+that range, not the whole file (#247 splits it). A PR that adds, moves, or
+deletes a module updates the map in the same PR.
+
+**Session budget.** Context starts at ~44k tokens and grows ~500 per
+message; a ticket that cannot land in ~150 tool calls does not fit one
+session — split it (file the second ticket, then continue) rather than push
+on. Half the growth is your own Edit/Write payloads and thinking, which no
+result-side rule can shrink; a ticket that adds three or more new modules
+delegates each module's implementation to a subagent in the same worktree
+and keeps only receipts (commit sha, gate lines) here, the way review is
+already delegated (#248 measures this per session).
 
 Long multi-PR sweeps (merge trains, cross-PR audits) shard per-PR into
 subagents; the orchestrating session keeps receipts, not diffs — past
@@ -208,33 +239,36 @@ later gets a real fix gets its line removed.
 
 - **R1 — Worktree sessions: pin every review and diff to `origin/main`.**
   The local `main` checkout lags while other worktrees merge; a diff
-  against local `main` sweeps in commits that are not yours. (Session
-  memory `worktree-main-is-stale`, 2026-08.)
+  against local `main` sweeps in commits that are not yours.
 - **R2 — Worktree pytest runs the main checkout's source.** The editable
   install points at the main working copy, so a new test in a worktree
-  fails against old code with no import error to warn you. Reinstall in
-  the worktree (`uv sync`) before trusting a red run. (Session memory
-  `worktree-tests-hit-main-checkout`, 2026-08.)
+  fails against old code with no import error to warn you. Run `uv sync`
+  in the worktree first, then trust a red run (21 sessions paid a turn
+  for this — the sync is the first command after `EnterWorktree`).
 - **R3 — `ruff format` is not a gate.** CI (`ci.yml`) runs `ruff check`
-  only; `ruff format --check` fails repo-wide by design. Don't "fix"
-  formatting the repo never enforced. (Session memory
-  `ruff-format-is-not-a-gate`, 2026-08.)
+  only; `ruff format --check` fails repo-wide by design. Leave formatting
+  the repo never enforced.
+- **R4 — Merging is the human's.** Auto mode denies `gh pr merge` (nine
+  sessions rediscovered it); the session's last act is the PR open plus the
+  ticket comment, and the human merges.
 
 ## Doc maintenance
 
-A dated `/writing-for-agents` pass over CLAUDE.md, CONTEXT.md and `docs/`
-runs periodically (last: 2026-08-10, CLAUDE.md and CONTEXT.md only);
-session-memory facts that prove repo-general over multiple sessions
-graduate into this file and the memory note becomes history. Verified
-against mattpocock-skills 1.2.3.
+Every edit to CLAUDE.md, CONTEXT.md or `docs/agents/` goes through
+`/writing-for-agents` (step 2 above); a dated full pass over all three
+runs periodically (last: 2026-08-15, targeted; 2026-08-10, full on
+CLAUDE.md and CONTEXT.md). Session-memory facts that prove repo-general
+over multiple sessions graduate into this file and the memory note is
+deleted. Verified against mattpocock-skills 1.2.3.
 
 ## Agent skills
 
 ### Issue tracker
 
 Issues live as GitHub issues on `danielbaldwin47/resolve-mcp`, driven via
-the `gh` CLI. For issue CRUD **and the wayfinder map operations** — frontier
-query, claim, blocking edges, resolve — see `docs/agents/issue-tracker.md`.
+the `gh` CLI. For issue CRUD, native blocking edges, and — when a wayfinder
+map is open — frontier query, claim, resolve, see
+`docs/agents/issue-tracker.md`. Ticket splitting: `/to-tickets`.
 
 ### Triage labels
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -9,7 +9,7 @@ This repo is **single-context**.
 - **`CONTEXT.md`** at the repo root.
 - **`docs/adr/`** — read ADRs that touch the area you're about to work in.
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grilling` and `/codebase-design`) creates them lazily when terms or decisions actually get resolved.
 
 ## File structure
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -5,7 +5,7 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **Read an issue**: `gh issue view <number> --json body,labels,comments > issue.scratch.log`, then Grep the section you need — the context guard blocks an unredirected `--comments` pull.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
@@ -19,7 +19,7 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 
 When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
 
-- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **Read a PR**: `gh pr view <number> --json body,comments > pr.scratch.log` and `gh pr diff <number> > pr.scratch.log`, then Grep.
 - **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
 - **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
@@ -31,7 +31,7 @@ Create a GitHub issue.
 
 ## When a skill says "fetch the relevant ticket"
 
-Run `gh issue view <number> --comments`.
+Run `gh issue view <number> --json body,comments > issue.scratch.log` and Grep it.
 
 ## Wayfinding operations
 


### PR DESCRIPTION
Docs-only follow-up to the 2026-08-15 workflow audit (session "Workflow Audit"). The code/hook/CI findings are ticketed as #247–#251; this PR carries the parts that are pure prose.

## What changed

- **CLAUDE.md**
  - Test seams: "every AC line ends with its seam"; live-smoke section gains the run-it paragraph graduated from session memory (project `mcp-tests-zinc`, one `-m live` at a time across sessions, `DeleteProject` refuses → hand deletion under Needs-from-you, `-k real_separator` needs no Resolve, switch-then-delete crash); live record lives on the ticket, PR may duplicate.
  - Session workflow: prose review runs under `/writing-for-agents` and the review line names it; steps 6–7 collapsed (merge-commit is the default per `dispatch.json`); step 8 requires a close comment on every ticket (#219, #167–#178 were silent); `## Needs from you` drops "merge PR #n" (fourteen identical sections buried the two real asks).
  - Context discipline: the six one-command redirect shapes the worktree guard accepts (154 rejections + 25 `sleep` blocks were the largest wasted-turn class); CI waits are one Monitor, not `--watch`/sleep loops; `sed -n`/`head` on a blocked file is the same cost; CONTEXT.md is Grepped and read ranged until #247 lands; new **Session budget** paragraph (~44k baseline, ~500 tok/message, ~150 tool calls per ticket, split or delegate implementation — #248).
  - Gotchas: R1–R3 lose the memory-note citations (notes deleted); R4 added (auto mode denies `gh pr merge`; nine sessions rediscovered it).
  - Doc maintenance: every prose edit goes through `/writing-for-agents`; dated pass updated; graduated notes are deleted, not kept.
  - forest-shell provenance trimmed to one clause each.
- **docs/agents/issue-tracker.md**: the three `gh … --comments` examples now show the redirected form the context guard accepts.
- **docs/agents/domain.md**: skill names corrected to the installed `/grilling` and `/codebase-design`.

Session memory swept in the same pass (outside the repo): 12 notes graduated or stale → deleted; MEMORY.md index rewritten.

## Review record

`/writing-for-agents` pass over the diff: prohibitions paired with the positive target (switch-then-delete → "delete in a later pass"; `| tail` → the redirect shape); no duplicated meaning — live-tier facts live only in the live-smoke section, guard shapes only in context discipline; history cut where it was exposition (forest-shell), kept where it is the reason for a rule (#219 silent close, 154 rejections). Word count 1891 → 2609: the growth is five graduated facts and two new rules, each with a transcript count behind it. Sprawl risk noted for the periodic full pass.

Review: clean — prose only, /writing-for-agents pass
