### PR TITLE
Prune merged branches and worktrees (#250)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,10 @@ produced no work; relaunch rather than assume.)
    alone proves nothing (#45: squashed PR #109 read as unlanded). The risk
    the check exists for is real either way: a PR that merges into a
    just-consumed parent branch reads MERGED while its commits never reach
-   main.
+   main. Then prune the residue: `uv run python scripts/prune_merged.py`
+   lists the merged remote branches, local branches and worktrees it would
+   drop; `--apply` drops them (locked, dirty, open-PR and unmerged-commit
+   items are never touched).
 7. **If the PR was squashed, continue its ticket on a fresh branch.** The
    old branch then sits on history main no longer shares; a second PR from
    it drags the already-merged commits back in. Branch from `origin/main`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -508,6 +508,15 @@ route (`bake_taurus_cards.py` bakes a `%04d` RGBA frame run per card, fade
 ramps included, for a project whose media pool holds no GUI-authored Text+
 template; `titles/schema.py` §6).
 
+## Tooling — `scripts/`
+
+Repo maintenance, not server code. `prune_merged.py` — the post-merge sweep
+(CLAUDE.md step 6): lists, or with `--apply` removes, remote branches whose PR
+merged, their local branches, and `.claude/worktrees/` worktrees whose branch
+is merged; never a locked or dirty worktree, an open-PR branch, or a tip with
+commits `origin/main` lacks. Every `gh`/`git` call goes through one injectable
+`Runner`, which is the seam `tests/test_prune_merged.py` drives on fixtures.
+
 ## Docs
 
 - `docs/adr/` — 0001 interpreter must be a registered install; 0002

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -477,6 +477,10 @@ unless `RESOLVE_MCP_SCENE_SCAN_CLIP` names a real one. That variable is
 render, only raw continuous angles — so the generated clip is the default there,
 and the variable is for a project that does have an edit to scan.
 
+`test_prune_merged.py` covers `scripts/prune_merged.py` (Tooling, below) through
+its `Runner` seam — a fake answers every `gh`/`git` argv from fixtures and
+records the removals it would have run.
+
 ## Agent-owned trees — `gauntlet/`, `projects/`
 
 Neither is read by server code; both are the agent's own working record, and
@@ -513,8 +517,11 @@ template; `titles/schema.py` §6).
 Repo maintenance, not server code. `prune_merged.py` — the post-merge sweep
 (CLAUDE.md step 6): lists, or with `--apply` removes, remote branches whose PR
 merged, their local branches, and `.claude/worktrees/` worktrees whose branch
-is merged; never a locked or dirty worktree, an open-PR branch, or a tip with
-commits `origin/main` lacks. Every `gh`/`git` call goes through one injectable
+is merged. Merged means the tip is on `origin/main`, or a PR **into main** was
+squashed from exactly that tip — a PR merged into another branch does not count
+(the stacked-PR trap in CLAUDE.md step 6). Never a locked or dirty worktree, the
+branch a locked worktree holds, an open-PR branch, or a tip with commits
+`origin/main` lacks. Every `gh`/`git` call goes through one injectable
 `Runner`, which is the seam `tests/test_prune_merged.py` drives on fixtures.
 
 ## Docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ markers = [
 
 [tool.ruff]
 line-length = 100
-src = ["src", "tests"]
+src = ["src", "tests", "."]
 extend-exclude = [".claude"]
 
 [tool.ruff.lint]
@@ -131,7 +131,7 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 
 [tool.mypy]
 python_version = "3.12"
-files = ["src", "tests"]
+files = ["src", "tests", "scripts"]
 strict = true
 warn_unused_ignores = true
 

--- a/scripts/prune_merged.py
+++ b/scripts/prune_merged.py
@@ -8,13 +8,16 @@ Dry-run by default — prints what it would remove and why. ``--apply`` removes 
 What counts as merged, for a branch ``N`` whose tip is ``T``:
 
 * ``T`` is already on ``origin/main`` (``git branch --merged origin/main``), or
-* a merged PR's head was ``N`` at exactly ``T`` — the squash case, where the content landed
-  but the commits themselves never became ancestors of main.
+* a PR from ``N`` **into main** merged with ``T`` as its head — the squash case, where the
+  content landed but the commits themselves never became ancestors of main. A PR merged into
+  any other base does not count: a stacked PR reads MERGED while its commits may never reach
+  main (CLAUDE.md step 6).
 
 Never touched: ``main`` / ``HEAD``; any branch that has an open PR; a branch whose tip
 carries commits ``origin/main`` does not (a merged PR followed by new commits included); a
-worktree that is locked (a running session holds it), dirty, or on a detached HEAD; and a
-local branch still checked out in a worktree that survives.
+worktree that is locked (a running session holds it), dirty, or on a detached HEAD; the
+branch a locked worktree holds, local and remote; and a local branch still checked out in
+any worktree that survives.
 
 Everything the script learns comes through one ``Runner`` (a callable from argv to stdout),
 so the fake tier drives it on fixtures of the ``gh`` and ``git`` output
@@ -33,7 +36,12 @@ from dataclasses import dataclass, field
 Runner = Callable[[Sequence[str]], str]
 
 WORKTREE_DIR = ".claude/worktrees/"
-PROTECTED = frozenset({"main", "master", "HEAD"})
+PROTECTED = frozenset({"main", "HEAD"})
+BASE = "main"
+
+
+class CommandError(RuntimeError):
+    """A command the Runner issued failed; the message carries argv and stderr."""
 
 
 @dataclass(frozen=True)
@@ -43,6 +51,16 @@ class Worktree:
     branch: str | None  # short name; None when detached
     locked: bool
     prunable: bool
+
+
+@dataclass(frozen=True)
+class MergeFacts:
+    """What the repo and the forge say about branches, gathered once."""
+
+    merged_into_main: dict[str, set[str]]  # head name -> head SHAs of PRs merged into main
+    merged_elsewhere: set[str]  # head names of PRs merged into some other base
+    open_prs: set[str]  # head names with an open PR
+    held: set[str]  # branch names a locked worktree checks out
 
 
 @dataclass(frozen=True)
@@ -87,12 +105,10 @@ def parse_worktrees(porcelain: str) -> list[Worktree]:
     return out
 
 
-def parse_pr_heads(gh_json: str) -> dict[str, set[str]]:
-    """``gh pr list --json headRefName,headRefOid`` -> head name -> set of head SHAs."""
-    heads: dict[str, set[str]] = {}
-    for pr in json.loads(gh_json or "[]"):
-        heads.setdefault(pr["headRefName"], set()).add(pr.get("headRefOid", ""))
-    return heads
+def parse_prs(gh_json: str) -> list[dict[str, str]]:
+    """``gh pr list --json headRefName,headRefOid,baseRefName`` -> list of those dicts."""
+    prs: list[dict[str, str]] = json.loads(gh_json or "[]")
+    return prs
 
 
 def parse_refs(for_each_ref: str) -> dict[str, str]:
@@ -112,139 +128,141 @@ def parse_names(listing: str) -> set[str]:
 # --- the decision ---------------------------------------------------------------------------
 
 
-def _merged_reason(
-    name: str,
-    tip: str,
-    *,
-    merged_prs: dict[str, set[str]],
-    open_prs: dict[str, set[str]],
-    on_main: set[str],
-) -> tuple[bool, str]:
+def _prune_decision(name: str, tip: str, on_main: set[str], facts: MergeFacts) -> tuple[bool, str]:
     """(prune?, reason) for a branch called ``name`` whose tip is ``tip``."""
     if name in PROTECTED:
         return False, "protected"
-    if name in open_prs:
+    if name in facts.held:
+        return False, "held by a locked worktree"
+    if name in facts.open_prs:
         return False, "open PR"
     if name in on_main:
         return True, "tip is on origin/main"
-    if name in merged_prs:
-        if tip in merged_prs[name]:
+    if name in facts.merged_into_main:
+        if tip in facts.merged_into_main[name]:
             return True, "PR merged (squash) at this tip"
         return False, "PR merged but branch has commits after it"
+    if name in facts.merged_elsewhere:
+        return False, "PR merged into a branch, not main"
     return False, "commits not on origin/main"
 
 
+def _record(plan: Plan, bucket: list[str], item: str, label: str, ok: bool, why: str) -> None:
+    if ok:
+        bucket.append(item)
+        plan.reasons[label] = why
+    elif why != "protected":
+        plan.skipped.append((label, why))
+
+
+def _gh_heads(run: Runner, state: str) -> list[dict[str, str]]:
+    return parse_prs(
+        run(
+            ["gh", "pr", "list", "--state", state, "--limit", "1000",
+             "--json", "headRefName,headRefOid,baseRefName"]
+        )
+    )
+
+
+def _refs(run: Runner, namespace: str) -> dict[str, str]:
+    return parse_refs(
+        run(["git", "for-each-ref", namespace, "--format=%(refname:short) %(objectname)"])
+    )
+
+
+def _on_main(run: Runner, *flags: str) -> set[str]:
+    return parse_names(
+        run(["git", "branch", *flags, "--merged", f"origin/{BASE}", "--format=%(refname:short)"])
+    )
+
+
 def build_plan(run: Runner) -> Plan:
-    merged_prs = parse_pr_heads(
-        run(
-            ["gh", "pr", "list", "--state", "merged", "--limit", "1000",
-             "--json", "headRefName,headRefOid"]
-        )
-    )
-    open_prs = parse_pr_heads(
-        run(
-            ["gh", "pr", "list", "--state", "open", "--limit", "1000",
-             "--json", "headRefName,headRefOid"]
-        )
-    )
     worktrees = parse_worktrees(run(["git", "worktree", "list", "--porcelain"]))
-    local_refs = parse_refs(
-        run(["git", "for-each-ref", "refs/heads", "--format=%(refname:short) %(objectname)"])
+    if not worktrees:
+        raise CommandError("git worktree list returned nothing - not inside a repo?")
+    root = worktrees[0].path.rstrip("/")
+
+    merged_into_main: dict[str, set[str]] = {}
+    merged_elsewhere: set[str] = set()
+    for pr in _gh_heads(run, "merged"):
+        if pr.get("baseRefName") == BASE:
+            merged_into_main.setdefault(pr["headRefName"], set()).add(pr.get("headRefOid", ""))
+        else:
+            merged_elsewhere.add(pr["headRefName"])
+    facts = MergeFacts(
+        merged_into_main=merged_into_main,
+        merged_elsewhere=merged_elsewhere,
+        open_prs={pr["headRefName"] for pr in _gh_heads(run, "open")},
+        held={wt.branch for wt in worktrees if wt.locked and wt.branch},
     )
+    local_refs = _refs(run, "refs/heads")
     remote_refs = {
         name.removeprefix("origin/"): sha
-        for name, sha in parse_refs(
-            run(
-                ["git", "for-each-ref", "refs/remotes/origin",
-                 "--format=%(refname:short) %(objectname)"]
-            )
-        ).items()
+        for name, sha in _refs(run, "refs/remotes/origin").items()
         if name != "origin/HEAD"
     }
-    local_on_main = parse_names(
-        run(["git", "branch", "--merged", "origin/main", "--format=%(refname:short)"])
-    )
-    remote_on_main = {
-        n.removeprefix("origin/")
-        for n in parse_names(
-            run(["git", "branch", "-r", "--merged", "origin/main", "--format=%(refname:short)"])
-        )
-    }
+    local_on_main = _on_main(run)
+    remote_on_main = {n.removeprefix("origin/") for n in _on_main(run, "-r")}
 
     plan = Plan()
-    if not worktrees:
-        raise SystemExit("git worktree list returned nothing - not inside a repo?")
-    root = worktrees[0].path.rstrip("/")
     surviving_checkouts: dict[str, str] = {}  # branch -> worktree path that keeps it
-
-    for wt in worktrees[1:]:
-        if not wt.path.startswith(root + "/" + WORKTREE_DIR):
-            if wt.branch:
-                surviving_checkouts[wt.branch] = wt.path
-            continue
-        label = f"worktree {wt.path}"
-        if wt.prunable:
-            plan.skipped.append((label, "prunable - `git worktree prune` handles it"))
-            continue
-        if wt.locked:
-            plan.skipped.append((label, "locked (a session holds it)"))
-        elif wt.branch is None:
-            plan.skipped.append((label, "detached HEAD"))
-        else:
-            ok, why = _merged_reason(
-                wt.branch, wt.head, merged_prs=merged_prs, open_prs=open_prs,
-                on_main=local_on_main,
-            )
-            if ok and run(["git", "-C", wt.path, "status", "--porcelain"]).strip():
-                ok, why = False, "dirty (uncommitted or untracked files)"
-            if ok:
-                plan.worktrees.append(wt.path)
-                plan.reasons[label] = why
-                continue
-            plan.skipped.append((label, why))
-        if wt.branch:
-            surviving_checkouts[wt.branch] = wt.path
     if worktrees[0].branch:
         surviving_checkouts[worktrees[0].branch] = worktrees[0].path
+
+    for wt in worktrees[1:]:
+        label = f"worktree {wt.path}"
+        if not wt.path.startswith(root + "/" + WORKTREE_DIR):
+            ok, why = False, "outside " + WORKTREE_DIR
+        elif wt.locked:
+            ok, why = False, "locked (a session holds it)"
+        elif wt.branch is None:
+            ok, why = False, "detached HEAD"
+        else:
+            ok, why = _prune_decision(wt.branch, wt.head, local_on_main, facts)
+            if ok and run(["git", "-C", wt.path, "status", "--porcelain"]).strip():
+                ok, why = False, "dirty (uncommitted or untracked files)"
+        _record(plan, plan.worktrees, wt.path, label, ok, why)
+        if not ok and wt.branch:
+            surviving_checkouts[wt.branch] = wt.path
 
     for name, sha in sorted(local_refs.items()):
         label = f"local {name}"
         if name in surviving_checkouts:
-            plan.skipped.append((label, f"checked out in {surviving_checkouts[name]}"))
-            continue
-        ok, why = _merged_reason(
-            name, sha, merged_prs=merged_prs, open_prs=open_prs, on_main=local_on_main
-        )
-        if ok:
-            plan.local_branches.append(name)
-            plan.reasons[label] = why
-        elif why != "protected":
-            plan.skipped.append((label, why))
+            ok, why = False, f"checked out in {surviving_checkouts[name]}"
+        else:
+            ok, why = _prune_decision(name, sha, local_on_main, facts)
+        _record(plan, plan.local_branches, name, label, ok, why)
 
     for name, sha in sorted(remote_refs.items()):
-        label = f"remote origin/{name}"
-        ok, why = _merged_reason(
-            name, sha, merged_prs=merged_prs, open_prs=open_prs, on_main=remote_on_main
-        )
-        if ok:
-            plan.remote_branches.append(name)
-            plan.reasons[label] = why
-        elif why != "protected":
-            plan.skipped.append((label, why))
+        ok, why = _prune_decision(name, sha, remote_on_main, facts)
+        _record(plan, plan.remote_branches, name, f"remote origin/{name}", ok, why)
     return plan
 
 
 # --- doing it -------------------------------------------------------------------------------
 
 
-def apply_plan(run: Runner, plan: Plan) -> None:
-    """Worktrees first (they pin branches), then local branches, then remote branches."""
+def apply_plan(run: Runner, plan: Plan) -> list[str]:
+    """Worktrees first (they pin branches), then local branches, then remote branches.
+
+    Each removal is its own command so one refusal cannot abort the rest; returns the
+    failure messages.
+    """
+    failures: list[str] = []
+
+    def attempt(argv: list[str]) -> None:
+        try:
+            run(argv)
+        except CommandError as e:
+            failures.append(str(e))
+
     for path in plan.worktrees:
-        run(["git", "worktree", "remove", path])
-    if plan.local_branches:
-        run(["git", "branch", "-D", *plan.local_branches])
+        attempt(["git", "worktree", "remove", path])
+    for name in plan.local_branches:
+        attempt(["git", "branch", "-D", name])
     for i in range(0, len(plan.remote_branches), 50):
-        run(["git", "push", "origin", "--delete", *plan.remote_branches[i : i + 50]])
+        attempt(["git", "push", "origin", "--delete", *plan.remote_branches[i : i + 50]])
+    return failures
 
 
 def render(plan: Plan, *, verbose: bool) -> str:
@@ -261,7 +279,7 @@ def render(plan: Plan, *, verbose: bool) -> str:
 def subprocess_runner(argv: Sequence[str]) -> str:
     proc = subprocess.run(list(argv), capture_output=True, text=True, encoding="utf-8")
     if proc.returncode != 0:
-        raise SystemExit(f"{' '.join(argv)} failed ({proc.returncode}):\n{proc.stderr.strip()}")
+        raise CommandError(f"{' '.join(argv)} failed ({proc.returncode}): {proc.stderr.strip()}")
     return proc.stdout
 
 
@@ -271,18 +289,25 @@ def main(argv: Sequence[str] | None = None, run: Runner = subprocess_runner) -> 
     ap.add_argument("--no-fetch", action="store_true", help="skip `git fetch --prune origin`")
     ap.add_argument("-v", "--verbose", action="store_true", help="also list what is kept and why")
     args = ap.parse_args(argv)
-    if not args.no_fetch:
-        run(["git", "fetch", "--prune", "origin"])
-    plan = build_plan(run)
+    try:
+        if not args.no_fetch:
+            run(["git", "fetch", "--prune", "origin"])
+        run(["git", "worktree", "prune"])  # drop admin files of worktrees whose dir is gone
+        plan = build_plan(run)
+    except CommandError as e:
+        print(e, file=sys.stderr)
+        return 1
     print(render(plan, verbose=args.verbose))
     if plan.empty:
         return 0
-    if args.apply:
-        apply_plan(run, plan)
-        print("applied.")
-    else:
+    if not args.apply:
         print("dry run - re-run with --apply to remove.")
-    return 0
+        return 0
+    failures = apply_plan(run, plan)
+    for msg in failures:
+        print(f"FAILED  {msg}", file=sys.stderr)
+    print(f"applied; {len(failures)} failure(s).")
+    return 1 if failures else 0
 
 
 if __name__ == "__main__":

--- a/scripts/prune_merged.py
+++ b/scripts/prune_merged.py
@@ -1,0 +1,289 @@
+"""Prune the residue merged work leaves behind: remote branches, local branches, worktrees.
+
+Dry-run by default — prints what it would remove and why. ``--apply`` removes it.
+
+    uv run python scripts/prune_merged.py            # list
+    uv run python scripts/prune_merged.py --apply    # remove
+
+What counts as merged, for a branch ``N`` whose tip is ``T``:
+
+* ``T`` is already on ``origin/main`` (``git branch --merged origin/main``), or
+* a merged PR's head was ``N`` at exactly ``T`` — the squash case, where the content landed
+  but the commits themselves never became ancestors of main.
+
+Never touched: ``main`` / ``HEAD``; any branch that has an open PR; a branch whose tip
+carries commits ``origin/main`` does not (a merged PR followed by new commits included); a
+worktree that is locked (a running session holds it), dirty, or on a detached HEAD; and a
+local branch still checked out in a worktree that survives.
+
+Everything the script learns comes through one ``Runner`` (a callable from argv to stdout),
+so the fake tier drives it on fixtures of the ``gh`` and ``git`` output
+(``tests/test_prune_merged.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+Runner = Callable[[Sequence[str]], str]
+
+WORKTREE_DIR = ".claude/worktrees/"
+PROTECTED = frozenset({"main", "master", "HEAD"})
+
+
+@dataclass(frozen=True)
+class Worktree:
+    path: str
+    head: str
+    branch: str | None  # short name; None when detached
+    locked: bool
+    prunable: bool
+
+
+@dataclass(frozen=True)
+class Plan:
+    worktrees: list[str] = field(default_factory=list)  # paths to remove
+    local_branches: list[str] = field(default_factory=list)
+    remote_branches: list[str] = field(default_factory=list)  # names without ``origin/``
+    reasons: dict[str, str] = field(default_factory=dict)  # item -> why it is in the plan
+    skipped: list[tuple[str, str]] = field(default_factory=list)  # (item, why not)
+
+    @property
+    def empty(self) -> bool:
+        return not (self.worktrees or self.local_branches or self.remote_branches)
+
+
+# --- parsing --------------------------------------------------------------------------------
+
+
+def parse_worktrees(porcelain: str) -> list[Worktree]:
+    """Parse ``git worktree list --porcelain``; the first entry is the main checkout."""
+    out: list[Worktree] = []
+    for block in porcelain.strip().split("\n\n"):
+        lines = [ln for ln in block.splitlines() if ln.strip()]
+        if not lines:
+            continue
+        path = head = ""
+        branch: str | None = None
+        locked = prunable = False
+        for ln in lines:
+            key, _, val = ln.partition(" ")
+            if key == "worktree":
+                path = val.replace("\\", "/")
+            elif key == "HEAD":
+                head = val
+            elif key == "branch":
+                branch = val.removeprefix("refs/heads/")
+            elif key == "locked":
+                locked = True
+            elif key == "prunable":
+                prunable = True
+        out.append(Worktree(path, head, branch, locked, prunable))
+    return out
+
+
+def parse_pr_heads(gh_json: str) -> dict[str, set[str]]:
+    """``gh pr list --json headRefName,headRefOid`` -> head name -> set of head SHAs."""
+    heads: dict[str, set[str]] = {}
+    for pr in json.loads(gh_json or "[]"):
+        heads.setdefault(pr["headRefName"], set()).add(pr.get("headRefOid", ""))
+    return heads
+
+
+def parse_refs(for_each_ref: str) -> dict[str, str]:
+    """``git for-each-ref --format='%(refname:short) %(objectname)'`` -> name -> SHA."""
+    refs: dict[str, str] = {}
+    for ln in for_each_ref.splitlines():
+        if ln.strip():
+            name, _, sha = ln.strip().partition(" ")
+            refs[name] = sha
+    return refs
+
+
+def parse_names(listing: str) -> set[str]:
+    return {ln.strip() for ln in listing.splitlines() if ln.strip()}
+
+
+# --- the decision ---------------------------------------------------------------------------
+
+
+def _merged_reason(
+    name: str,
+    tip: str,
+    *,
+    merged_prs: dict[str, set[str]],
+    open_prs: dict[str, set[str]],
+    on_main: set[str],
+) -> tuple[bool, str]:
+    """(prune?, reason) for a branch called ``name`` whose tip is ``tip``."""
+    if name in PROTECTED:
+        return False, "protected"
+    if name in open_prs:
+        return False, "open PR"
+    if name in on_main:
+        return True, "tip is on origin/main"
+    if name in merged_prs:
+        if tip in merged_prs[name]:
+            return True, "PR merged (squash) at this tip"
+        return False, "PR merged but branch has commits after it"
+    return False, "commits not on origin/main"
+
+
+def build_plan(run: Runner) -> Plan:
+    merged_prs = parse_pr_heads(
+        run(
+            ["gh", "pr", "list", "--state", "merged", "--limit", "1000",
+             "--json", "headRefName,headRefOid"]
+        )
+    )
+    open_prs = parse_pr_heads(
+        run(
+            ["gh", "pr", "list", "--state", "open", "--limit", "1000",
+             "--json", "headRefName,headRefOid"]
+        )
+    )
+    worktrees = parse_worktrees(run(["git", "worktree", "list", "--porcelain"]))
+    local_refs = parse_refs(
+        run(["git", "for-each-ref", "refs/heads", "--format=%(refname:short) %(objectname)"])
+    )
+    remote_refs = {
+        name.removeprefix("origin/"): sha
+        for name, sha in parse_refs(
+            run(
+                ["git", "for-each-ref", "refs/remotes/origin",
+                 "--format=%(refname:short) %(objectname)"]
+            )
+        ).items()
+        if name != "origin/HEAD"
+    }
+    local_on_main = parse_names(
+        run(["git", "branch", "--merged", "origin/main", "--format=%(refname:short)"])
+    )
+    remote_on_main = {
+        n.removeprefix("origin/")
+        for n in parse_names(
+            run(["git", "branch", "-r", "--merged", "origin/main", "--format=%(refname:short)"])
+        )
+    }
+
+    plan = Plan()
+    if not worktrees:
+        raise SystemExit("git worktree list returned nothing - not inside a repo?")
+    root = worktrees[0].path.rstrip("/")
+    surviving_checkouts: dict[str, str] = {}  # branch -> worktree path that keeps it
+
+    for wt in worktrees[1:]:
+        if not wt.path.startswith(root + "/" + WORKTREE_DIR):
+            if wt.branch:
+                surviving_checkouts[wt.branch] = wt.path
+            continue
+        label = f"worktree {wt.path}"
+        if wt.prunable:
+            plan.skipped.append((label, "prunable - `git worktree prune` handles it"))
+            continue
+        if wt.locked:
+            plan.skipped.append((label, "locked (a session holds it)"))
+        elif wt.branch is None:
+            plan.skipped.append((label, "detached HEAD"))
+        else:
+            ok, why = _merged_reason(
+                wt.branch, wt.head, merged_prs=merged_prs, open_prs=open_prs,
+                on_main=local_on_main,
+            )
+            if ok and run(["git", "-C", wt.path, "status", "--porcelain"]).strip():
+                ok, why = False, "dirty (uncommitted or untracked files)"
+            if ok:
+                plan.worktrees.append(wt.path)
+                plan.reasons[label] = why
+                continue
+            plan.skipped.append((label, why))
+        if wt.branch:
+            surviving_checkouts[wt.branch] = wt.path
+    if worktrees[0].branch:
+        surviving_checkouts[worktrees[0].branch] = worktrees[0].path
+
+    for name, sha in sorted(local_refs.items()):
+        label = f"local {name}"
+        if name in surviving_checkouts:
+            plan.skipped.append((label, f"checked out in {surviving_checkouts[name]}"))
+            continue
+        ok, why = _merged_reason(
+            name, sha, merged_prs=merged_prs, open_prs=open_prs, on_main=local_on_main
+        )
+        if ok:
+            plan.local_branches.append(name)
+            plan.reasons[label] = why
+        elif why != "protected":
+            plan.skipped.append((label, why))
+
+    for name, sha in sorted(remote_refs.items()):
+        label = f"remote origin/{name}"
+        ok, why = _merged_reason(
+            name, sha, merged_prs=merged_prs, open_prs=open_prs, on_main=remote_on_main
+        )
+        if ok:
+            plan.remote_branches.append(name)
+            plan.reasons[label] = why
+        elif why != "protected":
+            plan.skipped.append((label, why))
+    return plan
+
+
+# --- doing it -------------------------------------------------------------------------------
+
+
+def apply_plan(run: Runner, plan: Plan) -> None:
+    """Worktrees first (they pin branches), then local branches, then remote branches."""
+    for path in plan.worktrees:
+        run(["git", "worktree", "remove", path])
+    if plan.local_branches:
+        run(["git", "branch", "-D", *plan.local_branches])
+    for i in range(0, len(plan.remote_branches), 50):
+        run(["git", "push", "origin", "--delete", *plan.remote_branches[i : i + 50]])
+
+
+def render(plan: Plan, *, verbose: bool) -> str:
+    lines = [f"remove  {label}  - {why}" for label, why in plan.reasons.items()]
+    if verbose:
+        lines.extend(f"keep    {label}  - {why}" for label, why in plan.skipped)
+    lines.append(
+        f"{len(plan.worktrees)} worktree(s), {len(plan.local_branches)} local branch(es), "
+        f"{len(plan.remote_branches)} remote branch(es) to remove; {len(plan.skipped)} kept"
+    )
+    return "\n".join(lines)
+
+
+def subprocess_runner(argv: Sequence[str]) -> str:
+    proc = subprocess.run(list(argv), capture_output=True, text=True, encoding="utf-8")
+    if proc.returncode != 0:
+        raise SystemExit(f"{' '.join(argv)} failed ({proc.returncode}):\n{proc.stderr.strip()}")
+    return proc.stdout
+
+
+def main(argv: Sequence[str] | None = None, run: Runner = subprocess_runner) -> int:
+    ap = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n")[0])
+    ap.add_argument("--apply", action="store_true", help="remove instead of listing")
+    ap.add_argument("--no-fetch", action="store_true", help="skip `git fetch --prune origin`")
+    ap.add_argument("-v", "--verbose", action="store_true", help="also list what is kept and why")
+    args = ap.parse_args(argv)
+    if not args.no_fetch:
+        run(["git", "fetch", "--prune", "origin"])
+    plan = build_plan(run)
+    print(render(plan, verbose=args.verbose))
+    if plan.empty:
+        return 0
+    if args.apply:
+        apply_plan(run, plan)
+        print("applied.")
+    else:
+        print("dry run - re-run with --apply to remove.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_prune_merged.py
+++ b/tests/test_prune_merged.py
@@ -1,0 +1,280 @@
+"""scripts/prune_merged.py at its one seam: the Runner.
+
+Every ``gh`` / ``git`` command the script issues is answered from a fixture keyed on argv;
+mutating commands are recorded, never run. Fixture shapes are the real ones —
+``gh pr list --json headRefName,headRefOid`` and ``git worktree list --porcelain``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+import pytest
+
+from scripts.prune_merged import (
+    Plan,
+    apply_plan,
+    build_plan,
+    main,
+    parse_pr_heads,
+    parse_worktrees,
+)
+
+ROOT = "C:/Users/x/repos/resolve-mcp"
+WT = f"{ROOT}/.claude/worktrees"
+
+MAIN = "a" * 40
+SQUASHED_TIP = "b" * 40  # head of a squash-merged PR: never an ancestor of main
+AFTER_MERGE = "c" * 40  # commits pushed after the PR merged
+UNMERGED = "d" * 40
+OPEN_TIP = "e" * 40
+FRESH = "f" * 40  # a branch that is on main by ancestry (merge-commit PR, or no commits yet)
+
+MERGED_PRS = json.dumps(
+    [
+        {"headRefName": "issue-1", "headRefOid": SQUASHED_TIP},  # squash; branch still at tip
+        {"headRefName": "issue-2", "headRefOid": FRESH},  # merge-commit; ancestor of main
+        {"headRefName": "issue-3", "headRefOid": "9" * 40},  # merged, then more commits pushed
+    ]
+)
+OPEN_PRS = json.dumps([{"headRefName": "issue-4", "headRefOid": OPEN_TIP}])
+
+PORCELAIN = f"""worktree {ROOT}
+HEAD {MAIN}
+branch refs/heads/main
+
+worktree {WT}/issue-1
+HEAD {SQUASHED_TIP}
+branch refs/heads/issue-1
+
+worktree {WT}/issue-2
+HEAD {FRESH}
+branch refs/heads/issue-2
+
+worktree {WT}/issue-3
+HEAD {AFTER_MERGE}
+branch refs/heads/issue-3
+
+worktree {WT}/issue-4
+HEAD {OPEN_TIP}
+branch refs/heads/issue-4
+
+worktree {WT}/issue-5
+HEAD {FRESH}
+branch refs/heads/issue-5
+locked
+
+worktree {WT}/issue-6
+HEAD {UNMERGED}
+branch refs/heads/issue-6
+
+worktree {WT}/issue-7
+HEAD {FRESH}
+branch refs/heads/issue-7
+
+worktree {WT}/detached
+HEAD {FRESH}
+detached
+
+worktree {WT}/gone
+HEAD {FRESH}
+branch refs/heads/gone
+prunable gitdir file points to non-existent location
+
+worktree C:/Users/x/elsewhere
+HEAD {FRESH}
+branch refs/heads/elsewhere
+"""
+
+LOCAL_REFS = "\n".join(
+    [
+        f"main {MAIN}",
+        f"issue-1 {SQUASHED_TIP}",
+        f"issue-2 {FRESH}",
+        f"issue-3 {AFTER_MERGE}",
+        f"issue-4 {OPEN_TIP}",
+        f"issue-5 {FRESH}",
+        f"issue-6 {UNMERGED}",
+        f"issue-7 {FRESH}",
+        f"elsewhere {FRESH}",
+        f"orphan-on-main {FRESH}",  # no worktree, no PR, but nothing main lacks
+        f"orphan-ahead {UNMERGED}",
+    ]
+)
+REMOTE_REFS = "\n".join(
+    [
+        f"origin/HEAD {MAIN}",
+        f"origin/main {MAIN}",
+        f"origin/issue-1 {SQUASHED_TIP}",
+        f"origin/issue-2 {FRESH}",
+        f"origin/issue-3 {AFTER_MERGE}",
+        f"origin/issue-4 {OPEN_TIP}",
+        f"origin/issue-6 {UNMERGED}",
+    ]
+)
+# ``git branch --merged origin/main``: names whose tip is an ancestor of origin/main.
+LOCAL_ON_MAIN = "\n".join(
+    ["main", "issue-2", "issue-5", "issue-7", "elsewhere", "orphan-on-main"]
+)
+REMOTE_ON_MAIN = "\n".join(["origin/HEAD", "origin/main", "origin/issue-2"])
+
+
+class FakeRunner:
+    def __init__(self, dirty: frozenset[str] | set[str] = frozenset()) -> None:
+        self.dirty = set(dirty)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: Sequence[str]) -> str:
+        argv = list(argv)
+        self.calls.append(argv)
+        match argv:
+            case ["gh", "pr", "list", "--state", "merged", *_]:
+                return MERGED_PRS
+            case ["gh", "pr", "list", "--state", "open", *_]:
+                return OPEN_PRS
+            case ["git", "worktree", "list", "--porcelain"]:
+                return PORCELAIN
+            case ["git", "for-each-ref", "refs/heads", *_]:
+                return LOCAL_REFS
+            case ["git", "for-each-ref", "refs/remotes/origin", *_]:
+                return REMOTE_REFS
+            case ["git", "branch", "--merged", "origin/main", *_]:
+                return LOCAL_ON_MAIN
+            case ["git", "branch", "-r", "--merged", "origin/main", *_]:
+                return REMOTE_ON_MAIN
+            case ["git", "-C", path, "status", "--porcelain"]:
+                return "?? scratch.txt\n" if path in self.dirty else ""
+            case ["git", "fetch", *_] | ["git", "worktree", "remove", *_]:
+                return ""
+            case ["git", "branch", "-D", *_] | ["git", "push", "origin", "--delete", *_]:
+                return ""
+        raise AssertionError(f"unexpected command: {argv}")
+
+    def mutations(self) -> list[list[str]]:
+        return [
+            c
+            for c in self.calls
+            if c[:3] in (["git", "worktree", "remove"], ["git", "branch", "-D"])
+            or c[:4] == ["git", "push", "origin", "--delete"]
+        ]
+
+
+def test_parse_worktrees_reads_locked_detached_and_prunable() -> None:
+    wts = {w.path.rsplit("/", 1)[-1]: w for w in parse_worktrees(PORCELAIN)}
+    assert wts["issue-5"].locked and wts["issue-5"].branch == "issue-5"
+    assert wts["detached"].branch is None
+    assert wts["gone"].prunable
+    assert wts["resolve-mcp"].branch == "main"
+
+
+def test_parse_worktrees_normalises_backslashes() -> None:
+    wt = parse_worktrees("worktree C:\\repo\\.claude\\worktrees\\x\nHEAD 1\nbranch refs/heads/x\n")
+    assert wt[0].path == "C:/repo/.claude/worktrees/x"
+
+
+def test_parse_pr_heads_groups_oids_by_head() -> None:
+    heads = parse_pr_heads(
+        json.dumps(
+            [
+                {"headRefName": "b", "headRefOid": "1"},
+                {"headRefName": "b", "headRefOid": "2"},
+            ]
+        )
+    )
+    assert heads == {"b": {"1", "2"}}
+    assert parse_pr_heads("") == {}
+
+
+def test_plan_removes_only_merged_and_unheld() -> None:
+    plan = build_plan(FakeRunner())
+    assert plan.worktrees == [f"{WT}/issue-1", f"{WT}/issue-2", f"{WT}/issue-7"]
+    assert plan.local_branches == ["issue-1", "issue-2", "issue-7", "orphan-on-main"]
+    assert plan.remote_branches == ["issue-1", "issue-2"]
+    assert plan.reasons[f"worktree {WT}/issue-1"] == "PR merged (squash) at this tip"
+    assert plan.reasons["remote origin/issue-2"] == "tip is on origin/main"
+
+
+def test_plan_refuses_locked_worktree_and_keeps_its_branch() -> None:
+    plan = build_plan(FakeRunner())
+    kept = dict(plan.skipped)
+    assert kept[f"worktree {WT}/issue-5"].startswith("locked")
+    # issue-5's tip is on main, but the locked worktree still checks the branch out.
+    assert kept["local issue-5"] == f"checked out in {WT}/issue-5"
+    assert "issue-5" not in plan.local_branches
+
+
+def test_plan_refuses_worktree_with_commits_not_on_main() -> None:
+    plan = build_plan(FakeRunner())
+    kept = dict(plan.skipped)
+    assert kept[f"worktree {WT}/issue-6"] == "commits not on origin/main"
+    assert kept[f"worktree {WT}/issue-3"] == "PR merged but branch has commits after it"
+    assert kept["local orphan-ahead"] == "commits not on origin/main"
+    assert kept["remote origin/issue-3"] == "PR merged but branch has commits after it"
+    assert kept["remote origin/issue-6"] == "commits not on origin/main"
+    for name in ("issue-3", "issue-6"):
+        assert f"{WT}/{name}" not in plan.worktrees
+        assert name not in plan.local_branches
+        assert name not in plan.remote_branches
+
+
+def test_plan_never_touches_open_pr_branches() -> None:
+    plan = build_plan(FakeRunner())
+    kept = dict(plan.skipped)
+    assert kept[f"worktree {WT}/issue-4"] == "open PR"
+    assert kept["local issue-4"] == f"checked out in {WT}/issue-4"  # its worktree stays too
+    assert "issue-4" not in plan.local_branches
+    assert kept["remote origin/issue-4"] == "open PR"
+
+
+def test_plan_skips_detached_prunable_and_foreign_worktrees() -> None:
+    plan = build_plan(FakeRunner())
+    kept = dict(plan.skipped)
+    assert kept[f"worktree {WT}/detached"] == "detached HEAD"
+    assert kept[f"worktree {WT}/gone"] == "prunable - `git worktree prune` handles it"
+    # A worktree outside .claude/worktrees/ is never removed, and it pins its branch.
+    assert "C:/Users/x/elsewhere" not in plan.worktrees
+    assert kept["local elsewhere"] == "checked out in C:/Users/x/elsewhere"
+    assert kept["local main"] == f"checked out in {ROOT}"
+    assert "main" not in plan.local_branches
+    assert "main" not in plan.remote_branches
+
+
+def test_plan_refuses_dirty_worktree() -> None:
+    plan = build_plan(FakeRunner(dirty={f"{WT}/issue-2"}))
+    assert f"{WT}/issue-2" not in plan.worktrees
+    assert dict(plan.skipped)[f"worktree {WT}/issue-2"].startswith("dirty")
+    # The branch stays too — the worktree still checks it out.
+    assert "issue-2" not in plan.local_branches
+    # The remote branch is independent of the worktree and still goes.
+    assert "issue-2" in plan.remote_branches
+
+
+def test_dry_run_issues_no_mutations(capsys: pytest.CaptureFixture[str]) -> None:
+    run = FakeRunner()
+    assert main(["--no-fetch"], run=run) == 0
+    assert run.mutations() == []
+    out = capsys.readouterr().out
+    assert "3 worktree(s), 4 local branch(es), 2 remote branch(es) to remove" in out
+    assert "dry run" in out
+    assert not any(c[:2] == ["git", "fetch"] for c in run.calls)
+
+
+def test_apply_removes_worktrees_then_locals_then_remotes() -> None:
+    run = FakeRunner()
+    assert main(["--apply"], run=run) == 0
+    assert run.calls[0] == ["git", "fetch", "--prune", "origin"]
+    assert run.mutations() == [
+        ["git", "worktree", "remove", f"{WT}/issue-1"],
+        ["git", "worktree", "remove", f"{WT}/issue-2"],
+        ["git", "worktree", "remove", f"{WT}/issue-7"],
+        ["git", "branch", "-D", "issue-1", "issue-2", "issue-7", "orphan-on-main"],
+        ["git", "push", "origin", "--delete", "issue-1", "issue-2"],
+    ]
+
+
+def test_apply_batches_remote_deletes() -> None:
+    run = FakeRunner()
+    apply_plan(run, Plan(remote_branches=[f"b{i}" for i in range(120)]))
+    pushes = [c for c in run.calls if c[:2] == ["git", "push"]]
+    assert [len(c) - 4 for c in pushes] == [50, 50, 20]

--- a/tests/test_prune_merged.py
+++ b/tests/test_prune_merged.py
@@ -13,11 +13,11 @@ from collections.abc import Sequence
 import pytest
 
 from scripts.prune_merged import (
+    CommandError,
     Plan,
     apply_plan,
     build_plan,
     main,
-    parse_pr_heads,
     parse_worktrees,
 )
 
@@ -30,15 +30,21 @@ AFTER_MERGE = "c" * 40  # commits pushed after the PR merged
 UNMERGED = "d" * 40
 OPEN_TIP = "e" * 40
 FRESH = "f" * 40  # a branch that is on main by ancestry (merge-commit PR, or no commits yet)
+STACKED = "1" * 40  # head of a PR squash-merged into another branch, never into main
 
 MERGED_PRS = json.dumps(
     [
-        {"headRefName": "issue-1", "headRefOid": SQUASHED_TIP},  # squash; branch still at tip
-        {"headRefName": "issue-2", "headRefOid": FRESH},  # merge-commit; ancestor of main
-        {"headRefName": "issue-3", "headRefOid": "9" * 40},  # merged, then more commits pushed
+        # squash into main; branch still at the squashed tip
+        {"headRefName": "issue-1", "headRefOid": SQUASHED_TIP, "baseRefName": "main"},
+        # merge-commit into main; tip is an ancestor of main
+        {"headRefName": "issue-2", "headRefOid": FRESH, "baseRefName": "main"},
+        # merged into main, then more commits pushed to the branch
+        {"headRefName": "issue-3", "headRefOid": "9" * 40, "baseRefName": "main"},
+        # stacked: squash-merged into issue-2, never into main; reads MERGED on the forge
+        {"headRefName": "issue-8", "headRefOid": STACKED, "baseRefName": "issue-2"},
     ]
 )
-OPEN_PRS = json.dumps([{"headRefName": "issue-4", "headRefOid": OPEN_TIP}])
+OPEN_PRS = json.dumps([{"headRefName": "issue-4", "headRefOid": OPEN_TIP, "baseRefName": "main"}])
 
 PORCELAIN = f"""worktree {ROOT}
 HEAD {MAIN}
@@ -73,14 +79,13 @@ worktree {WT}/issue-7
 HEAD {FRESH}
 branch refs/heads/issue-7
 
+worktree {WT}/issue-8
+HEAD {STACKED}
+branch refs/heads/issue-8
+
 worktree {WT}/detached
 HEAD {FRESH}
 detached
-
-worktree {WT}/gone
-HEAD {FRESH}
-branch refs/heads/gone
-prunable gitdir file points to non-existent location
 
 worktree C:/Users/x/elsewhere
 HEAD {FRESH}
@@ -97,6 +102,7 @@ LOCAL_REFS = "\n".join(
         f"issue-5 {FRESH}",
         f"issue-6 {UNMERGED}",
         f"issue-7 {FRESH}",
+        f"issue-8 {STACKED}",
         f"elsewhere {FRESH}",
         f"orphan-on-main {FRESH}",  # no worktree, no PR, but nothing main lacks
         f"orphan-ahead {UNMERGED}",
@@ -110,24 +116,33 @@ REMOTE_REFS = "\n".join(
         f"origin/issue-2 {FRESH}",
         f"origin/issue-3 {AFTER_MERGE}",
         f"origin/issue-4 {OPEN_TIP}",
+        f"origin/issue-5 {FRESH}",
         f"origin/issue-6 {UNMERGED}",
+        f"origin/issue-8 {STACKED}",
     ]
 )
 # ``git branch --merged origin/main``: names whose tip is an ancestor of origin/main.
 LOCAL_ON_MAIN = "\n".join(
     ["main", "issue-2", "issue-5", "issue-7", "elsewhere", "orphan-on-main"]
 )
-REMOTE_ON_MAIN = "\n".join(["origin/HEAD", "origin/main", "origin/issue-2"])
+REMOTE_ON_MAIN = "\n".join(["origin/HEAD", "origin/main", "origin/issue-2", "origin/issue-5"])
 
 
 class FakeRunner:
-    def __init__(self, dirty: frozenset[str] | set[str] = frozenset()) -> None:
+    def __init__(
+        self,
+        dirty: frozenset[str] | set[str] = frozenset(),
+        failing: frozenset[str] | set[str] = frozenset(),
+    ) -> None:
         self.dirty = set(dirty)
+        self.failing = set(failing)  # last argv token of a command that should fail
         self.calls: list[list[str]] = []
 
     def __call__(self, argv: Sequence[str]) -> str:
         argv = list(argv)
         self.calls.append(argv)
+        if argv[-1] in self.failing:
+            raise CommandError(f"{' '.join(argv)} failed (1): refused")
         match argv:
             case ["gh", "pr", "list", "--state", "merged", *_]:
                 return MERGED_PRS
@@ -145,7 +160,9 @@ class FakeRunner:
                 return REMOTE_ON_MAIN
             case ["git", "-C", path, "status", "--porcelain"]:
                 return "?? scratch.txt\n" if path in self.dirty else ""
-            case ["git", "fetch", *_] | ["git", "worktree", "remove", *_]:
+            case ["git", "fetch", *_] | ["git", "worktree", "prune"]:
+                return ""
+            case ["git", "worktree", "remove", *_]:
                 return ""
             case ["git", "branch", "-D", *_] | ["git", "push", "origin", "--delete", *_]:
                 return ""
@@ -164,26 +181,17 @@ def test_parse_worktrees_reads_locked_detached_and_prunable() -> None:
     wts = {w.path.rsplit("/", 1)[-1]: w for w in parse_worktrees(PORCELAIN)}
     assert wts["issue-5"].locked and wts["issue-5"].branch == "issue-5"
     assert wts["detached"].branch is None
-    assert wts["gone"].prunable
     assert wts["resolve-mcp"].branch == "main"
+    gone = parse_worktrees(
+        f"worktree {WT}/gone\nHEAD {FRESH}\nbranch refs/heads/gone\n"
+        "prunable gitdir file points to non-existent location\n"
+    )
+    assert gone[0].prunable
 
 
 def test_parse_worktrees_normalises_backslashes() -> None:
     wt = parse_worktrees("worktree C:\\repo\\.claude\\worktrees\\x\nHEAD 1\nbranch refs/heads/x\n")
     assert wt[0].path == "C:/repo/.claude/worktrees/x"
-
-
-def test_parse_pr_heads_groups_oids_by_head() -> None:
-    heads = parse_pr_heads(
-        json.dumps(
-            [
-                {"headRefName": "b", "headRefOid": "1"},
-                {"headRefName": "b", "headRefOid": "2"},
-            ]
-        )
-    )
-    assert heads == {"b": {"1", "2"}}
-    assert parse_pr_heads("") == {}
 
 
 def test_plan_removes_only_merged_and_unheld() -> None:
@@ -199,9 +207,12 @@ def test_plan_refuses_locked_worktree_and_keeps_its_branch() -> None:
     plan = build_plan(FakeRunner())
     kept = dict(plan.skipped)
     assert kept[f"worktree {WT}/issue-5"].startswith("locked")
-    # issue-5's tip is on main, but the locked worktree still checks the branch out.
+    # issue-5's tip is on main, but the locked worktree still checks the branch out — and the
+    # lock holds the remote branch too, since the session may push again.
     assert kept["local issue-5"] == f"checked out in {WT}/issue-5"
+    assert kept["remote origin/issue-5"] == "held by a locked worktree"
     assert "issue-5" not in plan.local_branches
+    assert "issue-5" not in plan.remote_branches
 
 
 def test_plan_refuses_worktree_with_commits_not_on_main() -> None:
@@ -212,10 +223,19 @@ def test_plan_refuses_worktree_with_commits_not_on_main() -> None:
     assert kept["local orphan-ahead"] == "commits not on origin/main"
     assert kept["remote origin/issue-3"] == "PR merged but branch has commits after it"
     assert kept["remote origin/issue-6"] == "commits not on origin/main"
-    for name in ("issue-3", "issue-6"):
+    for name in ("issue-3", "issue-6", "issue-8"):
         assert f"{WT}/{name}" not in plan.worktrees
         assert name not in plan.local_branches
         assert name not in plan.remote_branches
+
+
+def test_plan_ignores_prs_merged_into_a_branch_other_than_main() -> None:
+    """A stacked PR reads MERGED on the forge while its commits never reached main."""
+    plan = build_plan(FakeRunner())
+    kept = dict(plan.skipped)
+    assert kept[f"worktree {WT}/issue-8"] == "PR merged into a branch, not main"
+    assert kept["local issue-8"] == f"checked out in {WT}/issue-8"
+    assert kept["remote origin/issue-8"] == "PR merged into a branch, not main"
 
 
 def test_plan_never_touches_open_pr_branches() -> None:
@@ -231,8 +251,8 @@ def test_plan_skips_detached_prunable_and_foreign_worktrees() -> None:
     plan = build_plan(FakeRunner())
     kept = dict(plan.skipped)
     assert kept[f"worktree {WT}/detached"] == "detached HEAD"
-    assert kept[f"worktree {WT}/gone"] == "prunable - `git worktree prune` handles it"
     # A worktree outside .claude/worktrees/ is never removed, and it pins its branch.
+    assert kept["worktree C:/Users/x/elsewhere"] == "outside .claude/worktrees/"
     assert "C:/Users/x/elsewhere" not in plan.worktrees
     assert kept["local elsewhere"] == "checked out in C:/Users/x/elsewhere"
     assert kept["local main"] == f"checked out in {ROOT}"
@@ -263,14 +283,32 @@ def test_dry_run_issues_no_mutations(capsys: pytest.CaptureFixture[str]) -> None
 def test_apply_removes_worktrees_then_locals_then_remotes() -> None:
     run = FakeRunner()
     assert main(["--apply"], run=run) == 0
-    assert run.calls[0] == ["git", "fetch", "--prune", "origin"]
+    assert run.calls[:2] == [["git", "fetch", "--prune", "origin"], ["git", "worktree", "prune"]]
     assert run.mutations() == [
         ["git", "worktree", "remove", f"{WT}/issue-1"],
         ["git", "worktree", "remove", f"{WT}/issue-2"],
         ["git", "worktree", "remove", f"{WT}/issue-7"],
-        ["git", "branch", "-D", "issue-1", "issue-2", "issue-7", "orphan-on-main"],
+        ["git", "branch", "-D", "issue-1"],
+        ["git", "branch", "-D", "issue-2"],
+        ["git", "branch", "-D", "issue-7"],
+        ["git", "branch", "-D", "orphan-on-main"],
         ["git", "push", "origin", "--delete", "issue-1", "issue-2"],
     ]
+
+
+def test_apply_reports_a_refusal_and_keeps_going(capsys: pytest.CaptureFixture[str]) -> None:
+    run = FakeRunner(failing={f"{WT}/issue-2", "issue-7"})
+    assert main(["--apply", "--no-fetch"], run=run) == 1
+    assert len(run.mutations()) == 8  # every removal was still attempted
+    err = capsys.readouterr().err
+    assert f"FAILED  git worktree remove {WT}/issue-2 failed (1): refused" in err
+    assert "FAILED  git branch -D issue-7 failed (1): refused" in err
+
+
+def test_a_failing_read_stops_before_anything_is_removed() -> None:
+    run = FakeRunner(failing={"--porcelain"})
+    assert main(["--apply", "--no-fetch"], run=run) == 1
+    assert run.mutations() == []
 
 
 def test_apply_batches_remote_deletes() -> None:


### PR DESCRIPTION
Closes #250.

## What

`scripts/prune_merged.py` — the post-merge sweep. Dry-run by default (`uv run python scripts/prune_merged.py`), `--apply` removes. It lists remote branches whose PR merged, the matching local branches, and `.claude/worktrees/` worktrees whose branch is merged.

Merged = tip is on `origin/main` (`git branch --merged`), or a PR **into main** was squashed from exactly that tip (squash heads never become ancestors of main). Never touched: `main`/`HEAD`; open-PR branches; tips with commits `origin/main` lacks (incl. a merged PR followed by new commits, and PRs merged into a non-main base — the stacked-PR trap in CLAUDE.md step 6); locked worktrees and the branch they hold (local + remote); dirty worktrees; detached HEADs; branches a surviving worktree checks out.

Every `gh`/`git` call goes through one injectable `Runner` — the seam.

## Seam

Fake tier: `tests/test_prune_merged.py` (14 tests) drives `build_plan`/`main` on fixtures of `gh pr list --json headRefName,headRefOid,baseRefName` and `git worktree list --porcelain`; mutations recorded, never run. Also asserts dry-run issues no mutations, `--apply` ordering (worktrees → locals → remotes), per-item refusal tolerance, and a failed read exiting before any removal.

Live dry-run on this box (`--no-fetch -v`): 56 worktrees, 113 local, 98 remote to remove; 33 kept (5 locked worktrees + their branches, 1 dirty, 1 detached, 2 merged-then-pushed, 3 unmerged tips, 1 open PR).

Also: `pyproject.toml` adds `scripts/` to mypy `files` and `"."` to ruff `src` (so `scripts` sorts as first-party); CLAUDE.md step 6 names the sweep; CONTEXT.md gains a Tooling section + test-map line.

## Review record

`/code-review` (mattpocock two-axis) against `origin/main`:

**Standards** — no hard violations. Judgement calls: test file missing from CONTEXT test map → added; triplicated decide/record shape in `build_plan` → extracted `_prune_decision` + `_record`; `merged_prs/open_prs/on_main` clump → `MergeFacts`; `_merged_reason` name → `_prune_decision`; `master` in PROTECTED → dropped; prunable worktree could pin a branch into a batched `-D` that then aborts the rest → `git worktree prune` runs before planning and removals are one command each with failures reported. Left as-is: `Runner` name collides with `ffmpeg.Runner`/`separator.Runner` (prior art, module-qualified); ruff `src` redundancy; case-sensitive root prefix (fail-safe direction).

**Spec** — ACs 1–3 met. Real gap: squash-tip match ignored the PR's base, so a stacked PR merged into a parent branch would count as merged → fixed, `baseRefName` now required to be `main`, fixture `issue-8` covers it. Minor: locked worktree's remote branch was still pruned → fixed, lock now holds the name everywhere, fixture `origin/issue-5` covers it. Noted scope beyond the spec's literal never-touch list, kept deliberately: dirty-worktree refusal; pruning no-PR branches whose tip is on main (nothing lost); `git fetch --prune` in dry-run (`--no-fetch` to skip).

Focused re-check of the fix commit (`efaf76d`): no findings.

Full fake tier: 2371 passed. mypy strict + ruff clean.

Review: clean

## Needs from you

- AC4: run the first sweep on the live checkout — `uv run python scripts/prune_merged.py -v` to inspect, then `--apply` — and record the result on #250. Note it will drop `worktree-*` branches and stale worktrees for merged tickets; anything locked by a running session is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Merge with origin/main (cdc105f)

`origin/main` merged in after #252 rewrote the same CLAUDE.md step 6. Resolution: #252's shortened text with this PR's `prune_merged.py` sentence appended. Fake tier 2568 passed; mypy strict and ruff clean.

Review: clean — merge resolution is CLAUDE.md prose only, single-pass.
