### PR TITLE
docs: record the #245 corpus diff — every claim survives on CUDA

### DIFF
--- a/docs/reference/compute-device-inventory.md
+++ b/docs/reference/compute-device-inventory.md
@@ -122,12 +122,49 @@ stored CPU results:
   kept** — per `docs/agents/style-layer.md`. Below it, the profile keeps its
   claims and gains a note that they were confirmed on the CUDA build.
 
-**Outcome: pending.** The corpus diff runs on the director's box — the
-projects live nowhere else — and is recorded on #245 as it completes. Until
-it is recorded, the profiles' `[measured]` tags stand on the CPU numbers and
-this row is a flip of the *compute path*, not yet a re-confirmation of the
-corpus. The two are separable on purpose: a new job today should use the
-card whatever the diff says about claims made a month ago.
+**Outcome: every corpus claim survives, 2026-08-15.** The diff ran on the
+director's box against the cached artifacts — the stored `*-beats.json` carry
+per-beat times and the stored `*.correlate.json` carry every cut's position, so
+the cut lists are byte-identical to the ones the published numbers came from and
+the grid underneath them is the only thing that changed. Nine stored beat grids
+and nine stored `tunes` variants were recomputed from the same master audio the
+originals were measured from. Full working: `styles/corpus.md`, "Every
+measurement below was confirmed on the CUDA torch build".
+
+- **Beat grid — inside tolerance.** Median delta **0.000 s on every file**, and
+  no beat moved by as much as a frame at any fps. Five of nine files are
+  bit-identical or inside 20 ms. The other four each disagree at exactly one
+  beat: three insertions, three deletions and three 20 ms nudges across the
+  ~45,300 beats in those four files. `Unisphere` and its independently-rendered copy produce the *same*
+  insertion and deletion, so this is beat_this's own edge behaviour at marginal
+  points, not GPU nondeterminism.
+- **Applause curve — inside tolerance, with room to spare.** All nine variants
+  reproduce: span counts identical, total span seconds identical to the
+  millisecond. No boundary moved at all. The raw evidence the tolerance asks for
+  had to be produced rather than read, since the curve is never persisted: PANNs
+  was run on both devices over the same audio, giving **max |Δp| = 5.8 × 10⁻⁴**
+  over 1,578,763 frames, median below 5 × 10⁻⁸, with **no frame** over 10⁻³. The CPU arm
+  reproduces the stored peaks exactly at four decimals, which is what makes the
+  CPU-to-CUDA gap readable as signal.
+- **Nothing was re-derived, because nothing moved.** Every grid-dependent number
+  was recomputed against the CUDA grid over the stored cut lists and compared to
+  the same derivation over the CPU grid — same code both sides. On all six
+  measured timelines `beat_offsets`, `bars`, `gated` and `grid_meter` are
+  identical. The only key that shifts anywhere is `grid_refused`, the tally of
+  beats the #112 gate discarded (Zinc 11,130 → 11,131; Concert Full Cut 267 →
+  266; Monkfish 1,486 → 1,483). That counter describes the grid, not a cut.
+
+The case that looked dangerous and was not: the anchor gained a beat, moved one
+downbeat flag and gave two more beats downbeat status — and its grid is
+`meter: 1`, refused whole, so it contributes to no beat claim and could not have
+moved one.
+
+Note for anyone re-running this: the stored `*.correlate.json` were written by
+older code (they predate the #160 `stranded` field, and Zinc predates the #112
+gate), so a replay under current code does *not* reproduce them and should not be
+expected to. That drift is documented history, not a fault. Compare CPU-grid and
+CUDA-grid derivations under one version of the code; comparing either against the
+stored header measures the code, not the card.
 
 Cost either way: beats + applause over a full concert were minutes-scale on
 this box's CPU, not the hours-scale the separator's bug was (#202, G10). The

--- a/styles/concert.md
+++ b/styles/concert.md
@@ -12,6 +12,14 @@ policy 3).
 Sections follow the schema settled in #13. Every claim carries a provenance
 tag; the vocabulary is in `docs/agents/style-layer.md`.
 
+**Confirmed on the CUDA torch build, 2026-08-15 (#245).** Every `[measured]`
+claim here was computed on the CPU torch build. The beat grid and the applause
+curve were re-run on CUDA and the grid-dependent numbers re-derived over the
+same cut lists: the bar-position shares in §1, the meter and tempo readings, and
+the paired-round histograms all come back **identical**. Nothing here was
+re-derived because nothing moved. Working in `corpus.md`, "Every measurement
+below was confirmed on the CUDA torch build".
+
 ## 1. Cut placement — transients, not the beat grid
 
 The base transient philosophy applies as written. What is concert-specific is

--- a/styles/corpus.md
+++ b/styles/corpus.md
@@ -57,26 +57,62 @@ a full-timeline export or the director rather than getting measured against a
 guess. Its 19 shots are the smallest sample in the corpus; publishing them
 against the wrong zero would cost more than leaving them out.
 
-## Every measurement below was made on the CPU torch build
+## Every measurement below was confirmed on the CUDA torch build
 
-**Open, 2026-08-15 (#245).** The beat grid and the applause curve now infer on
+**Settled 2026-08-15 (#245).** The beat grid and the applause curve now infer on
 CUDA — the analysis extra sources torch from the cu130 wheel index on Windows,
 where it used to get PyPI's CPU build. Every `[measured — …]` row in this file
-predates that flip and was computed on the CPU one.
+was computed on the CPU build, so each one was re-computed on the CUDA build and
+diffed before being left standing. **Every claim in this file survives, and one
+number moved** — Zinc's refused-beat count, which is not a claim about anything
+(see below).
 
-The re-computation is **pending**: per corpus project, beat grid and applause
-curve are recomputed on the CUDA build and diffed against the stored CPU
-results. A beat grid survives if its max delta is under one frame at the
-timeline's fps; an applause curve survives if no span appears, disappears or
-moves a boundary by more than a frame. Rows that survive get a line saying they
-were confirmed on the CUDA build; rows that do not are re-derived, and the
-profile claims resting on them are re-tagged per
-`docs/agents/style-layer.md`. The tolerance and the reasoning are recorded in
+The diff ran off the cached artifacts rather than off Resolve: the stored
+`*-beats.json` carry per-beat times and the stored `*.correlate.json` carry every
+cut's timeline position, so the cut list is byte-identical to the one the
+published numbers came from and the grid underneath it is the only thing that
+changed. All nine stored grids were recomputed from the same master audio the
+originals were measured from — not the staged copies, which hash differently.
+
+**The beat grid.** Five of the nine files come back bit-identical or inside
+20 ms; the other four disagree at exactly one beat each. Across the ~45,300
+beats in those four, the total disagreement is three insertions, three deletions
+and three 20 ms nudges — **median delta 0.000 s on every file**, and no beat
+anywhere moved by as much as a frame. The insertions and deletions sit where beat_this was already
+marginal, and `Unisphere` and its independently-rendered copy `scullers-mix-pcm24`
+produce the *same* insertion and the *same* deletion, which is how we know this is
+the model's own edge behaviour and not GPU nondeterminism.
+
+**The applause curve.** All nine stored `tunes` variants reproduce on CUDA: span
+counts identical (21, 15, 6, 1, 0) and total span seconds identical **to the
+millisecond** (146.407, 56.158, 22.395, 3.839). No span appeared, disappeared, or
+moved a boundary at all. Because the curve itself is never persisted, the raw
+delta the tolerance asked for was measured by running PANNs on both devices over
+the same audio: across 1,578,763 frames, **max |Δp| = 5.8 × 10⁻⁴**, median below
+5 × 10⁻⁸, and **not one frame** differs by more than 10⁻³. The CPU arm reproduces
+the stored peak probabilities exactly at four decimals (0.2977, 0.4397, 0.6528),
+which is what licenses reading the CPU-to-CUDA gap as the real signal.
+
+**What that did to the published numbers: nothing.** Every grid-dependent number
+in this file was re-derived against the CUDA grid, over the stored cut lists, and
+compared against the same derivation over the stored CPU grid — same code both
+sides, so the device is the only variable. On all six measured timelines the
+`beat_offsets`, `bars`, `gated` and `grid_meter` readings are **identical**. The
+only key that moves anywhere is `grid_refused`, the internal tally of beats the
+#112 gate threw out: Zinc 11,130 → 11,131 on bar position and 3,176 → 3,177 on
+tempo, Concert Full Cut 267 → 266 on bar position, Monkfish 1,486 → 1,483 on
+tempo. Those counters say how many beats were refused, not anything about a cut,
+and all three grids they belong to were already refused whole or gated at the
+same rate.
+
+The anchor is the case that looked dangerous and was not. Zinc gained a beat at
+4046.52 s, one downbeat flag moved (381.06 → 381.16) and two more beats gained
+downbeat status — and its grid reports `meter: 1`
+and is refused whole, so it contributes nothing to any beat claim and could not
+have moved one. Its bar histogram was never evidence, as this file already says.
+
+The tolerance and the reasoning are recorded in
 `docs/reference/compute-device-inventory.md`, "The torch decision".
-
-Until that diff is recorded on #245, read every tag below as measured on the
-CPU build — the numbers are what they always were, but nothing has yet
-confirmed the GPU produces them.
 
 ## Excluded, and why
 
@@ -364,7 +400,8 @@ this pass, as designed — the gate never touches them.
 **Half the corpus never described a bar position in the first place.** The
 offline prediction held exactly: three of the six grids report `meter: 1` and
 are refused whole. Every beat in all three is refused on bar position — 11,130
-on the anchor, 2,348 on Sunshine, 1,261 on Mercies — and their bar histograms
+on the anchor (11,131 on the CUDA build, #245: one more beat, refused like the
+rest), 2,348 on Sunshine, 1,261 on Mercies — and their bar histograms
 were therefore never evidence, whatever the entries above appeared to say. The
 anchor is the expensive case: 366 shots, the strongest exemplar in the corpus,
 and it contributes nothing to any beat claim. It still contributes its 360


### PR DESCRIPTION
Discharges the last two acceptance criteria on #245. PR #246 flipped the build
and left the corpus diff as the director's job; this records the diff, and
**every corpus claim survives**.

Docs only — no executable change.

## It did not need the director's hands after all

The diff runs off the cached artifacts. The stored `*-beats.json` carry per-beat
times and the stored `*.correlate.json` carry every cut's timeline position, so
the cut list is byte-identical to the one the published numbers came from and
the grid underneath it is the only thing that changes. Resolve was never opened
and nothing was re-cut. All nine stored grids were recomputed from the same
**master** audio the originals were measured from (P:/B:), not the staged cache
copies — those hash differently, and using them would have made it a
two-variable comparison.

## AC4 — the numbers

**Beat grid: inside tolerance.** Median delta **0.000 s on every file**, and no
beat moved by as much as a frame at any fps. Five of nine files are
bit-identical or inside 20 ms. The other four disagree at exactly one beat
each — three insertions, three deletions and three 20 ms nudges across the
~45,300 beats in those four. `Unisphere` and its independently-rendered copy
`scullers-mix-pcm24` produce the *same* insertion and the *same* deletion, which
is how we know this is beat_this's own edge behaviour at marginal points rather
than GPU nondeterminism.

**Applause: inside tolerance with room to spare.** All nine stored `tunes`
variants reproduce — span counts identical (21, 15, 6, 1, 0) and total span
seconds identical **to the millisecond** (146.407, 56.158, 22.395, 3.839).
Nothing appeared, disappeared, or moved a boundary.

The raw |Δp| the tolerance promised could not be read off disk, because the
curve is never persisted — only its summary and the derived tune rows. So it was
produced: PANNs ran on **both** devices over the same three masters, giving
**max |Δp| = 5.8 × 10⁻⁴** over 1,578,763 frames, median below 5 × 10⁻⁸, and
**no frame** over 10⁻³. The CPU arm reproduces the stored peak probabilities
exactly at four decimals (0.2977, 0.4397, 0.6528) — the check that licenses
reading the CPU-to-CUDA gap as signal, since a harness that cannot reproduce the
published number has no standing to move it.

## AC5 — nothing needed re-deriving

Every grid-dependent number was recomputed against the CUDA grid over the stored
cut lists and compared with the same derivation over the stored CPU grid, same
code both sides, so the device is the only variable. On **all six** measured
timelines `beat_offsets`, `bars`, `gated` and `grid_meter` are **identical** —
including the headline `concert.md` bar-position shares (49.0 / 71.6 / 49.4 /
71.8), `measured: 202`, `measured: 218`, and every median/mean/max in the
gated-pass tables.

The only key that shifts anywhere is `grid_refused`, the tally of beats the #112
gate discarded: Zinc 11,130 → 11,131 on bar position and 3,176 → 3,177 on tempo,
Concert Full Cut 267 → 266, Monkfish 1,486 → 1,483. That counter describes the
grid, not a cut. One cited number moves — Zinc's refused-beat count — and it is
updated in `corpus.md`.

The case that looked dangerous and was not: the anchor gained a beat at 4046.52 s
and shifted downbeat flags, and its grid is `meter: 1`, **refused whole** — it
contributes to no beat claim and could not have moved one.

## What changed on disk

- `styles/corpus.md` — the "pending" section becomes the recorded outcome, and
  Zinc's refused-beat count gains its CUDA reading.
- `docs/reference/compute-device-inventory.md` — "Outcome: pending" becomes the
  result, with the method and the re-run caveat.
- `styles/concert.md` — the confirmed-on-CUDA note the tolerance called for.
  `base.md` needed none: its grid mentions are `[stated principle]`, not
  `[measured]`.

## Seams

Docs only, so no test seam applies. The evidence behind the prose is the diff
itself, run on the live box: nine beat grids recomputed on CUDA, nine `tunes`
variants replayed, three applause curves computed on both devices, and six
timelines re-derived over their stored cut lists.

Gates: fake tier **2356 passed, 1 skipped**; mypy strict clean; ruff clean.

## One trap, recorded so it isn't rediscovered

The first harness pass compared a replay against the stored `correlate.json`
headers and **failed on every timeline**. That was code drift, not device drift:
those artifacts predate the #160 `stranded` field, and Zinc predates the #112
gate entirely. Comparing either grid against a stored header measures the code,
not the card. The comparison that isolates the device is CPU-grid vs CUDA-grid
under one version of the code, and that is what the numbers above are. The
failing check is the reason the conclusion is trustworthy; it is written into the
inventory so the next person does not read it as a regression.

## Review record

Pure prose — docs only — so one lightweight inline pass, per CLAUDE.md. The pass
caught three factual errors in my own draft before commit: the insertion and
deletion counts were written as four and four when the locator output shows three
and three, the beat total was rounded to ~47,000 when the four affected files
hold ~45,300, and Zinc's downbeat change was described as "three flags moved"
when one moved and two beats gained downbeat status. All three corrected in the
committed text.

Review: clean — prose only, single-pass; three factual errors caught inline and corrected before commit; fake tier 2356 passed, mypy strict and ruff clean.
