### PR TITLE
feat: context guard covers PowerShell, every reader, bare noisy runs (#248)

### DIFF
--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -1,51 +1,49 @@
 #!/usr/bin/env python3
-"""PreToolUse hook enforcing CLAUDE.md's context-discipline rules on Bash.
+"""PreToolUse hook enforcing CLAUDE.md's context-discipline rules on the shell
+tools (Bash and PowerShell — settings.json matches both).
 
 Blocks (exit 2, message to the model):
-  1. Noisy runs (NOISY_TOOLS below) piped to tail/head/cat — the
-     scratch-log+grep rule.
-  2. `gh` comment pulls that don't land in a file — the full thread is the
-     largest tool-result class measured.
-  3. `cat` of source/config files straight into context — that is a whole-file
-     Read with a worse interface; use the Read tool or pipe to grep.
+  1. Noisy runs (NOISY_TOOLS below) whose output does not land in a file —
+     bare, or piped to tail/head/grep. The scratch-log+grep rule.
+  2. `gh issue view` / `gh pr view` / `gh pr diff` that do not land in a
+     file — issue bodies, comment threads and PR diffs are the largest
+     tool-result class measured.
+  3. Whole-file dumps of a guarded file straight into context, whichever
+     reader fetches them: `cat`, `sed -n p` / `1,$p`, `head`/`tail` with no
+     count, `head -c`, `Get-Content` without `-TotalCount`/`-Tail`, `type`,
+     and a `for … cat` sweep. Ranged reads (`sed -n 10,40p`, `head -50`,
+     `Get-Content -TotalCount 50`) pass, as does anything piped onward or
+     redirected. Backslash and drive-letter paths count as paths.
 
-Measured motivation (2026-08 transcript audit): 233 piped harness runs with
-zero scratch-file adoption, and one 237k-token session that pulled 162KB via
-`cat` loops without a single Read call.
+`gh … --body …` (and `--title`, `-m`) arguments are prose and are never
+inspected. Heredoc bodies and here-strings are data, not commands.
+
+Measured motivation (2026-08 transcript audits): 233 piped harness runs with
+zero scratch-file adoption; one 237k-token session that pulled 162KB via
+`cat` loops without a single Read call; ~800 unguarded PowerShell calls; 44%
+of `gh … view` calls unredirected; `sed -n`, `head`, `Get-Content` and
+Windows paths all walking round the cat rule (#248).
+
+The guarded-extension list lives in guard_ext.py, shared with read-guard.py.
 
 starter-version: 2026-08-10 (claude-principles; locally tuned: LAUNCHERS,
-block messages use this repo's scratch-log names)
+PowerShell, the wider reader set, block messages use this repo's scratch-log
+names)
 """
 import json
+import os
 import re
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from guard_ext import GUARDED_EXT  # noqa: E402
+
+SHELL_TOOLS = ("Bash", "PowerShell")
 
 # The commands whose full output belongs in a scratch log, never in context.
 NOISY_TOOLS = r"pytest|mypy|ruff"
 # Launcher prefixes those commands may hide behind in this repo.
 LAUNCHERS = r"(?:uv\s+run\s+(?:-\S+\s+)*|python3?\s+-m\s+)"
-
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
-
-if data.get("tool_name") != "Bash":
-    sys.exit(0)
-
-cmd = data.get("tool_input", {}).get("command", "") or ""
-
-# Heredoc bodies are data, not commands; `<<-` terminators may be indented
-# (session note context-guard-blocks-some-heredocs, 2026-08 — now fixed).
-HEREDOC = r"<<-?\s*(['\"]?)(\w+)\1[\s\S]*?\n[ \t]*\2\b"
-blanked = re.sub(HEREDOC, "<<HEREDOC", cmd)
-# The noisy/gh rules also blank quoted strings: a commit message merely
-# mentioning pytest is prose. The cat rules instead use a quote-STRIPPED
-# copy (quotes removed, content kept): `cat "notes.md"` is still a cat, and
-# command-position anchoring is what protects those rules from prose.
-scan = re.sub(r"'[^']*'", "''", blanked)
-scan = re.sub(r'"[^"]*"', '""', scan)
-scan_cat = re.sub(r"[\"']", "", blanked)
 
 # Command position: line start, a separator (`;`, `&`, `|`, `(`, `)`, `{`,
 # backtick, newline), a $( substitution, or a then/do/else keyword — with
@@ -55,52 +53,192 @@ CMD_POS = r"(?:^\s*|[;&|(){`\n]\s*|\$\(\s*|\b(?:then|do|else)\s+)"
 NOISY = (
     CMD_POS
     + r"(?:\w+=\S+\s+)*"
-    + r"(?:" + LAUNCHERS + r")*"
-    + r"(?:" + NOISY_TOOLS + r")\b"
+    + r"(?P<tool>(?:" + LAUNCHERS + r")*"
+    + r"(?:" + NOISY_TOOLS + r")\b)"
 )
-if re.search(NOISY + r"[^|]*\|\s*(tail|head|less|more|cat)\b", scan):
-    sys.stderr.write(
-        "Blocked (context discipline): noisy runs never pipe to tail/head — a tail caps one run, runs repeat.\n"
-        "Use one bare command: <cmd> > pytest.scratch.log 2>&1. Then Grep the log for the decisive line (FAILED|passed|error).\n"
-        "On failure, Grep the log for the failing case by name; never cat the log.\n"
-    )
-    sys.exit(2)
 
-# gh comment pulls: the full thread is 5-7KB per call and repeats (measured
-# 2026-08-05). Piping to tail caps nothing that matters, and dropping the pipe
-# is worse — so the rule is: comments land in a file (or a --json filter),
-# never straight in context. Checked per pull, within that pull's own command
-# segment; a digit before `>` is an fd redirect (2>), not a landing.
-for m in re.finditer(r"\bgh\s+(issue|pr)\s+view\b[^|;&]*--comments", scan):
-    seg = re.split(r"[|;&]", scan[m.end():], 1)[0]
-    if not re.search(r"(?<!\d)>\s*\S", seg):
-        sys.stderr.write(
-            "Blocked (context discipline): a comment pull lands in a file, never straight in context.\n"
-            "Use one bare command: gh issue view <n> --comments > comments.scratch.log. Then Grep the log — or --json comments with a jq filter.\n"
+# A path token: POSIX or Windows (`C:\x\y.py`, `.\src\f.py`, `~/f.py`,
+# `$env:TMP\f.py`, `${VAR}/f.py`). Quotes were stripped before matching.
+PATH_TOKEN = r"[\w$./*:\\~{}+@%,=-]+"
+# One of the guarded extensions, as a regex on a (quote-stripped) arg string.
+GUARDED_EXT_RE = (
+    r"\.(?:" + "|".join(sorted(e[1:] for e in GUARDED_EXT)) + r")(?![\w])"
+)
+
+# Heredoc bodies are data, not commands; `<<-` terminators may be indented
+# (session note context-guard-blocks-some-heredocs, 2026-08 — now fixed).
+HEREDOC = r"<<-?\s*(['\"]?)(\w+)\1[\s\S]*?\n[ \t]*\2\b"
+# PowerShell here-strings: @'…'@ / @"…"@, terminator at line start.
+HERESTRING = r"@(['\"])[\s\S]*?\n\1@"
+# One alternation so an apostrophe inside a double-quoted string is consumed
+# with that string, not paired with the next apostrophe on the line — that
+# pairing is what turned `--body "…don't … pytest | tail …"` into a false
+# positive (#248).
+QUOTED = r"'[^']*'|\"(?:[^\"\\]|\\.)*\""
+# Prose arguments: never inspected. The value may be a quoted string, a
+# $(…) substitution (heredoc already blanked) or a bare word.
+PROSE_ARG = (
+    r"(?<!\S)(--body|--title|--message|-m|-b|-t)(=|\s+)"
+    r"(?:" + QUOTED + r"|\$\([^)]*\))"
+)
+# Whole-file readers, anchored at command position; args are path-ish tokens.
+READER = re.compile(
+    CMD_POS
+    + r"(?P<cmd>cat|sed|head|tail|type|Get-Content|gc)\b(?P<args>(?:\s+"
+    + PATH_TOKEN
+    + r")*)"
+)
+
+WHOLE_FILE_MSG = (
+    "Blocked (context discipline): don't dump whole files into context — the rules govern "
+    "content entering context, not which command fetched it (cat, sed -n p, head/tail with no "
+    "count, Get-Content, type all cost the same).\n"
+    "Use the Read tool (ranged: grep -n first, then offset/limit), a ranged read "
+    "(sed -n 10,40p / head -50 / Get-Content -TotalCount 50), or pipe to grep for the "
+    "decisive lines.\n"
+)
+NOISY_MSG = (
+    "Blocked (context discipline): a noisy run (pytest/mypy/ruff) lands in a scratch log, never "
+    "in context — bare or piped to tail/head/grep, a run's output caps nothing that matters "
+    "and runs repeat.\n"
+    "Use one bare command, from the session cwd, no chain:\n"
+    "    uv run pytest -m 'not live' > pytest.scratch.log 2>&1\n"
+    "    uv run mypy src tests > mypy.scratch.log 2>&1\n"
+    "    uv run ruff check src tests > ruff.scratch.log 2>&1\n"
+    "Then Grep the log for the decisive line (FAILED|passed|error); never cat the log.\n"
+)
+GH_MSG = (
+    "Blocked (context discipline): gh views and diffs land in a file, never straight in context — "
+    "issue bodies, comment threads and PR diffs are the largest tool results measured.\n"
+    "Use one bare command, no chain:\n"
+    "    gh issue view <n> --json body,comments > issue.scratch.log\n"
+    "    gh pr view <n> --json body,comments > pr.scratch.log\n"
+    "    gh pr diff <n> > pr.scratch.log\n"
+    "Then Grep the log for the section you need.\n"
+)
+CAT_LOOP_MSG = (
+    "Blocked (context discipline): a cat loop over source files is a mass whole-file Read.\n"
+    "Use the Read tool per file you will edit, or grep for the lines you actually need.\n"
+)
+
+
+def prepare(cmd):
+    """Return (scan, scan_cat): the command with data blanked for scanning.
+
+    *scan* has heredocs, here-strings, prose args and quoted strings blanked —
+    for the noisy/gh rules, where a commit message merely mentioning pytest is
+    prose. *scan_cat* keeps quoted content but drops the quote characters —
+    `cat "notes.md"` is still a cat, and command-position anchoring is what
+    protects the reader rules from prose.
+    """
+    blanked = re.sub(HEREDOC, "<<HEREDOC", cmd)
+    blanked = re.sub(HERESTRING, "''", blanked)
+    blanked = re.sub(PROSE_ARG, r"\1 ''", blanked)
+    scan = re.sub(QUOTED, lambda m: "''" if m.group(0)[0] == "'" else '""', blanked)
+    scan_cat = re.sub(QUOTED, lambda m: m.group(0)[1:-1], blanked)
+    return scan, scan_cat
+
+
+# A command segment ends at `;`, newline, `&&`, `||`, or a bare `&` — but not
+# at the `&` of `2>&1` / `&>`. Pipes are kept: landing is judged per pipeline.
+SEG_END = re.compile(r"\|\||&&|[;\n]|(?<![>\d])&(?!>)")
+
+
+def segment(text, start):
+    """The command segment beginning at *start* (up to the next separator)."""
+    m = SEG_END.search(text, start)
+    return text[start : m.start()] if m else text[start:]
+
+
+def lands_in_file(seg):
+    """True when the segment's output reaches a file, not the context.
+
+    A file redirect in the first pipe stage (a digit before `>` is an fd
+    redirect, `2>`, not a landing), or a PowerShell file cmdlet downstream.
+    """
+    first = seg.split("|", 1)[0]
+    if re.search(r"(?<!\d)>\s*\S", first):
+        return True
+    return re.search(r"\|\s*(?:Out-File|Set-Content|Add-Content)\b", seg) is not None
+
+
+def piped_or_redirected(seg):
+    """True when a reader's output is piped onward or lands in a file."""
+    return "|" in seg or lands_in_file(seg)
+
+
+def check(tool_name, cmd):
+    """The block message for *cmd*, or None when it passes."""
+    if tool_name not in SHELL_TOOLS:
+        return None
+    scan, scan_cat = prepare(cmd or "")
+
+    # 1. Noisy runs land in a file.
+    for m in re.finditer(NOISY, scan):
+        if not lands_in_file(segment(scan, m.start("tool"))):
+            return NOISY_MSG
+
+    # 2. gh views/diffs land in a file.
+    for m in re.finditer(r"\bgh\s+(?:issue\s+view|pr\s+view|pr\s+diff)\b", scan):
+        if not lands_in_file(segment(scan, m.start())):
+            return GH_MSG
+
+    # 3a. for-loop cat sweep: `for f in src/*.py; do cat $f; done`
+    if re.search(r"\bfor\b[^;]*" + GUARDED_EXT_RE + r".*\bcat\b", scan_cat):
+        return CAT_LOOP_MSG
+
+    # 3b. Whole-file readers.
+    for m in READER.finditer(scan_cat):
+        name = m.group("cmd")
+        args = m.group("args")
+        if not re.search(GUARDED_EXT_RE, args):
+            continue
+        if piped_or_redirected(segment(scan_cat, m.start("cmd"))):
+            continue
+        if whole_file(name, args):
+            return WHOLE_FILE_MSG
+
+    return None
+
+
+def whole_file(name, args):
+    """True when reader *name* with *args* (guarded path present) dumps it all."""
+    tokens = args.split()
+    if name in ("cat", "type", "Get-Content", "gc"):
+        if name == "cat":
+            return True
+        # Get-Content and type (its alias) — bounded by -TotalCount / -Tail
+        # (aliases -Head/-First/-Last).
+        return not any(
+            re.match(r"-(?:TotalCount|Tail|Head|First|Last)\b", t, re.I) for t in tokens
         )
-        sys.exit(2)
+    if name in ("head", "tail"):
+        if any(re.match(r"-c\b|--bytes\b", t) for t in tokens):
+            return True
+        return not any(re.match(r"-n(?:\d|$)|-\d+$|--lines(?:=|$)", t) for t in tokens)
+    if name == "sed":
+        # The script is the first non-flag token (quotes already stripped);
+        # `p`, `1,$p` and no script at all (`sed '' file`) are the whole file.
+        flags = [t for t in tokens if t.startswith("-")]
+        if any(t in ("-e", "--expression") for t in flags):
+            idx = next(i for i, t in enumerate(tokens) if t in ("-e", "--expression"))
+            script = tokens[idx + 1] if idx + 1 < len(tokens) else ""
+        else:
+            rest = [t for t in tokens if not t.startswith("-")]
+            script = rest[0] if len(rest) > 1 else ""
+        return script.replace("\\", "") in ("", "p", "1,$p")
+    return False
 
-SRC_EXT = r"\.(md|sh|py|js|ts|json|yml|yaml|txt|log|conf|ini)\b"
 
-# for-loop cat sweep: `for f in src/*.py; do cat $f; done`
-if re.search(r"\bfor\b[^;]*" + SRC_EXT + r".*\bcat\b", scan_cat):
-    sys.stderr.write(
-        "Blocked (context discipline): a cat loop over source files is a mass whole-file Read.\n"
-        "Use the Read tool per file you will edit, or grep for the lines you actually need.\n"
+if __name__ == "__main__":
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    msg = check(
+        data.get("tool_name"), (data.get("tool_input", {}) or {}).get("command", "")
     )
-    sys.exit(2)
-
-# bare cat of a source file, not piped onward and not a redirect/heredoc —
-# anchored at command position so prose mentioning "cat" never matches
-for m in re.finditer(CMD_POS + r"cat\b(?:\s+-[\w]+)*((?:\s+[\w$./*-]+)+)", scan_cat):
-    args = m.group(1)
-    rest = scan_cat[m.end():]
-    if re.search(SRC_EXT, args) and not re.match(r"\s*[|>]", rest):
-        sys.stderr.write(
-            "Blocked (context discipline): don't cat files into context — the rules govern content entering "
-            "context, not which tool fetched it.\n"
-            "Use the Read tool (ranged: grep -n first, then offset/limit), or pipe to grep for the decisive lines.\n"
-        )
+    if msg:
+        sys.stderr.write(msg)
         sys.exit(2)
-
-sys.exit(0)
+    sys.exit(0)

--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -12,8 +12,9 @@ Blocks (exit 2, message to the model):
      reader fetches them: `cat`, `sed -n p` / `1,$p`, `head`/`tail` with no
      count, `head -c`, `Get-Content` without `-TotalCount`/`-Tail`, `type`,
      and a `for … cat` sweep. Ranged reads (`sed -n 10,40p`, `head -50`,
-     `Get-Content -TotalCount 50`) pass, as does anything piped onward or
-     redirected. Backslash and drive-letter paths count as paths.
+     `Get-Content -TotalCount 50`) pass, as does anything redirected or
+     piped onward into a real filter (not `| cat`, `| less`, `| Out-String`
+     and friends). Backslash and drive-letter paths count as paths.
 
 `gh … --body …` (and `--title`, `-m`) arguments are prose and are never
 inspected. Heredoc bodies and here-strings are data, not commands.
@@ -59,10 +60,29 @@ NOISY = (
 
 # A path token: POSIX or Windows (`C:\x\y.py`, `.\src\f.py`, `~/f.py`,
 # `$env:TMP\f.py`, `${VAR}/f.py`). Quotes were stripped before matching.
-PATH_TOKEN = r"[\w$./*:\\~{}+@%,=-]+"
+PATH_TOKEN = r"[\w$./*:\\~{}+@%,=!-]+"
 # One of the guarded extensions, as a regex on a (quote-stripped) arg string.
-GUARDED_EXT_RE = (
-    r"\.(?:" + "|".join(sorted(e[1:] for e in GUARDED_EXT)) + r")(?![\w])"
+GUARDED_EXT_RE = re.compile(
+    r"\.(?:" + "|".join(sorted(e[1:] for e in GUARDED_EXT)) + r")(?![\w.])", re.I
+)
+# Pipe stages that pass a file through unchanged (or paged): a reader piped
+# into one of these is still a whole-file dump.
+PASSTHROUGH = re.compile(
+    r"^\s*(?:cat|nl|tee|less|more|Out-String|Out-Host|Out-Default|Write-Output|Format-\w+)\b"
+)
+# PowerShell accepts any unambiguous parameter prefix: -Tot, -Total, -Ta …
+_PS_COUNT_PARAMS = ("TotalCount", "Tail", "Head", "First", "Last")
+PS_COUNT_FLAG = re.compile(
+    r"-(?:"
+    + "|".join(
+        sorted(
+            {w[:i] for w in _PS_COUNT_PARAMS for i in range(2, len(w) + 1)},
+            key=len,
+            reverse=True,
+        )
+    )
+    + r")(?::|$)",
+    re.I,
 )
 
 # Heredoc bodies are data, not commands; `<<-` terminators may be indented
@@ -123,11 +143,11 @@ CAT_LOOP_MSG = (
 
 
 def prepare(cmd):
-    """Return (scan, scan_cat): the command with data blanked for scanning.
+    """Return (scan, scan_readers): the command with data blanked for scanning.
 
     *scan* has heredocs, here-strings, prose args and quoted strings blanked —
     for the noisy/gh rules, where a commit message merely mentioning pytest is
-    prose. *scan_cat* keeps quoted content but drops the quote characters —
+    prose. *scan_readers* keeps quoted content but drops the quote characters —
     `cat "notes.md"` is still a cat, and command-position anchoring is what
     protects the reader rules from prose.
     """
@@ -135,8 +155,8 @@ def prepare(cmd):
     blanked = re.sub(HERESTRING, "''", blanked)
     blanked = re.sub(PROSE_ARG, r"\1 ''", blanked)
     scan = re.sub(QUOTED, lambda m: "''" if m.group(0)[0] == "'" else '""', blanked)
-    scan_cat = re.sub(QUOTED, lambda m: m.group(0)[1:-1], blanked)
-    return scan, scan_cat
+    scan_readers = re.sub(QUOTED, lambda m: m.group(0)[1:-1], blanked)
+    return scan, scan_readers
 
 
 # A command segment ends at `;`, newline, `&&`, `||`, or a bare `&` — but not
@@ -153,25 +173,29 @@ def segment(text, start):
 def lands_in_file(seg):
     """True when the segment's output reaches a file, not the context.
 
-    A file redirect in the first pipe stage (a digit before `>` is an fd
-    redirect, `2>`, not a landing), or a PowerShell file cmdlet downstream.
+    A file redirect in any pipe stage (`… | jq .body > x` lands; a digit
+    before `>` is an fd redirect, `2>`, not a landing), or a PowerShell file
+    cmdlet downstream.
     """
-    first = seg.split("|", 1)[0]
-    if re.search(r"(?<!\d)>\s*\S", first):
+    if re.search(r"(?<!\d)>\s*\S", seg):
         return True
     return re.search(r"\|\s*(?:Out-File|Set-Content|Add-Content)\b", seg) is not None
 
 
 def piped_or_redirected(seg):
-    """True when a reader's output is piped onward or lands in a file."""
-    return "|" in seg or lands_in_file(seg)
+    """True when a reader's output is piped onward (into something that is
+    not a pass-through filter) or lands in a file."""
+    if lands_in_file(seg):
+        return True
+    stages = seg.split("|")[1:]
+    return bool(stages) and not any(PASSTHROUGH.match(st) for st in stages)
 
 
 def check(tool_name, cmd):
     """The block message for *cmd*, or None when it passes."""
     if tool_name not in SHELL_TOOLS:
         return None
-    scan, scan_cat = prepare(cmd or "")
+    scan, scan_readers = prepare(cmd or "")
 
     # 1. Noisy runs land in a file.
     for m in re.finditer(NOISY, scan):
@@ -180,20 +204,28 @@ def check(tool_name, cmd):
 
     # 2. gh views/diffs land in a file.
     for m in re.finditer(r"\bgh\s+(?:issue\s+view|pr\s+view|pr\s+diff)\b", scan):
-        if not lands_in_file(segment(scan, m.start())):
+        seg = segment(scan, m.start())
+        if not lands_in_file(seg) and "--web" not in seg:
             return GH_MSG
 
-    # 3a. for-loop cat sweep: `for f in src/*.py; do cat $f; done`
-    if re.search(r"\bfor\b[^;]*" + GUARDED_EXT_RE + r".*\bcat\b", scan_cat):
+    # 3a. for-loop cat sweep: `for f in src/*.py; do cat $f; done` — the cat
+    # must sit inside the loop body.
+    if re.search(
+        r"\bfor\b[^;\n]*"
+        + GUARDED_EXT_RE.pattern
+        + r"[\s\S]*?\bdo\b[\s\S]*?\bcat\b[\s\S]*?\bdone\b",
+        scan_readers,
+        re.I,
+    ):
         return CAT_LOOP_MSG
 
     # 3b. Whole-file readers.
-    for m in READER.finditer(scan_cat):
+    for m in READER.finditer(scan_readers):
         name = m.group("cmd")
         args = m.group("args")
-        if not re.search(GUARDED_EXT_RE, args):
+        if not GUARDED_EXT_RE.search(args):
             continue
-        if piped_or_redirected(segment(scan_cat, m.start("cmd"))):
+        if piped_or_redirected(segment(scan_readers, m.start("cmd"))):
             continue
         if whole_file(name, args):
             return WHOLE_FILE_MSG
@@ -209,9 +241,7 @@ def whole_file(name, args):
             return True
         # Get-Content and type (its alias) — bounded by -TotalCount / -Tail
         # (aliases -Head/-First/-Last).
-        return not any(
-            re.match(r"-(?:TotalCount|Tail|Head|First|Last)\b", t, re.I) for t in tokens
-        )
+        return not any(PS_COUNT_FLAG.match(t) for t in tokens)
     if name in ("head", "tail"):
         if any(re.match(r"-c\b|--bytes\b", t) for t in tokens):
             return True
@@ -226,7 +256,10 @@ def whole_file(name, args):
         else:
             rest = [t for t in tokens if not t.startswith("-")]
             script = rest[0] if len(rest) > 1 else ""
-        return script.replace("\\", "") in ("", "p", "1,$p")
+            # `1,$ p` splits the address from the command.
+            if script == "1,$" and len(rest) > 2 and rest[1] == "p":
+                script = "1,$p"
+        return script.replace("\\", "") in ("", "p", "1,$p", "$!p")
     return False
 
 

--- a/.claude/hooks/guard_ext.py
+++ b/.claude/hooks/guard_ext.py
@@ -1,0 +1,37 @@
+"""The one guarded-extension list both context hooks import.
+
+Text formats where a whole-file pull is the thing being rationed — by the
+Read guard's size rule and by the context guard's whole-file-dump rules
+(`cat`, `sed -n p`, `head`/`tail` with no count, `Get-Content`, `type`).
+Anything unlisted (images, PDFs, notebooks, extensionless files) passes: a
+line count is meaningless there.
+
+Markdown is in the list for the shell readers — `cat CONTEXT.md` is a
+whole-file pull like any other — but the Read guard's *size* rule exempts it
+locally: reading a whole ADR or CONTEXT.md through Read is the intended use.
+
+Defined once here so the two hooks cannot drift again (#248: `.toml` was
+guarded by one hook and not the other).
+"""
+
+GUARDED_EXT = frozenset(
+    {
+        ".md",
+        ".py",
+        ".pyi",
+        ".js",
+        ".jsx",
+        ".ts",
+        ".tsx",
+        ".json",
+        ".yml",
+        ".yaml",
+        ".toml",
+        ".sh",
+        ".ini",
+        ".cfg",
+        ".conf",
+        ".txt",
+        ".log",
+    }
+)

--- a/.claude/hooks/read-guard.py
+++ b/.claude/hooks/read-guard.py
@@ -8,7 +8,7 @@ PreToolUse on Read, blocking (exit 2) on either rule:
      buys nothing. Any offset/limit is the escape: wanting a different section
      of a big file is legitimate.
   2. Big first read: a whole-file Read of a guarded-extension repo file
-     (GUARDED_EXT below) over BIG_FILE_LINES — CLAUDE.md's "ranged (grep first)
+     (GUARDED_EXT, shared via guard_ext.py) over BIG_FILE_LINES — CLAUDE.md's "ranged (grep first)
      on big files". Here the escape is `limit`, since a bare `offset` still
      pulls Read's 2000-line default. A deliberate `offset: 1, limit: <n>` passes,
      so this is a speed bump rather than a wall.
@@ -29,28 +29,13 @@ import tempfile
 
 BIG_FILE_LINES = 400
 
-# Text formats where a whole-file pull is the thing being rationed. Markdown is
-# deliberately absent: reading a whole ADR or CONTEXT.md is the intended use.
-# Anything unlisted (images, PDFs, notebooks, extensionless files) passes — a
-# line count is meaningless there.
-GUARDED_EXT = {
-    ".py",
-    ".pyi",
-    ".js",
-    ".jsx",
-    ".ts",
-    ".tsx",
-    ".json",
-    ".yml",
-    ".yaml",
-    ".toml",
-    ".sh",
-    ".ini",
-    ".cfg",
-    ".conf",
-    ".txt",
-    ".log",
-}
+# The guarded-extension list is shared with context-guard.py (guard_ext.py,
+# same directory) so the two hooks cannot drift. Markdown is exempt from the
+# *size* rule here: reading a whole ADR or CONTEXT.md is the intended use.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from guard_ext import GUARDED_EXT  # noqa: E402
+
+SIZE_RULE_EXEMPT = {".md"}
 
 
 def in_project(path):
@@ -121,7 +106,7 @@ if event == "PreToolUse" and tool == "Read":
     # whole of any file this rule covers.
     if (
         "limit" not in tool_input
-        and os.path.splitext(path)[1].lower() in GUARDED_EXT
+        and os.path.splitext(path)[1].lower() in GUARDED_EXT - SIZE_RULE_EXEMPT
         and in_project(path)
     ):
         lines = line_count(path)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|PowerShell",
         "hooks": [
           {
             "type": "command",

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.test_read_guard import hook_env
+
 HOOKS = Path(__file__).resolve().parents[1] / ".claude" / "hooks"
 HOOK = HOOKS / "context-guard.py"
 SETTINGS = Path(__file__).resolve().parents[1] / ".claude" / "settings.json"
@@ -39,7 +41,7 @@ def run_hook(command: str, tool: str = "Bash") -> subprocess.CompletedProcess[st
         input=json.dumps(payload),
         capture_output=True,
         text=True,
-        env={"SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"), "PATH": ""},
+        env=hook_env(Path(os.environ.get("TEMP", "."))),
     )
 
 
@@ -157,6 +159,8 @@ def test_unredirected_gh_view_or_diff_is_blocked(command: str) -> None:
         "gh pr view 252 --json body,comments > pr.scratch.log",
         "gh pr diff 252 > pr.scratch.log",
         "gh pr diff 252 > pr.scratch.log 2>&1",
+        "gh issue view 248 --json body | jq -r .body > issue.scratch.log",
+        "gh issue view 248 --web",
         "gh pr checks 252",
         "gh pr list --json number,title",
         "gh issue list --label bug",
@@ -219,6 +223,15 @@ def test_git_commit_message_mentioning_pytest_and_cat_passes() -> None:
         "cd src && cat x.py",
         "ls; cat src/x.py",
         "if true; then cat src/x.py; fi",
+        "cat src/X.PY",
+        "cat SRC\\CONFIG.JSON",
+        "cat src/x.py | cat",
+        "cat src/x.py | cat -n",
+        "cat src/x.py | nl",
+        "cat src/x.py | tee copy.py",
+        "cat src/x.py | less",
+        "cat src/x.py | more",
+        "cat src/x.py | grep -v '^$' | cat -n",
     ],
 )
 def test_cat_of_guarded_file_is_blocked(command: str) -> None:
@@ -232,7 +245,10 @@ def test_cat_of_guarded_file_is_blocked(command: str) -> None:
     [
         "cat src/x.py | grep -n def",
         "cat src/x.py | head -20",
+        "cat src/x.py | jq . > out.json",
         "cat src/x.py > /tmp/copy.py",
+        "cat src/x.py.bak",
+        "cat src/x.py.orig",
         "cat src/x.py >> combined.py",
         "cat > out.py <<'EOF'\nprint(1)\nEOF",
         "cat <<'EOF' > out.py\nprint(1)\nEOF",
@@ -251,6 +267,19 @@ def test_cat_piped_redirected_or_not_a_guarded_file_passes(command: str) -> None
 def test_for_loop_cat_sweep_is_blocked() -> None:
     msg = blocked("for f in src/resolve_mcp/*.py; do cat $f; done")
     assert "cat loop" in msg
+    blocked("for f in src/*.py\ndo\n  cat $f\ndone")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "for f in src/*.py; do wc -l $f; done | cat",
+        "for f in src/*.py; do wc -l $f; done; git cat-file -p HEAD:x",
+        "for f in src/*.py; do grep -c def $f; done",
+    ],
+)
+def test_for_loop_without_cat_in_body_passes(command: str) -> None:
+    passes(command)
 
 
 @pytest.mark.parametrize(
@@ -264,6 +293,8 @@ def test_for_loop_cat_sweep_is_blocked() -> None:
         "sed '' src/x.py",
         "sed -e p src/x.py",
         "sed -n p CLAUDE.md",
+        "sed -n '1,$ p' src/x.py",
+        "sed -n '$!p' src/x.py",
     ],
 )
 def test_sed_whole_file_is_blocked(command: str) -> None:
@@ -339,6 +370,11 @@ def test_head_tail_with_count_or_no_file_passes(command: str) -> None:
         "type pytest.scratch.log",
         "cat .\\src\\x.py",
         "Get-Content $env:CLAUDE_JOB_DIR\\tmp\\out.log",
+        "Get-Content src/x.py | Out-String",
+        "Get-Content src/x.py | Write-Output",
+        "Get-Content src/x.py | Format-Table",
+        "Get-Content src/x.py | Out-Host",
+        "Get-Content SRC\\X.PY",
     ],
 )
 def test_powershell_whole_file_readers_are_blocked(command: str) -> None:
@@ -354,6 +390,9 @@ def test_powershell_whole_file_readers_are_blocked(command: str) -> None:
         "Get-Content src/x.py -Head 20",
         "Get-Content src/x.py -First 20",
         "Get-Content src/x.py -Last 20",
+        "gc src/x.py -tot 5",
+        "Get-Content src/x.py -Total 5",
+        "Get-Content src/x.py -TotalCount:5",
         "Get-Content C:\\repo\\src\\x.py -TotalCount 50",
         "Get-Content src/x.py | Select-String def",
         "Get-Content src/x.py | Select-Object -Last 20",
@@ -425,7 +464,7 @@ def test_garbage_payload_passes() -> None:
         input="not json",
         capture_output=True,
         text=True,
-        env={"SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"), "PATH": ""},
+        env=hook_env(Path(os.environ.get("TEMP", "."))),
     )
     assert result.returncode == 0
 
@@ -477,14 +516,7 @@ def test_every_shared_extension_is_guarded_by_both_hooks(ext: str, tmp_path: Pat
         input=json.dumps(payload),
         capture_output=True,
         text=True,
-        env={
-            "SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"),
-            "PATH": "",
-            "TMPDIR": str(tmp_path),
-            "TEMP": str(tmp_path),
-            "TMP": str(tmp_path),
-            "CLAUDE_PROJECT_DIR": str(tmp_path),
-        },
+        env=hook_env(tmp_path, tmp_path),
     )
     assert result.returncode == 2, result.stderr
 

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -1,0 +1,510 @@
+"""Fake-tier tests for the PreToolUse shell guard in ``.claude/hooks/``.
+
+Like ``test_read_guard.py``: the hook is executable config, so the process
+boundary is the seam — each case drives the real script with the tool payload
+on stdin and reads the exit code (2 = blocked, message on stderr).
+
+Coverage follows #248: bare and piped noisy runs, ``gh`` views/diffs with and
+without a redirect, whole-file vs ranged reads for every reader the rule names,
+backslash and drive-letter paths, the ``--body`` false positives, heredoc
+forms, the PowerShell tool, and the shared guarded-extension list.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS = Path(__file__).resolve().parents[1] / ".claude" / "hooks"
+HOOK = HOOKS / "context-guard.py"
+SETTINGS = Path(__file__).resolve().parents[1] / ".claude" / "settings.json"
+
+
+def run_hook(command: str, tool: str = "Bash") -> subprocess.CompletedProcess[str]:
+    payload = {
+        "session_id": "s1",
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool,
+        "tool_input": {"command": command},
+    }
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={"SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"), "PATH": ""},
+    )
+
+
+def blocked(command: str, tool: str = "Bash") -> str:
+    """Assert the command is blocked; return the block message."""
+    result = run_hook(command, tool)
+    assert result.returncode == 2, f"expected block for {command!r}: {result.stderr}"
+    assert result.stderr.startswith("Blocked (context discipline)")
+    return result.stderr
+
+
+def passes(command: str, tool: str = "Bash") -> None:
+    result = run_hook(command, tool)
+    assert result.returncode == 0, f"expected pass for {command!r}: {result.stderr}"
+
+
+# --- noisy runs ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "uv run pytest -m 'not live'",
+        "uv run pytest tests/test_config.py -q",
+        "pytest",
+        "python -m pytest tests",
+        "python3 -m pytest -q",
+        "uv run mypy src tests",
+        "uv run ruff check src",
+        "CI=1 uv run pytest",
+        "uv run pytest -q 2>&1",
+        "cd src && uv run pytest",
+    ],
+)
+def test_bare_noisy_run_is_blocked(command: str) -> None:
+    msg = blocked(command)
+    assert "pytest.scratch.log" in msg
+    assert "> pytest.scratch.log 2>&1" in msg
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "uv run pytest -q | tail -20",
+        "uv run pytest -q 2>&1 | tail",
+        "uv run mypy src | head -30",
+        "uv run ruff check src | grep -c error",
+        "uv run pytest 2>&1 | Select-Object -Last 20",
+    ],
+)
+def test_piped_noisy_run_is_blocked(command: str) -> None:
+    blocked(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "uv run pytest -m 'not live' > pytest.scratch.log 2>&1",
+        "uv run pytest tests/test_config.py -q > pytest.scratch.log 2>&1",
+        "uv run mypy src tests > mypy.scratch.log 2>&1",
+        "uv run ruff check src tests > ruff.scratch.log 2>&1",
+        "uv run pytest -q >> pytest.scratch.log 2>&1",
+        "uv run pytest -q &> pytest.scratch.log",
+        "uv run pytest -q 2>&1 | Out-File pytest.scratch.log",
+        "python -m pytest > pytest.scratch.log 2>&1",
+    ],
+)
+def test_redirected_noisy_run_passes(command: str) -> None:
+    passes(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "grep -E 'FAILED|passed|error' pytest.scratch.log",
+        "rm pytest.scratch.log ruff.scratch.log",
+        "git commit -m 'fix: pytest run was flaky'",
+        'git commit -m "run pytest | tail after this"',
+        "echo pytest",
+        "ls tests/test_pytest_things.py",
+    ],
+)
+def test_prose_and_paths_mentioning_noisy_tools_pass(command: str) -> None:
+    passes(command)
+
+
+# --- gh views and diffs -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh issue view 248",
+        "gh issue view 248 --comments",
+        "gh issue view 248 --json body -q .body",
+        "gh pr view 252",
+        "gh pr view 252 --json state,title -q .state",
+        "gh pr diff 252",
+        "gh pr diff 252 --name-only",
+        "gh pr diff 252 | head -100",
+        "gh issue view 248 --json body,comments 2>&1",
+    ],
+)
+def test_unredirected_gh_view_or_diff_is_blocked(command: str) -> None:
+    msg = blocked(command)
+    assert "issue.scratch.log" in msg
+    assert "gh pr diff <n> > pr.scratch.log" in msg
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh issue view 248 --json body -q .body > issue.scratch.log",
+        "gh issue view 248 --comments > comments.scratch.log 2>&1",
+        "gh pr view 252 --json body,comments > pr.scratch.log",
+        "gh pr diff 252 > pr.scratch.log",
+        "gh pr diff 252 > pr.scratch.log 2>&1",
+        "gh pr checks 252",
+        "gh pr list --json number,title",
+        "gh issue list --label bug",
+    ],
+)
+def test_redirected_gh_view_or_other_gh_passes(command: str) -> None:
+    passes(command)
+
+
+# --- the --body false positives -----------------------------------------------
+
+
+def test_pr_create_body_mentioning_a_cat_loop_passes() -> None:
+    """Observed false positive: the body's prose read as a `for … *.py … cat` sweep."""
+    passes(
+        "gh pr create --title 'refactor: hooks' --body \"Before: for f in src/*.py; "
+        'do cat $f; done pulled 162KB into context. Now blocked."'
+    )
+
+
+def test_issue_comment_body_mentioning_a_tail_pipe_passes() -> None:
+    """Observed false positive: an apostrophe inside the double-quoted body
+    paired with a later one, unquoting `pytest … | tail` in between."""
+    passes(
+        'gh issue comment 248 --body "Don\'t run uv run pytest -q | tail -20; '
+        "it caps one run. That's the rule.\""
+    )
+
+
+def test_pr_create_body_from_heredoc_passes() -> None:
+    passes(
+        "gh pr create --title 'x' --body \"$(cat <<'EOF'\n"
+        "## Summary\n"
+        "for f in tests/*.py; do cat $f; done — was the pattern.\n"
+        "uv run pytest | tail is also gone. gh pr diff 1 too.\n"
+        "EOF\n)\""
+    )
+
+
+def test_git_commit_message_mentioning_pytest_and_cat_passes() -> None:
+    passes("git commit -m 'test: cat src/x.py and pytest | tail no more'")
+
+
+# --- whole-file readers -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat src/resolve_mcp/config.py",
+        "cat -n src/resolve_mcp/config.py",
+        "cat CLAUDE.md",
+        "cat pyproject.toml",
+        "cat pytest.scratch.log",
+        "cat .claude/settings.json",
+        "cat 'src/resolve_mcp/config.py'",
+        'cat "docs/notes.md"',
+        "cat src/a.py src/b.py",
+        "cat src/x.py 2>&1",
+        "cd src && cat x.py",
+        "ls; cat src/x.py",
+        "if true; then cat src/x.py; fi",
+    ],
+)
+def test_cat_of_guarded_file_is_blocked(command: str) -> None:
+    msg = blocked(command)
+    assert "Read tool" in msg
+    assert "offset/limit" in msg
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat src/x.py | grep -n def",
+        "cat src/x.py | head -20",
+        "cat src/x.py > /tmp/copy.py",
+        "cat src/x.py >> combined.py",
+        "cat > out.py <<'EOF'\nprint(1)\nEOF",
+        "cat <<'EOF' > out.py\nprint(1)\nEOF",
+        "cat <<EOF\nnot a file\nEOF",
+        "cat frame.png",
+        "cat Makefile",
+        "cat",
+        "echo cat src/x.py",
+        "git cat-file -p HEAD:src/x.py",
+    ],
+)
+def test_cat_piped_redirected_or_not_a_guarded_file_passes(command: str) -> None:
+    passes(command)
+
+
+def test_for_loop_cat_sweep_is_blocked() -> None:
+    msg = blocked("for f in src/resolve_mcp/*.py; do cat $f; done")
+    assert "cat loop" in msg
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sed -n p src/x.py",
+        "sed -n '1,$p' src/x.py",
+        'sed -n "1,$p" src/x.py',
+        "sed -n 1,\\$p src/x.py",
+        "sed p src/x.py",
+        "sed '' src/x.py",
+        "sed -e p src/x.py",
+        "sed -n p CLAUDE.md",
+    ],
+)
+def test_sed_whole_file_is_blocked(command: str) -> None:
+    blocked(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sed -n 10,40p src/x.py",
+        "sed -n '10,40p' src/x.py",
+        "sed -n 130,175p pr252.scratch.log",
+        "sed -n '/^def /,/^$/p' src/x.py",
+        "sed -n 5p src/x.py",
+        "sed -i 's/old/new/' src/x.py",
+        "sed -i '' 's/old/new/' src/x.py",
+        "sed 's/a/b/' src/x.py > out.py",
+        "sed -n p src/x.py | grep def",
+        "sed -e 's/a/b/' -e 's/c/d/' src/x.py",
+    ],
+)
+def test_sed_ranged_or_editing_passes(command: str) -> None:
+    passes(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "head src/x.py",
+        "tail src/x.py",
+        "head -c 4000 src/x.py",
+        "head --bytes=400 src/x.py",
+        "tail -f pytest.scratch.log",
+        "head CLAUDE.md",
+        "tail pytest.scratch.log",
+    ],
+)
+def test_head_tail_without_count_is_blocked(command: str) -> None:
+    blocked(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "head -50 src/x.py",
+        "head -n 50 src/x.py",
+        "head -n50 src/x.py",
+        "head --lines=50 src/x.py",
+        "tail -20 pytest.scratch.log",
+        "tail -n 20 pytest.scratch.log",
+        "tail -n +5 src/x.py",
+        "grep -n def src/x.py | head -5",
+        "git log --oneline | head -20",
+        "head src/x.py | grep import",
+        "head src/x.py > first.txt",
+    ],
+)
+def test_head_tail_with_count_or_no_file_passes(command: str) -> None:
+    passes(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "Get-Content src/x.py",
+        "Get-Content -Path src\\resolve_mcp\\config.py",
+        "Get-Content C:\\Users\\Daniel\\repos\\resolve-mcp\\src\\x.py",
+        "Get-Content .\\CLAUDE.md",
+        "Get-Content 'C:\\Users\\Daniel\\repos\\resolve-mcp\\pyproject.toml'",
+        "Get-Content src/x.py -Raw",
+        "gc src/x.py",
+        "type src\\x.py",
+        "type pytest.scratch.log",
+        "cat .\\src\\x.py",
+        "Get-Content $env:CLAUDE_JOB_DIR\\tmp\\out.log",
+    ],
+)
+def test_powershell_whole_file_readers_are_blocked(command: str) -> None:
+    blocked(command, tool="PowerShell")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "Get-Content src/x.py -TotalCount 50",
+        "Get-Content -TotalCount 50 src\\x.py",
+        "Get-Content src/x.py -Tail 20",
+        "Get-Content src/x.py -Head 20",
+        "Get-Content src/x.py -First 20",
+        "Get-Content src/x.py -Last 20",
+        "Get-Content C:\\repo\\src\\x.py -TotalCount 50",
+        "Get-Content src/x.py | Select-String def",
+        "Get-Content src/x.py | Select-Object -Last 20",
+        "Get-Content src/x.py > copy.py",
+        "type python3",
+        "Get-Content frame.png -Encoding Byte",
+        "gc",
+    ],
+)
+def test_powershell_ranged_or_piped_readers_pass(command: str) -> None:
+    passes(command, tool="PowerShell")
+
+
+def test_same_rules_apply_under_both_shell_tools() -> None:
+    """A PowerShell command (`Get-Content x.py`) is blocked in the fake tier — #248 AC."""
+    blocked("Get-Content x.py", tool="PowerShell")
+    blocked("Get-Content x.py", tool="Bash")
+    blocked("cat x.py", tool="PowerShell")
+    blocked("uv run pytest -q", tool="PowerShell")
+    blocked("gh pr diff 252", tool="PowerShell")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat C:\\Users\\Daniel\\repos\\resolve-mcp\\src\\x.py",
+        "cat .\\src\\x.py",
+        "cat src\\x.py",
+        "head C:/Users/Daniel/repos/resolve-mcp/src/x.py",
+        "sed -n p C:\\repo\\src\\x.py",
+    ],
+)
+def test_backslash_and_drive_letter_paths_are_recognised(command: str) -> None:
+    blocked(command)
+
+
+# --- heredoc and here-string forms --------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python3 - <<'EOF'\nimport subprocess\nsubprocess.run(['pytest'])\nEOF",
+        "cat <<'EOF' > tests/new.py\nfor f in src/*.py:\n    cat = 1\nEOF",
+        "cat <<-EOF > x.md\n\tuv run pytest | tail\n\tEOF",
+        "git commit -m @'\nrun pytest | tail\ncat src/x.py\n'@",
+        'git commit -F - <<EOF\ncat src/x.py\ngh pr diff 3\nEOF',
+    ],
+)
+def test_heredoc_and_herestring_bodies_are_data(command: str) -> None:
+    passes(command)
+
+
+def test_command_after_a_heredoc_is_still_checked() -> None:
+    blocked("cat <<'EOF' > x.md\nhello\nEOF\ncat src/x.py")
+
+
+# --- unrelated tools and payloads ---------------------------------------------
+
+
+def test_other_tools_pass() -> None:
+    passes("cat src/x.py", tool="Read")
+    passes("uv run pytest", tool="Grep")
+
+
+def test_garbage_payload_passes() -> None:
+    result = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input="not json",
+        capture_output=True,
+        text=True,
+        env={"SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"), "PATH": ""},
+    )
+    assert result.returncode == 0
+
+
+def test_empty_command_passes() -> None:
+    passes("")
+
+
+# --- the shared guarded-extension list ----------------------------------------
+
+
+def _load_guard_ext() -> frozenset[str]:
+    spec = importlib.util.spec_from_file_location("guard_ext", HOOKS / "guard_ext.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    ext: frozenset[str] = module.GUARDED_EXT
+    return ext
+
+
+def test_guarded_extension_list_is_defined_once_and_imported_by_both_hooks() -> None:
+    """The one list lives in guard_ext.py; neither hook keeps its own literal."""
+    ext = _load_guard_ext()
+    assert {".py", ".toml", ".json", ".log", ".md"} <= ext
+    for hook in ("context-guard.py", "read-guard.py"):
+        source = (HOOKS / hook).read_text(encoding="utf-8")
+        assert "from guard_ext import GUARDED_EXT" in source, hook
+        assert not re.search(r"^GUARDED_EXT\s*=", source, re.M), hook
+        assert not re.search(r"^SRC_EXT\s*=", source, re.M), hook
+
+
+@pytest.mark.parametrize("ext", sorted(_load_guard_ext() - {".md"}))
+def test_every_shared_extension_is_guarded_by_both_hooks(ext: str, tmp_path: Path) -> None:
+    """Identical lists in practice: each extension blocks a `cat` here and a big
+    whole-file Read in the Read guard (markdown is that guard's documented
+    size-rule exemption, checked separately)."""
+    blocked(f"cat src/file{ext}")
+
+    big = tmp_path / f"file{ext}"
+    big.write_text("".join(f"line {i}\n" for i in range(500)), encoding="utf-8")
+    payload = {
+        "session_id": "s-ext",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(big)},
+    }
+    result = subprocess.run(
+        [sys.executable, str(HOOKS / "read-guard.py")],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={
+            "SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"),
+            "PATH": "",
+            "TMPDIR": str(tmp_path),
+            "TEMP": str(tmp_path),
+            "TMP": str(tmp_path),
+            "CLAUDE_PROJECT_DIR": str(tmp_path),
+        },
+    )
+    assert result.returncode == 2, result.stderr
+
+
+def test_markdown_is_cat_guarded_but_read_size_exempt(tmp_path: Path) -> None:
+    blocked("cat CONTEXT.md")
+    passes("cat CONTEXT.md | grep -n seam")
+
+
+# --- settings.json wiring -----------------------------------------------------
+
+
+def test_settings_match_both_shell_tools_for_the_context_guard() -> None:
+    settings = json.loads(SETTINGS.read_text(encoding="utf-8"))
+    guards = [
+        entry
+        for entry in settings["hooks"]["PreToolUse"]
+        if any("context-guard.py" in h["command"] for h in entry["hooks"])
+    ]
+    assert len(guards) == 1
+    matcher = guards[0]["matcher"]
+    assert re.fullmatch(matcher, "Bash")
+    assert re.fullmatch(matcher, "PowerShell")


### PR DESCRIPTION
Closes #248.

## What

The context-discipline hook fired only on `Bash` and only on the `| tail` form; the PowerShell tool, bare `pytest|mypy|ruff` runs, unredirected `gh … view` / `pr diff`, and every reader but `cat` walked round it. Now:

- `settings.json` matches `Bash|PowerShell`; the hook checks both tools with the same rules.
- Noisy runs and `gh issue view|pr view|pr diff` are blocked unless their output lands in a file (`>` in any pipe stage, `Out-File`/`Set-Content`); the block messages show the one-command redirect templates. `gh … --web` passes.
- Whole-file dumps of a guarded file are blocked whichever reader fetches them — `cat`, `sed -n p` / `1,$p` / `1,$ p` / `$!p` / `sed ''`, `head`/`tail` with no count, `head -c`, `Get-Content`/`gc`/`type` without `-TotalCount`/`-Tail`/`-Head`/`-First`/`-Last` (PowerShell prefixes like `-Tot` accepted). Ranged reads pass; so does anything redirected or piped into a real filter — but not into a pass-through (`| cat`, `| nl`, `| tee`, `| less`, `| Out-String`, `| Format-*` …). Backslash and drive-letter paths are recognised; extension match is case-insensitive.
- One guarded-extension list, `.claude/hooks/guard_ext.py`, imported by both hooks (`.toml`, `.pyi`, `.jsx`, `.tsx`, `.cfg` now cat-guarded too). The Read guard keeps its documented markdown size-rule exemption locally.
- `--body` / `--title` / `-m` arguments are never inspected, and quotes are parsed as one alternation so an apostrophe inside a double-quoted string no longer unquotes the text after it — the two observed false positives (`gh pr create --body …` as a cat loop, `gh issue comment --body …` as a tail pipe).
- `tests/test_context_guard.py` (214 cases with `test_read_guard.py`) drives the real script over the process seam: bare/piped/redirected noisy runs, gh with and without redirect, whole-file vs ranged for every reader, backslash/drive-letter paths, both `--body` false positives, heredoc and here-string forms, PowerShell tool, the shared list, the settings matcher.

## Seam

Fake tier — hooks are executable config; the process boundary (JSON on stdin, exit code out) is the seam, same as `test_read_guard.py`. Full fake tier: 2527 passed; mypy strict and ruff clean.

## AC4 (CLAUDE.md prose)

Lives in open PR #252, which rewrites the same context-discipline paragraph (all six redirect templates + "`sed -n` or `head` on the same file is the same cost"). Not touched here to avoid a conflict. Two small gaps for #252 or a follow-up: no `gh pr view <n>` template in the block, and the "hooks enforce" sentence should name PowerShell readers (`Get-Content`, `type`).

## Review record

`/code-review` (mattpocock two-axis) against `origin/main`.

**Standards** — conform (test seam, hook-test style). Findings and resolutions:
- `gh … | jq .body > x` blocked (redirect only checked in first pipe stage) → any stage counts now.
- `for … done | cat` / `done; git cat-file` matched the cat-loop rule → rule requires `cat` inside `do … done`.
- `x.py.bak` matched the extension → `(?![\w.])`.
- `head -c` blocked — kept, the ticket names it.
- `hook_env` re-inlined in tests → imported from `test_read_guard`; `scan_cat` → `scan_readers`.
- Bypasses noted, out of scope (not spec-listed readers): `find -exec cat`, `xargs cat`, `awk 1`, `grep '' file`, `less`/`more` direct, non-`uv`/`python -m` launchers. Speed-bump philosophy as in the Read guard.

**Spec** — every AC met except AC4 (see above; acceptable per the issue comment). Findings and resolutions:
- Pass-through pipes (`| cat`, `| nl`, `| tee`, `| less`, `| Out-String`, `| Write-Output`, `| Format-*`) counted as "piped onward" → now still a whole-file dump.
- Case-sensitive extension (`cat src/X.PY` passed) → `re.I`.
- `sed -n '1,$ p'`, `sed -n '$!p'` passed → whole-file.
- `-tot 5` prefix abbreviations blocked → prefixes accepted; `gh … --web` blocked → passes.
- Strict `gh pr view … -q .state` block — kept, the ticket says redirect required.

Focused re-check of the fix diff (`2bc1c77..d75d46c`): one finding, a misread (the `| cat`/`| less` cases sit in the *blocked* parametrize); the rest verified.

Review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
