### PR TITLE
Context guard: PowerShell matcher, bare pytest/gh redirects, all whole-file readers, tests (#249)

### DIFF
--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -7,19 +7,20 @@ Blocks (exit 2, message to the model):
      tail/head/cat/Select-Object, or piped anywhere else — the scratch-log+grep
      rule. `--version`, `--help` and `--collect-only` are not runs.
   2. `gh issue view` / `gh pr view` / `gh pr diff` that do not land in a file.
-     A `--json … -q` field filter passes unless it pulls the body or the
-     comment thread; `gh pr diff --name-only|--stat` passes.
+     A `--json … -q`/`--template` field filter passes unless it pulls the body
+     or the comment thread; `gh pr diff --name-only|--stat` passes.
   3. A whole-file dump of a guarded file (guarded_ext.py) by any reader —
      `cat`, `more`, `less`, `type`, `Get-Content`/`gc`, `sed -n` with no range
      or `1,$p`, `head`/`tail` with no count, `head -c` — that is neither piped
-     onward nor redirected. Ranged reads (`sed -n 10,40p`, `head -50`,
-     `Get-Content -TotalCount 50`) pass. Backslash and drive-letter paths count.
-  4. A `for` loop that cats guarded files.
+     to a filter nor redirected. Ranged reads (`sed -n 10,40p`, `head -50`,
+     `Get-Content -TotalCount 50`) pass. Backslash and drive-letter paths count,
+     and so do readers fed by `xargs`, `find -exec`, or a `Get-ChildItem` pipe.
+  4. A `for`/`foreach` loop over guarded files whose body dumps them.
 
-Heredoc / here-string bodies and `--body`/`--message`/`--title` arguments are
-data, not commands, and are blanked before any rule looks (the two false
-positives measured in the 2026-08-15 audit were `gh pr create --body …` and
-`gh issue comment --body …`).
+Heredoc / here-string bodies and quoted `--body`/`--message`/`--title`
+arguments are data, not commands, and are blanked before any rule looks (the
+two false positives measured in the 2026-08-15 audit were `gh pr create
+--body …` and `gh issue comment --body …`).
 
 Measured motivation (2026-08 transcript audits): 233 piped harness runs with
 zero scratch-file adoption; one 237k-token session that pulled 162KB via `cat`
@@ -39,8 +40,13 @@ from guarded_ext import GUARDED_EXT_RE  # noqa: E402
 SHELL_TOOLS = {"Bash", "PowerShell"}
 # The commands whose full output belongs in a scratch log, never in context.
 NOISY_TOOLS = r"pytest|mypy|ruff"
-# Launcher prefixes those commands may hide behind in this repo.
-LAUNCHERS = r"(?:uv\s+run\s+(?:-\S+\s+)*|python3?\s+-m\s+)"
+# Launcher prefixes those commands may hide behind in this repo (`.exe` and
+# `py` are the Windows spellings; `uv run --directory X` carries an option value).
+LAUNCHERS = (
+    r"(?:uv(?:\.exe)?\s+run\s+(?:--?[\w-]+(?:[= ]\S+)?\s+)*"
+    r"|uvx(?:\.exe)?\s+"
+    r"|py(?:thon3?)?(?:\.exe)?\s+-m\s+)"
+)
 
 try:
     data = json.load(sys.stdin)
@@ -63,96 +69,119 @@ def block(message: str) -> None:
 HEREDOC = r"<<-?\s*(['\"]?)(\w+)\1[\s\S]*?\n[ \t]*\2\b"
 # PowerShell here-strings: @' … '@ and @" … "@ (closing token at line start).
 HERESTRING = r"@(['\"])[\s\S]*?\n\1@"
-# Prose arguments: what follows --body/--message/--title (and their short
+# Prose arguments: what follows --body/--message/--title (and the -b/-m short
 # forms) in quotes is text about commands, never a command.
-PROSE_ARG = r"(?i)(?:--body|--message|--title|-[bmt])(?:=|\s+)(?:'[^']*'|\"[^\"]*\")"
+PROSE_ARG = r"(?i)(?:--body|--message|--title|-[bm])(?:=|\s+)(?:'[^']*'|\"[^\"]*\")"
 
 blanked = re.sub(HEREDOC, "<<HEREDOC", cmd)
 blanked = re.sub(HERESTRING, "@HERESTRING@", blanked)
 blanked = re.sub(PROSE_ARG, "--PROSE ''", blanked)
-# The noisy/gh rules blank the remaining quoted strings: a commit message
-# merely mentioning pytest is prose. The dump rules use a quote-STRIPPED copy
-# (quotes removed, content kept): `cat "notes.md"` is still a cat, and
-# command-position anchoring is what protects those rules from prose.
+# The noisy rule blanks the remaining quoted strings: a commit message merely
+# mentioning pytest is prose. The gh rule keeps quotes (a jq filter is what it
+# reads). The dump rules use a quote-STRIPPED copy (quotes removed, content
+# kept): `cat "notes.md"` is still a cat, and command-position anchoring is
+# what protects those rules from prose.
 scan = re.sub(r"'[^']*'", "''", blanked)
 scan = re.sub(r'"[^"]*"', '""', scan)
 scan_cat = re.sub(r"[\"']", "", blanked)
 
 # Command position: line start, a separator (`;`, `&`, `|`, `(`, `)`, `{`,
-# backtick, newline), a $( substitution, or a then/do/else keyword — with
-# env-var assignments (`CI=1 pytest …`) and any chain of launchers
-# (`uv run python -m pytest`) allowed before the tool name.
-CMD_POS = r"(?:^\s*|[;&|(){`\n]\s*|\$\(\s*|\b(?:then|do|else)\s+)"
-# One shell-argument: word chars plus the path characters of both shells —
+# backtick, newline), a `$(` substitution, an `=` (`$c = Get-Content …`), or a
+# then/do/else keyword — with env-var assignments (`CI=1 pytest …`) and any
+# chain of launchers (`uv run python -m pytest`) allowed before the tool name.
+CMD_POS = r"(?:^\s*|[;&|(){`\n=]\s*|\$\(\s*|\b(?:then|do|else)\s+)"
+# One shell argument: word chars plus the path characters of both shells —
 # `\` and `:` so `C:\repo\a.py` and `.\src\a.py` are seen as one arg.
 ARG = r"[\w$./*:\\~{}%+=@,-]+"
-GUARDED = r"\.(?:" + GUARDED_EXT_RE + r")\b"
+# A guarded extension ends the argument: `foo.py.bak`, `foo.py~`, `x.py.orig`
+# are not the file.
+GUARDED = r"\.(?:" + GUARDED_EXT_RE + r")(?![\w.~-])"
+STATEMENT_SEP = r"&&|[;\n]"
 
 
 def statement(text: str, start: int) -> str:
     """The rest of the statement from *start*: up to `;`, `&&`, or a newline —
     pipes stay in, so a pipeline's later stages (its sink) are visible."""
-    return re.split(r"&&|[;\n]", text[start:], 1)[0]
+    return re.split(STATEMENT_SEP, text[start:], 1)[0]
 
 
 def lands_in_file(seg: str) -> bool:
-    """True when the statement's stdout reaches a file: a `>`/`>>`/`1>`/`&>`/`*>`
+    """True when the statement's stdout leaves the context: a `>`/`>>`/`1>`/`&>`/`*>`
     redirect (a `2>` alone is stderr; `>&` is an fd dup), or a PowerShell sink."""
     if re.search(r"(?<![2-9])>(?!&)\s*[^\s&|;]", seg):
         return True
-    return re.search(r"\|\s*(?:Out-File|Set-Content|Add-Content)\b", seg, re.I) is not None
+    return re.search(r"\|\s*(?:Out-File|Set-Content|Add-Content|Out-Null)\b", seg, re.I) is not None
 
 
-PAGERS = r"tail|head|less|more|cat|tee|Select-Object|select|Out-Host|Tee-Object|Out-String"
+# Pipe targets that re-emit rather than filter: after one of these a dump still
+# enters context whole.
+REEMITTERS = r"less|more|cat|nl|tee|Tee-Object|Out-Host|Out-String"
+# For a noisy run, a capping pipe (tail/head/Select-Object) is no better: it caps
+# one run, and runs repeat.
+PAGERS = REEMITTERS + r"|tail|head|Select-Object|select(?![\w-])"
+
+
+def piped_to_filter(seg: str) -> bool:
+    """True when the statement pipes onward to something that bounds or filters
+    it (grep, head -50, Select-Object -First 30, wc …) rather than re-emits it."""
+    stages = seg.split("|")[1:]
+    return bool(stages) and not all(
+        re.match(r"\s*(?:" + REEMITTERS + r")(?![\w-])", st, re.I) for st in stages
+    )
+
 
 # ---------------------------------------------------------------- 1. noisy runs
 NOISY = (
     CMD_POS
     + r"(?:\w+=\S+\s+)*"
     + r"(?:" + LAUNCHERS + r")*"
-    + r"(?P<tool>" + NOISY_TOOLS + r")\b(?![.-])"
+    + r"(?P<tool>" + NOISY_TOOLS + r")(?:\.exe)?\b(?![.-])"
 )
 for m in re.finditer(NOISY, scan):
     seg = statement(scan, m.end())
     tool = m.group("tool")
     if re.search(r"(?:^|\s)(?:--version|--help|-h|--co|--collect-only)\b", seg):
         continue
-    if re.search(r"\|\s*(?:" + PAGERS + r")\b", seg, re.I):
+    if re.search(r"\|\s*(?:" + PAGERS + r")(?![\w-])", seg, re.I):
         block(
             "Blocked (context discipline): noisy runs never pipe to tail/head - a tail caps one run, runs repeat.\n"
-            f"Use one bare command: uv run {tool} > {tool}.scratch.log 2>&1. Then Grep the log for the decisive line (FAILED|passed|error).\n"
+            f"Use one bare command: uv run {tool}{' check' if tool == 'ruff' else ''} > {tool}.scratch.log 2>&1. "
+            "Then Grep the log for the decisive line (FAILED|passed|error).\n"
             "On failure, Grep the log for the failing case by name; never cat the log."
         )
-    if not lands_in_file(seg):
-        block(
-            f"Blocked (context discipline): a bare {tool} run puts its whole output in context.\n"
-            f"Use one bare command: uv run {tool} > {tool}.scratch.log 2>&1 (a redirect the worktree guard accepts - "
-            "no cd, no ;-chain). Then Grep the log for the decisive line (FAILED|passed|error)."
-        )
+    if lands_in_file(seg):
+        continue
+    block(
+        f"Blocked (context discipline): a bare {tool} run puts its whole output in context.\n"
+        f"Use one bare command: uv run {tool}{' check' if tool == 'ruff' else ''} > {tool}.scratch.log 2>&1 "
+        "(a redirect the worktree guard accepts - no cd, no ;-chain). "
+        "Then Grep the log for the decisive line (FAILED|passed|error)."
+    )
 
 # ---------------------------------------------------------------- 2. gh views
 # Issue bodies, comment threads and PR diffs are the largest tool results
 # measured (2026-08-05, 2026-08-15). They land in a file, never in context; a
-# `--json … -q` field filter is fine unless it is the body or the thread.
+# `--json … -q`/`--template` field filter is fine unless it is the body or the
+# thread. Quotes are intact here so the filter expression can be read.
 GH_VIEW = r"\bgh\s+(?P<sub>issue\s+view|pr\s+view|pr\s+diff)\b"
-for m in re.finditer(GH_VIEW, scan):
-    seg = statement(scan, m.end())
+FILTER = r"(?:-q|--jq|-t|--template)(?:=|\s+)(?:'([^']*)'|\"([^\"]*)\"|(\S+))"
+for m in re.finditer(GH_VIEW, blanked):
+    seg = statement(blanked, m.end())
     args = seg.split("|", 1)[0]
     if lands_in_file(seg):
         continue
     if "diff" in m.group("sub") and re.search(r"--(?:name-only|stat)\b", args):
         continue
-    if (
-        "diff" not in m.group("sub")
-        and re.search(r"--json\b", args)
-        and re.search(r"(?:^|\s)(?:-q|--jq)\b", args)
-        and not re.search(r"\b(?:body|comments)\b", args)
-    ):
-        continue
+    f = re.search(FILTER, args)
+    if "diff" not in m.group("sub") and re.search(r"--json\b", args) and f:
+        expr = next(g for g in f.groups() if g is not None)
+        if not re.search(r"\b(?:body|comments)\b", expr):
+            continue
     if "--comments" in args:
         block(
             "Blocked (context discipline): a comment pull lands in a file, never straight in context.\n"
-            "Use one bare command: gh issue view <n> --comments > comments.scratch.log. Then Grep the log - or --json comments with a jq filter to a file."
+            "Use one bare command: gh issue view <n> --comments > comments.scratch.log. "
+            "Then Grep the log - or --json comments with a jq filter to a file."
         )
     block(
         "Blocked (context discipline): gh issue/pr view and pr diff land in a file, never straight in context.\n"
@@ -174,53 +203,72 @@ def guarded_names(args: str) -> list:
     return [a for a in re.findall(ARG, args) if re.search(GUARDED, a)]
 
 
-def dump_block(args: str, seg: str) -> None:
-    """Block when *args* name a guarded file and the statement neither pipes
-    onward nor lands in a file."""
-    names = guarded_names(args)
-    if not names or lands_in_file(seg):
-        return
-    # A pipe to a filter (grep, wc, jq, Select-String…) bounds the read; a pipe
-    # to a pager or a re-emitter (`| cat -n`, `| Out-String`) does not.
-    stages = seg.split("|")[1:]
-    filtered = bool(stages) and not all(
-        re.match(r"\s*(?:cat|more|less|tee|Tee-Object|Out-Host|Out-String)\b", st, re.I)
-        for st in stages
-    )
-    if not filtered:
+def dump_block(names: list, seg: str) -> None:
+    """Block when *names* is non-empty and the statement neither pipes to a
+    filter nor lands in a file."""
+    if names and not lands_in_file(seg) and not piped_to_filter(seg):
         block(DUMP_MSG.format(name=names[0]))
 
 
-# for-loop cat sweep: `for f in src/*.py; do cat $f; done`
-if re.search(r"\bfor\b[^;]*" + GUARDED + r".*\bcat\b", scan_cat):
-    block(
-        "Blocked (context discipline): a cat loop over source files is a mass whole-file Read.\n"
-        "Use the Read tool per file you will edit, or grep for the lines you actually need."
-    )
+# A loop over guarded files whose body dumps them: `for f in src/*.py; do cat
+# $f; done`, `foreach ($f in ls *.py) { cat $f }`, `Get-ChildItem *.py | % { gc $_ }`.
+# The loop variable carries no extension, so the header (or the feeding pipe)
+# is where the extension is seen; the body is judged like any statement.
+READERS = r"(?:cat|more|less|type|Get-Content|gc)"
+LOOP = (
+    r"(?:\bfor\b|\bforeach\b|\bForEach-Object\b|%)(?P<head>[^;{\n]*)(?:;\s*do\b|\{)"
+    r"(?P<body>[\s\S]*?)(?:\bdone\b|\})"
+)
+for m in re.finditer(LOOP, scan_cat):
+    header = scan_cat[: m.start()].rsplit("\n", 1)[-1] + m.group("head")
+    if not guarded_names(header):
+        continue
+    if lands_in_file(statement(scan_cat, m.end())):
+        continue  # `for …; done > all.txt`: the loop's output lands
+    for r in re.finditer(r"(?:^|[;{|&\n])\s*" + READERS + r"\b(?P<rest>[^;}\n]*)", m.group("body"), re.I):
+        if not lands_in_file(r.group("rest")) and not piped_to_filter(r.group("rest")):
+            block(
+                "Blocked (context discipline): a cat loop over source files is a mass whole-file Read.\n"
+                "Use the Read tool per file you will edit, or grep for the lines you actually need."
+            )
 
 # cat / more / less / type / Get-Content / gc: every plain arg is a file. Options
 # and PowerShell parameters are stepped over; `-TotalCount`/`-Tail`/`-Head`/
-# `-First`/`-Last` bound the read and clear it. `cat < x.py` counts too.
-READERS = r"(?:cat|more|less|type|Get-Content|gc)"
-for m in re.finditer(CMD_POS + READERS + r"\b(?P<rest>[^|;&\n]*)", scan_cat, re.I):
-    rest = m.group("rest")
-    if re.search(r"-(?:TotalCount|Tail|Head|First|Last)\b", rest, re.I):
-        continue
-    dump_block(rest, statement(scan_cat, m.start("rest")))
+# `-First`/`-Last` bound the read and clear it, as does indexing or counting
+# the result (`(Get-Content f)[10..40]`, `.Count`). `cat < x.py` counts too. A
+# reader with no file arg fed by `xargs`, `find -exec`, or a pipe reads what
+# the stage before it named.
+READER_POS = r"(?:" + CMD_POS + r"|\bxargs\s+(?:-\S+\s+)*|-exec\s+)"
+for stmt in re.split(STATEMENT_SEP, scan_cat):
+    for m in re.finditer(READER_POS + READERS + r"\b(?P<rest>[^|;&\n]*)", stmt, re.I):
+        rest = m.group("rest")
+        seg = stmt[m.start("rest"):]
+        if re.search(r"-(?:TotalCount|Tail|Head|First|Last)\b", rest, re.I):
+            continue
+        if re.search(r"\)\s*(?:\.\w+|\[)", rest):
+            continue
+        names = guarded_names(rest)
+        if not names:
+            # The position match swallowed the `|` / `xargs` / `-exec` that feeds
+            # this reader; look at everything before the reader's own name.
+            fed = stmt[: m.start("rest")]
+            if re.search(r"(?:\|\s*|\bxargs\s+(?:-\S+\s+)*|-exec\s+)" + READERS + r"$", fed, re.I):
+                names = guarded_names(fed)
+        dump_block(names, seg)
 
 # sed: only an unbounded script (`p`, `1,$p`, or empty) is a dump; any range,
 # address or substitution is a targeted read or an edit. Quotes intact here so
-# the script token is one group.
+# the script token is one group; a `\$` is a `$`.
 SED = (
     CMD_POS
-    + r"sed\b(?P<flags>(?:\s+-[a-zA-Z]+)*)\s+"
+    + r"sed\b(?P<flags>(?:\s+--?[a-zA-Z-]+)*)\s+"
     + r"(?:'(?P<sq>[^']*)'|\"(?P<dq>[^\"]*)\"|(?P<bare>\S+))"
     + r"(?P<args>(?:\s+" + ARG + r")+)"
 )
 for m in re.finditer(SED, blanked):
     script = next(s for s in (m.group("sq"), m.group("dq"), m.group("bare")) if s is not None)
-    if script.strip() in ("", "p", "1,$p"):
-        dump_block(m.group("args"), statement(blanked, m.end("args")))
+    if script.replace("\\", "").strip() in ("", "p", "1,$p"):
+        dump_block(guarded_names(m.group("args")), statement(blanked, m.end("args")))
 
 # head / tail: a count bounds the read; `-c` (bytes) is a dump by another name.
 HEADTAIL = (
@@ -234,6 +282,6 @@ for m in re.finditer(HEADTAIL, scan_cat):
     bounded = re.search(r"-n\s*\d|-\d|--lines", flags)
     bytes_dump = re.search(r"-c\b|--bytes", flags)
     if bytes_dump or not bounded:
-        dump_block(m.group("args"), statement(scan_cat, m.end("args")))
+        dump_block(guarded_names(m.group("args")), statement(scan_cat, m.end("args")))
 
 sys.exit(0)

--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -216,17 +216,19 @@ def dump_block(names: list, seg: str) -> None:
 # is where the extension is seen; the body is judged like any statement.
 READERS = r"(?:cat|more|less|type|Get-Content|gc)"
 LOOP = (
-    r"(?:\bfor\b|\bforeach\b|\bForEach-Object\b|\|\s*%)(?P<head>[^;{\n]*)"
-    r"(?:;\s*do\b(?P<do>[\s\S]*?)\bdone\b|\{(?P<brace>[\s\S]*?)\})"
+    r"(?:\bfor\b|\bforeach\b|\bwhile\b|\bForEach-Object\b|\|\s*%)(?P<head>[^;{\n]*)"
+    r"(?:[;\n]\s*do\b(?P<do>[\s\S]*?)\bdone\b|\{(?P<brace>[\s\S]*?)\})"
 )
 BODY_POS = r"(?:^|[;{|&\n]|\$\(|\b(?:then|do|else))\s*"
 for m in re.finditer(LOOP, scan_cat):
     header = scan_cat[: m.start()].rsplit("\n", 1)[-1] + m.group("head")
     if not guarded_names(header):
         continue
-    if lands_in_file(statement(scan_cat, m.end())):
-        continue  # `for …; done > all.txt`: the loop's output lands
+    after = statement(scan_cat, m.end())
+    if lands_in_file(after) or piped_to_filter(after):
+        continue  # `for …; done > all.txt` / `… done | grep x`: the loop's output is bounded
     body = m.group("do") if m.group("do") is not None else m.group("brace")
+    body = body.replace("||", ";")  # `cat $f || true` is not a pipe
     for r in re.finditer(BODY_POS + READERS + r"\b(?P<rest>[^;}\n]*)", body, re.I):
         if not lands_in_file(r.group("rest")) and not piped_to_filter(r.group("rest")):
             block(
@@ -241,10 +243,10 @@ for m in re.finditer(LOOP, scan_cat):
 # reader with no file arg fed by `xargs`, `find -exec`, or a lister's pipe
 # (`ls`, `find`, `Get-ChildItem`) reads what that stage named — `git diff
 # a.py | cat` is a no-pager idiom, not a dump, so only listers feed.
-READER_POS = r"(?:" + CMD_POS + r"|\bxargs\s+(?:-\S+\s+)*|-exec\s+)"
+READER_POS = r"(?:" + CMD_POS + r"|\bxargs\s+(?:-\S+\s+)*|-(?:exec|x|X)\s+)"
 LISTERS = r"(?:ls|find|fd|dir|Get-ChildItem|gci)"
 FED_BY = (
-    r"(?:\bxargs\s+(?:-\S+\s+)*|-exec\s+|(?:^|[;&(|])\s*" + LISTERS + r"\b[^|]*\|\s*)"
+    r"(?:\bxargs\s+(?:-\S+\s+)*|-(?:exec|x|X)\s+|(?:^|[;&(|])\s*" + LISTERS + r"\b[^|]*\|\s*)"
     + READERS + r"$"
 )
 for stmt in re.split(STATEMENT_SEP, scan_cat):

--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -244,6 +244,19 @@ for m in re.finditer(LOOP, scan_cat):
 # reader with no file arg fed by `xargs`, `find -exec`, or a lister's pipe
 # (`ls`, `find`, `Get-ChildItem`) reads what that stage named — `git diff
 # a.py | cat` is a no-pager idiom, not a dump, so only listers feed.
+# PowerShell accepts any unambiguous prefix of a parameter name (`-tot 5`,
+# `-Total 5`, `-Fi 3`), so every prefix of the bounding parameters clears a
+# read; `-t` alone is ambiguous (Tail/TotalCount) and the shell rejects it, so
+# the guard errs towards passing a read the shell will refuse anyway.
+BOUNDING_PARAM = (
+    r"-(?:"
+    + "|".join(
+        name[:n]
+        for name in ("TotalCount", "Tail", "Head", "First", "Last")
+        for n in range(len(name), 0, -1)
+    )
+    + r")\b"
+)
 READER_POS = r"(?:" + CMD_POS + r"|\bxargs\s+(?:-\S+\s+)*|-(?:exec|x|X)\s+)"
 LISTERS = r"(?:ls|find|fd|dir|Get-ChildItem|gci)"
 FED_BY = (
@@ -254,8 +267,7 @@ for stmt in re.split(STATEMENT_SEP, scan_cat):
     for m in re.finditer(READER_POS + READERS + r"\b(?P<rest>[^|;&\n]*)", stmt, re.I):
         rest = m.group("rest")
         seg = stmt[m.start("rest"):]
-        # PowerShell accepts any unambiguous prefix: `-tot 5`, `-Total 5`, `-Fi 3`.
-        if re.search(r"-(?:tot[a-z]*|tai?l?|hea?d?|fir?s?t?|las?t?)\b", rest, re.I):
+        if re.search(BOUNDING_PARAM, rest, re.I):
             continue
         if re.search(r"\)\s*(?:\.\w+|\[)", rest):
             continue

--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -96,7 +96,7 @@ ARG = r"[\w$./*:\\~{}%+=@,-]+"
 # A guarded extension ends the argument: `foo.py.bak`, `foo.py~`, `x.py.orig`
 # are not the file.
 GUARDED = r"\.(?:" + GUARDED_EXT_RE + r")(?![\w.~-])"
-STATEMENT_SEP = r"&&|[;\n]"
+STATEMENT_SEP = r"&&|\|\||[;\n]"
 
 
 def statement(text: str, start: int) -> str:
@@ -175,7 +175,7 @@ for m in re.finditer(GH_VIEW, blanked):
     f = re.search(FILTER, args)
     if "diff" not in m.group("sub") and re.search(r"--json\b", args) and f:
         expr = next(g for g in f.groups() if g is not None)
-        if not re.search(r"\b(?:body|comments)\b", expr):
+        if not re.search(r"\b(?:body(?:Text|HTML)?|comments)\b", expr):
             continue
     if "--comments" in args:
         block(
@@ -216,16 +216,18 @@ def dump_block(names: list, seg: str) -> None:
 # is where the extension is seen; the body is judged like any statement.
 READERS = r"(?:cat|more|less|type|Get-Content|gc)"
 LOOP = (
-    r"(?:\bfor\b|\bforeach\b|\bForEach-Object\b|%)(?P<head>[^;{\n]*)(?:;\s*do\b|\{)"
-    r"(?P<body>[\s\S]*?)(?:\bdone\b|\})"
+    r"(?:\bfor\b|\bforeach\b|\bForEach-Object\b|\|\s*%)(?P<head>[^;{\n]*)"
+    r"(?:;\s*do\b(?P<do>[\s\S]*?)\bdone\b|\{(?P<brace>[\s\S]*?)\})"
 )
+BODY_POS = r"(?:^|[;{|&\n]|\$\(|\b(?:then|do|else))\s*"
 for m in re.finditer(LOOP, scan_cat):
     header = scan_cat[: m.start()].rsplit("\n", 1)[-1] + m.group("head")
     if not guarded_names(header):
         continue
     if lands_in_file(statement(scan_cat, m.end())):
         continue  # `for …; done > all.txt`: the loop's output lands
-    for r in re.finditer(r"(?:^|[;{|&\n])\s*" + READERS + r"\b(?P<rest>[^;}\n]*)", m.group("body"), re.I):
+    body = m.group("do") if m.group("do") is not None else m.group("brace")
+    for r in re.finditer(BODY_POS + READERS + r"\b(?P<rest>[^;}\n]*)", body, re.I):
         if not lands_in_file(r.group("rest")) and not piped_to_filter(r.group("rest")):
             block(
                 "Blocked (context discipline): a cat loop over source files is a mass whole-file Read.\n"
@@ -236,9 +238,15 @@ for m in re.finditer(LOOP, scan_cat):
 # and PowerShell parameters are stepped over; `-TotalCount`/`-Tail`/`-Head`/
 # `-First`/`-Last` bound the read and clear it, as does indexing or counting
 # the result (`(Get-Content f)[10..40]`, `.Count`). `cat < x.py` counts too. A
-# reader with no file arg fed by `xargs`, `find -exec`, or a pipe reads what
-# the stage before it named.
+# reader with no file arg fed by `xargs`, `find -exec`, or a lister's pipe
+# (`ls`, `find`, `Get-ChildItem`) reads what that stage named — `git diff
+# a.py | cat` is a no-pager idiom, not a dump, so only listers feed.
 READER_POS = r"(?:" + CMD_POS + r"|\bxargs\s+(?:-\S+\s+)*|-exec\s+)"
+LISTERS = r"(?:ls|find|fd|dir|Get-ChildItem|gci)"
+FED_BY = (
+    r"(?:\bxargs\s+(?:-\S+\s+)*|-exec\s+|(?:^|[;&(|])\s*" + LISTERS + r"\b[^|]*\|\s*)"
+    + READERS + r"$"
+)
 for stmt in re.split(STATEMENT_SEP, scan_cat):
     for m in re.finditer(READER_POS + READERS + r"\b(?P<rest>[^|;&\n]*)", stmt, re.I):
         rest = m.group("rest")
@@ -252,7 +260,7 @@ for stmt in re.split(STATEMENT_SEP, scan_cat):
             # The position match swallowed the `|` / `xargs` / `-exec` that feeds
             # this reader; look at everything before the reader's own name.
             fed = stmt[: m.start("rest")]
-            if re.search(r"(?:\|\s*|\bxargs\s+(?:-\S+\s+)*|-exec\s+)" + READERS + r"$", fed, re.I):
+            if re.search(FED_BY, fed, re.I):
                 names = guarded_names(fed)
         dump_block(names, seg)
 

--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -246,14 +246,14 @@ for m in re.finditer(LOOP, scan_cat):
 # a.py | cat` is a no-pager idiom, not a dump, so only listers feed.
 # PowerShell accepts any unambiguous prefix of a parameter name (`-tot 5`,
 # `-Total 5`, `-Fi 3`), so every prefix of the bounding parameters clears a
-# read; `-t` alone is ambiguous (Tail/TotalCount) and the shell rejects it, so
-# the guard errs towards passing a read the shell will refuse anyway.
+# read; a single letter does not (`-t` is ambiguous, `-h`/`-f`/`-l` read like
+# Unix flags).
 BOUNDING_PARAM = (
     r"-(?:"
     + "|".join(
         name[:n]
         for name in ("TotalCount", "Tail", "Head", "First", "Last")
-        for n in range(len(name), 0, -1)
+        for n in range(len(name), 1, -1)  # `-t`/`-h`/`-f`/`-l` alone do not clear
     )
     + r")\b"
 )

--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -1,25 +1,42 @@
 #!/usr/bin/env python3
-"""PreToolUse hook enforcing CLAUDE.md's context-discipline rules on Bash.
+"""PreToolUse hook enforcing CLAUDE.md's context-discipline rules on the shell
+tools (Bash and PowerShell — settings.json matches both).
 
 Blocks (exit 2, message to the model):
-  1. Noisy runs (NOISY_TOOLS below) piped to tail/head/cat — the
-     scratch-log+grep rule.
-  2. `gh` comment pulls that don't land in a file — the full thread is the
-     largest tool-result class measured.
-  3. `cat` of source/config files straight into context — that is a whole-file
-     Read with a worse interface; use the Read tool or pipe to grep.
+  1. Noisy runs (NOISY_TOOLS below) that do not land in a file: bare, piped to
+     tail/head/cat/Select-Object, or piped anywhere else — the scratch-log+grep
+     rule. `--version`, `--help` and `--collect-only` are not runs.
+  2. `gh issue view` / `gh pr view` / `gh pr diff` that do not land in a file.
+     A `--json … -q` field filter passes unless it pulls the body or the
+     comment thread; `gh pr diff --name-only|--stat` passes.
+  3. A whole-file dump of a guarded file (guarded_ext.py) by any reader —
+     `cat`, `more`, `less`, `type`, `Get-Content`/`gc`, `sed -n` with no range
+     or `1,$p`, `head`/`tail` with no count, `head -c` — that is neither piped
+     onward nor redirected. Ranged reads (`sed -n 10,40p`, `head -50`,
+     `Get-Content -TotalCount 50`) pass. Backslash and drive-letter paths count.
+  4. A `for` loop that cats guarded files.
 
-Measured motivation (2026-08 transcript audit): 233 piped harness runs with
-zero scratch-file adoption, and one 237k-token session that pulled 162KB via
-`cat` loops without a single Read call.
+Heredoc / here-string bodies and `--body`/`--message`/`--title` arguments are
+data, not commands, and are blanked before any rule looks (the two false
+positives measured in the 2026-08-15 audit were `gh pr create --body …` and
+`gh issue comment --body …`).
+
+Measured motivation (2026-08 transcript audits): 233 piped harness runs with
+zero scratch-file adoption; one 237k-token session that pulled 162KB via `cat`
+loops; ~800 unguarded PowerShell calls; 44% of `gh … view` calls unredirected.
 
 starter-version: 2026-08-10 (claude-principles; locally tuned: LAUNCHERS,
-block messages use this repo's scratch-log names)
+PowerShell, dump readers, block messages use this repo's scratch-log names)
 """
 import json
+import os
 import re
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from guarded_ext import GUARDED_EXT_RE  # noqa: E402
+
+SHELL_TOOLS = {"Bash", "PowerShell"}
 # The commands whose full output belongs in a scratch log, never in context.
 NOISY_TOOLS = r"pytest|mypy|ruff"
 # Launcher prefixes those commands may hide behind in this repo.
@@ -30,18 +47,32 @@ try:
 except Exception:
     sys.exit(0)
 
-if data.get("tool_name") != "Bash":
+if data.get("tool_name") not in SHELL_TOOLS:
     sys.exit(0)
 
 cmd = data.get("tool_input", {}).get("command", "") or ""
 
-# Heredoc bodies are data, not commands; `<<-` terminators may be indented
-# (session note context-guard-blocks-some-heredocs, 2026-08 — now fixed).
+
+def block(message: str) -> None:
+    sys.stderr.write(message.rstrip("\n") + "\n")
+    sys.exit(2)
+
+
+# ---------------------------------------------------------------- blanking
+# Heredoc bodies are data, not commands; `<<-` terminators may be indented.
 HEREDOC = r"<<-?\s*(['\"]?)(\w+)\1[\s\S]*?\n[ \t]*\2\b"
+# PowerShell here-strings: @' … '@ and @" … "@ (closing token at line start).
+HERESTRING = r"@(['\"])[\s\S]*?\n\1@"
+# Prose arguments: what follows --body/--message/--title (and their short
+# forms) in quotes is text about commands, never a command.
+PROSE_ARG = r"(?i)(?:--body|--message|--title|-[bmt])(?:=|\s+)(?:'[^']*'|\"[^\"]*\")"
+
 blanked = re.sub(HEREDOC, "<<HEREDOC", cmd)
-# The noisy/gh rules also blank quoted strings: a commit message merely
-# mentioning pytest is prose. The cat rules instead use a quote-STRIPPED
-# copy (quotes removed, content kept): `cat "notes.md"` is still a cat, and
+blanked = re.sub(HERESTRING, "@HERESTRING@", blanked)
+blanked = re.sub(PROSE_ARG, "--PROSE ''", blanked)
+# The noisy/gh rules blank the remaining quoted strings: a commit message
+# merely mentioning pytest is prose. The dump rules use a quote-STRIPPED copy
+# (quotes removed, content kept): `cat "notes.md"` is still a cat, and
 # command-position anchoring is what protects those rules from prose.
 scan = re.sub(r"'[^']*'", "''", blanked)
 scan = re.sub(r'"[^"]*"', '""', scan)
@@ -52,55 +83,157 @@ scan_cat = re.sub(r"[\"']", "", blanked)
 # env-var assignments (`CI=1 pytest …`) and any chain of launchers
 # (`uv run python -m pytest`) allowed before the tool name.
 CMD_POS = r"(?:^\s*|[;&|(){`\n]\s*|\$\(\s*|\b(?:then|do|else)\s+)"
+# One shell-argument: word chars plus the path characters of both shells —
+# `\` and `:` so `C:\repo\a.py` and `.\src\a.py` are seen as one arg.
+ARG = r"[\w$./*:\\~{}%+=@,-]+"
+GUARDED = r"\.(?:" + GUARDED_EXT_RE + r")\b"
+
+
+def statement(text: str, start: int) -> str:
+    """The rest of the statement from *start*: up to `;`, `&&`, or a newline —
+    pipes stay in, so a pipeline's later stages (its sink) are visible."""
+    return re.split(r"&&|[;\n]", text[start:], 1)[0]
+
+
+def lands_in_file(seg: str) -> bool:
+    """True when the statement's stdout reaches a file: a `>`/`>>`/`1>`/`&>`/`*>`
+    redirect (a `2>` alone is stderr; `>&` is an fd dup), or a PowerShell sink."""
+    if re.search(r"(?<![2-9])>(?!&)\s*[^\s&|;]", seg):
+        return True
+    return re.search(r"\|\s*(?:Out-File|Set-Content|Add-Content)\b", seg, re.I) is not None
+
+
+PAGERS = r"tail|head|less|more|cat|tee|Select-Object|select|Out-Host|Tee-Object|Out-String"
+
+# ---------------------------------------------------------------- 1. noisy runs
 NOISY = (
     CMD_POS
     + r"(?:\w+=\S+\s+)*"
     + r"(?:" + LAUNCHERS + r")*"
-    + r"(?:" + NOISY_TOOLS + r")\b"
+    + r"(?P<tool>" + NOISY_TOOLS + r")\b(?![.-])"
 )
-if re.search(NOISY + r"[^|]*\|\s*(tail|head|less|more|cat)\b", scan):
-    sys.stderr.write(
-        "Blocked (context discipline): noisy runs never pipe to tail/head — a tail caps one run, runs repeat.\n"
-        "Use one bare command: <cmd> > pytest.scratch.log 2>&1. Then Grep the log for the decisive line (FAILED|passed|error).\n"
-        "On failure, Grep the log for the failing case by name; never cat the log.\n"
-    )
-    sys.exit(2)
-
-# gh comment pulls: the full thread is 5-7KB per call and repeats (measured
-# 2026-08-05). Piping to tail caps nothing that matters, and dropping the pipe
-# is worse — so the rule is: comments land in a file (or a --json filter),
-# never straight in context. Checked per pull, within that pull's own command
-# segment; a digit before `>` is an fd redirect (2>), not a landing.
-for m in re.finditer(r"\bgh\s+(issue|pr)\s+view\b[^|;&]*--comments", scan):
-    seg = re.split(r"[|;&]", scan[m.end():], 1)[0]
-    if not re.search(r"(?<!\d)>\s*\S", seg):
-        sys.stderr.write(
-            "Blocked (context discipline): a comment pull lands in a file, never straight in context.\n"
-            "Use one bare command: gh issue view <n> --comments > comments.scratch.log. Then Grep the log — or --json comments with a jq filter.\n"
+for m in re.finditer(NOISY, scan):
+    seg = statement(scan, m.end())
+    tool = m.group("tool")
+    if re.search(r"(?:^|\s)(?:--version|--help|-h|--co|--collect-only)\b", seg):
+        continue
+    if re.search(r"\|\s*(?:" + PAGERS + r")\b", seg, re.I):
+        block(
+            "Blocked (context discipline): noisy runs never pipe to tail/head - a tail caps one run, runs repeat.\n"
+            f"Use one bare command: uv run {tool} > {tool}.scratch.log 2>&1. Then Grep the log for the decisive line (FAILED|passed|error).\n"
+            "On failure, Grep the log for the failing case by name; never cat the log."
         )
-        sys.exit(2)
+    if not lands_in_file(seg):
+        block(
+            f"Blocked (context discipline): a bare {tool} run puts its whole output in context.\n"
+            f"Use one bare command: uv run {tool} > {tool}.scratch.log 2>&1 (a redirect the worktree guard accepts - "
+            "no cd, no ;-chain). Then Grep the log for the decisive line (FAILED|passed|error)."
+        )
 
-SRC_EXT = r"\.(md|sh|py|js|ts|json|yml|yaml|txt|log|conf|ini)\b"
+# ---------------------------------------------------------------- 2. gh views
+# Issue bodies, comment threads and PR diffs are the largest tool results
+# measured (2026-08-05, 2026-08-15). They land in a file, never in context; a
+# `--json … -q` field filter is fine unless it is the body or the thread.
+GH_VIEW = r"\bgh\s+(?P<sub>issue\s+view|pr\s+view|pr\s+diff)\b"
+for m in re.finditer(GH_VIEW, scan):
+    seg = statement(scan, m.end())
+    args = seg.split("|", 1)[0]
+    if lands_in_file(seg):
+        continue
+    if "diff" in m.group("sub") and re.search(r"--(?:name-only|stat)\b", args):
+        continue
+    if (
+        "diff" not in m.group("sub")
+        and re.search(r"--json\b", args)
+        and re.search(r"(?:^|\s)(?:-q|--jq)\b", args)
+        and not re.search(r"\b(?:body|comments)\b", args)
+    ):
+        continue
+    if "--comments" in args:
+        block(
+            "Blocked (context discipline): a comment pull lands in a file, never straight in context.\n"
+            "Use one bare command: gh issue view <n> --comments > comments.scratch.log. Then Grep the log - or --json comments with a jq filter to a file."
+        )
+    block(
+        "Blocked (context discipline): gh issue/pr view and pr diff land in a file, never straight in context.\n"
+        "Use one bare command: gh issue view <n> --json body -q .body > issue.scratch.log "
+        "(gh pr diff <n> > pr.scratch.log). Then Grep the log for the section you need; "
+        "a --json field filter (-q .title, .state) is fine."
+    )
+
+# ---------------------------------------------------------------- 3. whole-file dumps
+DUMP_MSG = (
+    "Blocked (context discipline): a whole-file dump of {name} puts the whole file in context - "
+    "the rules govern content entering context, not which tool fetched it.\n"
+    "Grep for the lines you need first, then Read with offset/limit around the hit - or a ranged read "
+    "(sed -n 10,40p, head -50, Get-Content -TotalCount 50); a dump piped to grep or redirected to a file passes."
+)
+
+
+def guarded_names(args: str) -> list:
+    return [a for a in re.findall(ARG, args) if re.search(GUARDED, a)]
+
+
+def dump_block(args: str, seg: str) -> None:
+    """Block when *args* name a guarded file and the statement neither pipes
+    onward nor lands in a file."""
+    names = guarded_names(args)
+    if not names or lands_in_file(seg):
+        return
+    # A pipe to a filter (grep, wc, jq, Select-String…) bounds the read; a pipe
+    # to a pager or a re-emitter (`| cat -n`, `| Out-String`) does not.
+    stages = seg.split("|")[1:]
+    filtered = bool(stages) and not all(
+        re.match(r"\s*(?:cat|more|less|tee|Tee-Object|Out-Host|Out-String)\b", st, re.I)
+        for st in stages
+    )
+    if not filtered:
+        block(DUMP_MSG.format(name=names[0]))
+
 
 # for-loop cat sweep: `for f in src/*.py; do cat $f; done`
-if re.search(r"\bfor\b[^;]*" + SRC_EXT + r".*\bcat\b", scan_cat):
-    sys.stderr.write(
+if re.search(r"\bfor\b[^;]*" + GUARDED + r".*\bcat\b", scan_cat):
+    block(
         "Blocked (context discipline): a cat loop over source files is a mass whole-file Read.\n"
-        "Use the Read tool per file you will edit, or grep for the lines you actually need.\n"
+        "Use the Read tool per file you will edit, or grep for the lines you actually need."
     )
-    sys.exit(2)
 
-# bare cat of a source file, not piped onward and not a redirect/heredoc —
-# anchored at command position so prose mentioning "cat" never matches
-for m in re.finditer(CMD_POS + r"cat\b(?:\s+-[\w]+)*((?:\s+[\w$./*-]+)+)", scan_cat):
-    args = m.group(1)
-    rest = scan_cat[m.end():]
-    if re.search(SRC_EXT, args) and not re.match(r"\s*[|>]", rest):
-        sys.stderr.write(
-            "Blocked (context discipline): don't cat files into context — the rules govern content entering "
-            "context, not which tool fetched it.\n"
-            "Use the Read tool (ranged: grep -n first, then offset/limit), or pipe to grep for the decisive lines.\n"
-        )
-        sys.exit(2)
+# cat / more / less / type / Get-Content / gc: every plain arg is a file. Options
+# and PowerShell parameters are stepped over; `-TotalCount`/`-Tail`/`-Head`/
+# `-First`/`-Last` bound the read and clear it. `cat < x.py` counts too.
+READERS = r"(?:cat|more|less|type|Get-Content|gc)"
+for m in re.finditer(CMD_POS + READERS + r"\b(?P<rest>[^|;&\n]*)", scan_cat, re.I):
+    rest = m.group("rest")
+    if re.search(r"-(?:TotalCount|Tail|Head|First|Last)\b", rest, re.I):
+        continue
+    dump_block(rest, statement(scan_cat, m.start("rest")))
+
+# sed: only an unbounded script (`p`, `1,$p`, or empty) is a dump; any range,
+# address or substitution is a targeted read or an edit. Quotes intact here so
+# the script token is one group.
+SED = (
+    CMD_POS
+    + r"sed\b(?P<flags>(?:\s+-[a-zA-Z]+)*)\s+"
+    + r"(?:'(?P<sq>[^']*)'|\"(?P<dq>[^\"]*)\"|(?P<bare>\S+))"
+    + r"(?P<args>(?:\s+" + ARG + r")+)"
+)
+for m in re.finditer(SED, blanked):
+    script = next(s for s in (m.group("sq"), m.group("dq"), m.group("bare")) if s is not None)
+    if script.strip() in ("", "p", "1,$p"):
+        dump_block(m.group("args"), statement(blanked, m.end("args")))
+
+# head / tail: a count bounds the read; `-c` (bytes) is a dump by another name.
+HEADTAIL = (
+    CMD_POS
+    + r"(?:head|tail)\b(?P<flags>(?:\s+(?:-n\s*\d+|-\d+|--lines(?:=|\s+)\d+|-c\s*\d*|"
+    + r"--bytes(?:=|\s+)\S+|-[a-zA-Z]+))*)"
+    + r"(?P<args>(?:\s+(?:<\s*)?" + ARG + r")+)"
+)
+for m in re.finditer(HEADTAIL, scan_cat):
+    flags = m.group("flags")
+    bounded = re.search(r"-n\s*\d|-\d|--lines", flags)
+    bytes_dump = re.search(r"-c\b|--bytes", flags)
+    if bytes_dump or not bounded:
+        dump_block(m.group("args"), statement(scan_cat, m.end("args")))
 
 sys.exit(0)

--- a/.claude/hooks/guarded_ext.py
+++ b/.claude/hooks/guarded_ext.py
@@ -1,0 +1,38 @@
+"""The one guarded-extension list both context hooks import (#249).
+
+Before this module each hook carried its own list and they had drifted (`.toml`
+in one, not the other). A file with one of these extensions is what the rules
+ration: a whole-file dump of it — by any reader, from any shell tool — is the
+thing being blocked.
+
+GUARDED_EXT is the union. Markdown sits in it because catting a doc into
+context is still a whole-file read; the *size* rule in read-guard.py exempts it
+(reading a whole ADR or CONTEXT.md is the intended use), and names that
+exemption here so both hooks read from one place.
+"""
+
+GUARDED_EXT = {
+    ".py",
+    ".pyi",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".toml",
+    ".sh",
+    ".ini",
+    ".cfg",
+    ".conf",
+    ".txt",
+    ".log",
+    ".md",
+}
+
+# Extensions the big-file size rule (read-guard.py) leaves alone even when guarded.
+SIZE_RULE_EXEMPT = {".md"}
+
+# Regex alternation of the guarded extensions (without the dot), for command scanners.
+GUARDED_EXT_RE = "|".join(sorted(e.lstrip(".") for e in GUARDED_EXT))

--- a/.claude/hooks/read-guard.py
+++ b/.claude/hooks/read-guard.py
@@ -8,7 +8,7 @@ PreToolUse on Read, blocking (exit 2) on either rule:
      buys nothing. Any offset/limit is the escape: wanting a different section
      of a big file is legitimate.
   2. Big first read: a whole-file Read of a guarded-extension repo file
-     (GUARDED_EXT below) over BIG_FILE_LINES — CLAUDE.md's "ranged (grep first)
+     (guarded_ext.py, shared with context-guard.py) over BIG_FILE_LINES — CLAUDE.md's "ranged (grep first)
      on big files". Here the escape is `limit`, since a bare `offset` still
      pulls Read's 2000-line default. A deliberate `offset: 1, limit: <n>` passes,
      so this is a speed bump rather than a wall.
@@ -29,28 +29,16 @@ import tempfile
 
 BIG_FILE_LINES = 400
 
-# Text formats where a whole-file pull is the thing being rationed. Markdown is
-# deliberately absent: reading a whole ADR or CONTEXT.md is the intended use.
+# The guarded-extension list is shared with context-guard.py (guarded_ext.py):
+# text formats where a whole-file pull is the thing being rationed. Markdown is
+# guarded there (a cat of a doc is still a whole-file read) but exempt from the
+# size rule here: reading a whole ADR or CONTEXT.md is the intended use.
 # Anything unlisted (images, PDFs, notebooks, extensionless files) passes — a
 # line count is meaningless there.
-GUARDED_EXT = {
-    ".py",
-    ".pyi",
-    ".js",
-    ".jsx",
-    ".ts",
-    ".tsx",
-    ".json",
-    ".yml",
-    ".yaml",
-    ".toml",
-    ".sh",
-    ".ini",
-    ".cfg",
-    ".conf",
-    ".txt",
-    ".log",
-}
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from guarded_ext import GUARDED_EXT, SIZE_RULE_EXEMPT  # noqa: E402
+
+SIZE_GUARDED_EXT = GUARDED_EXT - SIZE_RULE_EXEMPT
 
 
 def in_project(path):
@@ -121,7 +109,7 @@ if event == "PreToolUse" and tool == "Read":
     # whole of any file this rule covers.
     if (
         "limit" not in tool_input
-        and os.path.splitext(path)[1].lower() in GUARDED_EXT
+        and os.path.splitext(path)[1].lower() in SIZE_GUARDED_EXT
         and in_project(path)
     ):
         lines = line_count(path)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|PowerShell",
         "hooks": [
           {
             "type": "command",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,15 +155,13 @@ runs repeat. The accepted one-command redirect shapes:
 Delegate exploration to
 a read-only subagent; Read only what you will edit, ranged (grep first) on
 big files; do not re-read a file after editing it. The hooks in
-`.claude/hooks/` enforce these on both shell tools (Bash and PowerShell)
-and every reader: a bare or piped `pytest|mypy|ruff` run, a `gh issue|pr
-view` or `pr diff` that does not land in a file, and any whole-file dump of
-a guarded file — `cat`, `sed -n p`, `head`/`tail` with no count, `head -c`,
-`Get-Content` without `-TotalCount`/`-Tail`, `type` — are blocked, while
-ranged reads (`sed -n 10,40p`, `head -50`, `Get-Content -TotalCount 50`)
-pass; plus whole-file re-reads, and whole-file Reads of code/config files
-over 400 lines (markdown exempt). A block from them is the rule firing, not
-an obstacle to route around; the block message names the fix (#249).
+`.claude/hooks/` enforce this on both shell tools and every reader: a
+`pytest|mypy|ruff` run or `gh … view|diff` that does not land in a file, and
+any whole-file dump of a guarded file (`cat`, `sed -n p`, uncounted
+`head`/`tail`, `Get-Content`, `type`) are blocked; ranged reads pass (#249).
+They also block whole-file re-reads and whole-file Reads of code/config
+files over 400 lines (markdown exempt). A block from them is the rule
+firing, not an obstacle to route around; the block message names the fix.
 
 The same scratch-file rule covers `gh` — issue bodies, comment threads,
 and PR diffs were the biggest single results in past sessions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,18 +143,32 @@ worktree — to a gitignored repo-local log:
 
 then Grep `FAILED|passed|error` in `pytest.scratch.log` (`*.scratch.log` is
 gitignored; never commit a log). Never `| tail` — a tail caps one run and
-runs repeat. Delegate exploration to
+runs repeat. The accepted one-command redirect shapes:
+
+    uv run pytest -m 'not live' > pytest.scratch.log 2>&1
+    uv run mypy > mypy.scratch.log 2>&1
+    uv run ruff check > ruff.scratch.log 2>&1
+    gh issue view <n> --json body -q .body > issue.scratch.log
+    gh pr diff <n> > pr.scratch.log
+    git merge origin/main > merge.scratch.log 2>&1
+
+Delegate exploration to
 a read-only subagent; Read only what you will edit, ranged (grep first) on
 big files; do not re-read a file after editing it. The hooks in
-`.claude/hooks/` enforce the cat/tail rules, whole-file re-reads, and
-whole-file reads of code/config files over 400 lines (markdown exempt) — a
-block from them is the rule firing, not an obstacle to route around; the
-block message names the fix.
+`.claude/hooks/` enforce these on both shell tools (Bash and PowerShell)
+and every reader: a bare or piped `pytest|mypy|ruff` run, a `gh issue|pr
+view` or `pr diff` that does not land in a file, and any whole-file dump of
+a guarded file — `cat`, `sed -n p`, `head`/`tail` with no count, `head -c`,
+`Get-Content` without `-TotalCount`/`-Tail`, `type` — are blocked, while
+ranged reads (`sed -n 10,40p`, `head -50`, `Get-Content -TotalCount 50`)
+pass; plus whole-file re-reads, and whole-file Reads of code/config files
+over 400 lines (markdown exempt). A block from them is the rule firing, not
+an obstacle to route around; the block message names the fix (#249).
 
 The same scratch-file rule covers `gh` — issue bodies, comment threads,
 and PR diffs were the biggest single results in past sessions:
 `gh issue view <n> --json body -q .body > issue.scratch.log`, then Grep
-back the section you need.
+back the section you need; a `--json` field filter (`-q .title`) is fine.
 
 **Orient from `CONTEXT.md` first** — the repo map answers "which module
 owns X, where is the seam, which test file covers Y"; explores are for

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -165,6 +165,7 @@ GH_BLOCKED = [
     "gh pr view 5 --json body,title",  # no filter at all
     "gh pr diff 243 | grep '^+'",  # a filter is not a landing
     "gh issue view 249 --json title,body --template '{{.body}}'",
+    "gh issue view 249 --json bodyText -q .bodyText",
 ]
 
 
@@ -226,6 +227,7 @@ WHOLE_FILE_DUMPS = [
     "Get-Content src/config.py | Out-String",
     "cat src/config.py | nl",
     "$c = Get-Content src/config.py; $c",
+    "cat src/config.py || true",  # `||` is not a pipe
     "sed --quiet p src/config.py",
     'sed -n "1,\\$p" src/config.py',
     "tail -n +10 src/config.py",  # an offset with no end is not a range
@@ -301,6 +303,12 @@ DUMP_ESCAPES = [
     "for f in src/*.py; do cat $f; done > all.txt",  # the loop lands
     "for f in src/*.py; do grep -c def $f; done # cat",
     "for f in *.py; do wc -l $f; done",
+    "git diff src/a.py | cat",  # the no-pager idiom: nothing is dumped
+    "git log --oneline -- src/a.py | cat",
+    "grep -n def src/a.py | cat -n",
+    "head -50 src/a.py | cat -A",
+    "python -c \"print('%s' % 'a.py')\" && echo '{ cat }'",
+    "if [ -f src/a.py ]; then echo hi; fi",
 ]
 
 
@@ -332,6 +340,9 @@ def test_backslash_and_drive_letter_paths_are_seen(cmd: str) -> None:
         "foreach ($f in ls *.py) { cat $f }",
         "Get-ChildItem *.py | % { gc $_ }",
         "Get-ChildItem -r *.py | ForEach-Object { Get-Content $_ }",
+        "for f in src/*.py; do echo ${f}; cat $f; done",
+        "for f in src/*.py; do if grep -q foo $f; then cat $f; fi; done",
+        "for f in src/*.py; do echo \"$f: $(cat $f)\"; done",
     ],
 )
 def test_loop_over_source_files_is_blocked(cmd: str) -> None:

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -242,6 +242,7 @@ WHOLE_FILE_DUMPS = [
     "Get-Content src/x.py | Write-Output",  # pass-through, not a filter
     "Get-Content src/x.py | Format-Table",
     "gc src/x.py -tal 5",  # not a prefix of any bounding parameter
+    "gc src/x.py -t 5",  # a single letter is ambiguous, not a bound
 ]
 
 

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -303,6 +303,7 @@ DUMP_ESCAPES = [
     "for f in src/*.py; do cat $f; done > all.txt",  # the loop lands
     "for f in src/*.py; do grep -c def $f; done # cat",
     "for f in *.py; do wc -l $f; done",
+    "for f in src/*.py; do cat $f; done | grep -c import",  # the loop's output is filtered
     "git diff src/a.py | cat",  # the no-pager idiom: nothing is dumped
     "git log --oneline -- src/a.py | cat",
     "grep -n def src/a.py | cat -n",
@@ -343,6 +344,9 @@ def test_backslash_and_drive_letter_paths_are_seen(cmd: str) -> None:
         "for f in src/*.py; do echo ${f}; cat $f; done",
         "for f in src/*.py; do if grep -q foo $f; then cat $f; fi; done",
         "for f in src/*.py; do echo \"$f: $(cat $f)\"; done",
+        "for f in src/*.py; do cat $f || true; done",
+        "for f in src/*.py\ndo\n  cat $f\ndone",
+        "find src -name '*.py' | while read f; do cat $f; done",
     ],
 )
 def test_loop_over_source_files_is_blocked(cmd: str) -> None:

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -1,0 +1,395 @@
+"""Fake-tier tests for the PreToolUse shell guard in ``.claude/hooks/context-guard.py`` (#249).
+
+Same seam as ``test_read_guard.py``: the hook is executable config, driven as a
+subprocess with the tool payload on stdin; exit 2 plus a stderr message is a
+block. Every rule, every documented bypass and both measured false positives
+have a case here — a rule without a test is the one that gets regex-tightened
+into silence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS = Path(__file__).resolve().parents[1] / ".claude" / "hooks"
+HOOK = HOOKS / "context-guard.py"
+SETTINGS = Path(__file__).resolve().parents[1] / ".claude" / "settings.json"
+
+
+def run_hook(command: str, tool: str = "Bash") -> subprocess.CompletedProcess[str]:
+    payload = {
+        "session_id": "s1",
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool,
+        "tool_input": {"command": command},
+    }
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={"SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"), "PATH": ""},
+    )
+
+
+def blocked(command: str, tool: str = "Bash") -> str:
+    """The block message, or '' when the command passes."""
+    r = run_hook(command, tool)
+    assert r.returncode in (0, 2), r.stderr
+    return r.stderr if r.returncode == 2 else ""
+
+
+# ------------------------------------------------------------ 1. noisy runs
+
+BARE_NOISY = [
+    "uv run pytest -m 'not live'",
+    "pytest tests/test_x.py -q",
+    "uv run mypy",
+    "ruff check src",
+    "python -m pytest tests",
+    "CI=1 uv run pytest",
+    "uv run pytest tests 2>&1",  # stderr dup is not a landing
+    "uv run pytest tests 2> err.log",  # stderr only
+    "uv run pytest tests | grep -E 'passed|FAILED'",  # a filter still floods the log
+]
+
+
+@pytest.mark.parametrize("cmd", BARE_NOISY)
+def test_bare_noisy_run_is_blocked_with_redirect_shape(cmd: str) -> None:
+    msg = blocked(cmd)
+    assert msg, cmd
+    assert re.search(r"uv run (?:pytest|mypy|ruff) > \w+\.scratch\.log 2>&1", msg), msg
+
+
+PIPED_NOISY = [
+    "uv run pytest | tail -20",
+    "uv run pytest 2>&1 | head -50",
+    "pytest tests | cat",
+    "uv run mypy | tee mypy.log",
+    "uv run pytest | tail -5 > pytest.scratch.log",  # tail before the landing
+]
+
+
+@pytest.mark.parametrize("cmd", PIPED_NOISY)
+def test_noisy_piped_to_a_pager_is_blocked_with_the_tail_message(cmd: str) -> None:
+    msg = blocked(cmd)
+    assert "never pipe to tail/head" in msg, cmd
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "uv run pytest 2>&1 | Select-Object -Last 20",
+        "uv run pytest | select -First 5",
+        "uv run mypy | Out-Host",
+    ],
+)
+def test_powershell_pagers_count_as_pagers(cmd: str) -> None:
+    assert "never pipe to tail/head" in blocked(cmd, "PowerShell"), cmd
+
+
+LANDED_NOISY = [
+    "uv run pytest -m 'not live' > pytest.scratch.log 2>&1",
+    "uv run mypy > mypy.scratch.log 2>&1",
+    "uv run ruff check > ruff.scratch.log 2>&1",
+    "uv run pytest tests/test_x.py 1> pytest.scratch.log 2>&1",
+    "uv run pytest tests &> pytest.scratch.log",
+    "uv run pytest > pytest.scratch.log 2>&1; uv run mypy > mypy.scratch.log 2>&1",
+    "uv run pytest tests/test_x.py >> pytest.scratch.log 2>&1",
+]
+
+
+@pytest.mark.parametrize("cmd", LANDED_NOISY)
+def test_noisy_run_landing_in_a_file_passes(cmd: str) -> None:
+    assert blocked(cmd) == "", cmd
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "uv run pytest *> pytest.scratch.log",
+        "uv run pytest 2>&1 | Out-File pytest.scratch.log",
+        "uv run mypy | Set-Content mypy.scratch.log",
+    ],
+)
+def test_powershell_landings_pass(cmd: str) -> None:
+    assert blocked(cmd, "PowerShell") == "", cmd
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "uv run pytest --version",
+        "pytest --help",
+        "uv run pytest --collect-only -q tests/test_x.py > co.scratch.log",
+        "grep -E 'FAILED|passed' pytest.scratch.log",  # the log's name is not a run
+        "git commit -m 'run pytest before pushing'",  # prose in quotes
+        "echo pytest",  # not at command position
+    ],
+)
+def test_noisy_lookalikes_pass(cmd: str) -> None:
+    assert blocked(cmd) == "", cmd
+
+
+def test_second_statement_without_landing_is_still_caught() -> None:
+    assert blocked("uv run pytest > pytest.scratch.log 2>&1 && uv run mypy")
+
+
+# ------------------------------------------------------------ 2. gh views
+
+GH_BLOCKED = [
+    "gh issue view 249",
+    "gh issue view 249 --comments",
+    "gh pr view 243",
+    "gh pr diff 243",
+    "gh issue view 249 --json body -q .body",  # the body, unredirected
+    "gh issue view 249 --json comments -q '.comments[].body'",
+    "gh pr view 5 --json body,title",  # no filter at all
+    "gh pr diff 243 | grep '^+'",  # a filter is not a landing
+]
+
+
+@pytest.mark.parametrize("cmd", GH_BLOCKED)
+def test_gh_view_without_landing_is_blocked(cmd: str) -> None:
+    msg = blocked(cmd)
+    assert msg, cmd
+    assert "issue.scratch.log" in msg or "comments.scratch.log" in msg, msg
+
+
+GH_PASSES = [
+    "gh issue view 249 --json body -q .body > issue.scratch.log",
+    "gh issue view 249 --comments > comments.scratch.log",
+    "gh pr diff 243 > pr.scratch.log",
+    "gh pr view 243 --json state -q .state",  # a field filter
+    "gh issue view 249 --json title,labels -q '.title'",
+    "gh pr diff 243 --name-only",
+    "gh pr diff 243 --stat",
+    "gh pr list --state merged --json headRefName",  # not a view
+    "gh issue comment 249 --body 'see gh issue view 5'",  # prose
+]
+
+
+@pytest.mark.parametrize("cmd", GH_PASSES)
+def test_gh_view_landing_or_filtered_passes(cmd: str) -> None:
+    assert blocked(cmd) == "", cmd
+
+
+# ------------------------------------------------------------ 3. whole-file dumps
+
+WHOLE_FILE_DUMPS = [
+    "cat src/resolve_mcp/config.py",
+    "cat -n tests/conftest.py",
+    "cat notes.md",
+    "cat pytest.scratch.log",
+    "cat 'src/my file.py'",
+    "cat < src/config.py",
+    "ls; cat pyproject.toml",
+    "cat src/a.py 2>&1",
+    "cat src/a.py | cat -n",  # a re-emitter is not a filter
+    "more README.md",
+    "less src/config.py",
+    "type src\\config.py",
+    "sed -n p src/config.py",
+    "sed -n '1,$p' src/config.py",
+    "sed -n \"1,$p\" src/config.py",
+    "sed '' src/config.py",
+    "head src/config.py",
+    "tail src/config.py",
+    "tail -f pytest.scratch.log",
+    "head -c 4000 src/config.py",
+    "head --bytes=4000 src/config.py",
+    "Get-Content src/config.py",
+    "Get-Content -Path .claude/settings.json",
+    "gc src/config.py -Raw",
+    "Get-Content src/config.py | Out-String",
+]
+
+
+@pytest.mark.parametrize("cmd", WHOLE_FILE_DUMPS)
+def test_whole_file_dump_of_guarded_file_is_blocked(cmd: str) -> None:
+    msg = blocked(cmd)
+    assert msg, cmd
+    assert "whole-file dump" in msg and "offset/limit" in msg, msg
+
+
+def test_powershell_tool_get_content_is_blocked() -> None:
+    assert "whole-file dump" in blocked("Get-Content x.py", "PowerShell")
+
+
+def test_powershell_tool_cat_alias_and_type_are_blocked() -> None:
+    assert blocked("cat x.py", "PowerShell")
+    assert blocked("type x.py", "PowerShell")
+
+
+RANGED_READS = [
+    "sed -n 10,40p src/config.py",
+    "sed -n '120,160p' src/config.py",
+    "sed -n 5p src/config.py",
+    "sed -n '/def main/,/^$/p' src/config.py",
+    "sed -i 's/a/b/' src/config.py",  # an edit, not a read
+    "head -50 src/config.py",
+    "head -n 50 src/config.py",
+    "head -n50 src/config.py",
+    "head --lines=50 src/config.py",
+    "tail -n 20 pytest.scratch.log",
+    "tail -20 pytest.scratch.log",
+    "Get-Content src/config.py -TotalCount 50",
+    "Get-Content -TotalCount 50 src/config.py",
+    "Get-Content src/config.py -Tail 20",
+    "gc src/config.py -Head 20",
+    "Get-Content src/config.py | Select-Object -First 30",
+    "Get-Content src/config.py | Select-String -Pattern def",
+]
+
+
+@pytest.mark.parametrize("cmd", RANGED_READS)
+def test_ranged_read_passes(cmd: str) -> None:
+    assert blocked(cmd) == "", cmd
+    assert blocked(cmd, "PowerShell") == "", cmd
+
+
+DUMP_ESCAPES = [
+    "cat src/config.py | grep -n def",
+    "cat src/config.py | wc -l",
+    "cat src/a.py src/b.py > combined.txt",
+    "cat notes.md >> all.md",
+    "cat > new.py <<'EOF'\nprint('hi')\nEOF",
+    "cat <<EOF > out.txt\ncat src/config.py\nEOF",  # a cat inside a heredoc body
+    "cat image.png",  # unguarded extension
+    "cat file_without_extension",
+    "wc -l src/config.py",
+    "grep -n def src/config.py",
+    "git diff origin/main -- src/config.py",
+    "python scripts/prune_merged.py > prune.scratch.log 2>&1",
+    "type python",  # bash `type` on a command name
+    "echo 'cat src/config.py'",
+    "head -20 pytest.scratch.log | grep FAILED",
+]
+
+
+@pytest.mark.parametrize("cmd", DUMP_ESCAPES)
+def test_dump_lookalikes_and_landings_pass(cmd: str) -> None:
+    assert blocked(cmd) == "", cmd
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "cat C:\\Users\\me\\repo\\src\\config.py",
+        "cat .\\src\\config.py",
+        "type C:\\repo\\pyproject.toml",
+        "Get-Content C:\\repo\\.claude\\settings.json",
+        "cat 'C:\\Program Files\\x\\config.py'",
+        "head C:/repo/src/config.py",
+    ],
+)
+def test_backslash_and_drive_letter_paths_are_seen(cmd: str) -> None:
+    assert "whole-file dump" in blocked(cmd), cmd
+
+
+def test_cat_loop_over_source_files_is_blocked() -> None:
+    msg = blocked("for f in src/*.py; do cat $f; done")
+    assert "cat loop" in msg
+
+
+# ------------------------------------------------------------ false positives
+
+FALSE_POSITIVES = [
+    # Measured 2026-08-15: a PR body that talks about cat/tail is prose.
+    "gh pr create --title 'x' --body 'Review: run cat src/a.py | tail -5 first'",
+    "gh issue comment 249 --body \"never cat pytest.scratch.log | tail\"",
+    "gh pr create --body='cat foo.py'",
+    "git commit -m 'sed -n p src/config.py was the bug'",
+    "gh issue create --title 'cat src/a.py hangs' --body 'see head -c 10 x.py'",
+]
+
+
+@pytest.mark.parametrize("cmd", FALSE_POSITIVES)
+def test_body_and_message_arguments_are_never_inspected(cmd: str) -> None:
+    assert blocked(cmd) == "", cmd
+
+
+HEREDOC_FORMS = [
+    "gh pr create --body-file - <<'EOF'\ncat src/a.py | tail -3\nuv run pytest\nEOF",
+    "gh issue comment 249 -F - <<EOF\ngh issue view 5\nEOF",
+    "cat <<-EOF\n\tcat src/a.py\n\tEOF",
+    "python - <<'PY'\nprint(open('src/a.py').read())\nPY",
+    "git commit -F - <<'MSG'\nfix: cat src/config.py no longer used\nMSG",
+]
+
+
+@pytest.mark.parametrize("cmd", HEREDOC_FORMS)
+def test_heredoc_bodies_are_data(cmd: str) -> None:
+    assert blocked(cmd) == "", cmd
+
+
+def test_powershell_here_string_body_is_data() -> None:
+    cmd = "gh pr create --body @'\ncat src/a.py | tail -3\nuv run pytest\n'@"
+    assert blocked(cmd, "PowerShell") == ""
+
+
+def test_command_after_a_heredoc_is_still_checked() -> None:
+    cmd = "cat > x.txt <<'EOF'\nhello\nEOF\ncat src/config.py"
+    assert "whole-file dump" in blocked(cmd)
+
+
+# ------------------------------------------------------------ plumbing
+
+
+def test_other_tools_pass() -> None:
+    assert blocked("cat src/config.py", tool="Read") == ""
+    assert blocked("uv run pytest", tool="Edit") == ""
+
+
+def test_malformed_stdin_passes() -> None:
+    r = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input="not json",
+        capture_output=True,
+        text=True,
+        env={"SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"), "PATH": ""},
+    )
+    assert r.returncode == 0
+
+
+def test_settings_match_both_shell_tools_for_the_guard() -> None:
+    settings = json.loads(SETTINGS.read_text(encoding="utf-8"))
+    entries = [
+        e
+        for e in settings["hooks"]["PreToolUse"]
+        if any("context-guard.py" in h["command"] for h in e["hooks"])
+    ]
+    assert entries, "context-guard.py is not wired as a PreToolUse hook"
+    for tool in ("Bash", "PowerShell"):
+        assert any(re.fullmatch(e["matcher"], tool) for e in entries), tool
+
+
+def test_guarded_extension_list_is_defined_once_and_shared() -> None:
+    shared = HOOKS / "guarded_ext.py"
+    assert shared.exists()
+    for hook in ("context-guard.py", "read-guard.py"):
+        src = (HOOKS / hook).read_text(encoding="utf-8")
+        assert re.search(r"^from guarded_ext import ", src, re.M), hook
+        assert not re.search(r"^(?:GUARDED_EXT|SRC_EXT)\s*=", src, re.M), (
+            f"{hook} carries its own extension list"
+        )
+    # And the two hooks agree by construction: run each module's view of the list.
+    probe = (
+        "import sys; sys.path.insert(0, sys.argv[1]); "
+        "from guarded_ext import GUARDED_EXT, GUARDED_EXT_RE, SIZE_RULE_EXEMPT; "
+        "print(sorted(GUARDED_EXT)); print(GUARDED_EXT_RE); print(sorted(SIZE_RULE_EXEMPT))"
+    )
+    r = subprocess.run(
+        [sys.executable, "-c", probe, str(HOOKS)], capture_output=True, text=True, check=True
+    )
+    exts, alternation, exempt = r.stdout.splitlines()
+    assert ".md" in exts and ".toml" in exts and ".py" in exts
+    assert set(alternation.split("|")) == {e.lstrip(".") for e in eval(exts)}
+    assert exempt == "['.md']"

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -9,14 +9,16 @@ into silence.
 
 from __future__ import annotations
 
+import ast
 import json
-import os
 import re
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+from tests.test_read_guard import hook_env
 
 HOOKS = Path(__file__).resolve().parents[1] / ".claude" / "hooks"
 HOOK = HOOKS / "context-guard.py"
@@ -35,7 +37,7 @@ def run_hook(command: str, tool: str = "Bash") -> subprocess.CompletedProcess[st
         input=json.dumps(payload),
         capture_output=True,
         text=True,
-        env={"SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"), "PATH": ""},
+        env=hook_env(HOOKS),
     )
 
 
@@ -58,6 +60,14 @@ BARE_NOISY = [
     "uv run pytest tests 2>&1",  # stderr dup is not a landing
     "uv run pytest tests 2> err.log",  # stderr only
     "uv run pytest tests | grep -E 'passed|FAILED'",  # a filter still floods the log
+    "py -m pytest tests",
+    "python.exe -m pytest",
+    "uv.exe run pytest",
+    "pytest.exe tests",
+    "uv run --directory C:\\repo pytest",
+    "uvx ruff check src",
+    "$x = uv run pytest",
+    "uv run pytest 2>&1 | Select-String passed",  # a filter, not a pager: still bare
 ]
 
 
@@ -65,7 +75,7 @@ BARE_NOISY = [
 def test_bare_noisy_run_is_blocked_with_redirect_shape(cmd: str) -> None:
     msg = blocked(cmd)
     assert msg, cmd
-    assert re.search(r"uv run (?:pytest|mypy|ruff) > \w+\.scratch\.log 2>&1", msg), msg
+    assert re.search(r"uv run (?:pytest|mypy|ruff check) > \w+\.scratch\.log 2>&1", msg), msg
 
 
 PIPED_NOISY = [
@@ -117,6 +127,7 @@ def test_noisy_run_landing_in_a_file_passes(cmd: str) -> None:
         "uv run pytest *> pytest.scratch.log",
         "uv run pytest 2>&1 | Out-File pytest.scratch.log",
         "uv run mypy | Set-Content mypy.scratch.log",
+        "uv run pytest | Out-Null",
     ],
 )
 def test_powershell_landings_pass(cmd: str) -> None:
@@ -153,6 +164,7 @@ GH_BLOCKED = [
     "gh issue view 249 --json comments -q '.comments[].body'",
     "gh pr view 5 --json body,title",  # no filter at all
     "gh pr diff 243 | grep '^+'",  # a filter is not a landing
+    "gh issue view 249 --json title,body --template '{{.body}}'",
 ]
 
 
@@ -171,6 +183,9 @@ GH_PASSES = [
     "gh issue view 249 --json title,labels -q '.title'",
     "gh pr diff 243 --name-only",
     "gh pr diff 243 --stat",
+    "gh issue view 249 --json body,title -q .title",  # the filter picks a small field
+    "gh issue view 249 --json title,url --template '{{.title}}'",
+    "gh pr view 5 -t '{{.state}}' --json state",
     "gh pr list --state merged --json headRefName",  # not a view
     "gh issue comment 249 --body 'see gh issue view 5'",  # prose
 ]
@@ -209,6 +224,11 @@ WHOLE_FILE_DUMPS = [
     "Get-Content -Path .claude/settings.json",
     "gc src/config.py -Raw",
     "Get-Content src/config.py | Out-String",
+    "cat src/config.py | nl",
+    "$c = Get-Content src/config.py; $c",
+    "sed --quiet p src/config.py",
+    'sed -n "1,\\$p" src/config.py',
+    "tail -n +10 src/config.py",  # an offset with no end is not a range
 ]
 
 
@@ -246,6 +266,8 @@ RANGED_READS = [
     "gc src/config.py -Head 20",
     "Get-Content src/config.py | Select-Object -First 30",
     "Get-Content src/config.py | Select-String -Pattern def",
+    "(Get-Content src/config.py).Count",
+    "(Get-Content src/config.py)[10..40]",
 ]
 
 
@@ -271,6 +293,14 @@ DUMP_ESCAPES = [
     "type python",  # bash `type` on a command name
     "echo 'cat src/config.py'",
     "head -20 pytest.scratch.log | grep FAILED",
+    "cat src/config.py.bak",  # a backup, not the file
+    "cat src/config.py.orig src/config.py.rej",
+    "cat src/config.py~",
+    "cat notes.md.gz | zcat | grep x",
+    "for f in a.py b.py; do cat $f > $f.bak; done",  # each cat lands
+    "for f in src/*.py; do cat $f; done > all.txt",  # the loop lands
+    "for f in src/*.py; do grep -c def $f; done # cat",
+    "for f in *.py; do wc -l $f; done",
 ]
 
 
@@ -294,9 +324,45 @@ def test_backslash_and_drive_letter_paths_are_seen(cmd: str) -> None:
     assert "whole-file dump" in blocked(cmd), cmd
 
 
-def test_cat_loop_over_source_files_is_blocked() -> None:
-    msg = blocked("for f in src/*.py; do cat $f; done")
-    assert "cat loop" in msg
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "for f in src/*.py; do cat $f; done",
+        "for f in src/*.py; do cat $f | cat -n; done",
+        "foreach ($f in ls *.py) { cat $f }",
+        "Get-ChildItem *.py | % { gc $_ }",
+        "Get-ChildItem -r *.py | ForEach-Object { Get-Content $_ }",
+    ],
+)
+def test_loop_over_source_files_is_blocked(cmd: str) -> None:
+    assert "cat loop" in blocked(cmd), cmd
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "ls src/*.py | xargs cat",
+        "find src -name '*.py' -exec cat {} +",
+        "find src -name '*.py' -exec cat {} \\;",
+        "Get-ChildItem *.py | Get-Content",
+        "gci -r *.py | gc",
+    ],
+)
+def test_reader_fed_by_pipe_xargs_or_exec_is_blocked(cmd: str) -> None:
+    assert "whole-file dump" in blocked(cmd), cmd
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "ls src/*.py | xargs cat | grep def",
+        "find src -name '*.py' -exec cat {} + > all.txt",
+        "Get-ChildItem *.py | Get-Content | Select-String def",
+        "ls src/*.py | xargs wc -l",
+    ],
+)
+def test_reader_fed_by_pipe_but_filtered_or_landing_passes(cmd: str) -> None:
+    assert blocked(cmd) == "", cmd
 
 
 # ------------------------------------------------------------ false positives
@@ -354,7 +420,7 @@ def test_malformed_stdin_passes() -> None:
         input="not json",
         capture_output=True,
         text=True,
-        env={"SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"), "PATH": ""},
+        env=hook_env(HOOKS),
     )
     assert r.returncode == 0
 
@@ -391,5 +457,5 @@ def test_guarded_extension_list_is_defined_once_and_shared() -> None:
     )
     exts, alternation, exempt = r.stdout.splitlines()
     assert ".md" in exts and ".toml" in exts and ".py" in exts
-    assert set(alternation.split("|")) == {e.lstrip(".") for e in eval(exts)}
+    assert set(alternation.split("|")) == {e.lstrip(".") for e in ast.literal_eval(exts)}
     assert exempt == "['.md']"

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -241,6 +241,7 @@ WHOLE_FILE_DUMPS = [
     "sed -n '$!p' src/x.py",
     "Get-Content src/x.py | Write-Output",  # pass-through, not a filter
     "Get-Content src/x.py | Format-Table",
+    "gc src/x.py -tal 5",  # not a prefix of any bounding parameter
 ]
 
 


### PR DESCRIPTION
Closes #249.

## What

`context-guard.py` now fires for both shell tools (`settings.json` matcher `Bash|PowerShell`) and enforces the widened context-discipline rules from the 2026-08-15 audit:

- **Noisy runs must land in a file.** Bare `pytest|mypy|ruff` (any launcher: `uv run`, `uv.exe`, `uvx`, `py -m`, `python.exe -m`, `pytest.exe`, `uv run --directory X`) and runs piped anywhere — pager or filter — are blocked; the message shows the one-command redirect the worktree guard accepts. `--version/--help/--collect-only` are not runs.
- **`gh issue|pr view` and `pr diff` must land in a file.** A `--json … -q`/`--template` filter passes unless the expression pulls `body`/`bodyText`/`comments`; `pr diff --name-only|--stat` passes.
- **Any whole-file dump of a guarded file is blocked, by any reader:** `cat`, `more`, `less`, `type`, `Get-Content`/`gc`, `sed -n` with no range or `1,$p`, `head`/`tail` with no count, `head -c`; readers fed by `ls|find|Get-ChildItem … |`, `xargs`, `find -exec`; `for`/`foreach`/`while`/`%` loops whose body dumps. Ranged reads pass (`sed -n 10,40p`, `head -50`, `Get-Content -TotalCount 50`, `(Get-Content f)[10..40]`), as does a dump piped to a filter or redirected. Backslash and drive-letter paths are seen; the extension must end the arg (`foo.py.bak` is not the file).
- **Never inspected:** heredoc bodies, PowerShell here-strings, quoted `--body`/`--message`/`--title` args (the two measured false positives).
- **One guarded-extension list** — `.claude/hooks/guarded_ext.py`, imported by both hooks; the read guard's size rule keeps its markdown exemption via `SIZE_RULE_EXEMPT`.
- `tests/test_context_guard.py` (188 cases) drives the hook as a subprocess, same seam as `test_read_guard.py`: every rule, ranged-vs-whole per reader, backslash paths, `--body` false positives, heredoc forms, the settings matcher, and the shared list. CLAUDE.md names the widened rule and lists the redirect templates (pytest/mypy/ruff/gh issue/gh pr diff/git merge).

## Seam

Fake tier: `uv run pytest tests/test_context_guard.py tests/test_read_guard.py` — 206 passed; full tier 2542 passed; mypy strict and ruff clean.

## Interpretations worth a look

- "blocked with the same message the Read guard uses" → same shape and remedy (Grep first, then Read with offset/limit), with the reader-specific ranged forms named; not the literal big-file text.
- "gh view … blocked unless redirected" → a `--json` field filter that does not name the body/thread passes (`-q .title`, `.state`); CLAUDE.md says so.
- Known gaps, by design or cost: `fd -e py -x cat` (no `.py` token to see); `git ls-files '*.py' | cat` (not a lister); `sed -n 1,9999p`.

## Review record

`/code-review` (Standards + Spec sub-agents) on `664d698` against `origin/main`, then focused re-checks on each fix commit.

**Standards** — hard: CLAUDE.md overclaimed vs. PowerShell bypasses (fixed by closing them: `$c = Get-Content`, `foreach`, `gci | gc`, `xargs cat`, `-exec cat`, `.exe`/`py -m`/`uvx` launchers); test file inlined the env dict twice (now reuses `hook_env`) and used `eval` (now `ast.literal_eval`). Regex: `\b` after the extension blocked `foo.py.bak` (fixed: extension must end the arg); `select\b` matched `Select-String` (fixed); `Out-Null` (now a landing); `--json body,title -q .title` false positive (filter judged by its expression); `sed --quiet` / `"1,\$p"` (fixed); ruff remedy said `uv run ruff` (now `ruff check`); `for` rule ignored landing/pipes (rewritten). Smells noted (pager alternation duplicated → split into `REEMITTERS`/`PAGERS`; verdict strings) — accepted.
**Spec** — no requirement missing. CLAUDE.md rule paragraph exceeded "one or two lines" (trimmed). Extras beyond spec noted above.
**Re-check 1** (`d3a3916`) — all prior items confirmed fixed; new: `git diff a.py | cat` false positive from the fed-reader lookback (fixed: only listers/xargs/-exec feed), `||` read as a pipe (now a separator), loop body cut at `}`/missing then-do-else anchors, loose `%` (all fixed), `bodyText` (fixed).
**Re-check 2** (`87bb23e`) — all confirmed fixed; new: `|| true` inside a loop body, newline before `do`, `while read` loops, loop piped to a filter blocked (all fixed in `87a1e1c`, each with a test).

Review: clean — findings above resolved; the last commit is covered by the tests that reproduce the re-check probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Merge with origin/main (6c2683c, ae4658c, e9f48b6)

`origin/main` merged in after #248 (PR #255) landed a parallel rewrite of the same hooks — `context-guard.py`, `read-guard.py`, a shared extension module (`guard_ext.py`) and `tests/test_context_guard.py` — plus #252's CLAUDE.md paragraph. Resolution:

- This PR's implementation and shared module (`guarded_ext.py`) kept; `guard_ext.py` dropped (identical list). Both hooks import `guarded_ext`.
- #248's probe set was run against this hook; every behaviour it had that this PR lacked is ported, each with #248's case added to the tests: extension match is case-insensitive (`cat src/X.PY`, `SRC\CONFIG.JSON`); `sed -n '1,$ p'` and `'$!p'` are dumps; `| Write-Output`, `| Format-*`, `| Out-Default` are re-emitters, not filters; `gh … view --web`/`-w` passes; PowerShell parameter prefixes clear a read (`gc x.py -tot 5`, `-Total 5`).
- Kept from this PR where the two disagreed (each already a documented case here): a `--json` field filter that does not pull the body passes (`-q .state`); `gh pr diff --name-only|--stat` passes; `tail -n +N` is still a dump; a dump piped through a real filter passes even if a `| cat -n` follows.
- CLAUDE.md: #252's paragraph as base, with this PR's sentence naming both shell tools, every reader and the fed/loop forms, and the `--json` field-filter note.

Fake tier 2557 passed; mypy strict and ruff clean.

**Focused re-check of the merge diff** (`87a1e1c..6c2683c`, hooks + tests + CLAUDE.md): one finding — the ported prefix regex also cleared non-prefixes (`-tal`, `-hed`, `-fit`); fixed in `ae4658c` (`BOUNDING_PARAM` enumerates the exact prefixes of TotalCount/Tail/Head/First/Last, with a `-tal` blocked case); the sanity pass then noted single-letter prefixes (`-t`, `-h`) also cleared a read — `e9f48b6` starts prefixes at two letters, with a `-t 5` blocked case. Nothing else.

Review: clean — merge resolution re-checked; the one finding is fixed and tested.
