### PR TITLE
Review gate proves the reviewed sha; CI --locked; no silent ticket closes (#251)

### DIFF
--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -9,13 +9,16 @@ Blocks (exit 2, message to the model):
   2. `gh issue view` / `gh pr view` / `gh pr diff` that do not land in a file.
      A `--json … -q`/`--template` field filter passes unless it pulls the body
      or the comment thread; `gh pr diff --name-only|--stat` passes.
-  3. A whole-file dump of a guarded file (guarded_ext.py) by any reader —
+  3. `gh issue close` with no `--comment`/`-c` — a ticket's implementation
+     record lives on the ticket, and a silent close loses it. A `gh issue
+     comment <n>` on the same number in the same command counts as the record.
+  4. A whole-file dump of a guarded file (guarded_ext.py) by any reader —
      `cat`, `more`, `less`, `type`, `Get-Content`/`gc`, `sed -n` with no range
      or `1,$p`, `head`/`tail` with no count, `head -c` — that is neither piped
      to a filter nor redirected. Ranged reads (`sed -n 10,40p`, `head -50`,
      `Get-Content -TotalCount 50`) pass. Backslash and drive-letter paths count,
      and so do readers fed by `xargs`, `find -exec`, or a `Get-ChildItem` pipe.
-  4. A `for`/`foreach` loop over guarded files whose body dumps them.
+  5. A `for`/`foreach` loop over guarded files whose body dumps them.
 
 Heredoc / here-string bodies and quoted `--body`/`--message`/`--title`
 arguments are data, not commands, and are blanked before any rule looks (the
@@ -190,7 +193,30 @@ for m in re.finditer(GH_VIEW, blanked):
         "a --json field filter (-q .title, .state) is fine."
     )
 
-# ---------------------------------------------------------------- 3. whole-file dumps
+# ---------------------------------------------------------------- 3. silent closes
+# A ticket's implementation record belongs on the ticket: what landed, which
+# live ACs ran, what the close needs from the human (CLAUDE.md step 8). The
+# 2026-08-15 audit found #167-#178, #184, #164 and #139 bulk-closed with no
+# comment at all, and #219 closed with zero comments — its live record survives
+# only on PR #243, where nobody reading the ticket will find it. A `gh issue
+# comment <n>` on the same number in the same command is that record.
+GH_CLOSE = r"\bgh\s+issue\s+close\b(?P<args>[^;&|\n]*)"
+COMMENT_FLAG = r"(?<!\S)(?:--comment(?:=|\s+)|-c(?:=|\s+))\S"
+for m in re.finditer(GH_CLOSE, blanked):
+    args = m.group("args")
+    if re.search(COMMENT_FLAG, args):
+        continue
+    number = re.search(r"(?<!\S)#?(\d+)(?!\S)", args)
+    if number and re.search(r"\bgh\s+issue\s+comment\s+#?" + number.group(1) + r"\b", blanked):
+        continue  # the record was posted in the same command, then the ticket closed
+    block(
+        "Blocked (workflow): a ticket closed with no comment loses its implementation record "
+        "- what landed, the PR link, which live ACs ran, and the ## Needs from you section.\n"
+        "Close with the record: gh issue close <n> --comment \"...\" (a long record can go up "
+        "first as gh issue comment <n> -F - <<'EOF' ... EOF in the same command)."
+    )
+
+# ---------------------------------------------------------------- 4. whole-file dumps
 DUMP_MSG = (
     "Blocked (context discipline): a whole-file dump of {name} puts the whole file in context - "
     "the rules govern content entering context, not which tool fetched it.\n"

--- a/.claude/hooks/context-guard.py
+++ b/.claude/hooks/context-guard.py
@@ -201,19 +201,26 @@ for m in re.finditer(GH_VIEW, blanked):
 # only on PR #243, where nobody reading the ticket will find it. A `gh issue
 # comment <n>` on the same number in the same command is that record.
 GH_CLOSE = r"\bgh\s+issue\s+close\b(?P<args>[^;&|\n]*)"
-COMMENT_FLAG = r"(?<!\S)(?:--comment(?:=|\s+)|-c(?:=|\s+))\S"
-for m in re.finditer(GH_CLOSE, blanked):
+# A flag with an *empty* value is no record: `--comment ""` closes silently.
+COMMENT_FLAG = r"(?<!\S)(?:--comment|-c)(?:=|\s+)(?:'[^']+'|\"[^\"]+\"|[^'\"\s]\S*)"
+# A record is prose and carries `;` and `|` of its own ("landed as PR #260; live
+# ACs run"), which would end the statement early: quoted runs collapse to one
+# placeholder character, keeping only whether they are empty.
+scan_close = re.sub(r"'([^']*)'", lambda q: "'X'" if q.group(1) else "''", blanked)
+scan_close = re.sub(r"\"([^\"]*)\"", lambda q: '"X"' if q.group(1) else '""', scan_close)
+for m in re.finditer(GH_CLOSE, scan_close):
     args = m.group("args")
     if re.search(COMMENT_FLAG, args):
         continue
     number = re.search(r"(?<!\S)#?(\d+)(?!\S)", args)
-    if number and re.search(r"\bgh\s+issue\s+comment\s+#?" + number.group(1) + r"\b", blanked):
+    if number and re.search(r"\bgh\s+issue\s+comment\s+#?" + number.group(1) + r"\b", scan_close):
         continue  # the record was posted in the same command, then the ticket closed
     block(
         "Blocked (workflow): a ticket closed with no comment loses its implementation record "
         "- what landed, the PR link, which live ACs ran, and the ## Needs from you section.\n"
         "Close with the record: gh issue close <n> --comment \"...\" (a long record can go up "
-        "first as gh issue comment <n> -F - <<'EOF' ... EOF in the same command)."
+        "first as gh issue comment <n> -F - <<'EOF' ... EOF in the same command). If the comment "
+        "already went up in an earlier call, name it here: --comment \"see the comment above\"."
     )
 
 # ---------------------------------------------------------------- 4. whole-file dumps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+      # --locked: resolve exactly what uv.lock pins and fail if the lock is
+      # stale, rather than silently re-resolving (2026-08-15 audit, #251) —
+      # a green CI must mean the checked-in lock is what was tested.
       - name: Sync dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: Unit tests (fake tier)
         run: uv run pytest -m 'not live'
       - name: Type check

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -35,4 +35,4 @@ jobs:
         env:
           BODY: ${{ github.event.pull_request.body }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: python3 scripts/review_gate.py
+        run: python3 -m scripts.review_gate

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,11 +1,18 @@
 name: review-gate
 
-# Requires the PR body's last `Review:` line to read `Review: clean` before
-# merge. Ported from forest-shell, where the skill-text-only version of this
-# gate was walked past twice: PR #128 merged by hand over `Review: findings
-# held`, and by 2026-08-05, 10 of 14 post-fix PRs carried that same
-# contentless token. A held finding must be written out and resolved, not
-# tokenized past the gate.
+# Requires the PR body's last `Review:` line to read `Review: clean @<sha>`,
+# naming the commit the PR is about to merge, before merge. Ported from
+# forest-shell, where the skill-text-only version of this gate was walked past
+# twice: PR #128 merged by hand over `Review: findings held`, and by 2026-08-05,
+# 10 of 14 post-fix PRs carried that same contentless token. A held finding must
+# be written out and resolved, not tokenized past the gate.
+#
+# The sha is what makes the check real (2026-08-15 audit, #251): the gate re-runs
+# on `synchronize` with an unchanged body, so before the sha a PR that gained
+# commits after its review stayed green. Now the reviewed commit must be the PR
+# head — any push after the review reddens the gate until a fresh `Review:` line
+# lands. The verdict itself lives in `scripts/review_gate.py`, driven at the fake
+# tier by `tests/test_review_gate.py`; this file is the checkout and the trigger.
 #
 # `review-line` is a required status check on main via branch protection —
 # renaming the job means updating the protection rule's contexts to match.
@@ -18,21 +25,14 @@ jobs:
   review-line:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Require "Review: clean" in the PR body'
+      # refs/pull/<n>/head exists in this repository for every PR (a fork's head
+      # sha does not), and the full history is what reachability is judged on.
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          fetch-depth: 0
+      - name: 'Require "Review: clean @<sha>" naming the PR head'
         env:
           BODY: ${{ github.event.pull_request.body }}
-        run: |
-          line=$(printf '%s' "$BODY" | tr -d '\r' | grep -E '^Review:' | tail -1 || true)
-          case "$line" in
-            "Review: clean"|"Review: clean "*)
-              echo "gate: $line" ;;
-            "")
-              echo "::error::PR body has no 'Review:' line — run /code-review (two-axis), then append 'Review: clean' or 'Review:' plus the findings themselves."
-              exit 1 ;;
-            "Review: findings held"|"Review: findings held.")
-              echo "::error::'findings held' is a contentless token — write the findings into the body, resolve them, then set 'Review: clean'."
-              exit 1 ;;
-            *)
-              echo "::error::Review line reads '$line', not 'Review: clean' — resolve what it names before merging."
-              exit 1 ;;
-          esac
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/review_gate.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ produced no work; relaunch rather than assume.)
    - **Pure prose** — docs, README, CLAUDE.md — is written and reviewed
      under `/writing-for-agents` (load the skill before the first edit;
      the pass checks pointers, hierarchy, leading words, negation,
-     pruning), and the line reads `Review: clean — prose only,
+     pruning), and the line reads `Review: clean @<sha> — prose only,
      /writing-for-agents pass`.
 3. **Fix findings; re-check the fix diff only** — a focused pass over what
    changed, not a second full review. One full review per PR is the
@@ -94,12 +94,15 @@ produced no work; relaunch rather than assume.)
    diff.
 4. **Open the PR with the review record already in the body**: findings and
    their resolutions (if any) first, ending with the `Review:` line. The
-   gate reads only the **last** `Review:` line in the body and passes only
-   `Review: clean` (optionally followed by a summary) — any other last line
-   blocks merge — so a PR opened this way is green from its first gate run.
-   If a PR gains commits after opening (human feedback, CI failures),
-   re-review the new diff and append a fresh `Review:` line; the earlier
-   lines stay above it as the record.
+   line names the commit you reviewed — `Review: clean @<sha>` (the short
+   sha, `git rev-parse --short HEAD` on the reviewed branch), optionally
+   followed by a summary. The gate reads only the **last** `Review:` line
+   outside a fenced code block (leading `-`, `>` and `**` are tolerated) and
+   passes only when that sha is the PR head, so a PR opened this way is
+   green from its first gate run. Any commit pushed after the line — human
+   feedback, a CI fix, a merge from `origin/main` — reddens the gate until
+   you re-review the new diff and append a fresh `Review: clean @<newsha>`;
+   the earlier lines stay above it as the record.
 5. **Merge through the PR** — everything reaches `main` through a PR, never
    a direct commit.
 6. **After a stacked PR merges, verify its commits reached main by
@@ -118,9 +121,13 @@ produced no work; relaunch rather than assume.)
    the old branch would drag merged commits back in. After a merge-commit
    PR the same branch is safe.
 8. **Close the ticket with a comment** — PR link, what landed, the live
-   record, any unrun live ACs. Never a bare close: a ticket the PR
-   auto-closed still gets the comment (#219 closed with none; #167–#178
-   were bulk-closed silent and a reader has no outcome).
+   record, any unrun live ACs. The live record's home is the **ticket**; the
+   PR body may repeat it, and a record that lives only on the PR is lost to
+   anyone reading the ticket (#219's live pass survives only on PR #243).
+   Never a bare close: a ticket the PR auto-closed still gets the comment
+   (#167–#178 were bulk-closed silent and a reader has no outcome), and
+   `context-guard.py` blocks a `gh issue close` that carries no
+   `--comment`.
 
 When resolving merge conflicts, grep every conflicted file for `<<<<<<<`
 before committing — especially markdown: CI never reads it, and a leftover

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -138,7 +138,7 @@ audio or synthetic frames; `live`: a running Resolve Studio (`pytest -m live`);
 fake), `test_rough_cut_pillar` (the P4 pillar end to end; fake), `test_style_layer`
 (server code never touches `styles/`; pure), `test_text_plus_probe` (the Text+
 template-append probe; fake), `test_read_guard` and `test_context_guard` (the Read hook and
-the shell hook; sub), `test_context_map` (this map covers the tree; pure), `test_prune_merged` (`scripts/prune_merged.py` over an injected `Runner`; pure). Live tier: `test_live_smoke`, `test_live_analysis`, and
+the shell hook; sub), `test_context_map` (this map covers the tree; pure), `test_prune_merged` (`scripts/prune_merged.py` over an injected `Runner`; pure), `test_review_gate` (`scripts/review_gate.py` over an injected `Runner`; pure). Live tier: `test_live_smoke`, `test_live_analysis`, and
 the state it builds in `live_state` (decisions covered by `test_live_state`; fake).
 Fixtures and helpers: `conftest` (installs the fake seam, hermetic `Config`),
 `cutfile`, `roughcut`, `mediapool`, `otio`, `text_plus_probe`, `currency_probe`.
@@ -147,4 +147,4 @@ package: `fakes/core`, `fakes/connection`, `fakes/project`, `fakes/pool`,
 `fakes/media`, `fakes/timeline`, `fakes/timeline_item`, `fakes/fusion`,
 `fakes/interchange`, `fakes/separator`, `fakes/fixtures`, `fakes/builders`. `tests/data/`: the one committed real footage (occlusion evidence grids).
 
-**Not modules.** `styles/`, `gauntlet/`, `projects/` — agent-owned data, never read by server code; `scripts/` — repo maintenance (`prune_merged.py`, CLAUDE.md step 6). Both: `docs/context/repo.md`. ADRs cited above: `docs/adr/`.
+**Not modules.** `styles/`, `gauntlet/`, `projects/` — agent-owned data, never read by server code; `scripts/` — repo maintenance (`prune_merged.py`, CLAUDE.md step 6) and the workflows' own logic (`review_gate.py`, the `Review: clean @<sha>` verdict `.github/workflows/review-gate.yml` runs). Both: `docs/context/repo.md`. ADRs cited above: `docs/adr/`.

--- a/gauntlet/HANDOFF.md
+++ b/gauntlet/HANDOFF.md
@@ -28,7 +28,9 @@ filed via `/to-tickets` (user skill; if absent post-compact, ask or use
    `gauntlet/tools/`, hooks — everything.
 2. Fix findings; re-check fix diff only.
 3. PR body: findings + resolutions first, LAST line must read
-   `Review: clean` (gate reads only the last `Review:` line).
+   `Review: clean @<sha>`, the short sha of the reviewed commit — the gate
+   reads the last `Review:` line outside a code fence and passes only when
+   that sha is the PR head (#251).
 4. CI gates: `uv run pytest -m 'not live'` (last known 1721+ passing),
    `uv run mypy` strict, `ruff check` — all were green at each commit.
 5. Merge through the PR; never direct to main. After merge, verify commits

--- a/scripts/_run.py
+++ b/scripts/_run.py
@@ -1,0 +1,30 @@
+"""The one subprocess seam the scripts in this directory share.
+
+Every script here learns what it knows through a ``Runner`` — a callable from
+argv to stdout — so the fake tier drives it on fixtures of the ``git`` / ``gh``
+output instead of a real repository. ``subprocess_runner`` is the real one.
+
+Kept in its own module because the shape was copied once and drifted (the copy
+lost ``encoding="utf-8"``, which is what decodes a UTF-8 ``git log`` on the
+Windows box). Both scripts are run as modules from the repo root —
+``uv run python -m scripts.prune_merged``, ``python3 -m scripts.review_gate`` —
+so this import resolves the same way in CI, in a session, and under pytest.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable, Sequence
+
+Runner = Callable[[Sequence[str]], str]
+
+
+class CommandError(RuntimeError):
+    """A command the Runner issued failed; the message carries argv and stderr."""
+
+
+def subprocess_runner(argv: Sequence[str]) -> str:
+    proc = subprocess.run(list(argv), capture_output=True, text=True, encoding="utf-8")
+    if proc.returncode != 0:
+        raise CommandError(f"{' '.join(argv)} failed ({proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout

--- a/scripts/prune_merged.py
+++ b/scripts/prune_merged.py
@@ -2,8 +2,8 @@
 
 Dry-run by default — prints what it would remove and why. ``--apply`` removes it.
 
-    uv run python scripts/prune_merged.py            # list
-    uv run python scripts/prune_merged.py --apply    # remove
+    uv run python -m scripts.prune_merged            # list
+    uv run python -m scripts.prune_merged --apply    # remove
 
 What counts as merged, for a branch ``N`` whose tip is ``T``:
 
@@ -28,20 +28,15 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 
-Runner = Callable[[Sequence[str]], str]
+from scripts._run import CommandError, Runner, subprocess_runner
 
 WORKTREE_DIR = ".claude/worktrees/"
 PROTECTED = frozenset({"main", "HEAD"})
 BASE = "main"
-
-
-class CommandError(RuntimeError):
-    """A command the Runner issued failed; the message carries argv and stderr."""
 
 
 @dataclass(frozen=True)
@@ -274,13 +269,6 @@ def render(plan: Plan, *, verbose: bool) -> str:
         f"{len(plan.remote_branches)} remote branch(es) to remove; {len(plan.skipped)} kept"
     )
     return "\n".join(lines)
-
-
-def subprocess_runner(argv: Sequence[str]) -> str:
-    proc = subprocess.run(list(argv), capture_output=True, text=True, encoding="utf-8")
-    if proc.returncode != 0:
-        raise CommandError(f"{' '.join(argv)} failed ({proc.returncode}): {proc.stderr.strip()}")
-    return proc.stdout
 
 
 def main(argv: Sequence[str] | None = None, run: Runner = subprocess_runner) -> int:

--- a/scripts/review_gate.py
+++ b/scripts/review_gate.py
@@ -3,7 +3,7 @@
 
 Run by ``.github/workflows/review-gate.yml`` in a checkout of the PR head::
 
-    BODY=... HEAD_SHA=... python3 scripts/review_gate.py
+    BODY=... HEAD_SHA=... python3 -m scripts.review_gate
 
 Why the sha (2026-08-15 workflow audit, #251): the old gate matched the literal
 ``Review: clean`` and re-ran on ``synchronize`` with an unchanged body, so a PR
@@ -27,11 +27,9 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess
 import sys
-from collections.abc import Callable, Sequence
 
-Runner = Callable[[Sequence[str]], str]
+from scripts._run import CommandError, Runner, subprocess_runner
 
 # A fence opens or closes on ``` / ~~~ at any indent; the info string of an
 # opening fence is ignored. Toggling is enough: an unclosed fence swallows the
@@ -43,20 +41,9 @@ LEADING_MARKUP = re.compile(r"^(?:[-*+]\s+|\d+[.)]\s+|>\s*)+")
 EMPHASIS_OPEN = re.compile(r"^(?:\*{1,2}|_{1,2})")
 EMPHASIS_CLOSE = re.compile(r"(?:\*{1,2}|_{1,2})$")
 REVIEW = re.compile(r"^Review:")
-CLEAN = re.compile(r"^Review:\s+clean\s+@(?P<sha>[0-9a-fA-F]{7,40})\b(?P<summary>.*)$")
+CLEAN = re.compile(r"^Review:\s+clean\s+@(?P<sha>[0-9a-fA-F]{7,40})\b.*$")  # a summary may follow
 CLEAN_NO_SHA = re.compile(r"^Review:\s+clean\b")
 HELD = re.compile(r"^Review:\s+findings\s+held\b", re.I)
-
-
-class CommandError(RuntimeError):
-    """A command the Runner issued failed; the message carries argv and stderr."""
-
-
-def run_git(argv: Sequence[str]) -> str:
-    proc = subprocess.run(list(argv), capture_output=True, text=True)
-    if proc.returncode != 0:
-        raise CommandError(f"{' '.join(argv)}: {proc.stderr.strip()}")
-    return proc.stdout
 
 
 def normalise(line: str) -> str:
@@ -85,9 +72,9 @@ def review_lines(body: str) -> list[str]:
     return found
 
 
-def reviewed_commit(sha: str, head: str, run: Runner) -> str | None:
-    """The failure message for *sha* against the PR head, or None when it is the
-    head: unknown sha, a sha off this PR's history, or commits landed since."""
+def sha_failure(sha: str, head: str, run: Runner) -> str | None:
+    """Why *sha* does not stand for the PR head — unknown to the repository, off
+    this PR's history, or overtaken by commits — or None when it is the head."""
     try:
         full = run(["git", "rev-parse", "--verify", "--quiet", f"{sha}^{{commit}}"]).strip()
     except CommandError:
@@ -138,10 +125,10 @@ def check(body: str, head: str, run: Runner) -> str | None:
             f"Review line reads '{line}', not 'Review: clean @<sha>' — "
             "resolve what it names before merging."
         )
-    return reviewed_commit(match.group("sha"), head, run)
+    return sha_failure(match.group("sha"), head, run)
 
 
-def main(body: str | None = None, head: str | None = None, run: Runner = run_git) -> int:
+def main(body: str | None = None, head: str | None = None, run: Runner = subprocess_runner) -> int:
     body = os.environ.get("BODY", "") if body is None else body
     head = os.environ.get("HEAD_SHA", "") if head is None else head
     failure = check(body, head, run)

--- a/scripts/review_gate.py
+++ b/scripts/review_gate.py
@@ -1,0 +1,156 @@
+"""The review gate's body check: the PR body's last ``Review:`` line must read
+``Review: clean @<sha>`` and name the commit the PR is about to merge.
+
+Run by ``.github/workflows/review-gate.yml`` in a checkout of the PR head::
+
+    BODY=... HEAD_SHA=... python3 scripts/review_gate.py
+
+Why the sha (2026-08-15 workflow audit, #251): the old gate matched the literal
+``Review: clean`` and re-ran on ``synchronize`` with an unchanged body, so a PR
+that gained commits after its review passed the gate green — the habit of
+re-reviewing was followed 35/35 times, but the gate could not see it. A sha
+turns the convention into something checkable: the reviewed commit must *be*
+the PR head, so any commit pushed after the review reddens the gate until a
+fresh ``Review:`` line lands.
+
+The same audit found two shape holes, both closed here: ``Review: clean`` at
+column 0 **inside a fenced example** passed (fenced blocks are now stripped
+before the search), and ``**Review: clean**`` / ``- Review: clean`` blocked
+(leading list, quote and bold markup is now tolerated).
+
+Everything the check learns about the repository comes through one ``Runner``
+(a callable from argv to stdout), so the fake tier drives every verdict on
+fixtures of the ``git`` output (``tests/test_review_gate.py``).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+
+Runner = Callable[[Sequence[str]], str]
+
+# A fence opens or closes on ``` / ~~~ at any indent; the info string of an
+# opening fence is ignored. Toggling is enough: an unclosed fence swallows the
+# rest of the body, which is the safe direction (the line is not found).
+FENCE = re.compile(r"^[ \t]*(?:```|~~~)")
+# Markdown that may lead the line: list bullets, ordered items, block quotes.
+LEADING_MARKUP = re.compile(r"^(?:[-*+]\s+|\d+[.)]\s+|>\s*)+")
+# ...and the emphasis that may wrap it: **bold**, __bold__, *italic*, _italic_.
+EMPHASIS_OPEN = re.compile(r"^(?:\*{1,2}|_{1,2})")
+EMPHASIS_CLOSE = re.compile(r"(?:\*{1,2}|_{1,2})$")
+REVIEW = re.compile(r"^Review:")
+CLEAN = re.compile(r"^Review:\s+clean\s+@(?P<sha>[0-9a-fA-F]{7,40})\b(?P<summary>.*)$")
+CLEAN_NO_SHA = re.compile(r"^Review:\s+clean\b")
+HELD = re.compile(r"^Review:\s+findings\s+held\b", re.I)
+
+
+class CommandError(RuntimeError):
+    """A command the Runner issued failed; the message carries argv and stderr."""
+
+
+def run_git(argv: Sequence[str]) -> str:
+    proc = subprocess.run(list(argv), capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise CommandError(f"{' '.join(argv)}: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def normalise(line: str) -> str:
+    """Strip the markdown a ``Review:`` line may be dressed in, leaving the line
+    itself: ``- **Review: clean @abc1234**`` -> ``Review: clean @abc1234``."""
+    text = line.strip()
+    text = LEADING_MARKUP.sub("", text)
+    text = EMPHASIS_OPEN.sub("", text)
+    text = EMPHASIS_CLOSE.sub("", text)
+    return text.strip()
+
+
+def review_lines(body: str) -> list[str]:
+    """Every normalised ``Review:`` line outside a fenced code block, in order."""
+    found = []
+    fenced = False
+    for raw in body.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        if FENCE.match(raw):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        line = normalise(raw)
+        if REVIEW.match(line):
+            found.append(line)
+    return found
+
+
+def reviewed_commit(sha: str, head: str, run: Runner) -> str | None:
+    """The failure message for *sha* against the PR head, or None when it is the
+    head: unknown sha, a sha off this PR's history, or commits landed since."""
+    try:
+        full = run(["git", "rev-parse", "--verify", "--quiet", f"{sha}^{{commit}}"]).strip()
+    except CommandError:
+        full = ""
+    if not full:
+        return (
+            f"Review line names @{sha}, a commit this repository does not have — "
+            "use the short sha of the commit you reviewed (git rev-parse --short HEAD)."
+        )
+    if full == head:
+        return None
+    if int(run(["git", "rev-list", "--count", f"{head}..{full}"]).strip() or 0):
+        return (
+            f"Review line names @{sha}, which is not reachable from the PR head {head[:12]} — "
+            "review the branch as it stands and name its tip."
+        )
+    ahead = run(["git", "rev-list", "--count", f"{full}..{head}"]).strip()
+    return (
+        f"{ahead} commit(s) landed after the reviewed commit @{sha} — re-review the new diff "
+        f"and append a fresh 'Review: clean @{head[:7]}' line (the earlier lines stay above it)."
+    )
+
+
+def check(body: str, head: str, run: Runner) -> str | None:
+    """The gate's verdict on a PR body: a failure message, or None to pass."""
+    lines = review_lines(body or "")
+    if not lines:
+        return (
+            "PR body has no 'Review:' line — run /code-review (two-axis), then append "
+            "'Review: clean @<sha>' naming the commit you reviewed, or 'Review:' plus the "
+            "findings themselves."
+        )
+    line = lines[-1]
+    if HELD.match(line):
+        return (
+            "'findings held' is a contentless token — write the findings into the body, "
+            "resolve them, then set 'Review: clean @<sha>'."
+        )
+    match = CLEAN.match(line)
+    if not match:
+        if CLEAN_NO_SHA.match(line):
+            return (
+                f"Review line reads '{line}' with no commit — the gate proves the review "
+                "covered what merges: 'Review: clean @<sha>', the short sha of the reviewed "
+                "commit (git rev-parse --short HEAD)."
+            )
+        return (
+            f"Review line reads '{line}', not 'Review: clean @<sha>' — "
+            "resolve what it names before merging."
+        )
+    return reviewed_commit(match.group("sha"), head, run)
+
+
+def main(body: str | None = None, head: str | None = None, run: Runner = run_git) -> int:
+    body = os.environ.get("BODY", "") if body is None else body
+    head = os.environ.get("HEAD_SHA", "") if head is None else head
+    failure = check(body, head, run)
+    if failure is None:
+        print(f"gate: {review_lines(body)[-1]}")
+        return 0
+    print(f"::error::{failure}")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - the workflow's entry point
+    sys.exit(main())

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -225,7 +225,8 @@ def test_powershell_tool_silent_close_is_blocked() -> None:
 
 
 CLOSE_PASSES = [
-    'gh issue close 251 --comment "landed as PR #260; live ACs run"',
+    'gh issue close 251 --comment "landed as PR #260; live ACs run"',  # prose carries `;`
+    "gh issue close 251 --comment \"it's landed; see PR #260\"",  # ...and apostrophes
     "gh issue close 251 -c 'see PR #260'",
     "gh issue close 251 --comment='see PR #260'",
     'gh issue close 251 --reason completed --comment "see PR #260"',

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -199,7 +199,48 @@ def test_gh_view_landing_or_filtered_passes(cmd: str) -> None:
     assert blocked(cmd) == "", cmd
 
 
-# ------------------------------------------------------------ 3. whole-file dumps
+# ------------------------------------------------------ 3. silent ticket closes
+
+CLOSE_BLOCKED = [
+    "gh issue close 251",
+    "gh issue close 251 --reason completed",
+    "gh issue close #251",
+    "gh issue close 251 -R danielbaldwin47/resolve-mcp",
+    "gh issue comment 249 --body 'done' && gh issue close 251",  # a different ticket
+    "for n in 167 168; do gh issue close $n; done",
+]
+
+
+@pytest.mark.parametrize("cmd", CLOSE_BLOCKED)
+def test_closing_a_ticket_without_a_comment_is_blocked(cmd: str) -> None:
+    msg = blocked(cmd)
+    assert msg, cmd
+    assert "implementation record" in msg and "--comment" in msg, msg
+
+
+def test_powershell_tool_silent_close_is_blocked() -> None:
+    assert "implementation record" in blocked("gh issue close 251", "PowerShell")
+
+
+CLOSE_PASSES = [
+    'gh issue close 251 --comment "landed as PR #260; live ACs run"',
+    "gh issue close 251 -c 'see PR #260'",
+    "gh issue close 251 --comment='see PR #260'",
+    'gh issue close 251 --reason completed --comment "see PR #260"',
+    # The long record posted first, then the close, in one command.
+    "gh issue comment 251 -F - <<'EOF'\n## What landed\n...\nEOF\ngh issue close 251",
+    "gh issue comment 251 --body 'ready; do not gh issue close 251 yet'",  # prose
+    "gh pr close 260",  # a PR, not a ticket
+    "gh issue list --state closed",
+]
+
+
+@pytest.mark.parametrize("cmd", CLOSE_PASSES)
+def test_a_close_carrying_its_record_passes(cmd: str) -> None:
+    assert blocked(cmd) == "", cmd
+
+
+# ------------------------------------------------------------ 4. whole-file dumps
 
 WHOLE_FILE_DUMPS = [
     "cat src/resolve_mcp/config.py",

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -208,6 +208,8 @@ CLOSE_BLOCKED = [
     "gh issue close 251 -R danielbaldwin47/resolve-mcp",
     "gh issue comment 249 --body 'done' && gh issue close 251",  # a different ticket
     "for n in 167 168; do gh issue close $n; done",
+    'gh issue close 251 --comment ""',  # an empty record is no record
+    "gh issue close 251 -c ''",
 ]
 
 

--- a/tests/test_prune_merged.py
+++ b/tests/test_prune_merged.py
@@ -12,8 +12,8 @@ from collections.abc import Sequence
 
 import pytest
 
+from scripts._run import CommandError
 from scripts.prune_merged import (
-    CommandError,
     Plan,
     apply_plan,
     build_plan,

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -13,7 +13,8 @@ from collections.abc import Sequence
 
 import pytest
 
-from scripts.review_gate import CommandError, Runner, check, main, review_lines
+from scripts._run import CommandError, Runner
+from scripts.review_gate import check, main, review_lines
 
 OLD = "1" * 40
 MID = "2" * 40

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -1,0 +1,186 @@
+"""scripts/review_gate.py at its one seam: the Runner (#251).
+
+Every ``git`` command the check issues is answered from a fake linear history —
+the gate's verdicts are decisions about a PR body, and decisions verify at the
+fake tier. What no seam here covers is GitHub's half of it (the checkout ref,
+the event types the workflow fires on); that is verified once with a scratch PR
+and recorded on the ticket.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from scripts.review_gate import CommandError, Runner, check, main, review_lines
+
+OLD = "1" * 40
+MID = "2" * 40
+HEAD = "3" * 40
+HISTORY = [OLD, MID, HEAD]  # oldest first
+FOREIGN = "9" * 40  # a commit off this PR's history entirely
+
+
+def fake_git(history: Sequence[str] = tuple(HISTORY), extra: Sequence[str] = (FOREIGN,)) -> Runner:
+    """A Runner over a linear history: ``rev-parse`` resolves a short sha only
+    for a commit the repository has, ``rev-list --count a..b`` counts what *b*
+    carries that *a* does not."""
+    known = {c[:7]: c for c in [*history, *extra]}
+
+    def count(a: str, b: str) -> int:
+        if b not in history:
+            return 0 if a == b else 1
+        if a not in history:
+            return history.index(b) + 1
+        return max(0, history.index(b) - history.index(a))
+
+    def run(argv: Sequence[str]) -> str:
+        if argv[1] == "rev-parse":
+            ref = argv[-1].removesuffix("^{commit}")
+            full = known.get(ref[:7])
+            if full is None or not full.startswith(ref):
+                raise CommandError(f"{' '.join(argv)}: unknown revision")
+            return full + "\n"
+        if argv[1] == "rev-list":
+            a, b = argv[-1].split("..")
+            return f"{count(a, b)}\n"
+        raise AssertionError(f"unexpected command: {argv}")
+
+    return run
+
+
+def verdict(body: str, head: str = HEAD) -> str:
+    """The failure message, or '' when the body passes the gate."""
+    return check(body, head, fake_git()) or ""
+
+
+SHA = HEAD[:7]
+
+
+# ------------------------------------------------------- the sha names the head
+
+PASSING = [
+    f"Review: clean @{SHA}",
+    f"Review: clean @{HEAD}",  # a full sha is a sha
+    f"Review: clean @{SHA} — two findings, both fixed in 1a2b3c4",
+    f"Findings: none.\n\nReview: clean @{SHA}\n",
+    f"Review: clean @{SHA}\r\n",  # CRLF, as GitHub stores it
+]
+
+
+@pytest.mark.parametrize("body", PASSING)
+def test_a_clean_line_naming_the_head_passes(body: str) -> None:
+    assert verdict(body) == "", body
+
+
+MARKUP = [
+    f"**Review: clean @{SHA}**",
+    f"- Review: clean @{SHA}",
+    f"- **Review: clean @{SHA}**",
+    f"* __Review: clean @{SHA}__",
+    f"1. Review: clean @{SHA}",
+    f"> Review: clean @{SHA}",
+    f"  Review: clean @{SHA}  ",
+]
+
+
+@pytest.mark.parametrize("body", MARKUP)
+def test_leading_list_quote_and_bold_markup_is_tolerated(body: str) -> None:
+    assert verdict(body) == "", body
+
+
+# ------------------------------------------------------------ the sha is stale
+
+def test_a_commit_landed_after_the_reviewed_sha_is_red() -> None:
+    msg = verdict(f"Review: clean @{MID[:7]}")
+    assert "1 commit(s) landed after" in msg, msg
+    assert f"@{SHA}" in msg, msg  # the message names the line to append
+
+
+def test_two_commits_behind_counts_them() -> None:
+    assert "2 commit(s) landed after" in verdict(f"Review: clean @{OLD[:7]}")
+
+
+def test_a_sha_off_this_prs_history_is_red() -> None:
+    assert "not reachable from the PR head" in verdict(f"Review: clean @{FOREIGN[:7]}")
+
+
+def test_a_sha_the_repository_does_not_have_is_red() -> None:
+    assert "does not have" in verdict("Review: clean @abcdef0")
+
+
+# ------------------------------------------------------------- the line itself
+
+def test_no_review_line_is_red() -> None:
+    assert "no 'Review:' line" in verdict("Findings: none. Looks good.")
+
+
+def test_clean_without_a_sha_names_the_new_convention() -> None:
+    msg = verdict("Review: clean")
+    assert "with no commit" in msg and "Review: clean @<sha>" in msg, msg
+
+
+def test_clean_with_a_summary_but_no_sha_is_red() -> None:
+    assert "with no commit" in verdict("Review: clean — one finding, fixed")
+
+
+def test_findings_held_keeps_its_own_message() -> None:
+    assert "contentless token" in verdict("Review: findings held")
+
+
+def test_any_other_review_line_is_red() -> None:
+    msg = verdict("Review: two findings open")
+    assert "not 'Review: clean @<sha>'" in msg, msg
+
+
+def test_the_last_review_line_decides() -> None:
+    assert verdict(f"Review: findings held\n\nReview: clean @{SHA}") == ""
+    assert "contentless token" in verdict(f"Review: clean @{SHA}\n\nReview: findings held")
+
+
+# ----------------------------------------------------------------- code fences
+
+FENCED_ONLY = [
+    f"See the convention:\n\n```\nReview: clean @{SHA}\n```\n",
+    f"~~~\nReview: clean @{SHA}\n~~~\n",
+    f"```markdown\nReview: clean @{SHA}\n```\n",
+    f"  ```\n  Review: clean @{SHA}\n  ```\n",
+]
+
+
+@pytest.mark.parametrize("body", FENCED_ONLY)
+def test_a_review_line_inside_a_fence_is_not_the_review_line(body: str) -> None:
+    assert "no 'Review:' line" in verdict(body), body
+
+
+def test_a_fenced_example_does_not_override_the_real_line() -> None:
+    body = f"```\nReview: clean @{SHA}\n```\n\nReview: findings held\n"
+    assert "contentless token" in verdict(body)
+
+
+def test_a_fenced_example_after_the_real_line_does_not_count() -> None:
+    body = f"Review: clean @{SHA}\n\n```\nReview: findings held\n```\n"
+    assert verdict(body) == ""
+
+
+def test_review_lines_returns_the_lines_it_found_normalised() -> None:
+    body = f"- **Review: clean @{SHA}**\n```\nReview: findings held\n```\n"
+    assert review_lines(body) == [f"Review: clean @{SHA}"]
+
+
+# ------------------------------------------------------------------- the entry
+
+def test_main_prints_the_line_and_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(f"Review: clean @{SHA}", HEAD, fake_git()) == 0
+    assert capsys.readouterr().out.strip() == f"gate: Review: clean @{SHA}"
+
+
+def test_main_prints_a_workflow_error_and_exits_one(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main("Review: clean", HEAD, fake_git()) == 1
+    out = capsys.readouterr().out
+    assert out.startswith("::error::") and "\n" not in out.strip(), out
+
+
+def test_an_empty_body_is_red() -> None:
+    assert main("", HEAD, fake_git()) == 1


### PR DESCRIPTION
Closes #251.

The gate matched the literal `Review: clean` and re-ran on `synchronize` with an
unchanged body, so a PR that gained commits after its review passed green — the
habit was followed 35/35 times since #60, but the gate could not see it. It also
passed on `Review: clean` at column 0 inside a fenced example, and blocked on
`**Review: clean**` / `- Review: clean`.

**What changed**

- The convention is `Review: clean @<sha>`, and the gate resolves that sha in a
  full checkout of `refs/pull/<n>/head`: unknown sha, a sha off this PR's
  history, and commits landed since each get their own message (the last names
  the exact line to append). Fenced blocks are stripped before the search;
  leading list, quote and bold markup is tolerated.
- The verdict lives in `scripts/review_gate.py` behind one injected `Runner`, so
  every case verifies at the fake tier (`tests/test_review_gate.py`, 32 cases)
  instead of only on a live PR — the audit found the holes in the gate's own
  matching, which is exactly what no seam covered.
- `ci.yml` syncs with `uv sync --locked`: a stale `uv.lock` fails instead of
  silently re-resolving.
- `context-guard.py` rule 3 blocks a `gh issue close` carrying no `--comment`
  (an empty `--comment ""` does not count; a `gh issue comment <n>` on the same
  number in the same command does).
- CLAUDE.md steps 2, 4 and 8 state the `@<sha>` convention and that the live
  record's home is the ticket; `gauntlet/HANDOFF.md` no longer teaches the
  pre-sha line.

**Verification** — scratch PR #258 (closed unmerged, branch deleted) exercised
all four gate behaviours as real `pull_request` events, and a deliberately stale
lock failed CI at the sync step. Full record, run IDs and log lines:
https://github.com/danielbaldwin47/resolve-mcp/issues/251#issuecomment-5304384520

**Review findings and resolutions** — `/code-review` (two-axis) over
`origin/main...HEAD`.

Standards:

1. *Duplicated Code, with drift* — `review_gate.py` re-declared `Runner`,
   `CommandError` and the subprocess runner from `prune_merged.py`, and the copy
   had already lost `encoding="utf-8"`. Fixed: one `scripts/_run.py`, imported by
   both; both scripts now run as modules from the repo root
   (`python3 -m scripts.review_gate`, `uv run python -m scripts.prune_merged`),
   verified locally for each.
2. *Regex bypass* — `--comment ""` passed as a record. Fixed: the value must
   carry something. Fixing it surfaced a second bug the review had not seen: a
   record is prose and carries `;` of its own, which ended the statement inside
   the comment text, so the close rule now reads a copy with quoted runs
   collapsed to a placeholder. Both cases are tests, with an apostrophe case
   beside them.
3. *False block across calls* — the block message now names the case where the
   comment went up in an earlier call.
4. *Mysterious Name / Speculative Generality* — `reviewed_commit` returned a
   failure message, not a commit: it is `sha_failure`; the captured-but-unread
   `summary` group is gone.
5. *Stale instruction* — `gauntlet/HANDOFF.md:31` still taught `Review: clean`.
   Fixed.

Spec:

6. *Both "recorded on this ticket" clauses unmet at review time* — now posted
   (link above), which is what the two ACs outside the fake tier asked for.
7. *Scope creep, flagged not faulted* — the ticket's seam for the gate AC was
   "workflow YAML, verified with a scratch PR"; extracting the verdict to Python
   with a fake tier is more than asked. Kept: CLAUDE.md's seam rule says a
   verdict this branchy needs a seam, and CONTEXT.md is updated in the same PR.
   The scratch PR still ran.
8. *Added policy* — the same-command `gh issue comment <n>` exemption is not in
   the ticket's wording. Kept and tested: it keeps the guard from blocking the
   documented flow (long record first, then close).
9. *"Reachable" vs "equals the head"* — the AC's two clauses only agree if
   reachability is the validity check and passing requires the sha to be the
   head. That is what ships, and CLAUDE.md step 4 states it; a note is on the
   ticket so nobody "fixes" it toward literal ancestry later.

CI at this head: 2635 passed (fake tier), mypy strict clean over 227 files, ruff
clean.

Review: clean @57e3f9f — 9 findings, all resolved or recorded above
