### PR TITLE
Rename the two open_projects: load_project vs current_project (#228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pillar); the taste the concert cut is measured against lives in `styles/`.
 | --- | --- |
 | `get_status` | Connection state, Resolve version, current project + timeline, fps |
 | `list_projects` | Project names in the current database folder |
-| `open_project` | Loads a project by name; the result echoes the new context |
+| `load_project` | Loads a project by name; the result echoes the new context |
 | `snapshot_project` | Writes an opaque `.drp` backup before a big operation |
 | `import_media` | Imports files and image sequences into a bin, still-duration workaround applied |
 | `list_media` | Summarises media pool clips, with offline state; spills big listings to disk |

--- a/gauntlet/recon/mix_anchor.py
+++ b/gauntlet/recon/mix_anchor.py
@@ -26,7 +26,7 @@ def main() -> None:
     from resolve_mcp.resolve.timeline import Reader, find_timeline
 
     connection = get_connection()
-    project = current_project(connection, "No project is open.")
+    project = current_project(connection)
     timeline = find_timeline(project, TIMELINE)
     reader = Reader(connection)
 

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -54,7 +54,7 @@ from ..logging_config import get_logger
 from ..naming import keyed_name
 from ..resolve.connection import ResolveConnection
 from ..resolve.mix import MixShot, audio_shots
-from ..resolve.session import frame_rate
+from ..resolve.session import current_project, frame_rate
 from ..resolve.timeline import (
     Reader,
     angle_of,
@@ -64,7 +64,6 @@ from ..resolve.timeline import (
     item_enabled,
     items_in_track,
     name_of,
-    open_project,
     read_frames,
     start_frame,
     track_enabled,
@@ -447,7 +446,7 @@ def _read_cut(
     for everything off the current timeline (#84). Believing it there would read a whole
     concert as one black shot.
     """
-    project = open_project(connection)
+    project = current_project(connection)
     timeline = find_timeline(project, name)
     found = name_of(timeline)
     reader = Reader(connection, current=found == current_name(project))

--- a/src/resolve_mcp/errors.py
+++ b/src/resolve_mcp/errors.py
@@ -59,7 +59,7 @@ class UnsupportedInterpreterError(ResolveMcpError):
 class NoProjectOpenError(ResolveMcpError):
     code = "no_project_open"
     default_fix = (
-        "Open a project first — list_projects shows what is available, open_project loads one."
+        "Open a project first — list_projects shows what is available, load_project loads one."
     )
 
 
@@ -131,7 +131,7 @@ class MediaPoolUnavailableError(ResolveMcpError):
 
     code = "media_pool_unavailable"
     default_fix = (
-        "Reopen the project with open_project and retry; if it persists, check the project "
+        "Reopen the project with load_project and retry; if it persists, check the project "
         "is not mid-import in the GUI."
     )
 

--- a/src/resolve_mcp/resolve/build.py
+++ b/src/resolve_mcp/resolve/build.py
@@ -66,7 +66,7 @@ from . import pool as mediapool
 from . import tail as tail_route
 from . import timeline as timeline_read
 from .connection import ResolveConnection
-from .session import frame_rate
+from .session import current_project, frame_rate
 
 log = get_logger("build")
 
@@ -187,7 +187,7 @@ def build_timeline(
     # the schema — every read of it below is a field the rules have already been over.
     doc: dict[str, Any] = checked.loaded.doc
 
-    project = timeline_read.open_project(connection)
+    project = current_project(connection)
     pool = mediapool.media_pool(connection)
     base = str(doc["timeline"]["name"])
     existing = timeline_read.timeline_names(project)

--- a/src/resolve_mcp/resolve/interchange.py
+++ b/src/resolve_mcp/resolve/interchange.py
@@ -54,13 +54,13 @@ from ..logging_config import get_logger
 from ..naming import write_target
 from .connection import ResolveConnection
 from .pool import pool_of
+from .session import current_project
 from .timeline import (
     Reader,
     current_name,
     find_timeline,
     name_of,
     next_free_name,
-    open_project,
     summarise,
     timeline_names,
 )
@@ -117,7 +117,7 @@ def export_timeline(
     """Write one timeline (the open one by default) out as an interchange file."""
     spec = _format(export_format)
     resolve = connection.handle()
-    project = open_project(connection)
+    project = current_project(connection)
     timeline = find_timeline(project, name)
     timeline_name = name_of(timeline)
 
@@ -369,7 +369,7 @@ def import_timeline(
             detail={"requested": str(source)},
         )
 
-    project = open_project(connection)
+    project = current_project(connection)
     pool = pool_of(project)
     existing = set(timeline_names(project))
     native = source.suffix.lower() == NATIVE_SUFFIX

--- a/src/resolve_mcp/resolve/markers.py
+++ b/src/resolve_mcp/resolve/markers.py
@@ -36,13 +36,12 @@ from ..logging_config import get_logger
 from ..spill import capped
 from ..timing import dual_time, to_frames
 from .connection import ResolveConnection
-from .session import frame_rate
+from .session import current_project, frame_rate
 from .timeline import (
     Reader,
     Timeline,
     find_timeline,
     frame_window,
-    open_project,
     overlaps,
     read_frames,
 )
@@ -177,7 +176,7 @@ def list_markers(
     config: Config | None = None,
 ) -> dict[str, Any]:
     """Every marker on a timeline, in record time, narrowed by colour and range."""
-    project = open_project(connection)
+    project = current_project(connection)
     timeline = find_timeline(project, name)
     clock = MarkerClock(connection, timeline, frame_rate(project, timeline))
 
@@ -276,7 +275,7 @@ def set_markers(
     replace: bool = False,
 ) -> dict[str, Any]:
     """Write a batch of markers, each reported on its own. One bad entry sinks only itself."""
-    project = open_project(connection)
+    project = current_project(connection)
     timeline = find_timeline(project, name)
     clock = MarkerClock(connection, timeline, frame_rate(project, timeline))
     existing = _reported(clock)

--- a/src/resolve_mcp/resolve/session.py
+++ b/src/resolve_mcp/resolve/session.py
@@ -47,7 +47,7 @@ def context(connection: ResolveConnection) -> Context:
     reading["connected"] = True
     reading["resolve_version"] = _read(resolve.GetVersionString)
     try:
-        project = _current_project(resolve)
+        project = _project_or_none(resolve)
         timeline = project.GetCurrentTimeline() if project is not None else None
     except Exception:  # noqa: BLE001
         log.debug("Could not read the current project or timeline", exc_info=True)
@@ -72,7 +72,12 @@ def current_project(
     connection: ResolveConnection,
     cause: str = "No project is open.",
 ) -> Any:
-    """The open project, or a failure saying so. ``cause`` names what wanted it."""
+    """The open project, or a failure saying so — never a ``None`` to trip over later.
+
+    The one accessor for "the project Resolve currently has open"; ``cause`` names what
+    wanted it, so a caller with a sharper sentence passes one instead of reaching past
+    this for the raw manager.
+    """
     manager = connection.handle().GetProjectManager()
     project = manager.GetCurrentProject() if manager is not None else None
     if project is None:
@@ -96,7 +101,7 @@ def list_projects(connection: ResolveConnection) -> list[str]:
     return [str(name) for name in (manager.GetProjectListInCurrentFolder() or [])]
 
 
-def open_project(connection: ResolveConnection, name: str) -> str:
+def load_project(connection: ResolveConnection, name: str) -> str:
     """Load a project by name. Returns the loaded project's own name."""
     manager = connection.handle().GetProjectManager()
     project = manager.LoadProject(name)
@@ -142,7 +147,7 @@ def snapshot_project(
     return target, name
 
 
-def _current_project(resolve: Any) -> Any | None:
+def _project_or_none(resolve: Any) -> Any | None:
     manager = resolve.GetProjectManager()
     return manager.GetCurrentProject() if manager is not None else None
 

--- a/src/resolve_mcp/resolve/takes.py
+++ b/src/resolve_mcp/resolve/takes.py
@@ -42,6 +42,7 @@ from ..logging_config import get_logger
 from ..timing import dual_time
 from . import timeline as timeline_read
 from .connection import ResolveConnection
+from .session import current_project
 
 log = get_logger("takes")
 
@@ -168,7 +169,7 @@ def swap_take(
     listed = _selector_of(doc, chosen)
     _refuse_index(segment, take, listed)
 
-    project = timeline_read.open_project(connection)
+    project = current_project(connection)
     target = timeline_read.find_timeline(project, timeline)
     name = timeline_read.name_of(target)
     record, duration = placements(doc, timeline_read.start_frame(target))[segment]

--- a/src/resolve_mcp/resolve/timeline.py
+++ b/src/resolve_mcp/resolve/timeline.py
@@ -91,11 +91,6 @@ class Placement(NamedTuple):
 # --- reaching a timeline ------------------------------------------------------------------
 
 
-def open_project(connection: ResolveConnection) -> Project:
-    """The open project, or a structured refusal — never a ``None`` to trip over later."""
-    return current_project(connection, "No project is open, so there are no timelines to read.")
-
-
 def timelines_of(project: Project) -> list[Timeline]:
     """Every timeline the project holds, in Resolve's own order.
 
@@ -405,7 +400,7 @@ def list_timelines(
     config: Config | None = None,
 ) -> dict[str, Any]:
     """Every timeline in the project with its version, duration and track stack."""
-    project = open_project(connection)
+    project = current_project(connection)
     reader = Reader(connection)
     current = current_name(project)
 
@@ -463,7 +458,7 @@ def inspect_timeline(
             detail={"requested": detail, "available": list(DETAIL_LEVELS)},
         )
 
-    project = open_project(connection)
+    project = current_project(connection)
     timeline = find_timeline(project, name)
     current = current_name(project)
     is_current = name_of(timeline) == current

--- a/src/resolve_mcp/resolve/title_edit.py
+++ b/src/resolve_mcp/resolve/title_edit.py
@@ -93,7 +93,7 @@ class Placed:
 
 def list_titles(connection: ResolveConnection, timeline: str | None = None) -> dict[str, Any]:
     """Read the Titles track back: what each placed title says, and what it exposes."""
-    project = timeline_read.open_project(connection)
+    project = session.current_project(connection)
     target = timeline_read.find_timeline(project, timeline)
     name = timeline_read.name_of(target)
     fps = session.frame_rate(project, target)
@@ -136,7 +136,7 @@ def edit_title(
             detail={},
         )
 
-    project = timeline_read.open_project(connection)
+    project = session.current_project(connection)
     target = timeline_read.find_timeline(project, timeline)
     name = timeline_read.name_of(target)
     fps = session.frame_rate(project, target)

--- a/src/resolve_mcp/resolve/titles.py
+++ b/src/resolve_mcp/resolve/titles.py
@@ -40,7 +40,7 @@ from . import markers
 from . import pool as mediapool
 from . import timeline as timeline_read
 from .connection import ResolveConnection
-from .session import frame_rate
+from .session import current_project, frame_rate
 
 log = get_logger("titles")
 
@@ -97,7 +97,7 @@ def preflight(connection: ResolveConnection, titles_file: str) -> Preflight:
     asset_findings, assets = validate_assets(doc, base=loaded.path.parent)
     findings = [*findings, *asset_findings]
 
-    project = timeline_read.open_project(connection)
+    project = current_project(connection)
     timeline = timeline_read.find_timeline(project, doc.get("timeline"))
     fps = frame_rate(project, timeline)
     pool = mediapool.media_pool(connection)

--- a/src/resolve_mcp/tools/project.py
+++ b/src/resolve_mcp/tools/project.py
@@ -36,7 +36,8 @@ def load_project(name: str) -> dict[str, Any]:
     """Load the named project, making it the one every later tool call acts on.
 
     The name must match exactly; list_projects shows what is available. The result echoes
-    the new context, so you can confirm the switch landed.
+    the new context, so you can confirm the switch landed — under ``opened``, which names
+    the state the load left behind rather than the call that got there.
     """
     connection = get_connection()
     return {"opened": session.load_project(connection, name)}

--- a/src/resolve_mcp/tools/project.py
+++ b/src/resolve_mcp/tools/project.py
@@ -25,21 +25,21 @@ def get_status() -> dict[str, Any]:
 def list_projects() -> dict[str, Any]:
     """List the project names in Resolve's current database folder.
 
-    Use it to find the exact name to hand to open_project — names must match exactly.
+    Use it to find the exact name to hand to load_project — names must match exactly.
     """
     connection = get_connection()
     return {"projects": session.list_projects(connection)}
 
 
 @tool
-def open_project(name: str) -> dict[str, Any]:
-    """Open the named project, making it the one every later tool call acts on.
+def load_project(name: str) -> dict[str, Any]:
+    """Load the named project, making it the one every later tool call acts on.
 
     The name must match exactly; list_projects shows what is available. The result echoes
     the new context, so you can confirm the switch landed.
     """
     connection = get_connection()
-    return {"opened": session.open_project(connection, name)}
+    return {"opened": session.load_project(connection, name)}
 
 
 @tool
@@ -55,6 +55,6 @@ def snapshot_project(path: str | None = None) -> dict[str, Any]:
     return {"snapshot": str(target), "project": project}
 
 
-TOOLS: tuple[Any, ...] = (get_status, list_projects, open_project, snapshot_project)
+TOOLS: tuple[Any, ...] = (get_status, list_projects, load_project, snapshot_project)
 
-__all__ = ["TOOLS", "get_status", "list_projects", "open_project", "snapshot_project"]
+__all__ = ["TOOLS", "get_status", "list_projects", "load_project", "snapshot_project"]

--- a/tests/test_cut_tail.py
+++ b/tests/test_cut_tail.py
@@ -25,8 +25,8 @@ from resolve_mcp.cut import tail as tail_device
 from resolve_mcp.cut.validate import validate_structure
 from resolve_mcp.errors import BuildFailedError
 from resolve_mcp.resolve import pool as mediapool
+from resolve_mcp.resolve import session
 from resolve_mcp.resolve import tail as tail_route
-from resolve_mcp.resolve import timeline as timeline_read
 from resolve_mcp.resolve.connection import get_connection
 from resolve_mcp.tools.cut import build_timeline, validate_cut
 
@@ -683,7 +683,7 @@ def a_staging_cut(resolve: Any, tmp_path: Path) -> tail_route.Staging:
     """
     assert build_timeline(a_cut(tmp_path, valid_doc()))["ok"] is True
     connection = get_connection()
-    project = timeline_read.open_project(connection)
+    project = session.current_project(connection)
     return tail_route.Staging(
         project, mediapool.media_pool(connection), built(resolve, "sunset-set v1"), "sunset-set v1"
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,7 +21,7 @@ def test_registers_the_p1_session_media_timeline_cut_titling_render_and_job_tool
     assert tool_names() == {
         "get_status",
         "list_projects",
-        "open_project",
+        "load_project",
         "snapshot_project",
         "import_media",
         "list_media",

--- a/tests/test_session_tools.py
+++ b/tests/test_session_tools.py
@@ -10,7 +10,7 @@ from resolve_mcp.config import Config, set_config
 from resolve_mcp.tools.project import (
     get_status,
     list_projects,
-    open_project,
+    load_project,
     snapshot_project,
 )
 
@@ -76,10 +76,10 @@ def test_lists_projects_and_marks_the_open_one(attach: Attach) -> None:
     assert result["context"]["project"] == "sunset-set"
 
 
-def test_opening_a_project_echoes_the_new_context(attach: Attach) -> None:
+def test_loading_a_project_echoes_the_new_context(attach: Attach) -> None:
     attach(studio(project="sunset-set", extra_projects=("holiday-gig",)))
 
-    result = open_project("holiday-gig")
+    result = load_project("holiday-gig")
 
     assert result["ok"] is True
     assert result["opened"] == "holiday-gig"
@@ -88,10 +88,10 @@ def test_opening_a_project_echoes_the_new_context(attach: Attach) -> None:
     assert get_status()["context"]["project"] == "holiday-gig"
 
 
-def test_opening_an_unknown_project_lists_the_real_ones(attach: Attach) -> None:
+def test_loading_an_unknown_project_lists_the_real_ones(attach: Attach) -> None:
     attach(studio(project="sunset-set", extra_projects=("holiday-gig",)))
 
-    result = open_project("sunset set")
+    result = load_project("sunset set")
 
     assert result["ok"] is False
     assert result["error"]["code"] == "project_not_found"


### PR DESCRIPTION
Closes #228.

`session.open_project` (loads by name) and `timeline.open_project` (returns the
open one) meant opposite things under one name, and four call sites in
`deliver.py` / `audio/acquire.py` reached past the second for the lower-level
`session.current_project` purely to word the "no project" sentence differently.

## What changed

- `session.open_project` → **`session.load_project`** (loads by name).
- **`session.current_project(connection, cause=...)`** is now the single accessor
  for the open project. The `timeline.open_project` wrapper — a middle man that
  only forwarded with a fixed string — is deleted, so the callers that were
  bypassing it are no longer bypassing anything.
- The MCP tool follows its function: **`open_project` → `load_project`**. This is
  the one externally visible rename; the result payload keeps its `"opened"` key
  (the key names the resulting state, not the call), and the two `default_fix`
  sentences in `errors.py` plus the README tool table now say `load_project`.
- `session._current_project` → `_project_or_none`: the private helper takes a raw
  Resolve handle and never raises, so sharing a name with the new public accessor
  was the same confusion one level down.

**Deliberate standardisation (AC2's escape clause):** the ten timeline-domain
callers now take the standard cause `"No project is open."` instead of
`"No project is open, so there are no timelines to read."`. The dropped clause
added no action the `no_project_open` fix hint doesn't already give
("Open a project first — list_projects shows what is available, load_project
loads one."). `deliver.py` and `audio/acquire.py` keep the sharper sentences they
already passed. No test asserted the old sentence.

## Test seam

Fake tier (`tests/test_server.py` registration set, `tests/test_session_tools.py`)
plus mypy strict — the seam issue #228 names. No live AC: nothing here touches the
attach path.

- `uv run pytest -m 'not live'` → **2636 passed, 45 deselected**
- `uv run mypy src tests` → clean; `uv run ruff check .` → clean
- (Worktree `uv sync` run first, per CLAUDE.md gotcha R2.)

## Review record

Two-axis review (`/code-review`) against `origin/main`. **No hard violations on
either axis.** Findings and resolutions:

1. *Standards + Spec, judgement call* — the tailored refusal sentence is lost at
   ten call sites while `deliver`/`acquire` keep theirs. **Accepted and
   documented** rather than reverted: AC2 permits "deliberately standardised", and
   the PR body above records it since the diff alone doesn't show a reader that a
   sentence was dropped.
2. *Standards, Mysterious Name* — tool renamed to `load_project` but the wire key
   stayed `"opened"`. **Fixed**: the docstring now says why the key stayed.
3. *Spec, stale argument* — `gauntlet/recon/mix_anchor.py` passed a cause
   byte-identical to the default. **Fixed**: dropped.
4. *Spec, scope creep* — the `_current_project` → `_project_or_none` rename wasn't
   asked for. **Kept**: two lines, same confusion the ticket exists to remove.
5. *Standards, style* — `title_edit.py` calls `session.current_project(...)`
   module-qualified while siblings import the symbol. **Kept**: locally consistent,
   that file already calls `session.frame_rate`.
6. *Spec, not verified* — the Spec agent didn't run the fake tier (worktree/R2
   ambiguity). **Resolved**: run here after `uv sync`, result above.

Fix commit re-checked as a focused pass over the two-line fix diff only.

Review: clean @6cff803 — pure rename, no hard violations on either axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

