### PR TITLE
refactor: the @tool decorator hands the connection in (#229)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,7 +109,7 @@ audio or synthetic frames; `live`: a running Resolve Studio (`pytest -m live`);
 | `titles/validate` | 9 errors + 2 warnings | `test_titles_validate` | pure |
 | `tools/analysis` | analysis + correlate tools | `test_correlate_timeline` | fake |
 | `tools/cut` | cut tools: schema, dry run, build, swap, virtual transcript | `test_cut_tools` | fake |
-| `tools/envelope` | shared envelope + `@tool`/`@offline_tool` + connection injection + handle-death retry + job-record wrap | `test_envelope` | fake |
+| `tools/envelope` | shared envelope + `@tool`/`@tool_without_connection` + connection injection + handle-death retry + job-record wrap | `test_envelope` | fake |
 | `tools/escape_hatch` | `run_python` | `test_run_python` | fake |
 | `tools/jobs` | job status/list/cancel tools | `test_job_tools` | fake |
 | `tools/media` | the media tools over `resolve/media` | `test_media_tools` | fake |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,7 +109,7 @@ audio or synthetic frames; `live`: a running Resolve Studio (`pytest -m live`);
 | `titles/validate` | 9 errors + 2 warnings | `test_titles_validate` | pure |
 | `tools/analysis` | analysis + correlate tools | `test_correlate_timeline` | fake |
 | `tools/cut` | cut tools: schema, dry run, build, swap, virtual transcript | `test_cut_tools` | fake |
-| `tools/envelope` | shared envelope + `@tool` + handle-death retry + job-record wrap | `test_envelope` | fake |
+| `tools/envelope` | shared envelope + `@tool`/`@offline_tool` + connection injection + handle-death retry + job-record wrap | `test_envelope` | fake |
 | `tools/escape_hatch` | `run_python` | `test_run_python` | fake |
 | `tools/jobs` | job status/list/cancel tools | `test_job_tools` | fake |
 | `tools/media` | the media tools over `resolve/media` | `test_media_tools` | fake |

--- a/docs/context/tools.md
+++ b/docs/context/tools.md
@@ -8,13 +8,20 @@ holds the module → test → seam map itself.
 `get_titles_schema`), `validate` (9 errors + 2 warnings).
 
 `tools/` — MCP tool layer, thin, grouped by workflow: `analysis`, `cut`,
-`envelope` (**shared envelope + `@tool` decorator + handle-death retry + the
-job-record wrap**),
+`envelope` (**shared envelope + the `@tool` / `@offline_tool` decorators +
+handle-death retry + the job-record wrap**),
 `escape_hatch` (`run_python`), `jobs`, `media`, `project`, `render`,
 `stems`, `timeline`, `titles`, `video`. Registration: each module exposes
 `TOOLS: tuple`; `server.build_server()` iterates every module's `TOOLS`
 and calls `mcp.tool(fn)` — nothing binds to FastMCP at import, so every
 tool is callable in tests without the transport.
+
+Which decorator a tool takes says whether it touches Resolve (#229). `@tool`
+declares `connection: ResolveConnection` first and is handed the live one —
+no body calls `get_connection()` — and the decorator strips that parameter
+from the signature registration reads, so the agent never sees it. A tool
+that answers from documents alone (a schema, a cut file, a job record) takes
+`@offline_tool` and keeps its own signature.
 
 There is no `styles/` module and there never will be: the style layer is data
 the agent owns, not code the server runs.

--- a/docs/context/tools.md
+++ b/docs/context/tools.md
@@ -8,7 +8,7 @@ holds the module → test → seam map itself.
 `get_titles_schema`), `validate` (9 errors + 2 warnings).
 
 `tools/` — MCP tool layer, thin, grouped by workflow: `analysis`, `cut`,
-`envelope` (**shared envelope + the `@tool` / `@offline_tool` decorators +
+`envelope` (**shared envelope + the `@tool` / `@tool_without_connection` decorators +
 handle-death retry + the job-record wrap**),
 `escape_hatch` (`run_python`), `jobs`, `media`, `project`, `render`,
 `stems`, `timeline`, `titles`, `video`. Registration: each module exposes
@@ -21,7 +21,7 @@ declares `connection: ResolveConnection` first and is handed the live one —
 no body calls `get_connection()` — and the decorator strips that parameter
 from the signature registration reads, so the agent never sees it. A tool
 that answers from documents alone (a schema, a cut file, a job record) takes
-`@offline_tool` and keeps its own signature.
+`@tool_without_connection` and keeps its own signature.
 
 There is no `styles/` module and there never will be: the style layer is data
 the agent owns, not code the server runs.

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -22,11 +22,11 @@ from ..analysis import (
     whisper,
 )
 from ..analysis import bars as bars_module  # `bars` is a tool argument on correlate_timeline
-from ..resolve.connection import get_connection
-from .envelope import tool
+from ..resolve.connection import ResolveConnection
+from .envelope import offline_tool, tool
 
 
-@tool
+@offline_tool
 def analyze_music(
     audio: str,
     beats: bool = True,
@@ -61,7 +61,7 @@ def analyze_music(
     )
 
 
-@tool
+@offline_tool
 def analyze_structure(
     audio: str,
     tunes: bool = True,
@@ -152,6 +152,7 @@ def analyze_structure(
 
 @tool
 def transcribe_audio(
+    connection: ResolveConnection,
     clip: str | None = None,
     bin: str | None = None,  # noqa: A002 - "bin" is the Resolve term the agent uses
     timeline: str | None = None,
@@ -180,7 +181,6 @@ def transcribe_audio(
     low_confidence moves the threshold a word counts as unsure below; refresh re-transcribes
     audio the cache would otherwise answer for.
     """
-    connection = get_connection()
     return transcribe.transcribe_audio(
         connection,
         clip=clip,
@@ -197,6 +197,7 @@ def transcribe_audio(
 
 @tool
 def correlate_timeline(
+    connection: ResolveConnection,
     beats: str,
     timeline: str | None = None,
     audio: str | None = None,
@@ -304,7 +305,6 @@ def correlate_timeline(
     Nothing here judges the edit. Two frames late is reported as two frames late; what
     counts as musical belongs in your style profile, not in this server.
     """
-    connection = get_connection()
     return correlate.correlate_timeline(
         connection,
         beats=beats,
@@ -323,7 +323,7 @@ def correlate_timeline(
     )
 
 
-@tool
+@offline_tool
 def detect_drum_fills(
     stems: str,
     audio: str,
@@ -357,7 +357,7 @@ def detect_drum_fills(
     )
 
 
-@tool
+@offline_tool
 def detect_phrases(
     stems: str,
     audio: str,
@@ -396,7 +396,7 @@ def detect_phrases(
     )
 
 
-@tool
+@offline_tool
 def detect_bars(
     audio: str,
     stems: str | None = None,

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -23,10 +23,10 @@ from ..analysis import (
 )
 from ..analysis import bars as bars_module  # `bars` is a tool argument on correlate_timeline
 from ..resolve.connection import ResolveConnection
-from .envelope import offline_tool, tool
+from .envelope import tool, tool_without_connection
 
 
-@offline_tool
+@tool_without_connection
 def analyze_music(
     audio: str,
     beats: bool = True,
@@ -61,7 +61,7 @@ def analyze_music(
     )
 
 
-@offline_tool
+@tool_without_connection
 def analyze_structure(
     audio: str,
     tunes: bool = True,
@@ -323,7 +323,7 @@ def correlate_timeline(
     )
 
 
-@offline_tool
+@tool_without_connection
 def detect_drum_fills(
     stems: str,
     audio: str,
@@ -357,7 +357,7 @@ def detect_drum_fills(
     )
 
 
-@offline_tool
+@tool_without_connection
 def detect_phrases(
     stems: str,
     audio: str,
@@ -396,7 +396,7 @@ def detect_phrases(
     )
 
 
-@offline_tool
+@tool_without_connection
 def detect_bars(
     audio: str,
     stems: str | None = None,

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -13,10 +13,10 @@ from ..analysis import virtual
 from ..analysis.transcript import DEFAULT_LOW_CONFIDENCE
 from ..resolve import build, cut, takes
 from ..resolve.connection import ResolveConnection
-from .envelope import offline_tool, tool
+from .envelope import tool, tool_without_connection
 
 
-@offline_tool
+@tool_without_connection
 def get_cut_schema() -> dict[str, Any]:
     """Return the cut-file schema v1, its annotated example, and the validation rules.
 
@@ -43,7 +43,7 @@ def validate_cut(
     return cut.validate_cut(connection, cut_file, min_segment_frames)
 
 
-@offline_tool
+@tool_without_connection
 def virtual_transcript(
     cut_file: str,
     transcripts: dict[str, str] | None = None,

--- a/src/resolve_mcp/tools/cut.py
+++ b/src/resolve_mcp/tools/cut.py
@@ -12,11 +12,11 @@ from typing import Any
 from ..analysis import virtual
 from ..analysis.transcript import DEFAULT_LOW_CONFIDENCE
 from ..resolve import build, cut, takes
-from ..resolve.connection import get_connection
-from .envelope import tool
+from ..resolve.connection import ResolveConnection
+from .envelope import offline_tool, tool
 
 
-@tool
+@offline_tool
 def get_cut_schema() -> dict[str, Any]:
     """Return the cut-file schema v1, its annotated example, and the validation rules.
 
@@ -29,6 +29,7 @@ def get_cut_schema() -> dict[str, Any]:
 
 @tool
 def validate_cut(
+    connection: ResolveConnection,
     cut_file: str,
     min_segment_frames: int = cut.MIN_SEGMENT_FRAMES,
 ) -> dict[str, Any]:
@@ -39,11 +40,10 @@ def validate_cut(
     segment or overlay id, what is wrong and how to fix it — all of them at once, not the
     first. `min_segment_frames` tunes the W1 flash-frame warning only; it never blocks.
     """
-    connection = get_connection()
     return cut.validate_cut(connection, cut_file, min_segment_frames)
 
 
-@tool
+@offline_tool
 def virtual_transcript(
     cut_file: str,
     transcripts: dict[str, str] | None = None,
@@ -84,6 +84,7 @@ def virtual_transcript(
 
 @tool
 def build_timeline(
+    connection: ResolveConnection,
     cut_file: str,
     min_segment_frames: int = cut.MIN_SEGMENT_FRAMES,
     carry_markers: bool = True,
@@ -129,12 +130,12 @@ def build_timeline(
     record it if you note the version anywhere. A failure names what did not land; a
     partially built version, if one was made, is scrap and can be deleted.
     """
-    connection = get_connection()
     return build.build_timeline(connection, cut_file, min_segment_frames, carry_markers)
 
 
 @tool
 def swap_take(
+    connection: ResolveConnection,
     cut_file: str,
     segment: str,
     take: int,
@@ -157,7 +158,6 @@ def swap_take(
     a fix rather than swapped on a guess. That is a shape check, not proof of provenance —
     if it matters which version you are on, compare `content_hash` against the build report.
     """
-    connection = get_connection()
     return takes.swap_take(connection, cut_file, segment, take, timeline)
 
 

--- a/src/resolve_mcp/tools/envelope.py
+++ b/src/resolve_mcp/tools/envelope.py
@@ -1,6 +1,10 @@
 """The shape every tool result has.
 
-Three guarantees live here, so no individual tool has to remember them:
+Four guarantees live here, so no individual tool has to remember them:
+
+* a ``@tool`` is handed the connection as its first argument and never fetches one itself —
+  the retry below reconnects, so acquisition has exactly one owner (``@offline_tool`` is the
+  same envelope for the tools that answer without Resolve);
 
 * every result echoes the current project/timeline context, so a project switch is
   visible the moment it happens;
@@ -12,12 +16,13 @@ Three guarantees live here, so no individual tool has to remember them:
 from __future__ import annotations
 
 import functools
+import inspect
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Concatenate
 
 from ..errors import InternalError, ResolveMcpError, ResolveUnavailableError
 from ..logging_config import get_logger
-from ..resolve.connection import get_connection
+from ..resolve.connection import ResolveConnection, get_connection
 from ..resolve.session import context
 
 log = get_logger("tools")
@@ -47,29 +52,95 @@ def shaped(payload: dict[str, Any]) -> dict[str, Any]:
     return {"job": payload} if payload.keys() >= JOB_RECORD_KEYS else payload
 
 
-def tool[**P](fn: Callable[P, dict[str, Any]]) -> Callable[P, Envelope]:
-    """Wrap a wrapper-layer call as a tool: payload in, envelope out."""
+def tool[**P](
+    fn: Callable[Concatenate[ResolveConnection, P], dict[str, Any]],
+) -> Callable[P, Envelope]:
+    """Wrap a Resolve-touching call as a tool: payload in, envelope out.
 
+    The connection is the first parameter and the decorator hands it in — the envelope
+    already fetches one for its reconnect-retry path, so the tool body has no getter to
+    remember, and no way to hold a handle the retry has since replaced. The parameter is
+    the decorator's, not the agent's: it never reaches the transport.
+
+    A tool that answers from documents alone takes ``offline_tool`` instead.
+    """
+    return _as_a_tool(fn, wants_connection=True)
+
+
+def offline_tool[**P](fn: Callable[P, dict[str, Any]]) -> Callable[P, Envelope]:
+    """The same envelope for a tool that needs no Resolve at all.
+
+    A schema, a cut file read back as words, a job record from the store: these answer from
+    documents, and declaring a connection they never use would say the opposite. Two
+    decorators rather than one that guesses, because which one a tool takes is a fact about
+    the tool that should read off its ``def`` line.
+    """
+    return _as_a_tool(fn, wants_connection=False)
+
+
+def _as_a_tool[**P](
+    fn: Callable[..., dict[str, Any]], *, wants_connection: bool
+) -> Callable[P, Envelope]:
     @functools.wraps(fn)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Envelope:
+    def wrapper(*args: Any, **kwargs: Any) -> Envelope:
         try:
-            payload = fn(*args, **kwargs)
+            payload = _call(fn, wants_connection, args, kwargs)
         except ResolveMcpError as exc:
             log.info("%s failed: %s", fn.__name__, exc.cause)
             return failure(exc)
         except Exception as exc:  # noqa: BLE001 - a bug must not become a raw traceback
-            retried = _retry_if_the_handle_died(fn, args, kwargs, exc)
+            retried = _retry_if_the_handle_died(fn, wants_connection, args, kwargs, exc)
             if retried is not None:
                 return retried
             log.exception("%s raised unexpectedly", fn.__name__)
             return failure(InternalError(cause=f"{type(exc).__name__}: {exc}"))
         return {"ok": True, **shaped(payload), "context": current_context()}
 
+    if wants_connection:
+        _hide_the_connection_parameter(wrapper, fn)
     return wrapper
 
 
-def _retry_if_the_handle_died[**P](
-    fn: Callable[P, dict[str, Any]],
+def _hide_the_connection_parameter(
+    wrapper: Callable[..., Envelope], fn: Callable[..., dict[str, Any]]
+) -> None:
+    """Present the tool's own parameters and nothing else.
+
+    ``functools.wraps`` leaves the wrapped function's signature and annotations showing, and
+    that is what MCP registration reads to build the input schema — so without this the
+    injected parameter would arrive at the agent as an argument to fill in.
+    """
+    signature = inspect.signature(fn)
+    wrapper.__signature__ = signature.replace(  # type: ignore[attr-defined]
+        parameters=list(signature.parameters.values())[1:]
+    )
+    injected = next(iter(signature.parameters))
+    wrapper.__annotations__ = {
+        name: annotation
+        for name, annotation in wrapper.__annotations__.items()
+        if name != injected
+    }
+
+
+def _call(
+    fn: Callable[..., dict[str, Any]],
+    wants_connection: bool,
+    args: Any,
+    kwargs: Any,
+) -> dict[str, Any]:
+    """Call the tool body, fetching the connection for it if it declared one.
+
+    Fetched per call, never captured: after a reconnect the singleton hands back the new
+    handle, and a tool holding the old one would be working on a corpse.
+    """
+    if wants_connection:
+        return fn(get_connection(), *args, **kwargs)
+    return fn(*args, **kwargs)
+
+
+def _retry_if_the_handle_died(
+    fn: Callable[..., dict[str, Any]],
+    wants_connection: bool,
     args: Any,
     kwargs: Any,
     original: Exception,
@@ -88,7 +159,7 @@ def _retry_if_the_handle_died[**P](
     log.info("%s failed on a dead Resolve handle; reconnecting once", fn.__name__)
     connection.invalidate()
     try:
-        payload = fn(*args, **kwargs)
+        payload = _call(fn, wants_connection, args, kwargs)
     except ResolveMcpError as exc:
         return failure(exc)
     except Exception:  # noqa: BLE001 - the reconnect did not save it

--- a/src/resolve_mcp/tools/envelope.py
+++ b/src/resolve_mcp/tools/envelope.py
@@ -3,8 +3,9 @@
 Four guarantees live here, so no individual tool has to remember them:
 
 * a ``@tool`` is handed the connection as its first argument and never fetches one itself —
-  the retry below reconnects, so acquisition has exactly one owner (``@offline_tool`` is the
-  same envelope for the tools that answer without Resolve);
+  the retry below reconnects, so acquisition has exactly one owner
+  (``@tool_without_connection`` is the same envelope for the tools that answer without
+  Resolve);
 
 * every result echoes the current project/timeline context, so a project switch is
   visible the moment it happens;
@@ -62,47 +63,55 @@ def tool[**P](
     remember, and no way to hold a handle the retry has since replaced. The parameter is
     the decorator's, not the agent's: it never reaches the transport.
 
-    A tool that answers from documents alone takes ``offline_tool`` instead.
+    A tool that answers without Resolve takes ``tool_without_connection`` instead.
     """
-    return _as_a_tool(fn, wants_connection=True)
+    injected = _the_declared_connection(fn)
+
+    def call(args: Any, kwargs: Any) -> dict[str, Any]:
+        # Fetched per attempt, never captured: after a reconnect the singleton hands back
+        # the new handle, and a body holding the old one would be working on a corpse.
+        return fn(get_connection(), *args, **kwargs)
+
+    wrapper: Callable[P, Envelope] = _wrap_as_tool(fn, call, retries_a_dead_handle=True)
+    _hide(injected, on=wrapper, of=fn)
+    return wrapper
 
 
-def offline_tool[**P](fn: Callable[P, dict[str, Any]]) -> Callable[P, Envelope]:
+def tool_without_connection[**P](fn: Callable[P, dict[str, Any]]) -> Callable[P, Envelope]:
     """The same envelope for a tool that needs no Resolve at all.
 
     A schema, a cut file read back as words, a job record from the store: these answer from
     documents, and declaring a connection they never use would say the opposite. Two
     decorators rather than one that guesses, because which one a tool takes is a fact about
-    the tool that should read off its ``def`` line.
+    the tool that should read off its ``def`` line — and because a body that never holds a
+    handle cannot have lost one, so it is not retried.
     """
-    return _as_a_tool(fn, wants_connection=False)
+    return _wrap_as_tool(fn, lambda args, kwargs: fn(*args, **kwargs), retries_a_dead_handle=False)
 
 
-def _as_a_tool[**P](
-    fn: Callable[..., dict[str, Any]], *, wants_connection: bool
-) -> Callable[P, Envelope]:
-    @functools.wraps(fn)
-    def wrapper(*args: Any, **kwargs: Any) -> Envelope:
-        try:
-            payload = _call(fn, wants_connection, args, kwargs)
-        except ResolveMcpError as exc:
-            log.info("%s failed: %s", fn.__name__, exc.cause)
-            return failure(exc)
-        except Exception as exc:  # noqa: BLE001 - a bug must not become a raw traceback
-            retried = _retry_if_the_handle_died(fn, wants_connection, args, kwargs, exc)
-            if retried is not None:
-                return retried
-            log.exception("%s raised unexpectedly", fn.__name__)
-            return failure(InternalError(cause=f"{type(exc).__name__}: {exc}"))
-        return {"ok": True, **shaped(payload), "context": current_context()}
+def _the_declared_connection(fn: Callable[..., dict[str, Any]]) -> inspect.Parameter:
+    """The parameter ``tool`` will fill in, or a refusal at import time.
 
-    if wants_connection:
-        _hide_the_connection_parameter(wrapper, fn)
-    return wrapper
+    Injection is positional, so a ``@tool`` that forgot the parameter would bind a
+    connection to the author's first real argument and drop that argument from the MCP
+    schema — a wrong value with nothing raised. Checked here, where the fix is one line
+    away, rather than left to whatever the body does with a ResolveConnection.
+    """
+    first = next(iter(inspect.signature(fn).parameters.values()), None)
+    if first is None or first.annotation not in (ResolveConnection, "ResolveConnection"):
+        raise TypeError(
+            f"@tool {fn.__name__} must declare `connection: ResolveConnection` as its first "
+            f"parameter — the decorator hands it in. A tool that needs no Resolve takes "
+            f"@tool_without_connection instead."
+        )
+    return first
 
 
-def _hide_the_connection_parameter(
-    wrapper: Callable[..., Envelope], fn: Callable[..., dict[str, Any]]
+def _hide(
+    parameter: inspect.Parameter,
+    *,
+    on: Callable[..., Envelope],
+    of: Callable[..., dict[str, Any]],
 ) -> None:
     """Present the tool's own parameters and nothing else.
 
@@ -110,39 +119,48 @@ def _hide_the_connection_parameter(
     that is what MCP registration reads to build the input schema — so without this the
     injected parameter would arrive at the agent as an argument to fill in.
     """
-    signature = inspect.signature(fn)
-    wrapper.__signature__ = signature.replace(  # type: ignore[attr-defined]
-        parameters=list(signature.parameters.values())[1:]
+    signature = inspect.signature(of)
+    on.__signature__ = signature.replace(  # type: ignore[attr-defined]
+        parameters=[p for p in signature.parameters.values() if p.name != parameter.name]
     )
-    injected = next(iter(signature.parameters))
-    wrapper.__annotations__ = {
+    on.__annotations__ = {
         name: annotation
-        for name, annotation in wrapper.__annotations__.items()
-        if name != injected
+        for name, annotation in on.__annotations__.items()
+        if name != parameter.name
     }
 
 
-def _call(
+def _wrap_as_tool[**P](
     fn: Callable[..., dict[str, Any]],
-    wants_connection: bool,
-    args: Any,
-    kwargs: Any,
-) -> dict[str, Any]:
-    """Call the tool body, fetching the connection for it if it declared one.
+    call: Callable[[Any, Any], dict[str, Any]],
+    *,
+    retries_a_dead_handle: bool,
+) -> Callable[P, Envelope]:
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Envelope:
+        try:
+            payload = call(args, kwargs)
+        except ResolveMcpError as exc:
+            log.info("%s failed: %s", fn.__name__, exc.cause)
+            return failure(exc)
+        except Exception as exc:  # noqa: BLE001 - a bug must not become a raw traceback
+            retried = (
+                _retry_if_the_handle_died(fn.__name__, lambda: call(args, kwargs), exc)
+                if retries_a_dead_handle
+                else None
+            )
+            if retried is not None:
+                return retried
+            log.exception("%s raised unexpectedly", fn.__name__)
+            return failure(InternalError(cause=f"{type(exc).__name__}: {exc}"))
+        return {"ok": True, **shaped(payload), "context": current_context()}
 
-    Fetched per call, never captured: after a reconnect the singleton hands back the new
-    handle, and a tool holding the old one would be working on a corpse.
-    """
-    if wants_connection:
-        return fn(get_connection(), *args, **kwargs)
-    return fn(*args, **kwargs)
+    return wrapper
 
 
 def _retry_if_the_handle_died(
-    fn: Callable[..., dict[str, Any]],
-    wants_connection: bool,
-    args: Any,
-    kwargs: Any,
+    name: str,
+    invoke: Callable[[], dict[str, Any]],
     original: Exception,
 ) -> Envelope | None:
     """One retry when Resolve went away *during* the call, else ``None``.
@@ -156,14 +174,14 @@ def _retry_if_the_handle_died(
     if not connection.dropped():
         return None
 
-    log.info("%s failed on a dead Resolve handle; reconnecting once", fn.__name__)
+    log.info("%s failed on a dead Resolve handle; reconnecting once", name)
     connection.invalidate()
     try:
-        payload = _call(fn, wants_connection, args, kwargs)
+        payload = invoke()
     except ResolveMcpError as exc:
         return failure(exc)
     except Exception:  # noqa: BLE001 - the reconnect did not save it
-        log.exception("%s failed again after reconnecting", fn.__name__)
+        log.exception("%s failed again after reconnecting", name)
         return failure(
             ResolveUnavailableError(
                 cause=f"Resolve dropped the connection mid-call and did not come back "

--- a/src/resolve_mcp/tools/escape_hatch.py
+++ b/src/resolve_mcp/tools/escape_hatch.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from typing import Any
 
 from ..resolve import scripting
-from ..resolve.connection import get_connection
+from ..resolve.connection import ResolveConnection
 from .envelope import tool
 
 
 @tool
-def run_python(code: str) -> dict[str, Any]:
+def run_python(connection: ResolveConnection, code: str) -> dict[str, Any]:
     """Run DaVinci Resolve scripting-API Python in the server process.
 
     Prefer the real tools: they wrap known API footguns, echo context, and return
@@ -21,7 +21,7 @@ def run_python(code: str) -> dict[str, Any]:
     The returned value is the trailing expression, or a `result` variable if you set one;
     stdout is captured and returned alongside it. Long values are truncated.
     """
-    return scripting.run_python(get_connection(), code)
+    return scripting.run_python(connection, code)
 
 
 TOOLS: tuple[Any, ...] = (run_python,)

--- a/src/resolve_mcp/tools/jobs.py
+++ b/src/resolve_mcp/tools/jobs.py
@@ -11,12 +11,12 @@ from typing import Any
 
 from ..jobs import store
 from ..spill import capped
-from .envelope import tool
+from .envelope import offline_tool
 
 DEFAULT_JOB_LIMIT = 50
 
 
-@tool
+@offline_tool
 def get_job(job_id: str) -> dict[str, Any]:
     """Poll one job: running with progress, completed with its result, or failed with a fix.
 
@@ -29,7 +29,7 @@ def get_job(job_id: str) -> dict[str, Any]:
     return store.load(job_id).payload()
 
 
-@tool
+@offline_tool
 def list_jobs(state: str | None = None, limit: int = DEFAULT_JOB_LIMIT) -> dict[str, Any]:
     """List jobs newest first — how a restarted session picks up what it started.
 

--- a/src/resolve_mcp/tools/jobs.py
+++ b/src/resolve_mcp/tools/jobs.py
@@ -11,12 +11,12 @@ from typing import Any
 
 from ..jobs import store
 from ..spill import capped
-from .envelope import offline_tool
+from .envelope import tool_without_connection
 
 DEFAULT_JOB_LIMIT = 50
 
 
-@offline_tool
+@tool_without_connection
 def get_job(job_id: str) -> dict[str, Any]:
     """Poll one job: running with progress, completed with its result, or failed with a fix.
 
@@ -29,7 +29,7 @@ def get_job(job_id: str) -> dict[str, Any]:
     return store.load(job_id).payload()
 
 
-@offline_tool
+@tool_without_connection
 def list_jobs(state: str | None = None, limit: int = DEFAULT_JOB_LIMIT) -> dict[str, Any]:
     """List jobs newest first — how a restarted session picks up what it started.
 

--- a/src/resolve_mcp/tools/media.py
+++ b/src/resolve_mcp/tools/media.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 from typing import Any
 
 from ..resolve import media
-from ..resolve.connection import get_connection
+from ..resolve.connection import ResolveConnection
 from .envelope import tool
 
 
 @tool
 def import_media(
+    connection: ResolveConnection,
     paths: list[str] | None = None,
     bin: str | None = None,  # noqa: A002 - the agent-facing word for a media pool folder
     sequences: list[dict[str, Any]] | None = None,
@@ -42,12 +43,12 @@ def import_media(
     Returns a summary per imported clip, plus not_imported for anything Resolve refused —
     usually a path that is not readable from the machine Resolve runs on.
     """
-    connection = get_connection()
     return media.import_media(connection, paths=paths, bin_path=bin, sequences=sequences)
 
 
 @tool
 def list_media(
+    connection: ResolveConnection,
     bin: str | None = None,  # noqa: A002
     name_contains: str | None = None,
     offline_only: bool = False,
@@ -64,7 +65,6 @@ def list_media(
     written to disk and spilled_to holds the path, so a large pool never blows the token
     budget: read or grep that file for the rest.
     """
-    connection = get_connection()
     return media.list_media(
         connection,
         bin_path=bin,
@@ -77,6 +77,7 @@ def list_media(
 
 @tool
 def inspect_clip(
+    connection: ResolveConnection,
     clip: str,
     bin: str | None = None,  # noqa: A002
     recursive: bool = True,
@@ -94,12 +95,13 @@ def inspect_clip(
     recursive=false stops the search descending, so only the clips the named bin holds
     itself are looked at — the way to reach a copy that a subfolder also holds a copy of.
     """
-    connection = get_connection()
     return media.inspect_clip(connection, clip, bin_path=bin, recursive=recursive)
 
 
 @tool
-def set_clip_metadata(items: list[dict[str, Any]]) -> dict[str, Any]:
+def set_clip_metadata(
+    connection: ResolveConnection, items: list[dict[str, Any]]
+) -> dict[str, Any]:
     """Apply a batch of metadata writes: [{"clip": name, "bin": optional, "fields": {...}}].
 
     An item may add "recursive": false to keep its bin lookup out of that bin's subfolders.
@@ -108,12 +110,13 @@ def set_clip_metadata(items: list[dict[str, Any]]) -> dict[str, Any]:
     metadata. The route taken comes back per field in applied. One item failing never sinks
     the batch — every item gets its own result.
     """
-    connection = get_connection()
     return media.set_clip_metadata(connection, items)
 
 
 @tool
-def organize_media(operations: list[dict[str, Any]]) -> dict[str, Any]:
+def organize_media(
+    connection: ResolveConnection, operations: list[dict[str, Any]]
+) -> dict[str, Any]:
     """Run a batch of bin operations, each reported separately.
 
     Two operations:
@@ -123,12 +126,12 @@ def organize_media(operations: list[dict[str, Any]]) -> dict[str, Any]:
         "from_bin": optional, "recursive": optional} — moves clips, creating the target
         bin if needed. recursive: false keeps the from_bin lookup out of its subfolders.
     """
-    connection = get_connection()
     return media.organize_media(connection, operations)
 
 
 @tool
 def relink_media(
+    connection: ResolveConnection,
     clips: list[str],
     path: str,
     bin: str | None = None,  # noqa: A002
@@ -144,7 +147,6 @@ def relink_media(
     passed in.
     recursive=false keeps the bin lookup out of that bin's subfolders.
     """
-    connection = get_connection()
     return media.relink_media(connection, clips, path, bin_path=bin, recursive=recursive)
 
 

--- a/src/resolve_mcp/tools/project.py
+++ b/src/resolve_mcp/tools/project.py
@@ -5,52 +5,48 @@ from __future__ import annotations
 from typing import Any
 
 from ..resolve import session
-from ..resolve.connection import get_connection
+from ..resolve.connection import ResolveConnection
 from .envelope import tool
 
 
 @tool
-def get_status() -> dict[str, Any]:
+def get_status(connection: ResolveConnection) -> dict[str, Any]:
     """Report connection state, Resolve version, and the current project and timeline.
 
     Call this first in a session, and again whenever you are unsure what Resolve has open.
     The result — like every result from this server — echoes context: connected, Resolve
     version, project, timeline and fps.
     """
-    connection = get_connection()
     return {"product": session.product_name(connection)}
 
 
 @tool
-def list_projects() -> dict[str, Any]:
+def list_projects(connection: ResolveConnection) -> dict[str, Any]:
     """List the project names in Resolve's current database folder.
 
     Use it to find the exact name to hand to open_project — names must match exactly.
     """
-    connection = get_connection()
     return {"projects": session.list_projects(connection)}
 
 
 @tool
-def open_project(name: str) -> dict[str, Any]:
+def open_project(connection: ResolveConnection, name: str) -> dict[str, Any]:
     """Open the named project, making it the one every later tool call acts on.
 
     The name must match exactly; list_projects shows what is available. The result echoes
     the new context, so you can confirm the switch landed.
     """
-    connection = get_connection()
     return {"opened": session.open_project(connection, name)}
 
 
 @tool
-def snapshot_project(path: str | None = None) -> dict[str, Any]:
+def snapshot_project(connection: ResolveConnection, path: str | None = None) -> dict[str, Any]:
     """Write an opaque .drp backup of the open project, and return where it landed.
 
     Take a snapshot before any big operation — a build, a bulk media change, a risky
     escape-hatch script — so a mistake is a restore rather than a rebuild. Without a path,
     the snapshot goes to a timestamped file in the cache directory.
     """
-    connection = get_connection()
     target, project = session.snapshot_project(connection, path)
     return {"snapshot": str(target), "project": project}
 

--- a/src/resolve_mcp/tools/render.py
+++ b/src/resolve_mcp/tools/render.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from typing import Any
 
 from .. import deliver
-from ..resolve.connection import get_connection
+from ..resolve.connection import ResolveConnection
 from .envelope import tool
 
 
 @tool
-def list_render_presets() -> dict[str, Any]:
+def list_render_presets(connection: ResolveConnection) -> dict[str, Any]:
     """List the render presets this project offers, spelled the way render_timeline needs.
 
     Presets belong to the project and the machine, not to this server: what a preset renders
@@ -18,12 +18,12 @@ def list_render_presets() -> dict[str, Any]:
     so pick one by name rather than describing a shape. current is the format and codec the
     project would render with right now, which is the last preset anything loaded.
     """
-    connection = get_connection()
     return deliver.list_presets(connection)
 
 
 @tool
 def render_timeline(
+    connection: ResolveConnection,
     preset: str | None = None,
     timeline: str | None = None,
     name: str | None = None,
@@ -74,7 +74,6 @@ def render_timeline(
     A render leaves the Deliver page set to the preset it used, the same way rendering by
     hand would; the timeline the director had open is the one thing put back.
     """
-    connection = get_connection()
     return deliver.render_timeline(
         connection,
         preset=preset,

--- a/src/resolve_mcp/tools/stems.py
+++ b/src/resolve_mcp/tools/stems.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 from typing import Any
 
 from ..audio import acquire, stems
-from ..resolve.connection import get_connection
+from ..resolve.connection import ResolveConnection
 from .envelope import tool
 
 
 @tool
 def separate_stems(
+    connection: ResolveConnection,
     scope: str = acquire.TIMELINE_SCOPE,
     timeline: str | None = None,
     clip: str | None = None,
@@ -54,7 +55,7 @@ def separate_stems(
     the same audio twice, so it reports "waiting" for as long as the first one takes.
     """
     return stems.separate_stems(
-        get_connection(),
+        connection,
         scope=scope,
         timeline=timeline,
         clip=clip,

--- a/src/resolve_mcp/tools/timeline.py
+++ b/src/resolve_mcp/tools/timeline.py
@@ -14,12 +14,14 @@ from typing import Any
 from ..resolve import interchange
 from ..resolve import markers as marker_wrapper
 from ..resolve import timeline as timelines
-from ..resolve.connection import get_connection
+from ..resolve.connection import ResolveConnection
 from .envelope import tool
 
 
 @tool
-def list_timelines(limit: int = timelines.DEFAULT_LIST_LIMIT) -> dict[str, Any]:
+def list_timelines(
+    connection: ResolveConnection, limit: int = timelines.DEFAULT_LIST_LIMIT
+) -> dict[str, Any]:
     """List the project's timelines with version, duration, fps, resolution and track stack.
 
     resolution is the frame size each timeline is actually on — which is not the project's
@@ -31,12 +33,12 @@ def list_timelines(limit: int = timelines.DEFAULT_LIST_LIMIT) -> dict[str, Any]:
     carrying an angle per video track, so the track counts are what identifies it. Past
     limit entries the full listing spills to disk and spilled_to holds the path.
     """
-    connection = get_connection()
     return timelines.list_timelines(connection, limit=limit)
 
 
 @tool
 def inspect_timeline(
+    connection: ResolveConnection,
     timeline: str | None = None,
     detail: str = "tracks",
     start: Any = None,
@@ -70,7 +72,6 @@ def inspect_timeline(
     Past limit shots the reply is capped and the full reading spills to disk (spilled_to);
     narrow the range or read that file rather than raising the cap.
     """
-    connection = get_connection()
     return timelines.inspect_timeline(
         connection,
         name=timeline,
@@ -84,6 +85,7 @@ def inspect_timeline(
 
 @tool
 def list_markers(
+    connection: ResolveConnection,
     timeline: str | None = None,
     color: str | None = None,
     start: Any = None,
@@ -101,7 +103,6 @@ def list_markers(
     or seconds with an explicit snap. colors counts what came back, which is the shape of a
     review round. Past limit markers the full set spills to disk (spilled_to).
     """
-    connection = get_connection()
     return marker_wrapper.list_markers(
         connection,
         name=timeline,
@@ -114,6 +115,7 @@ def list_markers(
 
 @tool
 def set_markers(
+    connection: ResolveConnection,
     markers: list[dict[str, Any]],
     timeline: str | None = None,
     replace: bool = False,
@@ -132,12 +134,12 @@ def set_markers(
     ok with unchanged: true. Every entry is reported separately; one bad entry never sinks
     the batch.
     """
-    connection = get_connection()
     return marker_wrapper.set_markers(connection, markers, name=timeline, replace=replace)
 
 
 @tool
 def export_timeline(
+    connection: ResolveConnection,
     timeline: str | None = None,
     format: str = interchange.DEFAULT_FORMAT,  # noqa: A002 - the agent-facing word
     path: str | None = None,
@@ -154,12 +156,12 @@ def export_timeline(
     suffix. export_type names the Resolve export constant used — fcpxml is versioned and
     the newest one this build offers is written.
     """
-    connection = get_connection()
     return interchange.export_timeline(connection, name=timeline, export_format=format, path=path)
 
 
 @tool
 def import_timeline(
+    connection: ResolveConnection,
     path: str,
     name: str | None = None,
     import_source_clips: bool | None = None,
@@ -183,7 +185,6 @@ def import_timeline(
     result is still checked against the timelines the project already had, so an import
     that came back as an existing cut is reported as a failure, never as a new timeline.
     """
-    connection = get_connection()
     return interchange.import_timeline(
         connection,
         path,

--- a/src/resolve_mcp/tools/titles.py
+++ b/src/resolve_mcp/tools/titles.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 from typing import Any
 
 from ..resolve import apply, title_edit, titles
-from ..resolve.connection import get_connection
-from .envelope import tool
+from ..resolve.connection import ResolveConnection
+from .envelope import offline_tool, tool
 
 
-@tool
+@offline_tool
 def get_titles_schema() -> dict[str, Any]:
     """Return the titles-file schema v1, its annotated example, and the validation rules.
 
@@ -28,7 +28,7 @@ def get_titles_schema() -> dict[str, Any]:
 
 
 @tool
-def validate_titles(titles_file: str) -> dict[str, Any]:
+def validate_titles(connection: ResolveConnection, titles_file: str) -> dict[str, Any]:
     """Dry-run a titles file and return every error and warning it has, with fix hints.
 
     Worth running after every edit: apply_titles runs the identical checks first, and
@@ -37,11 +37,11 @@ def validate_titles(titles_file: str) -> dict[str, Any]:
     rule, the event or song it is about, what is wrong and how to fix it — all of them at
     once, not the first.
     """
-    return titles.validate_titles(get_connection(), titles_file)
+    return titles.validate_titles(connection, titles_file)
 
 
 @tool
-def apply_titles(titles_file: str) -> dict[str, Any]:
+def apply_titles(connection: ResolveConnection, titles_file: str) -> dict[str, Any]:
     """Place every event in a titles file onto the timeline's own Titles track.
 
     Declarative and re-runnable: the topmost video track named `Titles` belongs to this
@@ -63,11 +63,11 @@ def apply_titles(titles_file: str) -> dict[str, Any]:
     is current. The report says per title whether its fade read back — a fade that did
     not is the one thing here worth checking by eye in the GUI.
     """
-    return apply.apply_titles(get_connection(), titles_file)
+    return apply.apply_titles(connection, titles_file)
 
 
 @tool
-def list_titles(timeline: str | None = None) -> dict[str, Any]:
+def list_titles(connection: ResolveConnection, timeline: str | None = None) -> dict[str, Any]:
     """Read back every title standing on a timeline's Titles track, and what it exposes.
 
     The counterpart to apply_titles: that one writes the track from a file, this one reads
@@ -87,11 +87,12 @@ def list_titles(timeline: str | None = None) -> dict[str, Any]:
     is listed too, with `unreadable` saying why — a stray clip on the Titles track is
     worth knowing about, since the next apply_titles will delete it.
     """
-    return title_edit.list_titles(get_connection(), timeline)
+    return title_edit.list_titles(connection, timeline)
 
 
 @tool
 def edit_title(
+    connection: ResolveConnection,
     title: str | None = None,
     text: str | None = None,
     params: dict[str, Any] | None = None,
@@ -118,7 +119,7 @@ def edit_title(
     wording back. Fix the file too when the change is one you want to keep.
     """
     return title_edit.edit_title(
-        get_connection(),
+        connection,
         title,
         text=text,
         params=params,

--- a/src/resolve_mcp/tools/titles.py
+++ b/src/resolve_mcp/tools/titles.py
@@ -11,10 +11,10 @@ from typing import Any
 
 from ..resolve import apply, title_edit, titles
 from ..resolve.connection import ResolveConnection
-from .envelope import offline_tool, tool
+from .envelope import tool, tool_without_connection
 
 
-@offline_tool
+@tool_without_connection
 def get_titles_schema() -> dict[str, Any]:
     """Return the titles-file schema v1, its annotated example, and the validation rules.
 

--- a/src/resolve_mcp/tools/video.py
+++ b/src/resolve_mcp/tools/video.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..resolve.connection import get_connection
+from ..resolve.connection import ResolveConnection
 from ..video import frames, occlusion, quality, scenes
 from .envelope import tool
 
 
 @tool
 def grab_frames(
+    connection: ResolveConnection,
     clip: str,
     times: list[Any],
     bin: str | None = None,  # noqa: A002 - the agent-facing word for a media pool folder
@@ -33,7 +34,6 @@ def grab_frames(
     Use this to check an angle at a moment the audio left ambiguous; to find where the shots
     change in b-roll, run detect_scene_cuts instead.
     """
-    connection = get_connection()
     return frames.grab_frames(
         connection,
         clip,
@@ -46,6 +46,7 @@ def grab_frames(
 
 @tool
 def detect_scene_cuts(
+    connection: ResolveConnection,
     clip: str,
     bin: str | None = None,  # noqa: A002 - the agent-facing word for a media pool folder
     threshold: float = scenes.DEFAULT_THRESHOLD,
@@ -63,7 +64,6 @@ def detect_scene_cuts(
     The scan decodes the whole clip, so it is cached against the media — an unchanged clip is
     never scanned twice.
     """
-    connection = get_connection()
     return scenes.detect_scene_cuts(
         connection,
         clip,
@@ -75,6 +75,7 @@ def detect_scene_cuts(
 
 @tool
 def analyze_occlusion(
+    connection: ResolveConnection,
     clip: str,
     bin: str | None = None,  # noqa: A002 - the agent-facing word for a media pool folder
     start: Any = None,
@@ -113,7 +114,6 @@ def analyze_occlusion(
     the threshold is a partial block, so grab_frames the peak and look before you write the
     angle off.
     """
-    connection = get_connection()
     return occlusion.analyze_occlusion(
         connection,
         clip,
@@ -128,6 +128,7 @@ def analyze_occlusion(
 
 @tool
 def analyze_quality(
+    connection: ResolveConnection,
     clip: str,
     bin: str | None = None,  # noqa: A002 - the agent-facing word for a media pool folder
     start: Any = None,
@@ -161,7 +162,6 @@ def analyze_quality(
     read it to justify or dispute a window, and grab_frames the worst sample before you write
     an angle off.
     """
-    connection = get_connection()
     return quality.analyze_quality(
         connection,
         clip,

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -10,10 +10,11 @@ the shape can drift.
 
 from __future__ import annotations
 
+import inspect
 from typing import Any
 
-from resolve_mcp.resolve.connection import get_connection
-from resolve_mcp.tools.envelope import shaped, tool
+from resolve_mcp.resolve.connection import ResolveConnection, get_connection
+from resolve_mcp.tools.envelope import offline_tool, shaped, tool
 
 from .conftest import Attach
 from .fakes import studio
@@ -56,7 +57,7 @@ def test_a_record_is_recognised_in_every_state_it_can_come_back_in() -> None:
 def test_a_tool_that_starts_a_job_replies_with_the_record_under_job(attach: Attach) -> None:
     attach(studio())
 
-    @tool
+    @offline_tool
     def start_one() -> dict[str, Any]:
         return a_record()
 
@@ -71,7 +72,7 @@ def test_a_tool_that_starts_a_job_replies_with_the_record_under_job(attach: Atta
 def test_a_tool_that_returns_a_result_of_its_own_is_left_alone(attach: Attach) -> None:
     attach(studio())
 
-    @tool
+    @offline_tool
     def read_one() -> dict[str, Any]:
         return {"frames": ["a.jpg"]}
 
@@ -90,8 +91,8 @@ def test_a_job_started_after_a_reconnect_comes_back_in_the_same_envelope(
     connector = attach(dying, studio())
 
     @tool
-    def start_one() -> dict[str, Any]:
-        get_connection().handle().GetProjectManager()
+    def start_one(connection: ResolveConnection) -> dict[str, Any]:
+        connection.handle().GetProjectManager()
         return a_record()
 
     envelope = start_one()
@@ -100,3 +101,80 @@ def test_a_job_started_after_a_reconnect_comes_back_in_the_same_envelope(
     assert connector.attempts == 2
     assert envelope["job"] == a_record()
     assert "job_id" not in envelope
+
+
+# --- the decorator hands the connection in (#229) -----------------------------------------------
+
+
+def test_a_tool_that_declares_a_connection_is_handed_the_live_one(attach: Attach) -> None:
+    """The one line every tool body used to open with is now the decorator's job."""
+    attach(studio())
+
+    @tool
+    def reads_it(connection: ResolveConnection) -> dict[str, Any]:
+        return {"is_the_singleton": connection is get_connection()}
+
+    envelope = reads_it()
+
+    assert envelope["ok"] is True, envelope.get("error")
+    assert envelope["is_the_singleton"] is True
+
+
+def test_the_tool_s_own_arguments_still_arrive_beside_the_connection(attach: Attach) -> None:
+    """The injected parameter is first; everything the caller passes lands where it was."""
+    attach(studio())
+
+    @tool
+    def takes_both(connection: ResolveConnection, name: str, count: int = 2) -> dict[str, Any]:
+        return {"name": name, "count": count, "connected": connection.connected}
+
+    positional = takes_both("cam_a")
+    keywords = takes_both(name="cam_b", count=5)
+
+    assert (positional["name"], positional["count"]) == ("cam_a", 2)
+    assert (keywords["name"], keywords["count"]) == ("cam_b", 5)
+
+
+def test_an_offline_tool_is_handed_nothing_and_keeps_its_own_signature(attach: Attach) -> None:
+    """A tool that answers from documents takes the other decorator, and is left alone."""
+    attach(studio())
+
+    @offline_tool
+    def pure(schema: str = "cut") -> dict[str, Any]:
+        return {"schema": schema}
+
+    assert pure()["schema"] == "cut"
+    assert list(inspect.signature(pure).parameters) == ["schema"]
+
+
+def test_the_injected_connection_is_invisible_to_a_caller(attach: Attach) -> None:
+    """What the transport reads is the signature: the tool's own parameters, and no more."""
+    attach(studio())
+
+    @tool
+    def takes_both(connection: ResolveConnection, name: str) -> dict[str, Any]:
+        return {"name": name}
+
+    assert list(inspect.signature(takes_both).parameters) == ["name"]
+    assert "connection" not in takes_both.__annotations__
+
+
+def test_the_retried_call_is_handed_a_connection_that_reconnects(attach: Attach) -> None:
+    """The handle the retry works on is fresh — the dead one is never handed in twice."""
+    dying = studio()
+    dying.die_after(1)  # passes the connection's probe, dies on the very next call
+    connector = attach(dying, studio())
+    seen: list[Any] = []
+
+    @tool
+    def touches_resolve(connection: ResolveConnection) -> dict[str, Any]:
+        handle = connection.handle()
+        seen.append(handle)
+        handle.GetProjectManager()
+        return {"touched": True}
+
+    envelope = touches_resolve()
+
+    assert envelope["ok"] is True, envelope.get("error")
+    assert connector.attempts == 2
+    assert len(seen) == 2 and seen[0] is not seen[1]

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import inspect
 from typing import Any
 
+import pytest
+
 from resolve_mcp.resolve.connection import ResolveConnection, get_connection
-from resolve_mcp.tools.envelope import offline_tool, shaped, tool
+from resolve_mcp.tools.envelope import shaped, tool, tool_without_connection
 
 from .conftest import Attach
 from .fakes import studio
@@ -57,7 +59,7 @@ def test_a_record_is_recognised_in_every_state_it_can_come_back_in() -> None:
 def test_a_tool_that_starts_a_job_replies_with_the_record_under_job(attach: Attach) -> None:
     attach(studio())
 
-    @offline_tool
+    @tool_without_connection
     def start_one() -> dict[str, Any]:
         return a_record()
 
@@ -72,7 +74,7 @@ def test_a_tool_that_starts_a_job_replies_with_the_record_under_job(attach: Atta
 def test_a_tool_that_returns_a_result_of_its_own_is_left_alone(attach: Attach) -> None:
     attach(studio())
 
-    @offline_tool
+    @tool_without_connection
     def read_one() -> dict[str, Any]:
         return {"frames": ["a.jpg"]}
 
@@ -135,11 +137,11 @@ def test_the_tool_s_own_arguments_still_arrive_beside_the_connection(attach: Att
     assert (keywords["name"], keywords["count"]) == ("cam_b", 5)
 
 
-def test_an_offline_tool_is_handed_nothing_and_keeps_its_own_signature(attach: Attach) -> None:
+def test_a_connectionless_tool_is_handed_nothing_and_keeps_its_signature(attach: Attach) -> None:
     """A tool that answers from documents takes the other decorator, and is left alone."""
     attach(studio())
 
-    @offline_tool
+    @tool_without_connection
     def pure(schema: str = "cut") -> dict[str, Any]:
         return {"schema": schema}
 
@@ -178,3 +180,42 @@ def test_the_retried_call_is_handed_a_connection_that_reconnects(attach: Attach)
     assert envelope["ok"] is True, envelope.get("error")
     assert connector.attempts == 2
     assert len(seen) == 2 and seen[0] is not seen[1]
+
+
+def test_a_tool_that_forgot_the_connection_is_refused_at_decoration() -> None:
+    """Injection is positional: a forgotten parameter would silently eat the first argument.
+
+    The tool would still register — minus one parameter — and run with a ResolveConnection
+    where its caller's value belongs. Loud at import beats wrong at call time.
+    """
+    with pytest.raises(TypeError, match="connection: ResolveConnection"):
+
+        @tool  # type: ignore[arg-type]  # the mistake under test
+        def forgot(clip: str) -> dict[str, Any]:
+            return {"clip": clip}
+
+    with pytest.raises(TypeError, match="connection: ResolveConnection"):
+
+        @tool  # type: ignore[arg-type]  # the mistake under test
+        def declared_nothing() -> dict[str, Any]:
+            return {}
+
+
+def test_a_body_that_holds_no_handle_is_never_retried(attach: Attach) -> None:
+    """A dead handle cannot be why a document-only tool failed, so it does not run twice."""
+    dying = studio()
+    dying.die_after(1)  # the handle dies while the tool is running, as it does for any tool
+    attach(dying, studio())
+    calls: list[int] = []
+
+    @tool_without_connection
+    def reads_a_document() -> dict[str, Any]:
+        calls.append(1)
+        get_connection().handle().GetProjectManager()
+        raise RuntimeError("a bug of its own")
+
+    envelope = reads_a_document()
+
+    assert envelope["ok"] is False
+    assert envelope["error"]["code"] == "internal_error"
+    assert calls == [1]  # a second run would repeat whatever the body had already written

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from resolve_mcp.server import build_server
 
@@ -71,6 +72,29 @@ def test_every_tool_describes_itself() -> None:
 
 def test_the_escape_hatch_steers_back_to_the_real_tools() -> None:
     assert "prefer" in descriptions()["run_python"].lower()
+
+
+def schemas() -> dict[str, dict[str, Any]]:
+    tools = asyncio.run(build_server().list_tools())
+    return {tool.name: tool.parameters for tool in tools}
+
+
+def test_the_injected_connection_never_reaches_the_transport() -> None:
+    """The decorator hands the connection in (#229); the agent must never see the parameter."""
+    offenders = {
+        name: schema
+        for name, schema in schemas().items()
+        if "connection" in (schema.get("properties") or {})
+        or "connection" in (schema.get("required") or [])
+    }
+
+    assert offenders == {}
+
+
+def test_a_tool_s_own_parameters_survive_the_injection() -> None:
+    """Stripping one parameter must not strip the ones the agent is supposed to fill in."""
+    assert schemas()["open_project"]["required"] == ["name"]
+    assert set(schemas()["grab_frames"]["properties"]) >= {"clip", "times", "max_edge"}
 
 
 def test_python_m_entry_is_the_server_main() -> None:


### PR DESCRIPTION
Closes #229.

`connection = get_connection()` opened 33 tool bodies while the envelope decorator already fetched a connection for its reconnect-retry path. The decorator now hands it in: a `@tool` declares `connection: ResolveConnection` first and is given the live one, so acquisition has exactly one owner and no body can hold a handle the retry has already replaced. The injected parameter is stripped from the signature *and* the annotations MCP registration reads, so it never reaches the transport.

`@tool_without_connection` is the same envelope for the ten tools that answer without Resolve (schemas, `virtual_transcript`, the two job readers, the five document-only analysis tools).

**Seam: fake tier** — `tests/test_envelope.py` (injection, the tool's own arguments still binding, the retried call's fresh handle, the decoration-time guard, no retry for a body that holds no handle) and `tests/test_server.py` (no registered tool exposes `connection`; `open_project` still requires `name`). No live AC: nothing here needs Resolve running.

## Review

Two-axis review (`/code-review` since `origin/main`), run on `6eaeebc` before this PR existed.

### Spec axis — all three ACs met, one bug, one scope note

| Finding | Resolution |
| --- | --- |
| **Implemented but wrong:** the strip ran without checking the first parameter *is* a connection. A `@tool` whose author forgot it would bind a connection to their first real argument and drop that argument from the schema — a wrong value with nothing raised. | **Fixed** in `1d0f384`: `_the_declared_connection` refuses such a function at decoration time with a message naming the fix; `test_a_tool_that_forgot_the_connection_is_refused_at_decoration` pins both shapes (wrong first parameter, and none at all). |
| **Scope note:** the ticket suggested one mechanism — the decorator detecting the declaration — and this adds a second public decorator instead. | **Kept, deliberately.** Runtime detection needs a `@overload` pair over `Concatenate`/ParamSpec, and mypy cannot resolve it: every decorated tool infers as `(*Any, **Any) -> Any`, which cost 675 `no-untyped-call` errors across the suite under this repo's mypy strict gate. Two typed decorators keep the tools typed, and which one a tool takes is a fact worth reading off its `def` line. Documented in the envelope docstring and `docs/context/tools.md`. |

ACs verified: `get_connection` survives in `src/` only inside `envelope.py`; the retry invalidates then re-enters the call, which re-fetches (asserted as two distinct handles); every registered schema is swept for `connection`.

### Standards axis — no hard violations, five judgement calls, all taken

| Finding | Resolution |
| --- | --- |
| **Data Clumps + Repeated Switches:** `fn, wants_connection, args, kwargs` travelled into two helpers and the flag was switched on twice; the retry carried it only to pass it on. | **Fixed:** each decorator picks how to call the body once; the retry takes a thunk plus a name and knows nothing about injection. |
| **Duplicated knowledge:** `parameters[1:]` and `next(iter(...))` encoded the same positional assumption separately. | **Fixed:** one `inspect.Parameter`, both derived from it. |
| **Mysterious Name:** `offline_tool` — "offline" already means *missing media* here (`list_media(offline_only=…)`). | **Fixed:** renamed `tool_without_connection`. |
| **Retry ran for bodies that cannot have a dead handle** — a document-only tool could re-execute (e.g. a job-store write). Pre-existing, but the new split makes gating it one word. | **Fixed:** `tool_without_connection` does not retry; `test_a_body_that_holds_no_handle_is_never_retried` pins it. |
| `_as_a_tool` reads as a phrase, not an action. | **Fixed:** `_wrap_as_tool`. |

Compliance confirmed by the axis: `CONTEXT.md` and `docs/context/tools.md` updated in the same PR; connection-state logging survives the refactor unchanged.

### Checks

`uv run pytest -m 'not live'` → **2645 passed, 45 deselected**. `uv run mypy src tests` → clean (223 files). `uv run ruff check src tests` → clean.

Review: clean — both axes; the spec axis's one implementation bug and all five standards judgement calls fixed in `1d0f384`, fix diff re-checked.


### After opening: merge of `origin/main` (a303701)

#228 landed while this was in review and renamed `open_project` to `load_project` in the one file the injection also rewrites. Resolved by taking main's name and this branch's injection — `load_project(connection: ResolveConnection, name: str)`, getter line dropped — and pointing the schema assertion at `load_project`. Every conflicted file grepped for `<<<<<<<`. Re-checked on the merged tree: `pytest -m 'not live'` **2645 passed**, mypy strict clean, ruff clean.

Review: clean @a303701 — merge-only diff, no new logic, both gates re-run green.

