### PR TITLE
feat: a named catalog seam for framing deltas (#225)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -122,7 +122,7 @@ audio or synthetic frames; `live`: a running Resolve Studio (`pytest -m live`);
 | `video/blocking` | how blocked one frame is + the discriminator; numpy, no I/O | `test_occlusion` | pure |
 | `video/ffmpeg` | the commands video routes run; NVDEC flags, fallback, report | `test_hardware_decode` | pure |
 | `video/frames` | frame grabs — the one compute route that is not a job | `test_frame_grabs` | fake |
-| `video/framing` | how far the picture steps across a cut; the 30-degree flag | `test_visual_delta` | pure |
+| `video/framing` | how far the picture steps across a cut; the 30-degree flag; the cut-delta catalog both sides read | `test_visual_delta` | pure |
 | `video/jpeg` | read back dimensions | `test_frame_grabs` | fake |
 | `video/occlusion` | blocking as a cached job over a sampled range | `test_occlusion` | fake |
 | `video/picture` | sharpness, exposure, clipping, stability of one frame | `test_quality` | pure |

--- a/docs/context/video.md
+++ b/docs/context/video.md
@@ -29,7 +29,9 @@ a scan of a render onto the cut's own shots, #182), `framing`
 flag: layout, content and size terms over two grey frames, numpy only — and
 the catalog between the two sides of that measurement, `write_catalog` /
 `read_catalog` over `Cut` records, so the pack writes and `analysis/correlate`
-reads one shape rather than two agreeing by convention, #225),
+reads one shape rather than two agreeing by convention, #225 — the one place a
+`video` module reaches into `analysis`, for `records`' file layout and nothing
+else, which is a leaf on `errors` and so carries no cycle back),
 `supers` (the **super**: which burned-in graphics are up when, and which cuts land
 inside one. Pure numpy + scipy over frames somebody else decoded — the pack does
 both decodes, a coarse scan for where and a native-fps walk for the exact in and

--- a/docs/context/video.md
+++ b/docs/context/video.md
@@ -26,8 +26,10 @@ floors and a reason on every window; the floors are calibrated on the corpus,
 `docs/reference/image-quality-calibration.md`, and `analysis/correlate` joins
 a scan of a render onto the cut's own shots, #182), `framing`
 (how far the picture steps *across* a cut and the 30-degree-rule jump-cut
-flag: layout, content and size terms over two grey frames, numpy only, no
-I/O — the pack measures with it, `analysis/correlate` joins its catalog on),
+flag: layout, content and size terms over two grey frames, numpy only — and
+the catalog between the two sides of that measurement, `write_catalog` /
+`read_catalog` over `Cut` records, so the pack writes and `analysis/correlate`
+reads one shape rather than two agreeing by convention, #225),
 `supers` (the **super**: which burned-in graphics are up when, and which cuts land
 inside one. Pure numpy + scipy over frames somebody else decoded — the pack does
 both decodes, a coarse scan for where and a native-fps walk for the exact in and

--- a/gauntlet/tools/ab_pack.py
+++ b/gauntlet/tools/ab_pack.py
@@ -2149,8 +2149,10 @@ def build_label(
 
     # Through framing's writer rather than json.dumps: the reader on the other side is
     # framing's too, so the shape of a row stops being a convention this file agreed with
-    # correlate_timeline by hand. Everything above rides as the header, and the cut records
-    # land one to a line -- the layout analysis/records exists for.
+    # correlate_timeline by hand. The cut records land one to a line, which is the layout
+    # analysis/records exists for; everything else rides as the header, and a header value
+    # is one line however long it is -- so the shots array and the audio curves are no
+    # longer indented the way json.dumps left them. Grep the cuts, jq the rest.
     framing.write_catalog(label_dir / "cuts.json", cut_rows, header=cuts_doc)
     # The supers again as a catalog of their own, so correlate_timeline can join them onto a
     # timeline's cuts the way it joins the cut deltas: same records shape, one row per super.

--- a/gauntlet/tools/ab_pack.py
+++ b/gauntlet/tools/ab_pack.py
@@ -73,7 +73,7 @@ from typing import Any, NamedTuple
 import numpy as np
 
 from resolve_mcp.analysis import subject as subject_module
-from resolve_mcp.analysis.correlate import RHYTHM_BINS
+from resolve_mcp.analysis.rhythm import RHYTHM_BINS
 from resolve_mcp.ffmpeg import hwaccels
 from resolve_mcp.video import framing, picture, supers
 from resolve_mcp.video.quality import (
@@ -2066,6 +2066,31 @@ def build_label(
     if subject_track is not None:
         attach_subjects(shot_docs, subject_track["shots"])
 
+    # One record per boundary, carried by the interface that measured it: the reading goes
+    # down through framing's own writer, and correlate_timeline reads it back as a Delta
+    # rather than off a shape agreed by nobody. Everything this pack knows about the same
+    # cut rides along on the row -- a catalog is this file, not a second one beside it.
+    cut_rows = [
+        framing.Cut(
+            t=cut,
+            reading=deltas[i],
+            extra={
+                "index": i + 1,
+                "transition": transitions[i],
+                # Whether a graphic was on screen either side of this cut, and which kind
+                # (#183). Not on its own a fault: a lower third held across cut after cut
+                # is how the human deliverables are titled, while a cut inside a card is
+                # the thing none of them does. A super arriving with the shot, or clearing
+                # the frame before it, is neither -- the review told those apart already.
+                "straddles_super": int(round(cut * fps)) in straddled,
+                "super_kind": straddled.get(int(round(cut * fps))),
+                "strip_sheet": row_of.get(i + 1, {}).get("sheet"),
+                "strip_row": row_of.get(i + 1, {}).get("row"),
+            },
+        )
+        for i, cut in enumerate(cuts)
+    ]
+
     cuts_doc: dict[str, Any] = {
         "label": label,
         "clip_duration_sec": round(duration, 3),
@@ -2094,24 +2119,6 @@ def build_label(
             "unusable_shots": unusable_shots,
         },
         "cut_times_sec": cuts,
-        "cuts": [
-            {
-                "index": i + 1,
-                "t": cut,
-                "transition": transitions[i],
-                "delta": deltas[i].as_record() if deltas[i] is not None else None,
-                # Whether a graphic was on screen either side of this cut, and which kind
-                # (#183). Not on its own a fault: a lower third held across cut after cut
-                # is how the human deliverables are titled, while a cut inside a card is
-                # the thing none of them does. A super arriving with the shot, or clearing
-                # the frame before it, is neither -- the review told those apart already.
-                "straddles_super": int(round(cut * fps)) in straddled,
-                "super_kind": straddled.get(int(round(cut * fps))),
-                "strip_sheet": row_of.get(i + 1, {}).get("sheet"),
-                "strip_row": row_of.get(i + 1, {}).get("row"),
-            }
-            for i, cut in enumerate(cuts)
-        ],
         "shots": shot_docs,
         "ending": ending,
         "slow_transitions": slow_events,
@@ -2140,7 +2147,11 @@ def build_label(
             "windows": len(levels),
         }
 
-    (label_dir / "cuts.json").write_text(json.dumps(cuts_doc, indent=2), encoding="utf-8")
+    # Through framing's writer rather than json.dumps: the reader on the other side is
+    # framing's too, so the shape of a row stops being a convention this file agreed with
+    # correlate_timeline by hand. Everything above rides as the header, and the cut records
+    # land one to a line -- the layout analysis/records exists for.
+    framing.write_catalog(label_dir / "cuts.json", cut_rows, header=cuts_doc)
     # The supers again as a catalog of their own, so correlate_timeline can join them onto a
     # timeline's cuts the way it joins the cut deltas: same records shape, one row per super.
     (label_dir / "supers.json").write_text(

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -69,7 +69,7 @@ from ..resolve.timeline import (
     track_enabled,
 )
 from ..timing import dual_time, to_frames
-from ..video import supers
+from ..video import framing, supers
 from . import barmap, decode, energy, records, rhythm, subject
 from .beats import GridTrust, nearest, spacing, trust
 from .stats import histogram, measured, offsets, rounded
@@ -103,7 +103,7 @@ measurement, and refusing it would be trading one wrong answer for another.
 BLACK = "black"
 """Where the stretches nothing covers are counted — a known absence, not a missing label."""
 
-READING = 11
+READING = 12
 """What this measurement *is*; bumped whenever a rerun over unchanged inputs would differ.
 
 The cache is keyed on what was measured, not on the code that measured it, so a call whose
@@ -122,7 +122,11 @@ that never asked it, and a cached reading-8 file would hand back a report with n
 columns at all. 10 rather than 9 for the same reason one step further on: every record now
 carries the four image-quality columns and a ``quality_samples`` count (#182), and 11
 rather than 10 because every record now carries ``straddles_super`` and ``super_kind`` on
-the same terms (#183).
+the same terms (#183). 12 rather than 11 for a block rather than a column: ``visual_delta``
+is now the measurement's own summary shape (``video.framing``), where ``joined`` and
+``unjoined`` are ``cuts`` and ``cuts_unread``, the distribution carries a p10, and the
+threshold the flag was taken at sits beside the counts — a cached reading-11 file would
+hand back the block this one replaced, under the same name (#225).
 """
 
 DELTA_MATCH_SEC = 0.25
@@ -289,7 +293,7 @@ def correlate_timeline(
     roles = _roles(angles)
     subjects = _subjects(angles)
     music = _music(beats, audio, tunes, solos, bars, roles, subjects)
-    pictures = _optional_rows(deltas, "cut delta catalog", "cuts")
+    pictures = _delta_catalog(deltas)
     graphics = _optional_rows(
         supers,
         "supers catalog",
@@ -359,7 +363,7 @@ def correlate(
     onsets: Onsets | None = None,
     loudness: Levels | None = None,
     config: Config | None = None,
-    pictures: Sequence[Mapping[str, Any]] | None = None,
+    pictures: Sequence[framing.Cut] | None = None,
     graphics: Sequence[Mapping[str, Any]] | None = None,
     takes: Sequence[Mapping[str, Any]] | None = None,
     floors: Mapping[str, float] | None = None,
@@ -757,6 +761,21 @@ def _music(
     )
 
 
+def _delta_catalog(file: str | None) -> tuple[framing.Cut, ...] | None:
+    """The cut-delta catalog, read through the same module that writes one.
+
+    ``video.framing`` owns both halves of that file — the reading goes down as a record and
+    comes back as a ``Delta`` — so nothing downstream of here meets a dict whose shape it
+    has to guess. The path check stays on this side, where every other named input is
+    checked, so a path that is not there refuses in one shape for all of them.
+    """
+    if file is None:
+        return None
+    return framing.read_catalog(
+        _path(file, "cut delta catalog", "gauntlet/tools/ab_pack.py writes one as cuts.json")
+    )
+
+
 def _optional_rows(
     file: str | None,
     what: str,
@@ -901,7 +920,7 @@ def measure(
     music: Music,
     transients: Sequence[float] | None,
     grid: GridTrust | None = None,
-    pictures: Sequence[Mapping[str, Any]] | None = None,
+    pictures: Sequence[framing.Cut] | None = None,
     graphics: Sequence[Mapping[str, Any]] | None = None,
     takes: Sequence[Mapping[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
@@ -922,7 +941,7 @@ def measure(
     spans = subject.windows(music.solos)
     trusted = (grid if grid is not None else trust(music.beats)).trusted
     widths = spacing(times)
-    picture_times = [float(row["t"]) for row in (pictures or ())]
+    picture_times = [one.t for one in (pictures or ())]
     take_times = [float(row["t"]) for row in (takes or ())]
 
     rows: list[dict[str, Any]] = []
@@ -1119,23 +1138,25 @@ def _number(row: Mapping[str, Any], field: str) -> float:
 
 
 def _delta_at(
-    pictures: Sequence[Mapping[str, Any]] | None,
+    pictures: Sequence[framing.Cut] | None,
     times: Sequence[float],
     seconds: float,
 ) -> dict[str, Any]:
-    """The catalog row that lands on this cut, as ``delta`` and ``jump_cut`` columns."""
+    """The catalog cut that lands on this one, as ``delta`` and ``jump_cut`` columns.
+
+    The reading arrives typed from ``framing.read_catalog``, so there is one shape to read
+    here and no row to sniff. A cut the catalog holds but could not read lands the same way
+    as a cut it does not hold: null columns, counted as unread by the summary.
+    """
     if not pictures:
         return {"delta": None, "jump_cut": None}
     found = nearest(times, seconds)
     if found is None or abs(times[found] - seconds) > DELTA_MATCH_SEC:
         return {"delta": None, "jump_cut": None}
-    row = pictures[found]
-    # Two shapes reach here: the pack's ``cuts.json``, where the reading is nested under
-    # ``delta``, and a flat catalog that spreads the same fields across the row.
-    reading = row.get("delta")
-    if isinstance(reading, Mapping):
-        return {"delta": reading.get("delta"), "jump_cut": reading.get("jump_cut")}
-    return {"delta": reading, "jump_cut": row.get("jump_cut")}
+    reading = pictures[found].reading
+    if reading is None:
+        return {"delta": None, "jump_cut": None}
+    return {"delta": reading.delta, "jump_cut": reading.jump_cut}
 
 
 def _out_of_reach(seconds: float, beat: float, width: float | None) -> bool:
@@ -1224,7 +1245,7 @@ def _summary(
     grid: Sequence[float],
     trusted: GridTrust,
     levels: Sequence[tuple[float, float]] | None = None,
-    pictures: Sequence[Mapping[str, Any]] | None = None,
+    pictures: Sequence[framing.Cut] | None = None,
     graphics: Sequence[Mapping[str, Any]] | None = None,
     takes: Sequence[Mapping[str, Any]] | None = None,
     floors: Mapping[str, float] | None = None,
@@ -1297,24 +1318,32 @@ def _summary(
 
 
 def _deltas(
-    rows: Sequence[dict[str, Any]], pictures: Sequence[Mapping[str, Any]]
+    rows: Sequence[dict[str, Any]], pictures: Sequence[framing.Cut]
 ) -> dict[str, Any]:
     """How far the picture steps across this cut's boundaries, over the whole timeline.
 
-    ``unjoined`` is the number the reading lives or dies by. A catalog measured off a
-    different span, or off a render whose cuts the detector missed, still produces a
-    ``visual_delta`` block — one drawn from a handful of rows that happened to land. Said
-    out loud, that is a mismatch to fix; left out, it is a distribution nobody doubts.
+    The distribution itself is ``framing``'s own summary of the same measurement, taken
+    from there rather than written again: a pack's ``visual_delta`` block and a correlate
+    report's have to be one shape, or a critic reading both is reading two vocabularies for
+    one number. What this adds is what only the join knows — how big the catalog was, which
+    cuts were flagged, and how near a row had to sit to count.
+
+    ``cuts_unread`` is the number the reading lives or dies by, and here it is the cuts that
+    joined nothing. A catalog measured off a different span, or off a render whose cuts the
+    detector missed, still produces a block — one drawn from a handful of rows that happened
+    to land. Said out loud, that is a mismatch to fix; left out, it is a distribution nobody
+    doubts.
     """
-    found = [float(row["delta"]) for row in rows if row["delta"] is not None]
+    joined = [row for row in rows if row["delta"] is not None]
     flagged = [row for row in rows if row["jump_cut"]]
     return {
+        **framing.summarize_steps(
+            [float(row["delta"]) for row in joined],
+            jump_cuts=len(flagged),
+            unread=len(rows) - len(joined),
+        ),
         "catalog_rows": len(pictures),
-        "joined": len(found),
-        "unjoined": len(rows) - len(found),
-        "jump_cuts": len(flagged),
         "flagged_cuts": [row["cut"] for row in flagged[:INLINE_CUTS]],
-        "delta": _lengths([round(one, 4) for one in found]) if found else None,
         "match_tolerance_sec": DELTA_MATCH_SEC,
     }
 

--- a/src/resolve_mcp/analysis/correlate.py
+++ b/src/resolve_mcp/analysis/correlate.py
@@ -259,10 +259,10 @@ def correlate_timeline(
     clip on the timeline carries it and so none can be read.
 
     ``deltas`` is a cut-delta catalog — the per-cut visual step measured off a rendered
-    picture (``gauntlet/tools/ab_pack.py`` writes one as ``cuts.json``). Its ``t`` has to be
-    in the same clock as this timeline's cuts, which is what a full-length render gives; a
-    catalog measured off a span joins nothing, and the summary says how many rows joined
-    rather than leaving a silent hole.
+    picture, written and read through ``video.framing`` (``gauntlet/tools/ab_pack.py`` writes
+    one as ``cuts.json``). Its ``t`` has to be in the same clock as this timeline's cuts,
+    which is what a full-length render gives; a catalog measured off a span joins nothing,
+    and the summary's ``cuts`` and ``cuts_unread`` say so rather than leaving a silent hole.
 
     ``supers`` is the other catalog off that render: when each burned-in graphic — lower
     third, title card, bug — is on screen. Every cut is measured against them and carries

--- a/src/resolve_mcp/tools/analysis.py
+++ b/src/resolve_mcp/tools/analysis.py
@@ -242,8 +242,9 @@ def correlate_timeline(
     the 30-degree-rule check. Nothing on a timeline can answer that: it takes frames either
     side of every boundary, so the render comes first and this joins its numbers on by time.
     gauntlet/tools/ab_pack.py writes such a catalog as cuts.json. Render the whole timeline,
-    not a span, or the times will not line up — the visual_delta block in the result says how
-    many cuts joined and how many did not.
+    not a span, or the times will not line up — the visual_delta block in the result is the
+    measurement's own summary shape, so cuts and cuts_unread there say how many joined and
+    how many did not, beside the distribution and the threshold the flag was taken at.
 
     supers is the other catalog off that render: when each burned-in graphic — lower third,
     title card, bug — is on screen, which again nothing on a timeline can answer. Every cut is

--- a/src/resolve_mcp/video/framing.py
+++ b/src/resolve_mcp/video/framing.py
@@ -38,6 +38,13 @@ detail, and a 128x72 grid is enough shape to correlate and cheap enough that a w
 song's cuts cost milliseconds. Frames arrive as raw grey from the same ffmpeg route
 the occlusion scan uses.
 
+The measurement travels: what reads the boundaries is a render pass, and what joins them
+onto a timeline is ``analysis.correlate``, two processes and often two machines apart. So
+this module owns the file between them as well — ``write_catalog`` and ``read_catalog``
+over ``Cut`` records, the reading down through ``Delta.as_record`` and back up as a
+``Delta``. A catalog is the writer's own file, not a second one beside it: a row carries
+whatever else its writer knew about that cut, untouched.
+
 What this cannot do: it does not know who is on screen. Two different cameras
 pointed at the same soloist from twenty degrees apart score as a step here if the
 backgrounds differ enough, and the true 30-degree rule would call that a jump. The
@@ -47,11 +54,16 @@ so the human's own deliverables sit clear of it (see ``JUMP_DELTA``).
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from types import MappingProxyType
 from typing import Any, NamedTuple
 
 import numpy as np
 from numpy.typing import NDArray
+
+from ..analysis import records
+from ..errors import InvalidRequestError
 
 GRID_WIDTH = 128
 GRID_HEIGHT = 72
@@ -238,11 +250,28 @@ def summarize(readings: Sequence[Delta], unread: int = 0) -> dict[str, Any]:
     be read at all, and it belongs in the same block as the counts it qualifies — a
     consumer that pastes it on afterwards writes half of this shape somewhere else.
     """
-    values = np.asarray([one.delta for one in readings], dtype=np.float64)
+    return summarize_steps(
+        [one.delta for one in readings],
+        jump_cuts=sum(1 for one in readings if one.jump_cut),
+        unread=unread,
+    )
+
+
+def summarize_steps(steps: Sequence[float], jump_cuts: int, unread: int = 0) -> dict[str, Any]:
+    """The same summary from the two columns a written row keeps, for a reader that has
+    the catalog's numbers rather than its readings.
+
+    ``analysis.correlate`` joins a catalog onto a timeline and keeps a step and a flag per
+    cut; the four terms behind them belong to the boundary, not to the cut it landed on.
+    Handing back a shape built here, rather than one written again over there, is what
+    stops a pack's block and a correlate report's block from being two vocabularies for
+    one measurement.
+    """
+    values = np.asarray(list(steps), dtype=np.float64)
     return {
-        "cuts": len(readings),
+        "cuts": len(values),
         "cuts_unread": unread,
-        "jump_cuts": sum(1 for one in readings if one.jump_cut),
+        "jump_cuts": jump_cuts,
         "delta": {
             "min": round(float(values.min()), 4),
             "p10": round(float(np.quantile(values, 0.10)), 4),
@@ -250,7 +279,7 @@ def summarize(readings: Sequence[Delta], unread: int = 0) -> dict[str, Any]:
             "mean": round(float(values.mean()), 4),
             "max": round(float(values.max()), 4),
         }
-        if readings
+        if len(values)
         else None,
         "threshold": JUMP_DELTA,
     }
@@ -403,3 +432,136 @@ def _reason(layout: float, structure: float, scale: float) -> str:
     if same_size:
         return "same size"
     return "step below threshold"
+
+
+# --------------------------------------------------------------------------
+# the catalog
+
+
+CATALOG_KIND = "cut_deltas"
+"""What a file this module writes says it is, in its header."""
+
+CATALOG_FIELD = "cuts"
+"""The record field a catalog carries: one record per boundary, in time order."""
+
+CATALOG_TIME = "t"
+"""The column a record file is a timeline by — ``analysis.records``' own, named here
+because a row's other columns are the writer's and this one is not."""
+
+
+class Cut(NamedTuple):
+    """One boundary in a catalog: where it sits, and what the picture did across it.
+
+    ``reading`` is ``None`` where the boundary could not be read — a window without room
+    for both stacks, a ramp whose ends nobody located. Written as a null row rather than
+    left out: the catalog is the run's own list of cuts, and a dropped row reports a
+    shorter edit instead of an unread boundary.
+
+    ``extra`` is whatever else its writer knew about this cut — the pack's transition
+    typing, its filmstrip reference. This module carries those through and never reads
+    them, so a writer's own file can *be* the catalog. A catalog that could hold only
+    these two columns would send every writer back to a second file beside it, which is
+    the file convention this interface exists to replace.
+    """
+
+    t: float
+    reading: Delta | None
+    extra: Mapping[str, Any] = MappingProxyType({})
+
+
+def write_catalog(
+    path: Path,
+    cuts: Sequence[Cut],
+    header: Mapping[str, Any] | None = None,
+) -> Path:
+    """Write ``cuts`` as a catalog at ``path``, one record per line. Returns the path.
+
+    The reading goes down through ``as_record`` and comes back up through ``read_catalog``,
+    so the shape on disk is this module's to change and nobody else's to guess. ``header``
+    is whatever the writer wants above the records — a pack's own stats, the label it
+    built — and ``kind`` and ``count`` are written over it, being this file's own claim
+    about itself rather than the writer's.
+    """
+    rows = [
+        {
+            **dict(one.extra),
+            CATALOG_TIME: one.t,
+            "delta": None if one.reading is None else one.reading.as_record(),
+        }
+        for one in cuts
+    ]
+    return records.write(
+        path,
+        {**dict(header or {}), "kind": CATALOG_KIND, "count": len(rows)},
+        CATALOG_FIELD,
+        rows,
+    )
+
+
+def read_catalog(path: Path) -> tuple[Cut, ...]:
+    """A catalog back as typed readings, in time order.
+
+    The strong reader beside the writer, for the same reason ``analysis.records`` keeps
+    its own: what a catalog *is* belongs to this module, so every consumer gets the same
+    answer to a file that is not one — and gets a ``Delta`` rather than a dict whose shape
+    it has to sniff. ``records.rows`` refuses the four ways the path can be wrong; the
+    refusal below is the fifth, and the only one this module alone can name.
+    """
+    return tuple(_cut(path, row) for row in records.rows(path, CATALOG_FIELD))
+
+
+def _cut(path: Path, row: Mapping[str, Any]) -> Cut:
+    held = row.get("delta")
+    if held is not None and not isinstance(held, Mapping):
+        raise InvalidRequestError(
+            cause=(
+                f"{path.name} spreads a cut's reading across its row: the delta at "
+                f"t={row['t']} is a bare {type(held).__name__} rather than the record this "
+                "measurement writes."
+            ),
+            fix=(
+                "Write the catalog through resolve_mcp.video.framing.write_catalog, which "
+                'puts the whole reading under "delta" — a bare number there is a catalog '
+                "from before that interface, and rereading it would answer with terms "
+                "nobody measured."
+            ),
+            detail={"file": str(path), "t": row["t"]},
+        )
+    return Cut(
+        t=float(row[CATALOG_TIME]),
+        reading=None if held is None else _reading(held),
+        extra=MappingProxyType(
+            {key: value for key, value in row.items() if key not in (CATALOG_TIME, "delta")}
+        ),
+    )
+
+
+def _reading(record: Mapping[str, Any]) -> Delta:
+    """One catalog record read back as the reading that wrote it.
+
+    Every term is taken with a default rather than by subscript. A record missing one is
+    an older or hand-edited catalog, and the answer to that is a reading with a hole in it
+    — not a ``KeyError`` out of a worker, two seconds after a call that looked accepted.
+    """
+    return Delta(
+        delta=_term(record, "delta"),
+        content=_term(record, "content"),
+        layout=_term(record, "layout"),
+        structure=_term(record, "structure"),
+        scale=_term(record, "scale"),
+        shift_x=_shift(record, "shift_x"),
+        shift_y=_shift(record, "shift_y"),
+        jump_cut=bool(record.get("jump_cut")),
+        reason=str(record.get("reason") or ""),
+    )
+
+
+def _term(record: Mapping[str, Any], field: str) -> float:
+    found = record.get(field)
+    return float(found) if isinstance(found, int | float) and not isinstance(found, bool) else 0.0
+
+
+def _shift(record: Mapping[str, Any], field: str) -> int | None:
+    """A lag in grid pixels, or ``None`` — which is the ordinary answer at a real cut."""
+    found = record.get(field)
+    return int(found) if isinstance(found, int | float) and not isinstance(found, bool) else None

--- a/src/resolve_mcp/video/framing.py
+++ b/src/resolve_mcp/video/framing.py
@@ -444,9 +444,13 @@ CATALOG_KIND = "cut_deltas"
 CATALOG_FIELD = "cuts"
 """The record field a catalog carries: one record per boundary, in time order."""
 
-CATALOG_TIME = "t"
-"""The column a record file is a timeline by — ``analysis.records``' own, named here
-because a row's other columns are the writer's and this one is not."""
+CATALOG_COLUMNS = ("t", "delta")
+"""The two columns a catalog row owns: when the cut is, and what the picture did.
+
+Everything else on a row is its writer's. These two are written last and read first, so a
+writer whose own record already carries a ``t`` or a ``delta`` has that one replaced rather
+than silently deciding what this file means — the pack's own ``t`` is the same number, and
+its own ``delta`` would be the shape this interface exists to stop drifting."""
 
 
 class Cut(NamedTuple):
@@ -480,13 +484,15 @@ def write_catalog(
     so the shape on disk is this module's to change and nobody else's to guess. ``header``
     is whatever the writer wants above the records — a pack's own stats, the label it
     built — and ``kind`` and ``count`` are written over it, being this file's own claim
-    about itself rather than the writer's.
+    about itself rather than the writer's. ``CATALOG_COLUMNS`` are written over a row's
+    ``extra`` for the same reason.
     """
+    time, delta = CATALOG_COLUMNS
     rows = [
         {
             **dict(one.extra),
-            CATALOG_TIME: one.t,
-            "delta": None if one.reading is None else one.reading.as_record(),
+            time: one.t,
+            delta: None if one.reading is None else one.reading.as_record(),
         }
         for one in cuts
     ]
@@ -511,12 +517,13 @@ def read_catalog(path: Path) -> tuple[Cut, ...]:
 
 
 def _cut(path: Path, row: Mapping[str, Any]) -> Cut:
-    held = row.get("delta")
+    time, delta = CATALOG_COLUMNS
+    held = row.get(delta)
     if held is not None and not isinstance(held, Mapping):
         raise InvalidRequestError(
             cause=(
                 f"{path.name} spreads a cut's reading across its row: the delta at "
-                f"t={row['t']} is a bare {type(held).__name__} rather than the record this "
+                f"t={row[time]} is a bare {type(held).__name__} rather than the record this "
                 "measurement writes."
             ),
             fix=(
@@ -525,13 +532,13 @@ def _cut(path: Path, row: Mapping[str, Any]) -> Cut:
                 "from before that interface, and rereading it would answer with terms "
                 "nobody measured."
             ),
-            detail={"file": str(path), "t": row["t"]},
+            detail={"file": str(path), "t": row[time]},
         )
     return Cut(
-        t=float(row[CATALOG_TIME]),
+        t=float(row[time]),
         reading=None if held is None else _reading(held),
         extra=MappingProxyType(
-            {key: value for key, value in row.items() if key not in (CATALOG_TIME, "delta")}
+            {key: value for key, value in row.items() if key not in CATALOG_COLUMNS}
         ),
     )
 

--- a/tests/test_correlate_timeline.py
+++ b/tests/test_correlate_timeline.py
@@ -27,6 +27,7 @@ from resolve_mcp.errors import InvalidRequestError
 from resolve_mcp.jobs.runner import wait_for
 from resolve_mcp.resolve.connection import get_connection
 from resolve_mcp.tools import analysis as analysis_tools
+from resolve_mcp.video import framing
 
 from .conftest import Attach
 from .fakes import (
@@ -179,14 +180,9 @@ def solos_file(tmp_path: Path, first_from: str | None = None, first_t: float = 0
 
 
 
-def deltas_file(tmp_path: Path, rows: Sequence[dict[str, Any]], name: str = "pack") -> Path:
-    """A cut-delta catalog, in the shape gauntlet/tools/ab_pack.py writes as cuts.json."""
-    return records.write(
-        tmp_path / f"cut-deltas-{name}.json",
-        {"kind": "cut_deltas", "count": len(rows)},
-        "cuts",
-        list(rows),
-    )
+def deltas_file(tmp_path: Path, cuts: Sequence[framing.Cut], name: str = "pack") -> Path:
+    """A cut-delta catalog, written through the interface gauntlet/tools/ab_pack.py uses."""
+    return framing.write_catalog(tmp_path / f"cut-deltas-{name}.json", list(cuts))
 
 
 def supers_file(
@@ -257,13 +253,23 @@ def _scan_of(soft: Sequence[float] = (), **overrides: Any) -> list[dict[str, Any
     ]
 
 
-def _nested(t: float, delta: float, jump_cut: bool) -> dict[str, Any]:
-    """One pack row: the reading sits under ``delta`` beside the transition typing."""
-    return {
-        "t": t,
-        "transition": {"type": "hard"},
-        "delta": {"delta": delta, "jump_cut": jump_cut, "reason": "same angle" if jump_cut else ""},
-    }
+def _read(t: float, delta: float, jump_cut: bool) -> framing.Cut:
+    """One catalog cut: the reading, beside the transition typing the pack keeps on it."""
+    return framing.Cut(
+        t=t,
+        reading=framing.Delta(
+            delta=delta,
+            content=delta,
+            layout=delta,
+            structure=delta,
+            scale=delta,
+            shift_x=None,
+            shift_y=None,
+            jump_cut=jump_cut,
+            reason="same angle" if jump_cut else "",
+        ),
+        extra={"transition": {"type": "hard"}},
+    )
 
 
 def bars_file(tmp_path: Path, first: float = 0.0, name: str = "concert-bars.json") -> Path:
@@ -409,33 +415,57 @@ def test_every_shot_lands_on_disk_with_its_offsets_bar_and_section(
 def test_a_cut_delta_catalog_joins_onto_the_cuts(attach: Attach, tmp_path: Path) -> None:
     """The pack measured the render; this puts its numbers on the timeline's own cuts."""
     attach(studio(timeline=a_cut()))
-    catalog = deltas_file(tmp_path, [_nested(1.033, 0.62, False), _nested(2.483, 0.08, True)])
+    catalog = deltas_file(tmp_path, [_read(1.033, 0.62, False), _read(2.483, 0.08, True)])
 
     result = _measured(tmp_path, deltas=str(catalog))
 
     cuts = _rows(result)
     assert [one["delta"] for one in cuts] == [None, 0.62, 0.08]
     assert [one["jump_cut"] for one in cuts] == [None, False, True]
-    assert result["visual_delta"]["joined"] == 2
-    assert result["visual_delta"]["unjoined"] == 1
+    assert result["visual_delta"]["cuts"] == 2
+    assert result["visual_delta"]["cuts_unread"] == 1
     assert result["visual_delta"]["jump_cuts"] == 1
     assert result["visual_delta"]["flagged_cuts"] == [3]
     assert result["visual_delta"]["delta"]["max"] == 0.62
 
 
-def test_a_flat_catalog_reads_the_same_as_a_nested_one(attach: Attach, tmp_path: Path) -> None:
-    """A catalog that spreads the reading across the row, as the recon pass writes it."""
+def test_the_delta_block_is_the_measurement_s_own_summary_shape(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """One shape for one measurement: a pack's block and this one read the same.
+
+    Everything ``video.framing`` puts in a summary is here, the threshold the flag was
+    taken at included, and what the join adds sits beside it rather than replacing it.
+    """
     attach(studio(timeline=a_cut()))
-    catalog = deltas_file(
-        tmp_path,
-        [{"t": 1.033, "delta": 0.62, "jump_cut": False, "reason": ""}],
-        name="flat",
+    catalog = deltas_file(tmp_path, [_read(1.033, 0.62, False)], name="shape")
+
+    block = _measured(tmp_path, deltas=str(catalog))["visual_delta"]
+
+    assert set(framing.summarize([])) <= set(block)
+    assert block["threshold"] == framing.JUMP_DELTA
+    assert block["catalog_rows"] == 1
+    assert block["match_tolerance_sec"] == correlate.DELTA_MATCH_SEC
+
+
+def test_a_catalog_that_spreads_the_reading_across_the_row_is_refused(
+    attach: Attach, tmp_path: Path
+) -> None:
+    """The flat catalog a hand-rolled writer used to leave is one shape too many.
+
+    Read as an unread boundary it would report measured cuts as holes; the refusal comes
+    back from the call, and names the writer that fixes the file.
+    """
+    attach(studio(timeline=a_cut()))
+    catalog = records.write(
+        tmp_path / "flat.json",
+        {"kind": framing.CATALOG_KIND, "count": 1},
+        "cuts",
+        [{"t": 1.033, "delta": 0.62, "jump_cut": False}],
     )
 
-    cuts = _rows(_measured(tmp_path, deltas=str(catalog)))
-
-    assert cuts[1]["delta"] == 0.62
-    assert cuts[1]["jump_cut"] is False
+    with pytest.raises(InvalidRequestError, match="bare float"):
+        _measured(tmp_path, deltas=str(catalog))
 
 
 def test_a_catalog_row_out_of_reach_of_a_cut_does_not_join(
@@ -447,13 +477,13 @@ def test_a_catalog_row_out_of_reach_of_a_cut_does_not_join(
     that is not this one. The count of what failed to join is the tell.
     """
     attach(studio(timeline=a_cut()))
-    catalog = deltas_file(tmp_path, [_nested(1.633, 0.62, False)], name="offset")
+    catalog = deltas_file(tmp_path, [_read(1.633, 0.62, False)], name="offset")
 
     result = _measured(tmp_path, deltas=str(catalog))
 
     assert [one["delta"] for one in _rows(result)] == [None, None, None]
-    assert result["visual_delta"]["joined"] == 0
-    assert result["visual_delta"]["unjoined"] == 3
+    assert result["visual_delta"]["cuts"] == 0
+    assert result["visual_delta"]["cuts_unread"] == 3
     assert result["visual_delta"]["delta"] is None
 
 
@@ -472,8 +502,8 @@ def test_no_catalog_leaves_the_columns_null_and_the_block_out(
 def test_a_named_catalog_is_part_of_the_cache_key(attach: Attach, tmp_path: Path) -> None:
     """Rerunning with a different catalog measures again rather than answering from a file."""
     attach(studio(timeline=a_cut()))
-    first = deltas_file(tmp_path, [_nested(1.033, 0.62, False)], name="one")
-    second = deltas_file(tmp_path, [_nested(1.033, 0.09, True)], name="two")
+    first = deltas_file(tmp_path, [_read(1.033, 0.62, False)], name="one")
+    second = deltas_file(tmp_path, [_read(1.033, 0.09, True)], name="two")
 
     _measured(tmp_path, deltas=str(first))
     again = _measured(tmp_path, deltas=str(second))

--- a/tests/test_visual_delta.py
+++ b/tests/test_visual_delta.py
@@ -8,10 +8,16 @@ numbers stay inside their stated ranges.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any
+
 import numpy as np
 import pytest
 from numpy.typing import NDArray
 
+from resolve_mcp.analysis import records
+from resolve_mcp.errors import InvalidRequestError
 from resolve_mcp.video import framing
 
 
@@ -257,3 +263,99 @@ def test_a_reading_serialises_to_plain_json_types() -> None:
         "reason",
     }
     assert all(one is None or isinstance(one, float | int | bool | str) for one in record.values())
+
+
+def a_catalog(tmp_path: Path, *rows: dict[str, Any], name: str = "hand.json") -> Path:
+    """A catalog written past the interface, the way a hand-edited file arrives."""
+    return records.write(
+        tmp_path / name, {"kind": framing.CATALOG_KIND, "count": len(rows)}, "cuts", list(rows)
+    )
+
+
+def test_a_catalog_round_trips_through_write_and_read(tmp_path: Path) -> None:
+    """The record is the seam: what the writer measured is what the reader gets back."""
+    reading = framing.read_pair(stage(), stage(center=0.8))
+    path = framing.write_catalog(
+        tmp_path / "cuts.json",
+        [framing.Cut(t=1.033, reading=reading), framing.Cut(t=2.483, reading=None)],
+    )
+
+    back = framing.read_catalog(path)
+
+    assert [one.t for one in back] == [1.033, 2.483]
+    assert back[0].reading == reading
+    assert back[1].reading is None
+
+
+def test_a_catalog_is_read_back_in_time_order(tmp_path: Path) -> None:
+    """A catalog is a timeline, so the reader sorts it rather than trusting the writer."""
+    reading = framing.read_pair(stage(), stage(center=0.8))
+    path = framing.write_catalog(
+        tmp_path / "cuts.json",
+        [framing.Cut(t=4.0, reading=reading), framing.Cut(t=1.0, reading=reading)],
+    )
+
+    assert [one.t for one in framing.read_catalog(path)] == [1.0, 4.0]
+
+
+def test_a_catalog_row_carries_the_columns_its_writer_added(tmp_path: Path) -> None:
+    """The pack writes a transition typing and a filmstrip reference on the same row.
+
+    Those belong to the writer, not to this measurement, and the interface has to carry
+    them through untouched or the pack cannot use it for its own file.
+    """
+    reading = framing.read_pair(stage(), stage(center=0.8))
+    path = framing.write_catalog(
+        tmp_path / "cuts.json",
+        [framing.Cut(t=1.0, reading=reading, extra={"index": 1, "transition": {"type": "hard"}})],
+        header={"label": "human"},
+    )
+
+    back = framing.read_catalog(path)
+    doc = json.loads(path.read_text(encoding="utf-8"))
+
+    assert back[0].extra == {"index": 1, "transition": {"type": "hard"}}
+    assert doc["kind"] == framing.CATALOG_KIND
+    assert doc["count"] == 1
+    assert doc["label"] == "human"
+
+
+def test_a_row_that_spreads_the_reading_across_itself_is_refused(tmp_path: Path) -> None:
+    """One shape, said out loud.
+
+    A bare number under ``delta`` is the flat catalog a hand-rolled writer used to leave,
+    and reading it as an unread boundary would report a measured cut as a hole nobody
+    notices. The refusal names the writer that fixes it.
+    """
+    path = a_catalog(tmp_path, {"t": 1.0, "delta": 0.62, "jump_cut": False})
+
+    with pytest.raises(InvalidRequestError, match="bare float") as refused:
+        framing.read_catalog(path)
+
+    assert "write_catalog" in refused.value.fix
+
+
+def test_a_reading_missing_a_term_reads_as_a_hole_rather_than_a_crash(tmp_path: Path) -> None:
+    """An older or hand-edited record answers with what it holds, from the tool call.
+
+    A ``KeyError`` out of a worker two seconds later is the one answer nobody can act on.
+    """
+    path = a_catalog(tmp_path, {"t": 1.0, "delta": {"delta": 0.08, "jump_cut": True}})
+
+    reading = framing.read_catalog(path)[0].reading
+
+    assert reading is not None
+    assert (reading.delta, reading.jump_cut) == (0.08, True)
+    assert (reading.layout, reading.shift_x, reading.reason) == (0.0, None, "")
+
+
+def test_an_unread_boundary_is_written_as_one(tmp_path: Path) -> None:
+    """A boundary the reader refused is a null on disk, not an absent row.
+
+    The count of cuts is the pack's own; dropping the row would report a shorter edit.
+    """
+    path = framing.write_catalog(tmp_path / "cuts.json", [framing.Cut(t=1.0, reading=None)])
+
+    doc = json.loads(path.read_text(encoding="utf-8"))
+
+    assert doc["cuts"] == [{"t": 1.0, "delta": None}]

--- a/tests/test_visual_delta.py
+++ b/tests/test_visual_delta.py
@@ -320,6 +320,25 @@ def test_a_catalog_row_carries_the_columns_its_writer_added(tmp_path: Path) -> N
     assert doc["label"] == "human"
 
 
+def test_the_two_columns_a_row_owns_are_written_over_its_writer_s(tmp_path: Path) -> None:
+    """A writer that already keeps its own ``t`` or ``delta`` does not get to mean by them.
+
+    Silently letting either through would put a number this module never measured under the
+    name every reader of a catalog trusts.
+    """
+    reading = framing.read_pair(stage(), stage(center=0.8))
+    path = framing.write_catalog(
+        tmp_path / "cuts.json",
+        [framing.Cut(t=1.0, reading=reading, extra={"t": 9.0, "delta": 0.99})],
+    )
+
+    back = framing.read_catalog(path)
+
+    assert back[0].t == 1.0
+    assert back[0].reading == reading
+    assert back[0].extra == {}
+
+
 def test_a_row_that_spreads_the_reading_across_itself_is_refused(tmp_path: Path) -> None:
     """One shape, said out loud.
 


### PR DESCRIPTION
Closes #225.

`video/framing` measured the visual delta at a cut but owned nothing of the file that carried it: the gauntlet pack hand-built `cuts.json` rows, and `analysis/correlate` sniffed two shapes at runtime to read them back. The seam between measurement and reader was a JSON convention neither side owned.

## What changed

- **Framing owns the catalog.** `write_catalog` / `read_catalog` over `Cut` records — `Delta.as_record` on the way down, a `Delta` on the way up. A row carries whatever else its writer knew about that cut (`extra`), so a writer's own file *is* the catalog rather than needing a second one beside it. `CATALOG_COLUMNS` (`t`, `delta`) are the two the row owns and are written over a writer's own.
- **One shape, said out loud.** A row that spreads the reading across itself — the flat catalog a hand-rolled writer used to leave — is refused by name (cause names the row, fix names `write_catalog`) instead of read as a hole. A record missing a term still reads as a reading with a hole rather than a `KeyError` from inside a worker.
- **Correlate takes the typed reading.** `_delta_at` reads `Cut.reading`; the `isinstance(reading, Mapping)` sniff is gone, and `measure` / `_summary` / `correlate` are typed through as `Sequence[framing.Cut]`.
- **One summary shape.** `summarize_steps` is split out of `framing.summarize` for a reader holding the two columns a written row keeps; correlate's `visual_delta` block is now that shape plus what only the join knows (`catalog_rows`, `flagged_cuts`, `match_tolerance_sec`). `joined`/`unjoined` are therefore `cuts`/`cuts_unread`, and the block gains a p10 and the threshold the flag was taken at. **`READING` 11 → 12** so a cached reading-11 file cannot answer with the block this replaces.
- **The pack writes through the interface** (`gauntlet/tools/ab_pack.py`). Its `RHYTHM_BINS` import was also repaired: it named `analysis.correlate`, where the symbol no longer lives, so the module did not import at all on `main` — AC4 is unverifiable without it.

## Seams

Fake/pure tier, as #225 marks each AC. `tests/test_visual_delta.py` gains the catalog round trip, time order, extras carried, the column-precedence rule, the flat-row refusal and the missing-term hole; `tests/test_correlate_timeline.py` writes its catalogs through `write_catalog` and asserts the block is a superset of `framing.summarize`. No live AC. Full fake tier, `mypy` strict and `ruff check` green.

## Review

Two-axis review (`/code-review`) against `origin/main`, both axes as parallel sub-agents.

**Standards — no hard violations.** Eight judgement calls; five resolved in a331db4, three answered:

1. *The pack's `cuts.json` header arrays lost their indentation, and the comment overstated the win.* Resolved: the comment now says plainly that the records layout covers the cut records only, and that a header value is one line however long it is.
2. *`write_catalog` dropped an `extra` carrying `t` or `delta` silently.* Resolved: named in `CATALOG_COLUMNS` and in the docstring beside the `kind`/`count` overwrite, and pinned by a test.
3. *`CATALOG_TIME` half-applied — the refusal still reached for `row['t']`, and `"delta"` was a literal in four places.* Resolved: one `CATALOG_COLUMNS` pair, used everywhere the name is the row's rather than a record term's.
4. *First `video → analysis` edge, undocumented.* Resolved: `docs/context/video.md` names it and why it carries no cycle (`records` is a leaf on `errors`; both `__init__` are docstring-only).
5. *Stale "how many rows joined" in `correlate_timeline`'s docstring* (also the spec axis's one residual). Resolved.
6. *`supers.json` next door still hand-writes `records.write` with a "same records shape" comment.* Held: that is #183's catalog, not this ticket's — the same treatment is worth its own ticket.
7. *`Cut.extra` is an untyped bag on a typed record.* Held by design: five keys in use, and a catalog that could hold only the two typed columns sends every writer back to a second file — the convention this replaces.
8. *`summarize` / `summarize_steps` is a projecting adapter, not a Middle Man; `steps` a mild name.* Held.

**Spec — AC1–AC3 met, AC4 met on the half that exists.** The round trip is lossless and tested; the sniff is gone and the join is typed; the block is framing's shape with join facts added, and the cache version is bumped with an accurate note. AC4 says the pack "reads and writes" through the interface: it writes through it, and it has **no delta-catalog read site at all** — its only `cuts.json` read is `load_subject_track`, which reads a *correlate report* for subject columns, a different file. The read half is vacuous rather than missed; correlate is the reader.

No consumer breaks: `gauntlet/recon/`, `styles/`, `projects/` and docs were searched for a writer of the flat shape correlate now refuses. `gauntlet/recon/cut_delta_calib.py` still writes flat rows, but nested per song under its own field, so `records.rows(path, "cuts")` never sees them and no path feeds them to `correlate_timeline`. It is a calibration receipt cited in `framing`'s own docstring, and rewriting it without re-running the calibration would change committed evidence — left alone deliberately.

Fix diff re-checked on its own (a331db4): docstrings, one constant pair, one comment, one test, one doc line.

Review: clean @a331db4
